### PR TITLE
Add NAV-DOP to get all DOP values, as Pdop is sent as Hdop currently

### DIFF
--- a/APMrover2/test.pde
+++ b/APMrover2/test.pde
@@ -357,11 +357,14 @@ test_gps(uint8_t argc, const Menu::arg *argv)
 		g_gps->update();
 
 		if (g_gps->new_data){
-			cliSerial->printf_P(PSTR("Lat: %ld, Lon %ld, Alt: %ldm, #sats: %d\n"),
-					g_gps->latitude,
-					g_gps->longitude,
-					g_gps->altitude/100,
-					g_gps->num_sats);
+		    cliSerial->printf_P(PSTR("Lat: "));
+                        print_latlon(cliSerial, g_gps->latitude);
+                    cliSerial->printf_P(PSTR(", Lon "));
+                        print_latlon(cliSerial, g_gps->longitude);
+                    cliSerial->printf_P(PSTR(", Alt: %ldm, H_dop: %d, #sats: %d\n"),
+                            g_gps->altitude/100,
+                            g_gps->h_dop,
+                            g_gps->num_sats);
 		}else{
 			cliSerial->printf_P(PSTR("."));
 		}

--- a/ArduCopter/test.pde
+++ b/ArduCopter/test.pde
@@ -275,8 +275,9 @@ test_gps(uint8_t argc, const Menu::arg *argv)
             print_latlon(cliSerial, g_gps->latitude);
             cliSerial->printf_P(PSTR(", Lon "));
             print_latlon(cliSerial, g_gps->longitude);
-            cliSerial->printf_P(PSTR(", Alt: %ldm, #sats: %d\n"),
+            cliSerial->printf_P(PSTR(", Alt: %ldm, H_dop: %d, #sats: %d\n"),
                             g_gps->altitude/100,
+                            g_gps->h_dop,
                             g_gps->num_sats);
             g_gps->new_data = false;
         }else{

--- a/ArduPlane/test.pde
+++ b/ArduPlane/test.pde
@@ -450,11 +450,14 @@ test_gps(uint8_t argc, const Menu::arg *argv)
         g_gps->update();
 
         if (g_gps->new_data) {
-            cliSerial->printf_P(PSTR("Lat: %ld, Lon %ld, Alt: %ldm, #sats: %d\n"),
-                            (long)g_gps->latitude,
-                            (long)g_gps->longitude,
-                            (long)g_gps->altitude/100,
-                            (int)g_gps->num_sats);
+                cliSerial->printf_P(PSTR("Lat: "));
+                    print_latlon(cliSerial, g_gps->latitude);
+                cliSerial->printf_P(PSTR(", Lon "));
+                    print_latlon(cliSerial, g_gps->longitude);
+                cliSerial->printf_P(PSTR(", Alt: %ldm, H_dop: %d, #sats: %d\n"),
+                            g_gps->altitude/100,
+                            g_gps->h_dop,
+                            g_gps->num_sats);
         }else{
             cliSerial->printf_P(PSTR("."));
         }

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -243,6 +243,12 @@ AP_GPS_UBLOX::_parse_gps(void)
             fix = GPS::FIX_NONE;
         }
         break;
+    case MSG_DOP: // add for true HDOP mjc
+	Debug("MSG_DOP h_dop=%u h_dop=%u", _buffer.buffer.dop.horizontal_DOP);
+		p_dop		= _buffer.dop.positional_DOP; // note re-named positional_DOP with extra "al"
+		h_dop		= _buffer.dop.horizontal_DOP; // true HDOP 
+		v_dop		= _buffer.dop.vertical_DOP;   // optional VDOP value
+		break;	
     case MSG_SOL:
         Debug("MSG_SOL fix_status=%u fix_type=%u",
               _buffer.solution.fix_status,
@@ -382,6 +388,7 @@ AP_GPS_UBLOX::_configure_gps(void)
     // ask for the messages we parse to be sent on every navigation solution
     _configure_message_rate(CLASS_NAV, MSG_POSLLH, 1);
     _configure_message_rate(CLASS_NAV, MSG_STATUS, 1);
+    _configure_message_rate(CLASS_NAV, MSG_DOP, 1);
     _configure_message_rate(CLASS_NAV, MSG_SOL, 1);
     _configure_message_rate(CLASS_NAV, MSG_VELNED, 1);
 

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -267,7 +267,7 @@ AP_GPS_UBLOX::_parse_gps(void)
             fix = GPS::FIX_NONE;
         }
         num_sats        = _buffer.solution.satellites;
-        hdop            = _buffer.solution.position_DOP;
+        //hdop            = _buffer.solution.position_DOP; // depricated, see NAV_DOP for true H_dop values
         break;
     case MSG_VELNED:
         Debug("MSG_VELNED");

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -110,6 +110,16 @@ private:
         uint32_t time_to_first_fix;
         uint32_t uptime;                                // milliseconds
     };
+    struct PACKED ubx_nav_dop {			// added new DOP message for for GCS
+	uint32_t time;			
+	uint16_t geometric_DOP;			// g_dop  NOT sent
+	uint16_t positional_DOP;		// p_dop sent to GCS Note: New name positional_DOP with extra "al"
+	uint16_t time_DOP;			// t_dop  NOT sent   
+	uint16_t vertical_DOP;			// v_dop sent to GCS
+	uint16_t horizontal_DOP;		// h_dop sent to GCS Note: actual H_dop value when using UBLOX
+	uint16_t northing_DOP;			// n_dop  NOT sent
+	uint16_t easting_DOP;			// e_dop  NOT sent
+	};
     struct PACKED ubx_nav_solution {
         uint32_t time;
         int32_t time_nsec;
@@ -160,6 +170,7 @@ private:
         MSG_ACK_ACK = 0x01,
         MSG_POSLLH = 0x2,
         MSG_STATUS = 0x3,
+        MSG_DOP = 0x4,
         MSG_SOL = 0x6,
         MSG_VELNED = 0x12,
         MSG_CFG_PRT = 0x00,

--- a/libraries/AP_GPS/GPS.h
+++ b/libraries/AP_GPS/GPS.h
@@ -107,7 +107,11 @@ public:
     uint32_t ground_speed;      ///< ground speed in cm/sec
     int32_t ground_course;      ///< ground course in 100ths of a degree
     int32_t speed_3d;                   ///< 3D speed in cm/sec (not always available)
-    int16_t hdop;                       ///< horizontal dilution of precision in cm
+    //int16_t hdop;                       ///< horizontal dilution of precision in cm
+    
+    int16_t h_dop;			///< horizontal dilution of precision in cm mjc
+    int16_t p_dop;			///< position dilution of precision in cm
+    int16_t v_dop;			///< vertical dilution of precision in cm
     uint8_t num_sats;           ///< Number of visible satelites
 
     /// Set to true when new data arrives.  A client may set this


### PR DESCRIPTION
Add vars for NAV-DOP ubx message x04, to obtain true Hdop value as current code pulls Pdop and sends as Hdop
new vars: h_dop, p_dop, and v_dop.