### PR TITLE
ArduCopter: Adding version code identifier

### DIFF
--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -79,6 +79,9 @@ public:
         // Parachute object
         k_param_parachute,	// 17
 
+        // Version Code identifier
+        k_param_versionCode, 
+
         // Misc
         //
         k_param_log_bitmask = 20,
@@ -306,6 +309,7 @@ public:
 
     AP_Int16        format_version;
     AP_Int8         software_type;
+    AP_Int32        versionCode;
 
     // Telemetry control
     //

--- a/ArduCopter/Parameters.pde
+++ b/ArduCopter/Parameters.pde
@@ -38,6 +38,12 @@ const AP_Param::Info var_info[] PROGMEM = {
     // @User: Advanced
     GSCALAR(software_type,  "SYSID_SW_TYPE",   Parameters::k_software_type),
 
+    // @Param: VERSION_CODE
+    // @DisplayName: Version of the code
+    // @Description: An integer value that represents the version of the application code, relative to other versions.
+    // @User: Advanced
+    GSCALAR(versionCode, "VERSION_CODE",   VERSION_CODE),
+
     // @Param: SYSID_THISMAV
     // @DisplayName: Mavlink version
     // @Description: Allows reconising the mavlink version

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -750,6 +750,11 @@
 // Developer Items
 //
 
+// Incremental Version Code
+#ifndef VERSION_CODE
+ # define VERSION_CODE      1
+#endif
+
 // use this to completely disable the CLI
 #ifndef CLI_ENABLED
   #  define CLI_ENABLED           ENABLED


### PR DESCRIPTION
This is my first try on issue #1104.

A couple of things that needed to be fixed before merging:
* [ ] Make the version parameter consistent across Ardu*
* [ ] Possible moving the k_parm_versionCode to the top of the enum
* [ ] Make the version code be autogenerated by git, maybe by counting the number of TAGs.