### PR TITLE
Locate Lost Copter with Stick Combo when disarmed

### DIFF
--- a/ArduCopter/APM_Config.h
+++ b/ArduCopter/APM_Config.h
@@ -38,6 +38,7 @@
 //#define OPTFLOW               ENABLED             // enable optical flow sensor and OF_LOITER flight mode at a cost of 5K of flash space
 //#define SPRAYER               ENABLED             // enable the crop sprayer feature (two ESC controlled pumps the speed of which depends upon the vehicle's horizontal velocity)
 //#define EPM_ENABLED           ENABLED             // enable epm cargo gripper costs 500bytes of flash
+//#define LOSTMODELBUZZER       ENABLED             // enable lost model buzzer (activate when disarmed, throttle down, elevator back and roll right)
 
 // other settings
 //#define THROTTLE_IN_DEADBAND   100                // redefine size of throttle deadband in pwm (0 ~ 1000)

--- a/ArduCopter/APM_Config.h
+++ b/ArduCopter/APM_Config.h
@@ -38,7 +38,7 @@
 //#define OPTFLOW               ENABLED             // enable optical flow sensor and OF_LOITER flight mode at a cost of 5K of flash space
 //#define SPRAYER               ENABLED             // enable the crop sprayer feature (two ESC controlled pumps the speed of which depends upon the vehicle's horizontal velocity)
 //#define EPM_ENABLED           ENABLED             // enable epm cargo gripper costs 500bytes of flash
-//#define LOSTMODELBUZZER       ENABLED             // enable lost model buzzer (activate when disarmed, throttle down, elevator back and roll right)
+//#define NOTIFY_LOCATION_STICKCOMBO       ENABLED             // enable notify_location (activate when disarmed, throttle down, elevator back and roll right)
 
 // other settings
 //#define THROTTLE_IN_DEADBAND   100                // redefine size of throttle deadband in pwm (0 ~ 1000)

--- a/ArduCopter/APM_Config.h
+++ b/ArduCopter/APM_Config.h
@@ -38,6 +38,7 @@
 //#define OPTFLOW               ENABLED             // enable optical flow sensor and OF_LOITER flight mode at a cost of 5K of flash space
 //#define SPRAYER               ENABLED             // enable the crop sprayer feature (two ESC controlled pumps the speed of which depends upon the vehicle's horizontal velocity)
 //#define EPM_ENABLED           ENABLED             // enable epm cargo gripper costs 500bytes of flash
+
 //#define NOTIFY_LOCATION_STICKCOMBO       ENABLED             // enable notify_location (activate when disarmed, throttle down, elevator back and roll right)
 
 // other settings

--- a/ArduCopter/motors.pde
+++ b/ArduCopter/motors.pde
@@ -4,8 +4,8 @@
 #define DISARM_DELAY            20  // called at 10hz so 2 seconds
 #define AUTO_TRIM_DELAY         100 // called at 10hz so 10 seconds
 #define AUTO_DISARMING_DELAY    15  // called at 1hz so 15 seconds
-#if LOSTMODELBUZZER == ENABLED
-#define FIND_MODEL_ALARM_DELAY  1  // called at 1hz so 1 seconds
+#if NOTIFY_LOCATION_STICKCOMBO == ENABLED
+#define NOTIFY_LOCATION_DELAY  1  // called at 1hz so 1 seconds
 #endif
 
 // arm_motors_check - checks for pilot input to arm or disarm the copter
@@ -99,15 +99,15 @@ static void auto_disarm_check()
 {
     static uint8_t auto_disarming_counter;
 
-#if LOSTMODELBUZZER == ENABLED
+#if NOTIFY_LOCATION_STICKCOMBO == ENABLED
     
     static int16_t soundalarm_counter;
 
     // ensure throttle is down, motors not armed, pitch and roll rc at max. Note: rc1=roll rc2=pitch
     if (!g.rc_3.control_in > 0 && !motors.armed() && g.rc_1.control_in > 4000 && g.rc_2.control_in > 4000 ) {
-        if (soundalarm_counter >= FIND_MODEL_ALARM_DELAY) {
-            if (AP_Notify::flags.locatemodel == false) {
-                AP_Notify::flags.locatemodel = true;
+        if (soundalarm_counter >= NOTIFY_LOCATION_DELAY) {
+            if (AP_Notify::flags.notify_location == false) {
+                AP_Notify::flags.notify_location = true;
                 gcs_send_text_P(SEVERITY_HIGH,PSTR("Locate Copter Alarm!!"));
             }
         }else{
@@ -115,8 +115,8 @@ static void auto_disarm_check()
         }
     }else{
         soundalarm_counter = 0;
-        if (AP_Notify::flags.locatemodel == true) {
-            AP_Notify::flags.locatemodel = false;
+        if (AP_Notify::flags.notify_location == true) {
+            AP_Notify::flags.notify_location = false;
             gcs_send_text_P(SEVERITY_LOW,PSTR("Locate Copter Alarm Off"));
         }
     }

--- a/ArduCopter/motors.pde
+++ b/ArduCopter/motors.pde
@@ -4,6 +4,9 @@
 #define DISARM_DELAY            20  // called at 10hz so 2 seconds
 #define AUTO_TRIM_DELAY         100 // called at 10hz so 10 seconds
 #define AUTO_DISARMING_DELAY    15  // called at 1hz so 15 seconds
+#if LOSTMODELBUZZER == ENABLED
+#define FIND_MODEL_ALARM_DELAY  1  // called at 1hz so 1 seconds
+#endif
 
 // arm_motors_check - checks for pilot input to arm or disarm the copter
 // called at 10hz
@@ -96,7 +99,31 @@ static void auto_disarm_check()
 {
     static uint8_t auto_disarming_counter;
 
-    // exit immediately if we are already disarmed or throttle is not zero
+#if LOSTMODELBUZZER == ENABLED
+    
+    static int16_t soundalarm_counter;
+
+    // ensure throttle is down, motors not armed, pitch and roll rc at max. Note: rc1=roll rc2=pitch
+    if (!g.rc_3.control_in > 0 && !motors.armed() && g.rc_1.control_in > 4000 && g.rc_2.control_in > 4000 ) {
+        if (soundalarm_counter >= FIND_MODEL_ALARM_DELAY) {
+            if (AP_Notify::flags.locatemodel == false) {
+                AP_Notify::flags.locatemodel = true;
+                gcs_send_text_P(SEVERITY_HIGH,PSTR("Locate Copter Alarm!!"));
+            }
+        }else{
+            soundalarm_counter++;
+        }
+    }else{
+        soundalarm_counter = 0;
+        if (AP_Notify::flags.locatemodel == true) {
+            AP_Notify::flags.locatemodel = false;
+            gcs_send_text_P(SEVERITY_LOW,PSTR("Locate Copter Alarm Off"));
+        }
+    }
+    
+#endif
+    
+    // exit if we are already disarmed or throttle is not zero
     if (!motors.armed() || g.rc_3.control_in > 0) {
         auto_disarming_counter = 0;
         return;

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -46,6 +46,7 @@ public:
         uint16_t failsafe_gps       : 1;    // 1 if gps failsafe
         uint16_t arming_failed      : 1;    // 1 if copter failed to arm after user input
         uint16_t parachute_release  : 1;    // 1 if parachute is being released
+        uint16_t locatemodel        : 1;    // 1 if lost model alarm is to be enabled (sound buzzer and TODO Flash LED's)
 
         // additional flags
         uint16_t external_leds      : 1;    // 1 if external LEDs are enabled (normally only used for copter)

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -46,7 +46,7 @@ public:
         uint16_t failsafe_gps       : 1;    // 1 if gps failsafe
         uint16_t arming_failed      : 1;    // 1 if copter failed to arm after user input
         uint16_t parachute_release  : 1;    // 1 if parachute is being released
-        uint16_t locatemodel        : 1;    // 1 if lost model alarm is to be enabled (sound buzzer and TODO Flash LED's)
+        uint16_t notify_location    : 1;    // 1 if notify location by buzzer enabled (sound buzzer and TODO Flash LED's)
 
         // additional flags
         uint16_t external_leds      : 1;    // 1 if external LEDs are enabled (normally only used for copter)

--- a/libraries/AP_Notify/Buzzer.cpp
+++ b/libraries/AP_Notify/Buzzer.cpp
@@ -153,6 +153,12 @@ void Buzzer::update()
     if (AP_Notify::flags.failsafe_battery) {
         play_pattern(SINGLE_BUZZ);
     }
+#if LOSTMODELBUZZER == ENABLED
+    // locatemodel constantly double buzz
+    if (AP_Notify::flags.locatemodel) {
+        play_pattern(DOUBLE_BUZZ);
+    }
+#endif
 }
 
 // on - turns the buzzer on or off

--- a/libraries/AP_Notify/Buzzer.cpp
+++ b/libraries/AP_Notify/Buzzer.cpp
@@ -153,9 +153,9 @@ void Buzzer::update()
     if (AP_Notify::flags.failsafe_battery) {
         play_pattern(SINGLE_BUZZ);
     }
-#if LOSTMODELBUZZER == ENABLED
+#if NOTIFY_LOCATION_STICKCOMBO == ENABLED
     // locatemodel constantly double buzz
-    if (AP_Notify::flags.locatemodel) {
+    if (AP_Notify::flags.notify_location) {
         play_pattern(DOUBLE_BUZZ);
     }
 #endif


### PR DESCRIPTION
This will start beeping the buzzer when holding elevator back and aileron right when throttle is down and copter is disarmed.

Name can be discussed. FAILSAFE_LOCATE_COPTER, LOCATE_ME_ALARM,FAILSAFE_LOSTMODEL, FIND_MY_COPTER, +++

Feature is disabled by default since i'm unsure about the size of the feature and space on the APM 2
it will also send a message to the ground station saying that the alarm is enabled.

I would like to implement a mavlink message to set this off also but i haven't looked at that yet.

LED flashes should also be implemented and some way of triggering the AP_notify flag when the copter is entering failsafes and lands without RC or ground station telemetry. Which LED Should we use for this?

This is related to issues:
https://github.com/diydrones/ardupilot/issues/291
https://github.com/diydrones/ardupilot/issues/1119
https://github.com/diydrones/ardupilot/issues/441

it have been tested on APM2 and SITL
