### PR TITLE
Feature_copter extra channels mapping

### DIFF
--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -115,10 +115,10 @@ public:
         k_param_serial0_baud,
         k_param_serial1_baud,
         k_param_serial2_baud,
-        k_param_ch_flightmode,          //52
-        k_param_ch_tune,                //53
-        k_param_ch_aux1,                //54
-        k_param_ch_aux2,                //55
+        k_param_fltmode_ch = 52,             //52
+        k_param_tune_ch,                //53
+        k_param_aux1_ch,                //54
+        k_param_aux2_ch,                //55
 
         // 65: AP_Limits Library
         k_param_limits = 65,            // deprecated - remove
@@ -387,10 +387,10 @@ public:
     AP_Int8         ch7_option;
     AP_Int8         ch8_option;
     AP_Int8         arming_check;
-    AP_Int8         ch_flightmode;
-    AP_Int8         ch_tune;
-    AP_Int8         ch_aux1;
-    AP_Int8         ch_aux2;
+    AP_Int8         fltmode_ch;
+    AP_Int8         tune_ch;
+    AP_Int8         aux1_ch;
+    AP_Int8         aux2_ch;
 
 #if FRAME_CONFIG ==     HELI_FRAME
     // Heli

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -115,6 +115,10 @@ public:
         k_param_serial0_baud,
         k_param_serial1_baud,
         k_param_serial2_baud,
+        k_param_ch_flightmode,          //52
+        k_param_ch_tune,                //53
+        k_param_ch_aux1,                //54
+        k_param_ch_aux2,                //55
 
         // 65: AP_Limits Library
         k_param_limits = 65,            // deprecated - remove
@@ -383,6 +387,10 @@ public:
     AP_Int8         ch7_option;
     AP_Int8         ch8_option;
     AP_Int8         arming_check;
+    AP_Int8         ch_flightmode;
+    AP_Int8         ch_tune;
+    AP_Int8         ch_aux1;
+    AP_Int8         ch_aux2;
 
 #if FRAME_CONFIG ==     HELI_FRAME
     // Heli

--- a/ArduCopter/Parameters.pde
+++ b/ArduCopter/Parameters.pde
@@ -425,6 +425,38 @@ const AP_Param::Info var_info[] PROGMEM = {
     // @Values: 0:Very Soft, 25:Soft, 50:Medium, 75:Crisp, 100:Very Crisp
     GSCALAR(rc_feel_rp, "RC_FEEL_RP",  RC_FEEL_RP_VERY_CRISP),
 
+    // @Param: CH_FLIGHTMODE
+    // @DisplayName: Flight Mode Channel/CH5
+    // @Description: Flight Mode channel number. This is useful when you have a RC transmitter that can't change the channel order easily. Flight Mode is normally on channel 5, but you can move it to any channel with this parameter.
+    // @Range: 1 8
+    // @Increment: 1
+    // @User: Advanced
+    GSCALAR(ch_flightmode,          "CH_FLIGHTMODE",   5),
+    
+    // @Param: CH_TUNE
+    // @DisplayName: Tune channel/CH6
+    // @Description: Tune channel number. This is useful when you have a RC transmitter that can't change the channel order easily. Tune (also known as CH6) is normally on channel 6, but you can move it to any channel with this parameter.
+    // @Range: 1 8
+    // @Increment: 1
+    // @User: Advanced
+    GSCALAR(ch_tune,                "CH_TUNE",   6),
+  
+    // @Param: CH_AUX1
+    // @DisplayName: AUX1 channel/CH7 
+    // @Description: AUX1 channel number. This is useful when you have a RC transmitter that can't change the channel order easily. Aux1 (also known as CH7) is normally on channel 7, but you can move it to any channel with this parameter.
+    // @Range: 1 8
+    // @Increment: 1
+    // @User: Advanced
+    GSCALAR(ch_aux1,           "CH_AUX1",   7),
+    
+    // @Param: CH_AUX2
+    // @DisplayName: AUX2 channel/CH8
+    // @Description: AUX2 channel number. This is useful when you have a RC transmitter that can't change the channel order easily. Aux2 (also known as CH8) is normally on channel 8, but you can move it to any channel with this parameter.
+    // @Range: 1 8
+    // @Increment: 1
+    // @User: Advanced
+    GSCALAR(ch_aux2,           "CH_AUX2",   8),
+  
 #if HYBRID_ENABLED == ENABLED
     // @Param: HYBR_BRAKE_RATE
     // @DisplayName: Hybrid braking rate

--- a/ArduCopter/Parameters.pde
+++ b/ArduCopter/Parameters.pde
@@ -432,7 +432,7 @@ const AP_Param::Info var_info[] PROGMEM = {
     // @Increment: 1
     // @User: Advanced
     GSCALAR(ch_flightmode,          "CH_FLIGHTMODE",   5),
-    
+
     // @Param: CH_TUNE
     // @DisplayName: Tune channel/CH6
     // @Description: Tune channel number. This is useful when you have a RC transmitter that can't change the channel order easily. Tune (also known as CH6) is normally on channel 6, but you can move it to any channel with this parameter.
@@ -440,7 +440,7 @@ const AP_Param::Info var_info[] PROGMEM = {
     // @Increment: 1
     // @User: Advanced
     GSCALAR(ch_tune,                "CH_TUNE",   6),
-  
+
     // @Param: CH_AUX1
     // @DisplayName: AUX1 channel/CH7 
     // @Description: AUX1 channel number. This is useful when you have a RC transmitter that can't change the channel order easily. Aux1 (also known as CH7) is normally on channel 7, but you can move it to any channel with this parameter.
@@ -448,7 +448,17 @@ const AP_Param::Info var_info[] PROGMEM = {
     // @Increment: 1
     // @User: Advanced
     GSCALAR(ch_aux1,           "CH_AUX1",   7),
-    
+
+
+#if FRAME_CONFIG == HELI_FRAME
+    // @Param: CH_ROTORSPEED 
+    // @DisplayName: CH_ROTORSPEED channel/CH8
+    // @Description: CH_ROTORSPEED channel number. This is useful when you have a RC transmitter that can't change the channel order easily. RotorSpeed (also known as CH8) is normally on channel 8, but you can move it to any channel with this parameter.
+    // @Range: 1 8
+    // @Increment: 1
+    // @User: Advanced
+    GSCALAR(ch_aux2,           "CH_ROTORSPEED",   8),
+#else
     // @Param: CH_AUX2
     // @DisplayName: AUX2 channel/CH8
     // @Description: AUX2 channel number. This is useful when you have a RC transmitter that can't change the channel order easily. Aux2 (also known as CH8) is normally on channel 8, but you can move it to any channel with this parameter.
@@ -456,7 +466,8 @@ const AP_Param::Info var_info[] PROGMEM = {
     // @Increment: 1
     // @User: Advanced
     GSCALAR(ch_aux2,           "CH_AUX2",   8),
-  
+#endif
+
 #if HYBRID_ENABLED == ENABLED
     // @Param: HYBR_BRAKE_RATE
     // @DisplayName: Hybrid braking rate

--- a/ArduCopter/Parameters.pde
+++ b/ArduCopter/Parameters.pde
@@ -425,47 +425,47 @@ const AP_Param::Info var_info[] PROGMEM = {
     // @Values: 0:Very Soft, 25:Soft, 50:Medium, 75:Crisp, 100:Very Crisp
     GSCALAR(rc_feel_rp, "RC_FEEL_RP",  RC_FEEL_RP_VERY_CRISP),
 
-    // @Param: CH_FLIGHTMODE
+    // @Param: FLTMODE_CH
     // @DisplayName: Flight Mode Channel/CH5
     // @Description: Flight Mode channel number. This is useful when you have a RC transmitter that can't change the channel order easily. Flight Mode is normally on channel 5, but you can move it to any channel with this parameter.
     // @Range: 1 8
     // @Increment: 1
     // @User: Advanced
-    GSCALAR(ch_flightmode,          "CH_FLIGHTMODE",   5),
+    GSCALAR(fltmode_ch, "FLTMODE_CH", 5),
 
-    // @Param: CH_TUNE
+    // @Param: TUNE_CH
     // @DisplayName: Tune channel/CH6
     // @Description: Tune channel number. This is useful when you have a RC transmitter that can't change the channel order easily. Tune (also known as CH6) is normally on channel 6, but you can move it to any channel with this parameter.
     // @Range: 1 8
     // @Increment: 1
     // @User: Advanced
-    GSCALAR(ch_tune,                "CH_TUNE",   6),
+    GSCALAR(tune_ch, "TUNE_CH", 6),
 
-    // @Param: CH_AUX1
+    // @Param: AUX1_CH
     // @DisplayName: AUX1 channel/CH7 
     // @Description: AUX1 channel number. This is useful when you have a RC transmitter that can't change the channel order easily. Aux1 (also known as CH7) is normally on channel 7, but you can move it to any channel with this parameter.
     // @Range: 1 8
     // @Increment: 1
     // @User: Advanced
-    GSCALAR(ch_aux1,           "CH_AUX1",   7),
+    GSCALAR(aux1_ch, "AUX1_CH", 7),
 
 
 #if FRAME_CONFIG == HELI_FRAME
-    // @Param: CH_ROTORSPEED 
+    // @Param: ROTORSPEED_CH
     // @DisplayName: CH_ROTORSPEED channel/CH8
     // @Description: CH_ROTORSPEED channel number. This is useful when you have a RC transmitter that can't change the channel order easily. RotorSpeed (also known as CH8) is normally on channel 8, but you can move it to any channel with this parameter.
     // @Range: 1 8
     // @Increment: 1
     // @User: Advanced
-    GSCALAR(ch_aux2,           "CH_ROTORSPEED",   8),
+    GSCALAR(aux2_ch, "ROTORSPEED_CH", 8),
 #else
-    // @Param: CH_AUX2
+    // @Param: AUX2_CH
     // @DisplayName: AUX2 channel/CH8
     // @Description: AUX2 channel number. This is useful when you have a RC transmitter that can't change the channel order easily. Aux2 (also known as CH8) is normally on channel 8, but you can move it to any channel with this parameter.
     // @Range: 1 8
     // @Increment: 1
     // @User: Advanced
-    GSCALAR(ch_aux2,           "CH_AUX2",   8),
+    GSCALAR(aux2_ch, "AUX2_CH", 8),
 #endif
 
 #if HYBRID_ENABLED == ENABLED

--- a/ArduCopter/radio.pde
+++ b/ArduCopter/radio.pde
@@ -110,10 +110,10 @@ static void read_radio()
         set_throttle_and_failsafe(periods[rcmap.throttle()-1]);
 
         g.rc_4.set_pwm(periods[rcmap.yaw()-1]);
-        g.rc_5.set_pwm(periods[4]);
-        g.rc_6.set_pwm(periods[5]);
-        g.rc_7.set_pwm(periods[6]);
-        g.rc_8.set_pwm(periods[7]);
+        g.rc_5.set_pwm(periods[g.ch_flightmode-1]);
+        g.rc_6.set_pwm(periods[g.ch_tune-1]);
+        g.rc_7.set_pwm(periods[g.ch_aux1-1]);
+        g.rc_8.set_pwm(periods[g.ch_aux2-1]);
 
         // flag we must have an rc receiver attached
         if (!failsafe.rc_override_active) {

--- a/ArduCopter/radio.pde
+++ b/ArduCopter/radio.pde
@@ -110,10 +110,10 @@ static void read_radio()
         set_throttle_and_failsafe(periods[rcmap.throttle()-1]);
 
         g.rc_4.set_pwm(periods[rcmap.yaw()-1]);
-        g.rc_5.set_pwm(periods[g.ch_flightmode-1]);
-        g.rc_6.set_pwm(periods[g.ch_tune-1]);
-        g.rc_7.set_pwm(periods[g.ch_aux1-1]);
-        g.rc_8.set_pwm(periods[g.ch_aux2-1]);
+        g.rc_5.set_pwm(periods[g.fltmode_ch-1]);
+        g.rc_6.set_pwm(periods[g.tune_ch-1]);
+        g.rc_7.set_pwm(periods[g.aux1_ch-1]);
+        g.rc_8.set_pwm(periods[g.aux2_ch-1]);
 
         // flag we must have an rc receiver attached
         if (!failsafe.rc_override_active) {

--- a/libraries/AP_RCMapper/AP_RCMapper.cpp
+++ b/libraries/AP_RCMapper/AP_RCMapper.cpp
@@ -22,7 +22,7 @@ const AP_Param::GroupInfo RCMapper::var_info[] PROGMEM = {
 
     // @Param: THROTTLE
     // @DisplayName: Throttle channel
-    // @Description: Throttle channel number. This is useful when you have a RC transmitter that can't change the channel order easily. Throttle is normally on channel 3, but you can move it to any channel with this parameter.
+    // @Description: Throttle channel number. This is useful when you have a RC transmitter that can't change the channel order easily. Throttle is normally on channel 3, but you can move it to any channel with this parameter. Warning APM 2.X: Changing the throttle channel could produce unexpected fail-safe results if connection between receiver and on-board PPM Encoder is lost. Disabling on-board PPM Encoder is recommended.
     // @Range: 1 8
     // @Increment: 1
     // @User: Advanced


### PR DESCRIPTION
This adds parameters to copter for channels 5,6,7,8

The Parameter names are discussable.
Let me know and i'll change them.

Also there is a warning for changing RCMAP_THROTTLE since this can cause problems with internal PPM Encoder on APM

This resolves:
https://github.com/diydrones/ardupilot/issues/1096
https://github.com/diydrones/ardupilot/pull/1103
https://github.com/diydrones/ardupilot/issues/685
Heli have CH_ROTORSPEED instead of CH_AUX2
