### PR TITLE
Support both MAV_CMD_NAV_ROI and MAV_CMD_DO_SET_ROI in the command logic

### DIFF
--- a/ArduCopter/commands_logic.pde
+++ b/ArduCopter/commands_logic.pde
@@ -104,6 +104,7 @@ static void process_now_command()
                                          command_cond_queue.lat);
         break;
 
+    case MAV_CMD_NAV_ROI:                   // 80
     case MAV_CMD_DO_SET_ROI:                // 201
         // point the copter and camera at a region of interest (ROI)
         do_roi();


### PR DESCRIPTION
The reception and decoding of both command is supported, but the state
machine simply does not execute both.