### PR TITLE
Remove redundant calculations when inputs havn't changed 

### DIFF
--- a/ArduPlane/Attitude.pde
+++ b/ArduPlane/Attitude.pde
@@ -534,7 +534,7 @@ static bool auto_takeoff_check(void)
     }
 
     // Check ground speed and time delay
-    if (((g_gps->ground_speed_cm > g.takeoff_throttle_min_speed*100.0f || g.takeoff_throttle_min_speed == 0.0)) && 
+    if ((g_gps->ground_speed_cm > g.takeoff_throttle_min_speed*100.0f || g.takeoff_throttle_min_speed == 0.0) && 
         ((now - last_tkoff_arm_time) >= min(uint16_t(g.takeoff_throttle_delay)*100,2500))) {
         gcs_send_text_fmt(PSTR("Triggered AUTO, GPSspd = %.1f"), g_gps->ground_speed_cm*0.01f);
         launchTimerStarted = false;
@@ -611,13 +611,16 @@ static bool suppress_throttle(void)
         }
         return false;
     }
+/*  // If we are all ready at 10 m altitude, we must have flown there, so the throttle is already unsupressed.
+    // If its hand launched into a wind/slope the launch detector will start the motor and it will stay unsupressed.
+    // IMHU this condition has little if any value, but can cause an inadvertant motor start, so it's history ;)
     
     if (relative_altitude_abs_cm() >= 1000) {
         // we're more than 10m from the home altitude
         throttle_suppressed = false;
         return false;
     }
-
+*/
     if (g_gps != NULL && 
         g_gps->status() >= GPS::GPS_OK_FIX_2D && 
         g_gps->ground_speed_cm >= 500) {

--- a/libraries/AP_GPS/GPS.cpp
+++ b/libraries/AP_GPS/GPS.cpp
@@ -78,6 +78,7 @@ GPS::update(void)
 
         valid_read = true;
         new_data = true;
+		new_data_mnt = true;
 
         // reset the idle timer
         _idleTimer = tnow;

--- a/libraries/AP_GPS/GPS.h
+++ b/libraries/AP_GPS/GPS.h
@@ -97,6 +97,7 @@ public:
     /// to false in order to avoid processing data they have
     /// already seen.
     bool new_data;
+	bool new_data_mnt;
 
     Fix_Status fix;                        ///< 0 if we have no fix, 2 for 2D fix, 3 for 3D fix
     bool valid_read;                    ///< true if we have seen data from the GPS (use ::status instead)


### PR DESCRIPTION
Remove redundant calculations when inputs havn't changed to the stabilization method. Looks for stick input in RC MODE or a change from <calc_GPS_target_angle>. It also doesn't call <calc_GPS_target_angle> unless there is new gps data. I used a separate gps_new_data flag for the mount because the normal one was set false elsewhere.

Hope this helps, it seems to work as good as before.