### PR TITLE
vagrantfile: update to support current vagrant versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,9 @@ few minutes in Linux, OS X, or Windows.
 
  2. [Install vagrant](http://docs.vagrantup.com/v2/installation/).
 
- 4. In the `ardupilot` directory, run `vagrant up` from the command
- line.  This will create a new Ubuntu Linux VM.
-
- 5. Run `vagrant ssh -c "ardupilot/Tools/scripts/install-prereqs-ubuntu.sh -y"`.
- This will install all the prerequisites for doing ardupilot development.
+ 3. In the `ardupilot` directory, run `vagrant up` from the command
+ line.  This will create a new Ubuntu Linux VM, and install all the
+ dependencies required for ardupilot development.
 
 You can now run `vagrant ssh` to log in to the development
 environment.  The `~/ardupilot` directory in the VM is actually the

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,15 +1,29 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-Vagrant::Config.run do |config|
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu-12.04-32bit"
   config.vm.box_url = "http://files.vagrantup.com/precise32.box"
 
-  config.vm.share_folder("ardupilot", "/home/vagrant/ardupilot", ".")
+  config.vm.synced_folder ".", "/home/vagrant/ardupilot"
 
-  # Allow symlinks
-  config.vm.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/cross-compiler", "1"]
-  # Otherwise the compile will go into swap, making things slow
-  config.vm.customize ["modifyvm", :id, "--memory", "2048"]
+  config.vm.provision "shell" do |s|
+      s.privileged = false
+      s.path = "Tools/scripts/install-prereqs-ubuntu.sh"
+      s.args = ["-y"]
+    end
+
+  config.vm.provider "virtualbox" do |vb|
+
+    # Allow symlinks
+    vb.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/cross-compiler", "1"]
+
+    # Otherwise the compile will go into swap, making things slow
+    vb.customize ["modifyvm", :id, "--memory", "2048"]
+  end
+
 end
 


### PR DESCRIPTION
also automatically provisions the VM with the existing install-prereqs-ubuntu.sh script, rather than forcing developers to run that as a separate step.

updates the relevant documentation steps in the ReadMe.