### PR TITLE
#565 - set rc_override_active based on if any overrides are actually

### DIFF
--- a/ArduCopter/GCS_Mavlink.pde
+++ b/ArduCopter/GCS_Mavlink.pde
@@ -1870,10 +1870,10 @@ mission_failed:
         v[5] = packet.chan6_raw;
         v[6] = packet.chan7_raw;
         v[7] = packet.chan8_raw;
-        hal.rcin->set_overrides(v, 8);
 
         // record that rc are overwritten so we can trigger a failsafe if we lose contact with groundstation
-        ap.rc_override_active = true;
+        ap.rc_override_active = hal.rcin->set_overrides(v, 8);
+
         // a RC override message is consiered to be a 'heartbeat' from the ground station for failsafe purposes
         last_heartbeat_ms = millis();
         break;

--- a/ArduPlane/GCS_Mavlink.pde
+++ b/ArduPlane/GCS_Mavlink.pde
@@ -1911,7 +1911,8 @@ mission_failed:
         v[6] = packet.chan7_raw;
         v[7] = packet.chan8_raw;
 
-        hal.rcin->set_overrides(v, 8);
+        // record that rc are overwritten so we can trigger a failsafe if we lose contact with groundstation
+        failsafe.rc_override_active = hal.rcin->set_overrides(v, 8);
 
         // a RC override message is consiered to be a 'heartbeat' from
         // the ground station for failsafe purposes

--- a/libraries/AP_HAL/RCInput.cpp
+++ b/libraries/AP_HAL/RCInput.cpp
@@ -1,0 +1,39 @@
+#include <AP_HAL.h>
+
+#include <avr/io.h>
+#include <avr/interrupt.h>
+
+#include "RCInput.h"
+using namespace AP_HAL;
+
+void RCInput::init_overrides(uint16_t *buffer, uint8_t max_channels) {
+    _overrides = buffer;
+    this->max_channels = max_channels;
+}
+
+bool RCInput::set_overrides(int16_t *overrides, uint8_t len) {
+    bool res = false;
+    for (uint8_t i = 0; i < len; i++) {
+        res |= set_override(i, overrides[i]);
+    }
+    return res;
+}
+
+bool RCInput::set_override(uint8_t channel, int16_t override) {
+    if (override < 0) return _overrides[channel] != 0; /* -1: no change. */
+    if (channel < max_channels) {
+        _overrides[channel] = override;
+        if (override != 0) {
+            set_overrides_valid();
+            return true;
+        }
+    }
+    return false;
+}
+
+void RCInput::clear_overrides() {
+    for (uint8_t i = 0; i < max_channels; i++) {
+        _overrides[i] = 0;
+    }
+}
+

--- a/libraries/AP_HAL/RCInput.h
+++ b/libraries/AP_HAL/RCInput.h
@@ -38,15 +38,29 @@ public:
      *  v == -1 -> no change to this channel
      *  v == 0  -> do not override this channel
      *  v > 0   -> set v as override.
+     *
+     * This implementation is shared for most HALs.  If some HAL needs to customize, just change to be virtual.
+     *
+     * @return true only if we are now overriding any channels
+     *
      */
-
-    /* set_overrides: array starts at ch 0, for len channels */
-    virtual bool set_overrides(int16_t *overrides, uint8_t len) = 0;
+    bool set_overrides(int16_t *overrides, uint8_t len);
     /* set_override: set just a specific channel */
-    virtual bool set_override(uint8_t channel, int16_t override) = 0;
+    bool set_override(uint8_t channel, int16_t override);
     /* clear_overrides: equivelant to setting all overrides to 0 */
-    virtual void clear_overrides() = 0;
+    void clear_overrides();
 
+protected:
+    /** Subclasses must call this from their init() or constructor to provide storage for override data */
+    void init_overrides(uint16_t *buffer, uint8_t max_channels);
+
+    /** Allow subclasses to update valid_channels based on overrides */
+    virtual void set_overrides_valid() {}
+
+private:
+    /* override state */
+    uint16_t *_overrides; 
+    uint8_t max_channels;
 };
 
 #endif // __AP_HAL_RC_INPUT_H__

--- a/libraries/AP_HAL_AVR/RCInput.h
+++ b/libraries/AP_HAL_AVR/RCInput.h
@@ -23,7 +23,7 @@ public:
      * Could be less than or greater than 8 depending on your incoming radio
      * or PPM stream
      */
-    uint8_t  valid_channels();
+    virtual uint8_t  valid_channels();
 
     /**
      * read(uint8_t):
@@ -44,14 +44,17 @@ public:
      *  v == -1 -> no change to this channel
      *  v == 0  -> do not override this channel
      *  v > 0   -> set v as override.
+     * set_overrides: array starts at ch 0, for len channels 
+     * @return true only if we are now overriding any channels
      */
-
-    /* set_overrides: array starts at ch 0, for len channels */
     bool set_overrides(int16_t *overrides, uint8_t len);
     /* set_override: set just a specific channel */
     bool set_override(uint8_t channel, int16_t override);
     /* clear_overrides: equivelant to setting all overrides to 0 */
     void clear_overrides();
+
+protected:
+    virtual void set_overrides_valid() { _valid_channels = 1; }
 
 private:
     /* private callback for input capture ISR */
@@ -70,9 +73,10 @@ class AP_HAL_AVR::APM2RCInput : public AP_HAL::RCInput {
     uint8_t  valid_channels();
     uint16_t read(uint8_t ch);
     uint8_t  read(uint16_t* periods, uint8_t len);
-    bool set_overrides(int16_t *overrides, uint8_t len);
-    bool set_override(uint8_t channel, int16_t override);
-    void clear_overrides();
+
+protected:
+    virtual void set_overrides_valid() { _valid_channels = 1; }
+
 private:
     /* private callback for input capture ISR */
     static void _timer5_capt_cb(void);

--- a/libraries/AP_HAL_AVR/RCInput_APM1.cpp
+++ b/libraries/AP_HAL_AVR/RCInput_APM1.cpp
@@ -51,6 +51,8 @@ void APM1RCInput::_timer4_capt_cb(void) {
 
 void APM1RCInput::init(void* _isrregistry) {
     ISRRegistry* isrregistry = (ISRRegistry*) _isrregistry;
+
+    init_overrides(_override, AVR_RC_INPUT_NUM_CHANNELS);
     isrregistry->register_signal(ISR_REGISTRY_TIMER4_CAPT, _timer4_capt_cb);
 
     /* initialize overrides */
@@ -124,32 +126,6 @@ uint8_t APM1RCInput::read(uint16_t* periods, uint8_t len) {
     uint8_t v = _valid_channels;
     _valid_channels = 0;
     return v;
-}
-
-bool APM1RCInput::set_overrides(int16_t *overrides, uint8_t len) {
-    bool res = false;
-    for (uint8_t i = 0; i < len; i++) {
-        res |= set_override(i, overrides[i]);
-    }
-    return res;
-}
-
-bool APM1RCInput::set_override(uint8_t channel, int16_t override) {
-    if (override < 0) return false; /* -1: no change. */
-    if (channel < AVR_RC_INPUT_NUM_CHANNELS) {
-        _override[channel] = override;
-        if (override != 0) {
-            _valid_channels = 1;
-            return true;
-        }
-    }
-    return false;
-}
-
-void APM1RCInput::clear_overrides() {
-    for (uint8_t i = 0; i < AVR_RC_INPUT_NUM_CHANNELS; i++) {
-        _override[i] = 0;
-    }
 }
 
 #endif

--- a/libraries/AP_HAL_AVR/RCInput_APM2.cpp
+++ b/libraries/AP_HAL_AVR/RCInput_APM2.cpp
@@ -51,6 +51,9 @@ void APM2RCInput::_timer5_capt_cb(void) {
 
 void APM2RCInput::init(void* _isrregistry) {
     ISRRegistry* isrregistry = (ISRRegistry*) _isrregistry;
+
+    init_overrides(_override, AVR_RC_INPUT_NUM_CHANNELS);
+
     isrregistry->register_signal(ISR_REGISTRY_TIMER5_CAPT, _timer5_capt_cb);
 
     /* initialize overrides */
@@ -124,32 +127,6 @@ uint8_t APM2RCInput::read(uint16_t* periods, uint8_t len) {
     uint8_t v = _valid_channels;
     _valid_channels = 0;
     return v;
-}
-
-bool APM2RCInput::set_overrides(int16_t *overrides, uint8_t len) {
-    bool res = false;
-    for (int i = 0; i < len; i++) {
-        res |= set_override(i, overrides[i]);
-    }
-    return res;
-}
-
-bool APM2RCInput::set_override(uint8_t channel, int16_t override) {
-    if (override < 0) return false; /* -1: no change. */
-    if (channel < AVR_RC_INPUT_NUM_CHANNELS) {
-        _override[channel] = override;
-        if (override != 0) {
-            _valid_channels = 1;
-            return true;
-        }
-    }
-    return false;
-}
-
-void APM2RCInput::clear_overrides() {
-    for (int i = 0; i < AVR_RC_INPUT_NUM_CHANNELS; i++) {
-        _override[i] = 0;
-    }
 }
 
 #endif

--- a/libraries/AP_HAL_AVR_SITL/RCInput.cpp
+++ b/libraries/AP_HAL_AVR_SITL/RCInput.cpp
@@ -9,6 +9,7 @@ extern const AP_HAL::HAL& hal;
 
 void SITLRCInput::init(void* machtnichts)
 {
+    init_overrides(_override, 8);
     clear_overrides();
 }
 
@@ -30,29 +31,4 @@ uint8_t SITLRCInput::read(uint16_t* periods, uint8_t len) {
     return v;
 }
 
-bool SITLRCInput::set_overrides(int16_t *overrides, uint8_t len) {
-    bool res = false;
-    for (uint8_t i = 0; i < len; i++) {
-        res |= set_override(i, overrides[i]);
-    }
-    return res;
-}
-
-bool SITLRCInput::set_override(uint8_t channel, int16_t override) {
-    if (override < 0) return false; /* -1: no change. */
-    if (channel < 8) {
-        _override[channel] = override;
-        if (override != 0) {
-            return true;
-        }
-    }
-    return false;
-}
-
-void SITLRCInput::clear_overrides()
-{
-    for (uint8_t i = 0; i < 8; i++) {
-	_override[i] = 0;
-    }
-}
 #endif

--- a/libraries/AP_HAL_AVR_SITL/RCInput.h
+++ b/libraries/AP_HAL_AVR_SITL/RCInput.h
@@ -12,13 +12,9 @@ public:
 	    _sitlState = sitlState;
     }
     void init(void* machtnichts);
-    uint8_t  valid_channels();
+    virtual uint8_t  valid_channels();
     uint16_t read(uint8_t ch);
     uint8_t read(uint16_t* periods, uint8_t len);
-
-    bool set_overrides(int16_t *overrides, uint8_t len);
-    bool set_override(uint8_t channel, int16_t override);
-    void clear_overrides();
 
 private:
     SITL_State *_sitlState;

--- a/libraries/AP_HAL_Empty/RCInput.cpp
+++ b/libraries/AP_HAL_Empty/RCInput.cpp
@@ -3,10 +3,13 @@
 
 using namespace Empty;
 EmptyRCInput::EmptyRCInput()
-{}
+{
+  init_overrides(NULL, 0);
+}
 
 void EmptyRCInput::init(void* machtnichts)
-{}
+{
+}
 
 uint8_t EmptyRCInput::valid_channels() {
     return 0;
@@ -25,14 +28,4 @@ uint8_t EmptyRCInput::read(uint16_t* periods, uint8_t len) {
     return len;
 }
 
-bool EmptyRCInput::set_overrides(int16_t *overrides, uint8_t len) {
-    return true;
-}
-
-bool EmptyRCInput::set_override(uint8_t channel, int16_t override) {
-    return true;
-}
-
-void EmptyRCInput::clear_overrides()
-{}
 

--- a/libraries/AP_HAL_Empty/RCInput.h
+++ b/libraries/AP_HAL_Empty/RCInput.h
@@ -11,10 +11,6 @@ public:
     uint8_t  valid_channels();
     uint16_t read(uint8_t ch);
     uint8_t read(uint16_t* periods, uint8_t len);
-
-    bool set_overrides(int16_t *overrides, uint8_t len);
-    bool set_override(uint8_t channel, int16_t override);
-    void clear_overrides();
 };
 
 #endif // __AP_HAL_EMPTY_RCINPUT_H__

--- a/libraries/AP_HAL_FLYMAPLE/RCInput.cpp
+++ b/libraries/AP_HAL_FLYMAPLE/RCInput.cpp
@@ -37,7 +37,13 @@ volatile uint8_t  FLYMAPLERCInput::_valid_channels = 0;
 #define FLYMAPLE_RC_INPUT_PIN 6
 
 FLYMAPLERCInput::FLYMAPLERCInput()
-{}
+{
+  init_overrides(_override, FLYMAPLE_RC_INPUT_NUM_CHANNELS);
+}
+
+uint8_t FLYMAPLERCInput::valid_channels() {
+    return _valid_channels;
+}
 
 void FLYMAPLERCInput::_timer_capt_cb(void)
 {
@@ -106,10 +112,6 @@ void FLYMAPLERCInput::init(void* machtnichts)
     timer_resume(tdev); // reenabled
 }
 
-uint8_t FLYMAPLERCInput::valid_channels() {
-    return _valid_channels;
-}
-
 /* constrain captured pulse to be between min and max pulsewidth. */
 static inline uint16_t constrain_pulse(uint16_t p) {
     if (p > RC_INPUT_MAX_PULSEWIDTH) return RC_INPUT_MAX_PULSEWIDTH;
@@ -156,33 +158,6 @@ uint8_t FLYMAPLERCInput::read(uint16_t* periods, uint8_t len) {
     uint8_t v = _valid_channels;
     _valid_channels = 0;
     return v;
-}
-
-bool FLYMAPLERCInput::set_overrides(int16_t *overrides, uint8_t len) {
-    bool res = false;
-    for (uint8_t i = 0; i < len; i++) {
-        res |= set_override(i, overrides[i]);
-    }
-    return res;
-}
-
-bool FLYMAPLERCInput::set_override(uint8_t channel, int16_t override) {
-    if (override < 0) return false; /* -1: no change. */
-    if (channel < FLYMAPLE_RC_INPUT_NUM_CHANNELS) {
-        _override[channel] = override;
-        if (override != 0) {
-            _valid_channels = 1;
-            return true;
-        }
-    }
-    return false;
-}
-
-void FLYMAPLERCInput::clear_overrides()
-{
-    for (uint8_t i = 0; i < FLYMAPLE_RC_INPUT_NUM_CHANNELS; i++) {
-        _override[i] = 0;
-    }
 }
 
 #endif

--- a/libraries/AP_HAL_FLYMAPLE/RCInput.h
+++ b/libraries/AP_HAL_FLYMAPLE/RCInput.h
@@ -33,9 +33,8 @@ public:
     uint16_t read(uint8_t ch);
     uint8_t read(uint16_t* periods, uint8_t len);
 
-    bool set_overrides(int16_t *overrides, uint8_t len);
-    bool set_override(uint8_t channel, int16_t override);
-    void clear_overrides();
+protected:
+    virtual void set_overrides_valid() { _valid_channels = 1; }
 
 private:
     /* private callback for input capture ISR */

--- a/libraries/AP_HAL_PX4/RCInput.cpp
+++ b/libraries/AP_HAL_PX4/RCInput.cpp
@@ -11,6 +11,7 @@ extern const AP_HAL::HAL& hal;
 
 void PX4RCInput::init(void* unused)
 {
+	init_overrides(_override, RC_INPUT_MAX_CHANNELS);
 	_perf_rcin = perf_alloc(PC_ELAPSED, "APM_rcin");
 	_rc_sub = orb_subscribe(ORB_ID(input_rc));
 	if (_rc_sub == -1) {
@@ -49,37 +50,6 @@ uint8_t PX4RCInput::read(uint16_t* periods, uint8_t len)
 		periods[i] = read(i);
 	}
 	return len;
-}
-
-bool PX4RCInput::set_overrides(int16_t *overrides, uint8_t len) 
-{
-	bool res = false;
-	for (uint8_t i = 0; i < len; i++) {
-		res |= set_override(i, overrides[i]);
-	}
-	return res;
-}
-
-bool PX4RCInput::set_override(uint8_t channel, int16_t override) {
-	if (override < 0) {
-		return false; /* -1: no change. */
-	}
-	if (channel >= RC_INPUT_MAX_CHANNELS) {
-		return false;
-	}
-	_override[channel] = override;
-	if (override != 0) {
-		_override_valid = true;
-		return true;
-	}
-	return false;
-}
-
-void PX4RCInput::clear_overrides()
-{
-	for (uint8_t i = 0; i < RC_INPUT_MAX_CHANNELS; i++) {
-		set_override(i, 0);
-	}
 }
 
 void PX4RCInput::_timer_tick(void)

--- a/libraries/AP_HAL_PX4/RCInput.h
+++ b/libraries/AP_HAL_PX4/RCInput.h
@@ -9,15 +9,14 @@
 class PX4::PX4RCInput : public AP_HAL::RCInput {
 public:
     void init(void* machtnichts);
-    uint8_t  valid_channels();
+    override uint8_t  valid_channels();
     uint16_t read(uint8_t ch);
     uint8_t read(uint16_t* periods, uint8_t len);
 
-    bool set_overrides(int16_t *overrides, uint8_t len);
-    bool set_override(uint8_t channel, int16_t override);
-    void clear_overrides();
-
     void _timer_tick(void);
+
+protected:
+    virtual void set_overrides_valid() { _override_valid = true; }
 
 private:
     /* override state */

--- a/libraries/AP_HAL_SMACCM/RCInput.cpp
+++ b/libraries/AP_HAL_SMACCM/RCInput.cpp
@@ -22,6 +22,7 @@ static inline uint16_t constrain_pulse(uint16_t p)
 
 SMACCMRCInput::SMACCMRCInput()
 {
+  init_overrides(_override, SMACCM_RCINPUT_CHANNELS);
 }
 
 void SMACCMRCInput::init(void *unused)
@@ -71,37 +72,6 @@ uint8_t SMACCMRCInput::read(uint16_t *periods, uint8_t len)
 
   timer_clear_ppm();
   return result;
-}
-
-bool SMACCMRCInput::set_overrides(int16_t *overrides, uint8_t len)
-{
-  bool result = false;
-
-  for (int i = 0; i < len; ++i)
-    result |= set_override(i, overrides[i]);
-
-  return result;
-}
-
-bool SMACCMRCInput::set_override(uint8_t channel, int16_t override)
-{
-  if (override < 0)
-    return false;
-
-  if (channel < SMACCM_RCINPUT_CHANNELS) {
-    _override[channel] = override;
-    if (override != 0) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-void SMACCMRCInput::clear_overrides()
-{
-  for (int i = 0; i < SMACCM_RCINPUT_CHANNELS; ++i)
-    _override[i] = 0;
 }
 
 #endif // CONFIG_HAL_BOARD == HAL_BOARD_SMACCM

--- a/libraries/AP_HAL_SMACCM/RCInput.h
+++ b/libraries/AP_HAL_SMACCM/RCInput.h
@@ -14,10 +14,6 @@ public:
     uint16_t read(uint8_t ch);
     uint8_t read(uint16_t* periods, uint8_t len);
 
-    bool set_overrides(int16_t *overrides, uint8_t len);
-    bool set_override(uint8_t channel, int16_t override);
-    void clear_overrides();
-
 private:
     uint16_t _override[SMACCM_RCINPUT_CHANNELS];
 };


### PR DESCRIPTION
sent by the GCS.  previously rc_override_active would be set to true
if any override packet arrived - this is not correct because the GCS
sends a packet full of zeros to turn overrides _off_.

Since override behavior is common to nearly all HALs.  I moved the
rc_override code into the base class (under the DRY sw pricipal ;-)).

This is a WIP so DO NOT MERGE for now (best to wait for the AC3.1 branch
anyways).  I need to test it with plane and copter.  There are also a
couple of other rc_overrideish edge conditions we should address...

The only thing I ask is please no big refactoring on these files while I
have this change sitting out there - to avoid merge hell once I can check
in a complete set of changes...