### PR TITLE
RTL Always Climb

### DIFF
--- a/ArduCopter/commands.pde
+++ b/ArduCopter/commands.pde
@@ -113,6 +113,10 @@ static int32_t get_initial_RTL_alt() {
     }
     // needed in case we are RTLing from down in a valley below home
     if (initial_alt < g.rtl_altitude) initial_alt = g.rtl_altitude;
+    
+    // needed in case RTL altitude is set to zero
+    if (initial_alt < RTL_ALT_MARGIN) initial_alt = RTL_ALT_MARGIN;
+    
     return initial_alt;
 }
 

--- a/ArduCopter/commands.pde
+++ b/ArduCopter/commands.pde
@@ -106,9 +106,9 @@ static int32_t get_initial_RTL_alt() {
     // to ensure an initial climb, the initial RTL alt should be rtl_altitude greater than the current alt
     int32_t initial_alt = g.rtl_altitude + current_loc.alt;
     // if fence is enabled, RTL alt must be kept under the fence
-    if (fence.enabled() && fence.get_enabled_fences() & AC_FENCE_TYPE_ALT_MAX) {
+    if (fence.get_enabled_fences() & AC_FENCE_TYPE_ALT_MAX) {
         // keep under the fence by a margin
-        int32_t max_alt = fence.alt_max() * 1000 - RTL_ALT_MARGIN;
+        int32_t max_alt = fence.alt_max() * 100 - RTL_ALT_MARGIN;
         if(initial_alt > max_alt) initial_alt = max_alt;
     }
     // needed in case we are RTLing from down in a valley below home

--- a/ArduCopter/commands.pde
+++ b/ArduCopter/commands.pde
@@ -106,7 +106,7 @@ static int32_t get_initial_RTL_alt() {
     // to ensure an initial climb, the initial RTL alt should be rtl_altitude greater than the current alt
     int32_t initial_alt = g.rtl_altitude + current_loc.alt;
     // if fence is enabled, RTL alt must be kept under the fence
-    if (fence.enabled()) {
+    if (fence.enabled() && fence.get_enabled_fences() & AC_FENCE_TYPE_ALT_MAX) {
         // keep under the fence by a margin
         int32_t max_alt = fence.alt_max() * 1000 - RTL_ALT_MARGIN;
         if(initial_alt > max_alt) initial_alt = max_alt;

--- a/ArduCopter/commands.pde
+++ b/ArduCopter/commands.pde
@@ -121,11 +121,11 @@ static int32_t get_RTL_alt()
     int32_t rtl_alt = g.rtl_altitude;
     // set to zero means RTL at current altitude, but make sure it's above launch ground level by RTL_ALT_MARGIN
     if(rtl_alt <= 0) {
-	    rtl_alt = max(current_loc.alt, RTL_ALT_MARGIN);
+        rtl_alt = max(current_loc.alt, RTL_ALT_MARGIN);
     }
     // otherwise, RTL alt should be at least our currrent alt
     else if (rtl_alt < current_loc.alt) {
-		rtl_alt = current_loc.alt;
+        rtl_alt = current_loc.alt;
     }
     return rtl_alt;      
 }

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -709,8 +709,8 @@
  # define RTL_ALT 				    1500    // default alt to return to home in cm, 0 = Maintain current altitude
 #endif
 
-#ifndef RTL_ALT_MAX
- # define RTL_ALT_MAX               8000    // Max height to return to home in cm (i.e 80m)
+#ifndef RTL_ALT_MARGIN
+ # define RTL_ALT_MARGIN               500    // Height below fence for max RTL, or above ground for min RTL (i.e 5m)
 #endif
 
 #ifndef RTL_LOITER_TIME

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -40,7 +40,7 @@ public:
     bool enabled() const { return _enabled; }
 
     /// alt_max - returns upper altitude limit in meters
-    float alt_max() const { return _alt_max; }
+    float alt_max() const { return _alt_max.get(); }
 
     /// get_enabled_fences - returns bitmask of enabled fences
     uint8_t get_enabled_fences() const;

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -39,6 +39,9 @@ public:
     /// enabled - returns true if fence is enabled
     bool enabled() const { return _enabled; }
 
+    /// alt_max - returns upper altitude limit in meters
+    float alt_max() const { return _alt_max; }
+
     /// get_enabled_fences - returns bitmask of enabled fences
     uint8_t get_enabled_fences() const;
 


### PR DESCRIPTION
Not really "always climb", but with a few exceptions will cause a climb of RTL_ALT cm whenever RTL is entered. This is great for FPV over trees or terrain, where if you lose video or RC signal, the best way to get it back is a quick climb; whereas going straight home may cause a crash into whatever obstacle blocked the signal in the first place. Before the only solution was to set RTL_ALT higher than all possible obstacles, but in the mountains obstacles can be hundreds of meters high, and it can be annoying for a simple RTL intended just to get your craft back home to detour to hundreds of meters if not necessary.

Exceptions to the "always climb" rule:

* If a max alt fence is enabled, it will not climb higher than to RTL_ALT_MARGIN (500 cm) below the fence.

* If RTL_ALT is set to zero, it will RTL at current altitude

* If you are in a valley (below launch altitude) it will RTL at RTL_ALT

* If you are in a valley, or near the ground, even if RTL_ALT is set to zero, it will still RTL at RTL_ALT_MARGIN (500 cm) above home (so it's not scraping the ground by the time it arrives home).