### PR TITLE
Copter: Issue 901 severity values

### DIFF
--- a/ArduCopter/GCS_Mavlink.pde
+++ b/ArduCopter/GCS_Mavlink.pde
@@ -926,10 +926,10 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
     case MAVLINK_MSG_ID_PARAM_REQUEST_LIST:         // MAV ID: 21
     {
         // mark the firmware version in the tlog
-        send_text_P(SEVERITY_LOW, PSTR(FIRMWARE_STRING));
+        send_text_P(MAV_SEVERITY_WARNING, PSTR(FIRMWARE_STRING));
 
 #if defined(PX4_GIT_VERSION) && defined(NUTTX_GIT_VERSION)
-        send_text_P(SEVERITY_LOW, PSTR("PX4: " PX4_GIT_VERSION " NuttX: " NUTTX_GIT_VERSION));
+        send_text_P(MAV_SEVERITY_WARNING, PSTR("PX4: " PX4_GIT_VERSION " NuttX: " NUTTX_GIT_VERSION));
 #endif
         handle_param_request_list(msg);
         break;
@@ -1415,12 +1415,12 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
         
         if (packet.idx >= rally.get_rally_total() || 
             packet.idx >= rally.get_rally_max()) {
-            send_text_P(SEVERITY_LOW,PSTR("bad rally point message ID"));
+            send_text_P(MAV_SEVERITY_WARNING,PSTR("bad rally point message ID"));
             break;
         }
 
         if (packet.count != rally.get_rally_total()) {
-            send_text_P(SEVERITY_LOW,PSTR("bad rally point message count"));
+            send_text_P(MAV_SEVERITY_WARNING,PSTR("bad rally point message count"));
             break;
         }
 
@@ -1433,7 +1433,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
         rally_point.flags = packet.flags;
 
         if (!rally.set_rally_point_with_index(packet.idx, rally_point)) {
-            send_text_P(SEVERITY_HIGH, PSTR("error setting rally point"));
+            send_text_P(MAV_SEVERITY_CRITICAL, PSTR("error setting rally point"));
         }
 
         break;
@@ -1441,29 +1441,29 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
 
     //send a rally point to the GCS
     case MAVLINK_MSG_ID_RALLY_FETCH_POINT: {
-        //send_text_P(SEVERITY_HIGH, PSTR("## getting rally point in GCS_Mavlink.pde 1")); // #### TEMP
+        //send_text_P(MAV_SEVERITY_CRITICAL, PSTR("## getting rally point in GCS_Mavlink.pde 1")); // #### TEMP
 
         mavlink_rally_fetch_point_t packet;
         mavlink_msg_rally_fetch_point_decode(msg, &packet);
         if (mavlink_check_target(packet.target_system, packet.target_component))
             break;
 
-        //send_text_P(SEVERITY_HIGH, PSTR("## getting rally point in GCS_Mavlink.pde 2")); // #### TEMP
+        //send_text_P(MAV_SEVERITY_CRITICAL, PSTR("## getting rally point in GCS_Mavlink.pde 2")); // #### TEMP
 
         if (packet.idx > rally.get_rally_total()) {
-            send_text_P(SEVERITY_LOW, PSTR("bad rally point index"));   
+            send_text_P(MAV_SEVERITY_WARNING, PSTR("bad rally point index"));
             break;
         }
 
-        //send_text_P(SEVERITY_HIGH, PSTR("## getting rally point in GCS_Mavlink.pde 3")); // #### TEMP
+        //send_text_P(MAV_SEVERITY_CRITICAL, PSTR("## getting rally point in GCS_Mavlink.pde 3")); // #### TEMP
 
         RallyLocation rally_point;
         if (!rally.get_rally_point_with_index(packet.idx, rally_point)) {
-           send_text_P(SEVERITY_LOW, PSTR("failed to set rally point"));   
+           send_text_P(MAV_SEVERITY_WARNING, PSTR("failed to set rally point"));
            break;
         }
 
-        //send_text_P(SEVERITY_HIGH, PSTR("## getting rally point in GCS_Mavlink.pde 4")); // #### TEMP
+        //send_text_P(MAV_SEVERITY_CRITICAL, PSTR("## getting rally point in GCS_Mavlink.pde 4")); // #### TEMP
 
         mavlink_msg_rally_point_send_buf(msg,
                                          chan, msg->sysid, msg->compid, packet.idx, 
@@ -1471,7 +1471,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
                                          rally_point.alt, rally_point.break_alt, rally_point.land_dir, 
                                          rally_point.flags);
 
-        //send_text_P(SEVERITY_HIGH, PSTR("## getting rally point in GCS_Mavlink.pde 5")); // #### TEMP
+        //send_text_P(MAV_SEVERITY_CRITICAL, PSTR("## getting rally point in GCS_Mavlink.pde 5")); // #### TEMP
 
         break;
     }  
@@ -1510,7 +1510,7 @@ static void mavlink_delay_cb()
     }
     if (tnow - last_5s > 5000) {
         last_5s = tnow;
-        gcs_send_text_P(SEVERITY_LOW, PSTR("Initialising APM..."));
+        gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("Initialising APM..."));
     }
     check_usb_mux();
 
@@ -1557,7 +1557,7 @@ static void gcs_check_input(void)
     }
 }
 
-static void gcs_send_text_P(gcs_severity severity, const prog_char_t *str)
+static void gcs_send_text_P(MAV_SEVERITY severity, const prog_char_t *str)
 {
     for (uint8_t i=0; i<num_gcs; i++) {
         if (gcs[i].initialised) {
@@ -1574,7 +1574,7 @@ static void gcs_send_text_P(gcs_severity severity, const prog_char_t *str)
 void gcs_send_text_fmt(const prog_char_t *fmt, ...)
 {
     va_list arg_list;
-    gcs[0].pending_status.severity = (uint8_t)SEVERITY_LOW;
+    gcs[0].pending_status.severity = (uint8_t)MAV_SEVERITY_WARNING;
     va_start(arg_list, fmt);
     hal.util->vsnprintf_P((char *)gcs[0].pending_status.text,
             sizeof(gcs[0].pending_status.text), fmt, arg_list);

--- a/ArduCopter/Log.pde
+++ b/ArduCopter/Log.pde
@@ -156,9 +156,9 @@ process_logs(uint8_t argc, const Menu::arg *argv)
 
 static void do_erase_logs(void)
 {
-	gcs_send_text_P(SEVERITY_HIGH, PSTR("Erasing logs\n"));
+	gcs_send_text_P(MAV_SEVERITY_CRITICAL, PSTR("Erasing logs\n"));
     DataFlash.EraseAll();
-	gcs_send_text_P(SEVERITY_HIGH, PSTR("Log erase complete\n"));
+	gcs_send_text_P(MAV_SEVERITY_CRITICAL, PSTR("Log erase complete\n"));
 }
 
 #if AUTOTUNE_ENABLED == ENABLED

--- a/ArduCopter/compassmot.pde
+++ b/ArduCopter/compassmot.pde
@@ -31,7 +31,7 @@ static uint8_t mavlink_compassmot(mavlink_channel_t chan)
 
     // check compass is enabled
     if (!g.compass_enabled) {
-        gcs[chan-MAVLINK_COMM_0].send_text_P(SEVERITY_HIGH, PSTR("compass disabled\n"));
+        gcs[chan-MAVLINK_COMM_0].send_text_P(MAV_SEVERITY_CRITICAL, PSTR("compass disabled\n"));
         ap.compass_mot = false;
         return 1;
     }
@@ -40,7 +40,7 @@ static uint8_t mavlink_compassmot(mavlink_channel_t chan)
     compass.read();
     for (uint8_t i=0; i<compass.get_count(); i++) {
         if (!compass.healthy(i)) {
-            gcs[chan-MAVLINK_COMM_0].send_text_P(SEVERITY_HIGH, PSTR("check compass"));
+            gcs[chan-MAVLINK_COMM_0].send_text_P(MAV_SEVERITY_CRITICAL, PSTR("check compass"));
             ap.compass_mot = false;
             return 1;
         }
@@ -49,7 +49,7 @@ static uint8_t mavlink_compassmot(mavlink_channel_t chan)
     // check if radio is calibrated
     pre_arm_rc_checks();
     if (!ap.pre_arm_rc_check) {
-        gcs[chan-MAVLINK_COMM_0].send_text_P(SEVERITY_HIGH, PSTR("RC not calibrated"));
+        gcs[chan-MAVLINK_COMM_0].send_text_P(MAV_SEVERITY_CRITICAL, PSTR("RC not calibrated"));
         ap.compass_mot = false;
         return 1;
     }
@@ -57,14 +57,14 @@ static uint8_t mavlink_compassmot(mavlink_channel_t chan)
     // check throttle is at zero
     read_radio();
     if (g.rc_3.control_in != 0) {
-        gcs[chan-MAVLINK_COMM_0].send_text_P(SEVERITY_HIGH, PSTR("thr not zero"));
+        gcs[chan-MAVLINK_COMM_0].send_text_P(MAV_SEVERITY_CRITICAL, PSTR("thr not zero"));
         ap.compass_mot = false;
         return 1;
     }
 
     // check we are landed
     if (!ap.land_complete) {
-        gcs[chan-MAVLINK_COMM_0].send_text_P(SEVERITY_HIGH, PSTR("Not landed"));
+        gcs[chan-MAVLINK_COMM_0].send_text_P(MAV_SEVERITY_CRITICAL, PSTR("Not landed"));
         ap.compass_mot = false;
         return 1;
     }
@@ -89,13 +89,13 @@ static uint8_t mavlink_compassmot(mavlink_channel_t chan)
     AP_Notify::flags.esc_calibration = true;
 
     // warn user we are starting calibration
-    gcs[chan-MAVLINK_COMM_0].send_text_P(SEVERITY_HIGH, PSTR("STARTING CALIBRATION"));
+    gcs[chan-MAVLINK_COMM_0].send_text_P(MAV_SEVERITY_CRITICAL, PSTR("STARTING CALIBRATION"));
 
     // inform what type of compensation we are attempting
     if (comp_type == AP_COMPASS_MOT_COMP_CURRENT) {
-        gcs[chan-MAVLINK_COMM_0].send_text_P(SEVERITY_HIGH, PSTR("CURRENT"));
+        gcs[chan-MAVLINK_COMM_0].send_text_P(MAV_SEVERITY_CRITICAL, PSTR("CURRENT"));
     } else{
-        gcs[chan-MAVLINK_COMM_0].send_text_P(SEVERITY_HIGH, PSTR("THROTTLE"));
+        gcs[chan-MAVLINK_COMM_0].send_text_P(MAV_SEVERITY_CRITICAL, PSTR("THROTTLE"));
     }
 
     // disable throttle and battery failsafe
@@ -240,10 +240,10 @@ static uint8_t mavlink_compassmot(mavlink_channel_t chan)
         }
         compass.save_motor_compensation();
         // display success message
-        gcs[chan-MAVLINK_COMM_0].send_text_P(SEVERITY_HIGH, PSTR("Calibration Successful!"));
+        gcs[chan-MAVLINK_COMM_0].send_text_P(MAV_SEVERITY_CRITICAL, PSTR("Calibration Successful!"));
     } else {
         // compensation vector never updated, report failure
-        gcs[chan-MAVLINK_COMM_0].send_text_P(SEVERITY_HIGH, PSTR("Failed!"));
+        gcs[chan-MAVLINK_COMM_0].send_text_P(MAV_SEVERITY_CRITICAL, PSTR("Failed!"));
         compass.motor_compensation_type(AP_COMPASS_MOT_COMP_DISABLED);
     }
 

--- a/ArduCopter/control_autotune.pde
+++ b/ArduCopter/control_autotune.pde
@@ -851,16 +851,16 @@ void autotune_update_gcs(uint8_t message_id)
 {
     switch (message_id) {
         case AUTOTUNE_MESSAGE_STARTED:
-            gcs_send_text_P(SEVERITY_HIGH,PSTR("AutoTune: Started"));
+            gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("AutoTune: Started"));
             break;
         case AUTOTUNE_MESSAGE_STOPPED:
-            gcs_send_text_P(SEVERITY_HIGH,PSTR("AutoTune: Stopped"));
+            gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("AutoTune: Stopped"));
             break;
         case AUTOTUNE_MESSAGE_SUCCESS:
-            gcs_send_text_P(SEVERITY_HIGH,PSTR("AutoTune: Success"));
+            gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("AutoTune: Success"));
             break;
         case AUTOTUNE_MESSAGE_FAILED:
-            gcs_send_text_P(SEVERITY_HIGH,PSTR("AutoTune: Failed"));
+            gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("AutoTune: Failed"));
             break;
     }
 }

--- a/ArduCopter/crash_check.pde
+++ b/ArduCopter/crash_check.pde
@@ -55,7 +55,7 @@ void crash_check()
             // log an error in the dataflash
             Log_Write_Error(ERROR_SUBSYSTEM_CRASH_CHECK, ERROR_CODE_CRASH_CHECK_CRASH);
             // send message to gcs
-            gcs_send_text_P(SEVERITY_HIGH,PSTR("Crash: Disarming"));
+            gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("Crash: Disarming"));
             // disarm motors
             init_disarm_motors();
         }
@@ -157,7 +157,7 @@ void parachute_check()
 static void parachute_release()
 {
     // send message to gcs and dataflash
-    gcs_send_text_P(SEVERITY_HIGH,PSTR("Parachute: Released!"));
+    gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("Parachute: Released!"));
     Log_Write_Event(DATA_PARACHUTE_RELEASED);
 
     // disarm motors
@@ -179,7 +179,7 @@ static void parachute_manual_release()
     // do not release if we are landed or below the minimum altitude above home
     if (ap.land_complete || (parachute.alt_min() != 0 && (baro_alt < (uint32_t)parachute.alt_min() * 100))) {
         // warn user of reason for failure
-        gcs_send_text_P(SEVERITY_HIGH,PSTR("Parachute: Too Low"));
+        gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("Parachute: Too Low"));
         // log an error in the dataflash
         Log_Write_Error(ERROR_SUBSYSTEM_PARACHUTE, ERROR_CODE_PARACHUTE_TOO_LOW);
         return;

--- a/ArduCopter/ekf_check.pde
+++ b/ArduCopter/ekf_check.pde
@@ -64,7 +64,7 @@ void ekf_check()
                 Log_Write_Error(ERROR_SUBSYSTEM_EKFINAV_CHECK, ERROR_CODE_EKFINAV_CHECK_BAD_VARIANCE);
                 // send message to gcs
                 if ((hal.scheduler->millis() - ekf_check_state.last_warn_time) > EKF_CHECK_WARNING_TIME) {
-                    gcs_send_text_P(SEVERITY_HIGH,PSTR("EKF variance"));
+                    gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("EKF variance"));
                     ekf_check_state.last_warn_time = hal.scheduler->millis();
                 }
                 failsafe_ekf_event();

--- a/ArduCopter/esc_calibration.pde
+++ b/ArduCopter/esc_calibration.pde
@@ -35,7 +35,7 @@ static void esc_calibration_startup_check()
                 // we will enter esc_calibrate mode on next reboot
                 g.esc_calibrate.set_and_save(ESCCAL_PASSTHROUGH_IF_THROTTLE_HIGH);
                 // send message to gcs
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("ESC Cal: restart board"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("ESC Cal: restart board"));
                 // turn on esc calibration notification
                 AP_Notify::flags.esc_calibration = true;
                 // block until we restart
@@ -75,7 +75,7 @@ static void esc_calibration_passthrough()
     motors.set_update_rate(50);
 
     // send message to GCS
-    gcs_send_text_P(SEVERITY_HIGH,PSTR("ESC Cal: passing pilot thr to ESCs"));
+    gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("ESC Cal: passing pilot thr to ESCs"));
 
     while(1) {
         // arm motors
@@ -103,7 +103,7 @@ static void esc_calibration_auto()
     motors.set_update_rate(50);
 
     // send message to GCS
-    gcs_send_text_P(SEVERITY_HIGH,PSTR("ESC Cal: auto calibration"));
+    gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("ESC Cal: auto calibration"));
 
     // arm and enable motors
     motors.armed(true);
@@ -119,7 +119,7 @@ static void esc_calibration_auto()
     // wait for safety switch to be pressed
     while (hal.util->safety_switch_state() == AP_HAL::Util::SAFETY_DISARMED) {
         if (!printed_msg) {
-            gcs_send_text_P(SEVERITY_HIGH,PSTR("ESC Cal: push safety switch"));
+            gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("ESC Cal: push safety switch"));
             printed_msg = true;
         }
         delay(10);

--- a/ArduCopter/events.pde
+++ b/ArduCopter/events.pde
@@ -164,7 +164,7 @@ static void failsafe_battery_event(void)
     set_failsafe_battery(true);
 
     // warn the ground station and log to dataflash
-    gcs_send_text_P(SEVERITY_HIGH,PSTR("Low Battery!"));
+    gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("Low Battery!"));
     Log_Write_Error(ERROR_SUBSYSTEM_FAILSAFE_BATT, ERROR_CODE_FAILSAFE_OCCURRED);
 
 }
@@ -205,7 +205,7 @@ static void failsafe_gps_check()
     // GPS failsafe event has occured
     // update state, warn the ground station and log to dataflash
     set_failsafe_gps(true);
-    gcs_send_text_P(SEVERITY_HIGH,PSTR("Lost GPS!"));
+    gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("Lost GPS!"));
     Log_Write_Error(ERROR_SUBSYSTEM_FAILSAFE_GPS, ERROR_CODE_FAILSAFE_OCCURRED);
 
     // take action based on flight mode and FS_GPS_ENABLED parameter

--- a/ArduCopter/motor_test.pde
+++ b/ArduCopter/motor_test.pde
@@ -72,19 +72,19 @@ static bool mavlink_motor_test_check(mavlink_channel_t chan)
     // check rc has been calibrated
     pre_arm_rc_checks();
     if(!ap.pre_arm_rc_check) {
-        gcs[chan-MAVLINK_COMM_0].send_text_P(SEVERITY_HIGH,PSTR("Motor Test: RC not calibrated"));
+        gcs[chan-MAVLINK_COMM_0].send_text_P(MAV_SEVERITY_CRITICAL,PSTR("Motor Test: RC not calibrated"));
         return false;
     }
 
     // ensure we are landed
     if (!ap.land_complete) {
-        gcs[chan-MAVLINK_COMM_0].send_text_P(SEVERITY_HIGH,PSTR("Motor Test: vehicle not landed"));
+        gcs[chan-MAVLINK_COMM_0].send_text_P(MAV_SEVERITY_CRITICAL,PSTR("Motor Test: vehicle not landed"));
         return false;
     }
 
     // check if safety switch has been pushed
     if (hal.util->safety_switch_state() == AP_HAL::Util::SAFETY_DISARMED) {
-        gcs[chan-MAVLINK_COMM_0].send_text_P(SEVERITY_HIGH,PSTR("Motor Test: Safety Switch"));
+        gcs[chan-MAVLINK_COMM_0].send_text_P(MAV_SEVERITY_CRITICAL,PSTR("Motor Test: Safety Switch"));
         return false;
     }
 

--- a/ArduCopter/motors.pde
+++ b/ArduCopter/motors.pde
@@ -148,7 +148,7 @@ static void init_arm_motors()
 #endif
 
 #if HIL_MODE != HIL_MODE_DISABLED || CONFIG_HAL_BOARD == HAL_BOARD_AVR_SITL
-    gcs_send_text_P(SEVERITY_HIGH, PSTR("ARMING MOTORS"));
+    gcs_send_text_P(MAV_SEVERITY_CRITICAL, PSTR("ARMING MOTORS"));
 #endif
 
     // Remember Orientation
@@ -228,7 +228,7 @@ static void pre_arm_checks(bool display_failure)
     pre_arm_rc_checks();
     if(!ap.pre_arm_rc_check) {
         if (display_failure) {
-            gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: RC not calibrated"));
+            gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: RC not calibrated"));
         }
         return;
     }
@@ -238,14 +238,14 @@ static void pre_arm_checks(bool display_failure)
         // barometer health check
         if(!barometer.healthy()) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Baro not healthy"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Baro not healthy"));
             }
             return;
         }
         // check Baro & inav alt are within 1m
         if(fabs(inertial_nav.get_altitude() - baro_alt) > PREARM_MAX_ALT_DISPARITY_CM) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Alt disparity"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Alt disparity"));
             }
             return;
         }
@@ -256,7 +256,7 @@ static void pre_arm_checks(bool display_failure)
         // check the primary compass is healthy
         if(!compass.healthy(0)) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Compass not healthy"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Compass not healthy"));
             }
             return;
         }
@@ -264,7 +264,7 @@ static void pre_arm_checks(bool display_failure)
         // check compass learning is on or offsets have been set
         if(!compass.configured()) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Compass not calibrated"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Compass not calibrated"));
             }
             return;
         }
@@ -273,7 +273,7 @@ static void pre_arm_checks(bool display_failure)
         Vector3f offsets = compass.get_offsets();
         if(offsets.length() > 500) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Compass offsets too high"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Compass offsets too high"));
             }
             return;
         }
@@ -282,7 +282,7 @@ static void pre_arm_checks(bool display_failure)
         float mag_field = compass.get_field().length();
         if (mag_field > COMPASS_MAGFIELD_EXPECTED*1.65 || mag_field < COMPASS_MAGFIELD_EXPECTED*0.35) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Check mag field"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Check mag field"));
             }
             return;
         }
@@ -299,7 +299,7 @@ static void pre_arm_checks(bool display_failure)
                 Vector3f vec_diff = mag_vec - prime_mag_vec;
                 if (vec_diff.length() > COMPASS_ACCEPTABLE_VECTOR_DIFF) {
                     if (display_failure) {
-                        gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: compasses inconsistent"));
+                        gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: compasses inconsistent"));
                     }
                     return;
                 }
@@ -329,7 +329,7 @@ static void pre_arm_checks(bool display_failure)
         // check accelerometers have been calibrated
         if(!ins.calibrated()) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: INS not calibrated"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: INS not calibrated"));
             }
             return;
         }
@@ -337,7 +337,7 @@ static void pre_arm_checks(bool display_failure)
         // check accels are healthy
         if(!ins.get_accel_health_all()) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Accels not healthy"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Accels not healthy"));
             }
             return;
         }
@@ -352,7 +352,7 @@ static void pre_arm_checks(bool display_failure)
                 Vector3f vec_diff = accel_vec - prime_accel_vec;
                 if (vec_diff.length() > PREARM_MAX_ACCEL_VECTOR_DIFF) {
                     if (display_failure) {
-                        gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Accels inconsistent"));
+                        gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Accels inconsistent"));
                     }
                     return;
                 }
@@ -363,7 +363,7 @@ static void pre_arm_checks(bool display_failure)
         // check gyros are healthy
         if(!ins.get_gyro_health_all()) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Gyros not healthy"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Gyros not healthy"));
             }
             return;
         }
@@ -376,7 +376,7 @@ static void pre_arm_checks(bool display_failure)
                 Vector3f vec_diff = ins.get_gyro(i) - ins.get_gyro();
                 if (vec_diff.length() > PREARM_MAX_GYRO_VECTOR_DIFF) {
                     if (display_failure) {
-                        gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Gyros inconsistent"));
+                        gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Gyros inconsistent"));
                     }
                     return;
                 }
@@ -390,7 +390,7 @@ static void pre_arm_checks(bool display_failure)
     if ((g.arming_check == ARMING_CHECK_ALL) || (g.arming_check & ARMING_CHECK_VOLTAGE)) {
         if(hal.analogin->board_voltage() < BOARD_VOLTAGE_MIN || hal.analogin->board_voltage() > BOARD_VOLTAGE_MAX) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Check Board Voltage"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Check Board Voltage"));
             }
             return;
         }
@@ -404,7 +404,7 @@ static void pre_arm_checks(bool display_failure)
         // ensure ch7 and ch8 have different functions
         if ((g.ch7_option != 0 || g.ch8_option != 0) && g.ch7_option == g.ch8_option) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Ch7&Ch8 Opt cannot be same"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Ch7&Ch8 Opt cannot be same"));
             }
             return;
         }
@@ -414,7 +414,7 @@ static void pre_arm_checks(bool display_failure)
             // check throttle min is above throttle failsafe trigger and that the trigger is above ppm encoder's loss-of-signal value of 900
             if (g.rc_3.radio_min <= g.failsafe_throttle_value+10 || g.failsafe_throttle_value < 910) {
                 if (display_failure) {
-                    gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Check FS_THR_VALUE"));
+                    gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Check FS_THR_VALUE"));
                 }
                 return;
             }
@@ -423,7 +423,7 @@ static void pre_arm_checks(bool display_failure)
         // lean angle parameter check
     if (aparm.angle_max < 1000 || aparm.angle_max > 8000) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Check ANGLE_MAX"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Check ANGLE_MAX"));
             }
             return;
         }
@@ -431,7 +431,7 @@ static void pre_arm_checks(bool display_failure)
         // acro balance parameter check
         if ((g.acro_balance_roll > g.p_stabilize_roll.kP()) || (g.acro_balance_pitch > g.p_stabilize_pitch.kP())) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: ACRO_BAL_ROLL/PITCH"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: ACRO_BAL_ROLL/PITCH"));
             }
             return;
         }
@@ -482,7 +482,7 @@ static bool pre_arm_gps_checks(bool display_failure)
     // check GPS is not glitching
     if (gps_glitch.glitching()) {
         if (display_failure) {
-            gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: GPS Glitch"));
+            gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: GPS Glitch"));
         }
         return false;
     }
@@ -490,7 +490,7 @@ static bool pre_arm_gps_checks(bool display_failure)
     // ensure GPS is ok
     if (!GPS_ok()) {
         if (display_failure) {
-            gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Need 3D Fix"));
+            gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Need 3D Fix"));
         }
         return false;
     }
@@ -498,7 +498,7 @@ static bool pre_arm_gps_checks(bool display_failure)
     // check speed is below 50cm/s
     if (speed_cms == 0 || speed_cms > PREARM_MAX_VELOCITY_CMS) {
         if (display_failure) {
-            gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Bad Velocity"));
+            gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Bad Velocity"));
         }
         return false;
     }
@@ -506,7 +506,7 @@ static bool pre_arm_gps_checks(bool display_failure)
     // warn about hdop separately - to prevent user confusion with no gps lock
     if (gps.get_hdop() > g.gps_hdop_good) {
         if (display_failure) {
-            gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: High GPS HDOP"));
+            gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: High GPS HDOP"));
         }
         return false;
     }
@@ -528,7 +528,7 @@ static bool arm_checks(bool display_failure)
     if ((g.arming_check == ARMING_CHECK_ALL) || (g.arming_check & ARMING_CHECK_RC)) {
         if (g.rc_3.control_in > 0) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("Arm: Thr too high"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("Arm: Thr too high"));
             }
             return false;
         }
@@ -538,7 +538,7 @@ static bool arm_checks(bool display_failure)
     if ((g.arming_check == ARMING_CHECK_ALL) || (g.arming_check & ARMING_CHECK_BARO)) {
         if(fabs(inertial_nav.get_altitude() - baro_alt) > PREARM_MAX_ALT_DISPARITY_CM) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("Arm: Alt disparity"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("Arm: Alt disparity"));
             }
             return false;
         }
@@ -556,7 +556,7 @@ static bool arm_checks(bool display_failure)
         // check throttle is above failsafe throttle
         if (g.failsafe_throttle != FS_THR_DISABLED && g.rc_3.radio_in < g.failsafe_throttle_value) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("Arm: Thr below FS"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("Arm: Thr below FS"));
             }
             return false;
         }
@@ -566,7 +566,7 @@ static bool arm_checks(bool display_failure)
     if ((g.arming_check == ARMING_CHECK_ALL) || (g.arming_check & ARMING_CHECK_INS)) {
         if (labs(ahrs.roll_sensor) > aparm.angle_max || labs(ahrs.pitch_sensor) > aparm.angle_max) {
             if (display_failure) {
-                gcs_send_text_P(SEVERITY_HIGH,PSTR("Arm: Leaning"));
+                gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("Arm: Leaning"));
             }
             return false;
         }
@@ -575,7 +575,7 @@ static bool arm_checks(bool display_failure)
     // check if safety switch has been pushed
     if (hal.util->safety_switch_state() == AP_HAL::Util::SAFETY_DISARMED) {
         if (display_failure) {
-            gcs_send_text_P(SEVERITY_HIGH,PSTR("Arm: Safety Switch"));
+            gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("Arm: Safety Switch"));
         }
         return false;
     }
@@ -593,7 +593,7 @@ static void init_disarm_motors()
     }
 
 #if HIL_MODE != HIL_MODE_DISABLED || CONFIG_HAL_BOARD == HAL_BOARD_AVR_SITL
-    gcs_send_text_P(SEVERITY_HIGH, PSTR("DISARMING MOTORS"));
+    gcs_send_text_P(MAV_SEVERITY_CRITICAL, PSTR("DISARMING MOTORS"));
 #endif
 
     motors.armed(false);

--- a/ArduCopter/sensors.pde
+++ b/ArduCopter/sensors.pde
@@ -9,13 +9,13 @@ static void init_sonar(void)
 
 static void init_barometer(bool full_calibration)
 {
-    gcs_send_text_P(SEVERITY_LOW, PSTR("Calibrating barometer"));
+    gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("Calibrating barometer"));
     if (full_calibration) {
         barometer.calibrate();
     }else{
         barometer.update_calibration();
     }
-    gcs_send_text_P(SEVERITY_LOW, PSTR("barometer calibration complete"));
+    gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("barometer calibration complete"));
 }
 
 // return barometric altitude in centimeters

--- a/ArduCopter/switches.pde
+++ b/ArduCopter/switches.pde
@@ -451,7 +451,7 @@ static void save_trim()
     float pitch_trim = ToRad((float)g.rc_2.control_in/100.0f);
     ahrs.add_trim(roll_trim, pitch_trim);
     Log_Write_Event(DATA_SAVE_TRIM);
-    gcs_send_text_P(SEVERITY_HIGH, PSTR("Trim saved"));
+    gcs_send_text_P(MAV_SEVERITY_CRITICAL, PSTR("Trim saved"));
 }
 
 // auto_trim - slightly adjusts the ahrs.roll_trim and ahrs.pitch_trim towards the current stick positions

--- a/ArduCopter/system.pde
+++ b/ArduCopter/system.pde
@@ -183,10 +183,10 @@ static void init_ardupilot()
 #if LOGGING_ENABLED == ENABLED
     DataFlash.Init(log_structure, sizeof(log_structure)/sizeof(log_structure[0]));
     if (!DataFlash.CardInserted()) {
-        gcs_send_text_P(SEVERITY_HIGH, PSTR("No dataflash inserted"));
+        gcs_send_text_P(MAV_SEVERITY_CRITICAL, PSTR("No dataflash inserted"));
         g.log_bitmask.set(0);
     } else if (DataFlash.NeedErase()) {
-        gcs_send_text_P(SEVERITY_HIGH, PSTR("ERASING LOGS"));
+        gcs_send_text_P(MAV_SEVERITY_CRITICAL, PSTR("ERASING LOGS"));
         do_erase_logs();
         gcs[0].reset_cli_timeout();
     }
@@ -248,7 +248,7 @@ static void init_ardupilot()
     while (barometer.get_last_update() == 0) {
         // the barometer begins updating when we get the first
         // HIL_STATE message
-        gcs_send_text_P(SEVERITY_LOW, PSTR("Waiting for first HIL_STATE message"));
+        gcs_send_text_P(MAV_SEVERITY_WARNING, PSTR("Waiting for first HIL_STATE message"));
         delay(1000);
     }
 #endif
@@ -307,7 +307,7 @@ static void init_ardupilot()
 //******************************************************************************
 static void startup_ground(bool force_gyro_cal)
 {
-    gcs_send_text_P(SEVERITY_LOW,PSTR("GROUND START"));
+    gcs_send_text_P(MAV_SEVERITY_WARNING,PSTR("GROUND START"));
 
     // initialise ahrs (may push imu calibration into the mpu6000 if using that device).
     ahrs.init();

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -107,7 +107,7 @@ public:
     /// @param	severity	A value describing the importance of the message.
     /// @param	str			The text to be sent.
     ///
-    void        send_text(gcs_severity severity, const char *str) {
+    void        send_text(int severity, const char *str) {
     }
 
     /// Send a text message with a PSTR()
@@ -115,7 +115,7 @@ public:
     /// @param	severity	A value describing the importance of the message.
     /// @param	str			The text to be sent.
     ///
-    void        send_text_P(gcs_severity severity, const prog_char_t *str) {
+    void        send_text_P(int severity, const prog_char_t *str) {
     }
 
     // send streams which match frequency range
@@ -149,8 +149,8 @@ public:
     void        init(AP_HAL::UARTDriver *port);
     void        setup_uart(AP_HAL::UARTDriver *port, uint32_t baudrate, uint16_t rxS, uint16_t txS);
     void        send_message(enum ap_message id);
-    void        send_text(gcs_severity severity, const char *str);
-    void        send_text_P(gcs_severity severity, const prog_char_t *str);
+    void        send_text(int severity, const char *str);
+    void        send_text_P(int severity, const prog_char_t *str);
     void        data_stream_send(void);
     void        queued_param_send();
     void        queued_waypoint_send();

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -634,7 +634,7 @@ void GCS_MAVLINK::handle_param_set(mavlink_message_t *msg, DataFlash_Class *Data
 
 
 void
-GCS_MAVLINK::send_text(gcs_severity severity, const char *str)
+GCS_MAVLINK::send_text(int severity, const char *str)
 {
     if (severity != SEVERITY_LOW && 
         comm_get_txspace(chan) >= 
@@ -651,7 +651,7 @@ GCS_MAVLINK::send_text(gcs_severity severity, const char *str)
 }
 
 void
-GCS_MAVLINK::send_text_P(gcs_severity severity, const prog_char_t *str)
+GCS_MAVLINK::send_text_P(int severity, const prog_char_t *str)
 {
     mavlink_statustext_t m;
     uint8_t i;


### PR DESCRIPTION
partial fix for #901 . 

Here's how I changed severities:

was|is
----------|----------
SEVERITY_LOW | MAV_SEVERITY_WARNING
SEVERITY_MEDIUM | MAV_SEVERITY_ALERT
SEVERITY_HIGH | MAV_SEVERITY_CRITICAL
SEVERITY_USER_RESPONSE | MAV_SEVERITY_NOTICE

I made the mavlink library require an `int` rather than a `gcs_severity` because copter is now using `MAV_SEVERITY`s but all else is using the incorrect `gcs_severity`.  Once the other parts of the project have been fixed, then the library can be changed to accept a `MAV_SEVERITY` and the old enum `gcs_severity` can be removed.