### PR TITLE
Copter: Fixed a bug in circle_rate tuning.

### DIFF
--- a/ArduCopter/ArduCopter.pde
+++ b/ArduCopter/ArduCopter.pde
@@ -2287,7 +2287,7 @@ static void tuning(){
 
     case CH6_CIRCLE_RATE:
         // set circle rate
-        g.circle_rate.set(g.rc_6.control_in/25-20);     // allow approximately 45 degree turn rate in either direction
+        g.circle_rate.set(tuning_value);
         break;
 
     case CH6_SONAR_GAIN:


### PR DESCRIPTION
Previously, tuning the circle rate (for circle mode) using CH6 would set the
parameter to invalidly very large values.

This simple fix will correct the problem.

Signed-off-by: Quy Tonthat <qtonthat@gmail.com>