### PR TITLE
Make it possible to switch between Waypoints with ch7/ch8 opt.

### DIFF
--- a/ArduCopter/commands_process.pde
+++ b/ArduCopter/commands_process.pde
@@ -11,6 +11,7 @@ static void change_command(uint8_t cmd_index)
 
     // limit range
     cmd_index = min(g.command_total - 1, cmd_index);
+    cmd_index = max(1,cmd_index);
 
     // load command
     struct Location temp = get_cmd_with_index(cmd_index);

--- a/ArduCopter/control_modes.pde
+++ b/ArduCopter/control_modes.pde
@@ -109,6 +109,7 @@ static void init_aux_switches()
         case AUX_SWITCH_ACRO_TRAINER:
         case AUX_SWITCH_EPM:
         case AUX_SWITCH_SPRAYER:
+        case AUX_SWITCH_WP_CHANGE:
             do_aux_switch_function(g.ch7_option, ap.CH7_flag);
             break;
     }
@@ -122,6 +123,7 @@ static void init_aux_switches()
         case AUX_SWITCH_ACRO_TRAINER:
         case AUX_SWITCH_EPM:
         case AUX_SWITCH_SPRAYER:
+        case AUX_SWITCH_WP_CHANGE:
             do_aux_switch_function(g.ch8_option, ap.CH8_flag);
             break;
     }
@@ -365,6 +367,21 @@ static void do_aux_switch_function(int8_t ch_function, uint8_t ch_flag)
                 if (control_mode == LAND) {
                     reset_control_switch();
                 }
+            }
+            break;
+
+        case AUX_SWITCH_WP_CHANGE:
+            switch(ch_flag) {
+            case AUX_SWITCH_LOW:
+                // change to previous Waypoint
+                change_command(command_nav_index-1);
+                break;
+            case AUX_SWITCH_HIGH:
+                // change to next Waypoint
+                change_command(command_nav_index+1);
+                break;
+            default:
+                break;
             }
             break;
     }

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -73,6 +73,7 @@
 #define AUX_SWITCH_AUTOTUNE         17      // auto tune
 #define AUX_SWITCH_LAND             18      // change to LAND flight mode
 #define AUX_SWITCH_EPM              19      // Operate the EPM cargo gripper low=off, middle=neutral, high=on
+#define AUX_SWITCH_WP_CHANGE        20      // change to next/previous waypoint low = previous, high = next
 
 // values used by the ap.ch7_opt and ap.ch8_opt flags
 #define AUX_SWITCH_LOW              0       // indicates auxiliar switch is in the low position (pwm <1200)


### PR DESCRIPTION
This change will make it possible to switch between different Waypoints
with Ch7/Ch8 Opt, this is particularly useful if you define
"Loiter Unlimited" Waypoints and want to switch between them.

Signed-off-by: Simon Egli <simon.egli@tik.ee.ethz.ch>