### PR TITLE
Added Channel Mapping for CH5,6,7,8 to Copter and HELI

### DIFF
--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -121,6 +121,10 @@ public:
         k_param_terrain,
         k_param_acro_expo,
         k_param_throttle_deadzone,      // 57
+        k_param_fltmode_ch,             // 58
+        k_param_tune_ch,
+        k_param_aux1_ch,
+        k_param_aux2_ch,                // 61
 
         // 65: AP_Limits Library
         k_param_limits = 65,            // deprecated - remove
@@ -431,6 +435,14 @@ public:
 
     AP_Int16                rc_speed; // speed of fast RC Channels in Hz
 
+    //ChannelMapping
+    
+    AP_Int8         fltmode_ch;
+    AP_Int8         tune_ch;
+    AP_Int8         aux1_ch;
+    AP_Int8         aux2_ch;
+    
+    
     // Acro parameters
     AP_Float                acro_rp_p;
     AP_Float                acro_yaw_p;

--- a/ArduCopter/Parameters.pde
+++ b/ArduCopter/Parameters.pde
@@ -462,6 +462,51 @@ const AP_Param::Info var_info[] PROGMEM = {
     // @User: Advanced
     GSCALAR(ekfcheck_thresh, "EKF_CHECK_THRESH",    EKFCHECK_THRESHOLD_DEFAULT),
 
+    
+    // @Param: FLTMODE_CH
+    // @DisplayName: Flight Mode Channel/CH5
+    // @Description: Flight Mode channel number. This is useful when you have a RC transmitter that can't change the channel order easily. Flight Mode is normally on channel 5, but you can move it to any channel with this parameter.
+    // @Range: 1 8
+    // @Increment: 1
+    // @User: Advanced
+    GSCALAR(fltmode_ch, "FLTMODE_CH", 5),
+
+    // @Param: TUNE_CH
+    // @DisplayName: Tune channel/CH6
+    // @Description: Tune channel number. This is useful when you have a RC transmitter that can't change the channel order easily. Tune (also known as CH6) is normally on channel 6, but you can move it to any channel with this parameter.
+    // @Range: 1 8
+    // @Increment: 1
+    // @User: Advanced
+    GSCALAR(tune_ch, "TUNE_CH", 6),
+
+    // @Param: AUX1_CH
+    // @DisplayName: AUX1 channel/CH7 
+    // @Description: AUX1 channel number. This is useful when you have a RC transmitter that can't change the channel order easily. Aux1 (also known as CH7) is normally on channel 7, but you can move it to any channel with this parameter.
+    // @Range: 1 8
+    // @Increment: 1
+    // @User: Advanced
+    GSCALAR(aux1_ch, "AUX1_CH", 7),
+
+    
+#if FRAME_CONFIG == HELI_FRAME
+    // @Param: ROTORSPEED_CH
+    // @DisplayName: CH_ROTORSPEED channel/CH8
+    // @Description: CH_ROTORSPEED channel number. This is useful when you have a RC transmitter that can't change the channel order easily. RotorSpeed (also known as CH8) is normally on channel 8, but you can move it to any channel with this parameter.
+    // @Range: 1 8
+    // @Increment: 1
+    // @User: Advanced
+    GSCALAR(aux2_ch, "ROTORSPEED_CH", 8),
+#else
+    // @Param: AUX2_CH
+    // @DisplayName: AUX2 channel/CH8
+    // @Description: AUX2 channel number. This is useful when you have a RC transmitter that can't change the channel order easily. Aux2 (also known as CH8) is normally on channel 8, but you can move it to any channel with this parameter.
+    // @Range: 1 8
+    // @Increment: 1
+    // @User: Advanced
+    GSCALAR(aux2_ch, "AUX2_CH", 8),
+#endif
+    
+    
 #if FRAME_CONFIG ==     HELI_FRAME
     // @Group: HS1_
     // @Path: ../libraries/RC_Channel/RC_Channel.cpp

--- a/ArduCopter/radio.pde
+++ b/ArduCopter/radio.pde
@@ -88,10 +88,10 @@ static void read_radio()
         set_throttle_and_failsafe(periods[rcmap.throttle()-1]);
 
         g.rc_4.set_pwm(periods[rcmap.yaw()-1]);
-        g.rc_5.set_pwm(periods[4]);
-        g.rc_6.set_pwm(periods[5]);
-        g.rc_7.set_pwm(periods[6]);
-        g.rc_8.set_pwm(periods[7]);
+        g.rc_5.set_pwm(periods[g.fltmode_ch-1]);
+        g.rc_6.set_pwm(periods[g.tune_ch-1]);
+        g.rc_7.set_pwm(periods[g.aux1_ch-1]);
+        g.rc_8.set_pwm(periods[g.aux2_ch-1]);
 
         // flag we must have an rc receiver attached
         if (!failsafe.rc_override_active) {


### PR DESCRIPTION
Resolved conflicts from 1139
HELI have CH_ROTORSPEED instead of CH_AUX2

Tested in SITL and on APM 2.5 Quad

