### PR TITLE
Remove compiler warnings

### DIFF
--- a/ArduCopter/ArduCopter.pde
+++ b/ArduCopter/ArduCopter.pde
@@ -1076,7 +1076,7 @@ static void fifty_hz_loop()
     }
 
     if (g.log_bitmask & MASK_LOG_IMU && motors.armed())
-        DataFlash.Log_Write_IMU(&ins);
+        Log_Write_IMU();
 #endif
 
 }
@@ -1346,7 +1346,7 @@ static void update_GPS(void)
 
         // log location if we have at least a 2D fix
         if (g.log_bitmask & MASK_LOG_GPS && motors.armed()) {
-            DataFlash.Log_Write_GPS(g_gps, current_loc.alt);
+            Log_Write_GPS();
         }
 
         // for performance monitoring

--- a/ArduCopter/Log.pde
+++ b/ArduCopter/Log.pde
@@ -377,6 +377,16 @@ static void Log_Write_Compass()
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
 }
 
+static void Log_Write_GPS(void)
+{
+    DataFlash.Log_Write_GPS(g_gps, current_loc.alt);
+}
+
+static void Log_Write_IMU() 
+{
+    DataFlash.Log_Write_IMU(&ins);
+}
+
 struct PACKED log_Performance {
     LOG_PACKET_HEADER;
     uint8_t renorm_count;

--- a/ArduCopter/Log.pde
+++ b/ArduCopter/Log.pde
@@ -77,7 +77,7 @@ dump_log(uint8_t argc, const Menu::arg *argv)
         cliSerial->printf_P(PSTR("dumping all\n"));
         Log_Read(0, 1, 0);
         return(-1);
-    } else if ((argc != 2) || (dump_log <= (last_log_num - DataFlash.get_num_logs())) || (dump_log > last_log_num)) {
+    } else if ((argc != 2) || ((uint16_t)dump_log <= (last_log_num - DataFlash.get_num_logs())) || ((uint16_t)dump_log > last_log_num)) {
         cliSerial->printf_P(PSTR("bad log number\n"));
         return(-1);
     }

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -1096,7 +1096,7 @@ void AP_Param::convert_old_parameter(const struct ConversionInfo *info)
     }
 
     // see if they are the same type
-    if (ptype == header.type) {
+    if ((uint8_t)ptype == header.type) {
         // copy the value over only if the new parameter does not already
         // have the old value (via a default).
         if (memcmp(ap2, ap, sizeof(old_value)) != 0) {


### PR DESCRIPTION
there were a few compiler warnings in the ArduCopter source that involved comparing signed and unsigned ints. these minor adjustments clear the warnings.