### PR TITLE
Cygwin fixes for running SITL mode on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,74 @@ Back at the terminal:
 # make px4-upload  # (optional)
 ```
 
+## Development using Windows and Cygwin
+
+SITL mode of Ardupilot can be used in Windows via the Cygwin software suite:
+
+ 1. [Download Cygwin](http://cygwin.com/install.html). When installing, 
+ ensure the make, wget, git, gcc-core, gcc-g++, libintl2, gdb, xterm, 
+ python, python-numpy, python-imaging, autoconf, libtool, automake,
+ libexpat-devel, xinit, xkill, procps packages are selected.
+ 
+ 2. Start the Cygwin console and download the Ardupilot code, along with
+ the JSBSim, Mavlink, MAVProxy software:
+ 
+ ```
+ git clone https://github.com/diydrones/ardupilot.git
+ git clone https://github.com/tridge/jsbsim.git
+ wget https://bootstrap.pypa.io/ez_setup.py -O - | python
+ easy_install pymavlink
+ easy_install MAVProxy
+ easy_install Pexpect
+ ```
+
+ 3. Build JSBSim:
+
+ ```
+ cd ./jsbsim
+ ./autogen.sh
+ make
+ make install
+ cp ./src/JSBSim.exe /usr/local/bin
+ cd ../
+ ```
+
+ 4. Configure Ardupilot:
+
+ ```
+ cd ./ardupilot/ArduPlane
+ make configure
+ cd ../../
+ ```
+
+ 5. To build and run SITL mode for each of the 3 branches:
+ 
+ Plane:
+ ```
+ cd ./ardupilot/ArduPlane/
+ ../Tools/autotest/sim_vehicle.sh
+ ```
+
+ Copter:
+ ```
+ cd ./ardupilot/ArduCopter/
+ ../Tools/autotest/sim_vehicle.sh
+ ```
+
+ Rover:
+ ```
+ cd ./ardupilot/APMrover2/
+ ../Tools/autotest/sim_vehicle.sh
+ ```
+
+ 6. The Windows Firewall may ask to allow network access for the SITL environment.
+ 
+ 7. Start up your favourite ground station software (Mission Planner, APMPlanner2)
+ and connect via UDP port 14551.
+ 
+ 8. Use Ctrl+C in the main Cygwin console to end a SITL session
+ 
+ 
 # User Technical Support
 
 ArduPilot users should use the DIYDrones.com forums for technical support.

--- a/Tools/autotest/sim_vehicle.sh
+++ b/Tools/autotest/sim_vehicle.sh
@@ -117,7 +117,19 @@ shift $((OPTIND-1))
 kill_tasks() 
 {
     [ "$INSTANCE" -eq "0" ] && {
-        killall -q JSBSim lt-JSBSim ArduPlane.elf ArduCopter.elf APMrover2.elf AntennaTracker.elf
+        #Cygwin doesn't have killall, so use taskkill instead
+        if [ "$(expr substr $(uname -s) 1 6)" == "CYGWIN" ]; then
+            winkill="taskkill /F /IM "
+            $winkill JSBSim.exe
+            $winkill lt-JSBSim.exe
+            $winkill ArduPlane.elf
+            $winkill ArduCopter.elf
+            $winkill APMrover2.elf
+            $winkill AntennaTracker.elf
+            $winkill xterm.exe
+        else
+            killall -q JSBSim lt-JSBSim ArduPlane.elf ArduCopter.elf APMrover2.elf AntennaTracker.elf
+        fi
         pkill -f runsim.py
         pkill -f sim_tracker.py
         pkill -f sim_rover.py
@@ -178,6 +190,12 @@ case $FRAME in
         exit 1
         ;;
 esac
+
+#start Cygwin/X GUI backend if needed
+if [ "$(expr substr $(uname -s) 1 6)" == "CYGWIN" ]; then
+    run.exe -p /usr/X11R6/bin XWin -multiwindow -clipboard -silent-dup-error
+    export DISPLAY=:0.0
+fi
 
 autotest=$(dirname $(readlink -e $0))
 pushd $autotest/../../$VEHICLE || {

--- a/libraries/AP_HAL_AVR_SITL/sitl_ins.cpp
+++ b/libraries/AP_HAL_AVR_SITL/sitl_ins.cpp
@@ -129,11 +129,13 @@ void SITL_State::_update_ins(float roll, 	float pitch, 	float yaw,		// Relative 
 		return;
 	}
 
+#ifndef CYGWIN
         if (_sitl->float_exception) {
             feenableexcept(FE_INVALID | FE_OVERFLOW);
         } else {
             feclearexcept(FE_INVALID | FE_OVERFLOW);
         }
+#endif
 
 	SITL::convert_body_frame(roll, pitch,
 				 rollRate, pitchRate, yawRate,

--- a/mk/board_native.mk
+++ b/mk/board_native.mk
@@ -19,6 +19,10 @@ COPTS           =   -ffunction-sections -fdata-sections -fsigned-char
 
 ASOPTS          =   -x assembler-with-cpp 
 
+ifeq ($(findstring CYGWIN, $(SYSTYPE)),CYGWIN) 
+DEFINES        += -DCYGWIN=1
+endif
+
 # disable as this breaks distcc
 #ifneq ($(SYSTYPE),Darwin)
 #LISTOPTS        =   -adhlns=$(@:.o=.lst)


### PR DESCRIPTION
This patch allows APM's SITL mode to be used directly in Windows (via Cygwin).