### PR TITLE
Copter: Enable land detection with optional hardware switch(es)

### DIFF
--- a/ArduCopter/APM_Config.h
+++ b/ArduCopter/APM_Config.h
@@ -32,6 +32,7 @@
 
 // features below are disabled by default
 //#define SPRAYER               ENABLED             // enable the crop sprayer feature (two ESC controlled pumps the speed of which depends upon the vehicle's horizontal velocity)
+//#define LAND_SWITCH           ENABLED             // enable land detection (default is two active-high switches connected to AN0 and AN1, see config.h)
 //#define EPM_ENABLED           ENABLED             // enable epm cargo gripper costs 500bytes of flash
 
 // redefine size of throttle deadband in pwm (0 ~ 1000)

--- a/ArduCopter/APM_Config.h
+++ b/ArduCopter/APM_Config.h
@@ -5,6 +5,8 @@
 // If you used to define your CONFIG_APM_HARDWARE setting here, it is no longer
 // valid! You should switch to using a HAL_BOARD flag in your local config.mk.
 
+#include "defines.h"
+
 //#define FRAME_CONFIG QUAD_FRAME
 /*
  *  options:

--- a/ArduCopter/Attitude.pde
+++ b/ArduCopter/Attitude.pde
@@ -1196,7 +1196,20 @@ static void reset_land_detector()
 // returns true if we have landed
 static bool update_land_detector()
 {
-    // detect whether we have landed by watching for low climb rate and minimum throttle
+    // landing is detected if:
+    //   1. climb rate is low and optional land switches have triggered
+    //   2. climb rate is low and throttle out is at a minimum
+
+    // land detection using optional land switch
+    #if LAND_SWITCH == ENABLED
+      if (abs(climb_rate) < 20 && land_switch_is_active()) {
+        set_land_complete(true);
+        land_detector = 0;
+        return ap.land_complete;
+      }
+    #endif
+
+    // land detection based on reaching minimum throttle
     if (abs(climb_rate) < 20 && motors.limit.throttle_lower) {
         if (!ap.land_complete) {
             // run throttle controller if accel based throttle controller is enabled and active (active means it has been given a target)

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -192,6 +192,22 @@
  # define CONFIG_BARO AP_BARO_BMP085
 #endif
 
+////////////////////////////////////////////////////////////////////////////////
+// Land Switch
+#ifdef LAND_SWITCH
+ #ifndef LAND_SWITCH_PIN0
+  #define LAND_SWITCH_PIN0          AN0
+ #endif
+ #ifndef LAND_SWITCH_PIN1
+  #define LAND_SWITCH_PIN1          AN1
+ #endif
+ #ifndef LAND_SWITCH_ACTIVE_STATE
+  #define LAND_SWITCH_ACTIVE_STATE  HIGH
+ #endif
+#else
+ #define LAND_SWITCH                DISABLED
+#endif
+
 //////////////////////////////////////////////////////////////////////////////
 // Sonar
 //

--- a/ArduCopter/sensors.pde
+++ b/ArduCopter/sensors.pde
@@ -28,6 +28,28 @@ static int32_t read_barometer(void)
     return barometer.get_altitude() * 100.0f;
 }
 
+static void init_land_switch(void)
+{
+#if LAND_SWITCH == ENABLED
+    pinMode(LAND_SWITCH_PIN0, INPUT);
+    pinMode(LAND_SWITCH_PIN1, INPUT);
+#endif
+}
+
+static bool land_switch_is_active(void)
+{
+#if LAND_SWITCH == ENABLED
+    if (digitalRead(LAND_SWITCH_PIN0) == LAND_SWITCH_ACTIVE_STATE ||
+        digitalRead(LAND_SWITCH_PIN1) == LAND_SWITCH_ACTIVE_STATE) {
+        return true;
+    } else {
+        return false;
+    }
+#else
+    return false;
+#endif
+}
+
 // return sonar altitude in centimeters
 static int16_t read_sonar(void)
 {

--- a/ArduCopter/system.pde
+++ b/ArduCopter/system.pde
@@ -266,6 +266,10 @@ static void init_ardupilot()
     init_barometer();
 #endif
 
+#if LAND_SWITCH == ENABLED
+    init_land_switch();
+#endif
+
     // initialise sonar
 #if CONFIG_SONAR == ENABLED
     init_sonar();


### PR DESCRIPTION
- Fixes #523 
- User needs to enable use of land switches in ArduCopter/config.h.
- Default is for two active-high switches connected to AN0 and AN1.
- Current behavior is to trigger if either switch is closed.
- Works great with micro (snap action) switches.