### PR TITLE
Explicit failsafe

### DIFF
--- a/libraries/AP_HAL_PX4/RCInput.cpp
+++ b/libraries/AP_HAL_PX4/RCInput.cpp
@@ -111,7 +111,7 @@ void PX4RCInput::_timer_tick(void)
 		// rely on the vehicle code timeout while checking for the last valid input
 		if (orb_copy(ORB_ID(input_rc), _rc_sub, &_new_rcin) == OK) {
 			pthread_mutex_lock(&rcin_mutex);
-			if (!_new_rcin.rc_lost && !_new_rcin.rc_failsafe && _new_rcin.channel_count > 0) {
+			if (!_new_rcin.rc_lost && !_new_rcin.rc_failsafe && _new_rcin.channel_count >= 5) {
 				// rc ok, copy full rcin structure
 				memcpy(&_rcin, &_new_rcin, sizeof(_rcin));
 			}

--- a/libraries/AP_HAL_PX4/RCInput.cpp
+++ b/libraries/AP_HAL_PX4/RCInput.cpp
@@ -103,14 +103,21 @@ void PX4RCInput::clear_overrides()
 void PX4RCInput::_timer_tick(void)
 {
 	perf_begin(_perf_rcin);
-	bool rc_updated = false;
-	if (orb_check(_rc_sub, &rc_updated) == 0 && rc_updated) {
-            pthread_mutex_lock(&rcin_mutex);
-            orb_copy(ORB_ID(input_rc), _rc_sub, &_rcin);
-            pthread_mutex_unlock(&rcin_mutex);
+
+	// check for status and channel values and update them consistently
+	bool rc_updated = orb_check(_rc_sub, &rc_updated) == 0 && rc_updated;
+	if (rc_updated) {
+		// double-buffer rc input to avoid overwriting last valid channel values with zeros from PX4IO
+		// rely on the vehicle code timeout while checking for the last valid input
+		if (orb_copy(ORB_ID(input_rc), _rc_sub, &_new_rcin) == OK) {
+			pthread_mutex_lock(&rcin_mutex);
+			if (!_new_rcin.rc_lost && !_new_rcin.rc_failsafe && _new_rcin.channel_count > 0) {
+				// rc ok, copy full rcin structure
+				memcpy(&_rcin, &_new_rcin, sizeof(_rcin));
+			}
+			pthread_mutex_unlock(&rcin_mutex);
+		}
 	}
-        // note, we rely on the vehicle code checking new_input() 
-        // and a timeout for the last valid input to handle failsafe
 	perf_end(_perf_rcin);
 }
 

--- a/libraries/AP_HAL_PX4/RCInput.cpp
+++ b/libraries/AP_HAL_PX4/RCInput.cpp
@@ -105,9 +105,10 @@ void PX4RCInput::_timer_tick(void)
 	perf_begin(_perf_rcin);
 
 	// check for status and channel values and update them consistently
-	bool rc_updated = orb_check(_rc_sub, &rc_updated) == 0 && rc_updated;
-	if (rc_updated) {
-		// double-buffer rc input to avoid overwriting last valid channel values with zeros from PX4IO
+	bool rc_updated = false;
+	int res = orb_check(_rc_sub, &rc_updated);
+	if (res == OK && rc_updated) {
+		// double-buffer rc input to avoid overwriting last valid channel values with 
 		// rely on the vehicle code timeout while checking for the last valid input
 		if (orb_copy(ORB_ID(input_rc), _rc_sub, &_new_rcin) == OK) {
 			pthread_mutex_lock(&rcin_mutex);

--- a/libraries/AP_HAL_PX4/RCInput.h
+++ b/libraries/AP_HAL_PX4/RCInput.h
@@ -25,6 +25,7 @@ private:
     /* override state */
     uint16_t _override[RC_INPUT_MAX_CHANNELS];
     struct rc_input_values _rcin;
+    struct rc_input_values _new_rcin;
     int _rc_sub;
     uint64_t _last_read;
     bool _override_valid;


### PR DESCRIPTION
This PR is a rework of #966 . 

This change evaluates the rc status flags recently added to PX4Firmware to make the RC input handling more robust. RC channel values are double-buffered now and forwarded only if there is no condition that could lead to compromised channel values. 

Additonally, any RC input with channel_count < 5 is rejected, as such signals are obviously of no value for us.