### PR TITLE
add COMPASS_MOT learning

### DIFF
--- a/ArduCopter/ArduCopter.pde
+++ b/ArduCopter/ArduCopter.pde
@@ -157,6 +157,10 @@
 #endif
 #include <AP_Terrain.h>
 
+#if HAL_CPU_CLASS >= HAL_CPU_CLASS_75
+#include <AP_CompassMot.h>
+#endif
+
 // AP_HAL to Arduino compatibility layer
 #include "compat.h"
 // Configuration
@@ -1011,6 +1015,10 @@ static void fast_loop()
 
     // run the attitude controllers
     update_flight_mode();
+
+#if HAL_CPU_CLASS >= HAL_CPU_CLASS_75
+    compass.update_gyro(ins.get_gyro()+ahrs.get_gyro_drift());
+#endif
 }
 
 // rc_loops - reads user input from transmitter/receiver

--- a/ArduCopter/motors.pde
+++ b/ArduCopter/motors.pde
@@ -628,6 +628,8 @@ static void init_disarm_motors()
         compass.save_offsets();
     }
 
+    compass.save_motor_compensation();
+
     g.throttle_cruise.save();
 
 #if AUTOTUNE_ENABLED == ENABLED

--- a/ArduCopter/setup.pde
+++ b/ArduCopter/setup.pde
@@ -482,6 +482,12 @@ static void report_compass()
         if( compass.motor_compensation_type() == AP_COMPASS_MOT_COMP_CURRENT ) {
             cliSerial->print_P(PSTR("Current"));
         }
+        #if HAL_CPU_CLASS >= HAL_CPU_CLASS_75
+        if( compass.motor_compensation_type() == AP_COMPASS_MOT_COMP_CURRENT_LEARN ) {
+            cliSerial->print_P(PSTR("Learn"));
+        }
+        #endif
+
         Vector3f motor_compensation;
         for (uint8_t i=0; i<compass.get_count(); i++) {
             motor_compensation = compass.get_motor_compensation(i);

--- a/ArduCopter/system.pde
+++ b/ArduCopter/system.pde
@@ -220,6 +220,10 @@ static void init_ardupilot()
     // initialise attitude and position controllers
     attitude_control.set_dt(MAIN_LOOP_SECONDS);
     pos_control.set_dt(MAIN_LOOP_SECONDS);
+#if HAL_CPU_CLASS >= HAL_CPU_CLASS_75
+    compass.set_gyro_deltat(MAIN_LOOP_SECONDS);
+    compass.set_dataflash(&DataFlash);
+#endif
 
     // init the optical flow sensor
     init_optflow();

--- a/libraries/AP_CompassMot/AP_CompassMot.cpp
+++ b/libraries/AP_CompassMot/AP_CompassMot.cpp
@@ -1,0 +1,231 @@
+#include <AP_CompassMot.h>
+#include <AP_Common.h>
+#include <AP_Buffer.h>
+#include <AP_Param.h>
+#include <AP_HAL.h>
+#include <inttypes.h>
+#include <DataFlash.h>
+#include <matrix3.h>
+
+extern const AP_HAL::HAL& hal;
+
+void AP_CompassMot::set_gyro_deltat(float deltat) {
+    _gyro_deltat = deltat;
+}
+
+void AP_CompassMot::update_current(float current) {
+    _current = current;
+}
+
+void AP_CompassMot::update_gyro(Vector3f gyro) {
+    if(_gyro_deltat == 0) {
+        _clear_samples();
+        _gyro_buffer.clear();
+        return;
+    }
+    // Definable delay w/ interpolation. Max @ 400hz = 0.04sec
+    float delay_elements = constrain_float(AP_COMPASSMOT_MAG_DELAY/_gyro_deltat,0.0f,16.0f);
+    Vector3f omega;
+    if(_gyro_buffer.size() >= delay_elements && delay_elements != 0.0f) {
+        //interpolate
+        float interp = delay_elements-(int8_t)delay_elements;
+        Vector3f prev_gyro;
+        _gyro_buffer.pop_front(prev_gyro);
+        const Vector3f &next_gyro = _gyro_buffer.front();
+
+        omega = prev_gyro*interp + prev_gyro*(1.0f-interp);
+    } else {
+        omega = gyro;
+    }
+
+    _gyro_buffer.push_back(gyro);
+    _rottotal += omega.length() * _gyro_deltat;
+    _rot_quat.rotate_fast(omega * _gyro_deltat);
+    _rot_quat.normalize();
+    _rot_quat.rotation_matrix(_rot_matrix);
+}
+
+bool AP_CompassMot::update_compass(Vector3f mag) {
+    if(_gyro_buffer.is_empty()) {
+        //don't do anything without gyro.
+        return false;
+    }
+    //add sample
+    _sample_buffer_m.push_back(_rot_matrix * mag);
+    _sample_buffer_c.push_back(_current);
+    _sample_buffer_rot.push_back(_rottotal);
+    return _update();
+}
+
+bool AP_CompassMot::_update() {
+    if(!_sample_buffer_c.is_full()) {
+        return false;
+    }
+
+    uint8_t n = _sample_buffer_c.size();
+
+    float sumx = 0.0f;
+    for(uint8_t i=0; i<n; i++) {
+        sumx += _sample_buffer_c.peek(i);
+    }
+    float meancurrent = sumx/n;
+
+    float stdcurrent = 0.0f;
+    uint8_t abovecount = 0;
+    for(uint8_t i=0; i<n; i++) {
+        float residual = _sample_buffer_c.peek(i) - meancurrent;
+        if(residual > 0) {
+            abovecount++;
+        }
+        stdcurrent += sq(residual);
+    }
+    stdcurrent /= n-1;
+    stdcurrent = sqrt(stdcurrent);
+
+    float rotation = _sample_buffer_rot.peek(n-1) - _sample_buffer_rot.peek(0);
+    
+    // check if we're ready to do the linear regression
+    if(rotation > AP_COMPASSMOT_MAX_ROT || stdcurrent < AP_COMPASSMOT_MIN_DELTA || abovecount < ((float)n-1.0f)/2.0f || abovecount > ((float)n+1.0f)/2.0f) {
+        return false;
+    }
+
+    // sum up for linear regression
+    // sumx calculated above
+    float    sumx2 = 0;
+    Vector3f sumxy = Vector3f(0.0f,0.0f,0.0f);
+    Vector3f sumy  = Vector3f(0.0f,0.0f,0.0f);
+    Vector3f sumy2 = Vector3f(0.0f,0.0f,0.0f);
+
+    //rotate all samples in-place, add up the sums
+    for(uint8_t i=0; i<n; i++) {
+        Vector3f& mag = _sample_buffer_m.peek_mutable(i);
+        float curr = _sample_buffer_c.peek(i);
+        mag = _rot_matrix.mul_transpose(mag);
+
+        sumx2 += sq(curr);
+        sumxy += mag * curr;
+        sumy += mag;
+        sumy2 += _square_vector(mag);
+    }
+
+    float denom = n*sumx2-sq(sumx);
+
+    if(denom==0.0f) { // fail
+        _clear_samples();
+        return false;
+    }
+
+    Vector3f motfactors_computed = (sumxy*n - sumy*sumx)/denom;
+
+    Vector3f r2;
+    Vector3f r_denom_squared = (sumy2 - _square_vector(sumy)/n) * (sumx2 - sq(sumx)/n);
+    Vector3f r_numerator = sumxy - sumy*sumx/n;
+
+    if(r_denom_squared.x > 0.0f) {
+        r2.x = sq(r_numerator.x / safe_sqrt(r_denom_squared.x));
+    } else {
+        r2.x = 0.0f;
+    }
+    if(r_denom_squared.y > 0.0f) {
+        r2.y = sq(r_numerator.y / safe_sqrt(r_denom_squared.y));
+    } else {
+        r2.y = 0.0f;
+    }
+    if(r_denom_squared.z > 0.0f) {
+        r2.z = sq(r_numerator.z / safe_sqrt(r_denom_squared.z));
+    } else {
+        r2.z = 0.0f;
+    }
+
+    // Filter:
+    Vector3f motfactors_delta = motfactors_computed - _motfactors;
+
+    Vector3f weights = r2 * AP_COMPASSMOT_FILT_CONST * (stdcurrent-AP_COMPASSMOT_MIN_DELTA) * (AP_COMPASSMOT_MAX_ROT-rotation)/AP_COMPASSMOT_MAX_ROT;
+
+    _motfactors.x += constrain_float(weights.x,0.0f,1.0f) * motfactors_delta.x;
+    _motfactors.y += constrain_float(weights.y,0.0f,1.0f) * motfactors_delta.y;
+    _motfactors.z += constrain_float(weights.z,0.0f,1.0f) * motfactors_delta.z;
+
+    log_CMOT(_i, _motfactors, motfactors_computed, weights, stdcurrent, rotation);
+
+    //clear the buffer so that we don't reuse any data
+    _clear_samples();
+    return true;
+}
+
+#define LOG_MSG_CMOT 204
+#define LOG_MSG_CMO2 205
+
+struct PACKED log_CMOT {
+    LOG_PACKET_HEADER;
+    uint32_t timestamp;
+    float fmx;
+    float fmy;
+    float fmz;
+    float mx;
+    float my;
+    float mz;
+    float wx;
+    float wy;
+    float wz;
+    float curr;
+    float rot;
+};
+
+static const struct LogStructure cmot_log_structures[] PROGMEM = {
+    { LOG_MSG_CMOT, sizeof(log_CMOT), "CMOT", "Ifffffffffff", "TimeMS,fMX,fMY,fMZ,MX,MY,MZ,WX,WY,WZ,Curr,Rot" },
+    { LOG_MSG_CMO2, sizeof(log_CMOT), "CMO2", "Ifffffffffff", "TimeMS,fMX,fMY,fMZ,MX,MY,MZ,WX,WY,WZ,Curr,Rot" }
+};
+
+void AP_CompassMot::write_logging_headers() {
+    if (!_logging_started) {
+        _logging_started = true;
+        _DataFlash->AddLogFormats(cmot_log_structures, 2);
+    }
+}
+
+void AP_CompassMot::log_CMOT(uint8_t i, const Vector3f &mf, const Vector3f &m, const Vector3f &w, float curr, float rot) {
+    if (_DataFlash == NULL || !_DataFlash->logging_started()) {
+        return;
+    }
+
+    write_logging_headers();
+    struct log_CMOT pkt;
+    if(i==0) {
+        pkt = {
+            LOG_PACKET_HEADER_INIT(LOG_MSG_CMOT),
+            timestamp : hal.scheduler -> millis(),
+            fmx : mf.x,
+            fmy : mf.y,
+            fmz : mf.z,
+            mx : m.x,
+            my : m.y,
+            mz : m.z,
+            wx : w.x,
+            wy : w.y,
+            wz : w.z,
+            curr : curr,
+            rot : rot
+        };
+    } else if(i==1) {
+        pkt = {
+            LOG_PACKET_HEADER_INIT(LOG_MSG_CMO2),
+            timestamp : hal.scheduler -> millis(),
+            fmx : mf.x,
+            fmy : mf.y,
+            fmz : mf.z,
+            mx : m.x,
+            my : m.y,
+            mz : m.z,
+            wx : w.x,
+            wy : w.y,
+            wz : w.z,
+            curr : curr,
+            rot : rot
+        };
+    } else {
+        return;
+    }
+
+    _DataFlash->WriteBlock(&pkt, sizeof(pkt));
+}

--- a/libraries/AP_CompassMot/AP_CompassMot.h
+++ b/libraries/AP_CompassMot/AP_CompassMot.h
@@ -1,0 +1,91 @@
+#ifndef AP_CompassMot_h
+#define AP_CompassMot_h
+
+#include <AP_Math.h>
+#include <AP_Buffer.h>
+
+// larger buffer sizes are more susceptible to errors from rotating compass error, smaller buffer sizes are more susceptible to errors from noise and dont take advantage of enough data.
+#define AP_COMPASSMOT_BUFFER_SIZE 6
+
+// the filter constant isn't really a time constant. it gets multiplied by delta amperes. if delta amperes * r^2 * (maxrot-rot)/maxrot is high enough, we can do a full jump to the value
+#define AP_COMPASSMOT_FILT_CONST 0.05f
+
+// this is the minimum delta amperes to work on. this is here to keep the algorithm from working on a copter that has a current sensor that doesn't measure motor current
+#define AP_COMPASSMOT_MIN_DELTA 4
+
+// this is the maximum total rotation over a buffer. if there is more rotation than this, we will wait to compute until there is less.
+#define AP_COMPASSMOT_MAX_ROT ToRad(15)
+
+#define AP_COMPASSMOT_MAG_DELAY 0.04f
+
+class DataFlash_Class;
+
+class AP_CompassMot {
+public:
+    AP_CompassMot():
+    _current (0.0f),
+    _gyro_deltat(0.0f),
+    _i(0),
+    _DataFlash(NULL) {}
+
+    void set_i(uint8_t i) {
+        _i = i;
+    }
+
+    void set_motfactors(Vector3f motfactors) {
+        _motfactors = motfactors;
+    }
+
+    const Vector3f &get_motfactors() {
+        return _motfactors;
+    }
+
+    void set_dataflash(DataFlash_Class *df) {
+        _DataFlash = df;
+    }
+    void set_gyro_deltat(float);
+    void update_current(float);
+    void update_gyro(Vector3f);
+    bool update_compass(Vector3f);
+
+private:
+    AP_Buffer<Vector3f, AP_COMPASSMOT_BUFFER_SIZE> _sample_buffer_m;
+    AP_Buffer<float, AP_COMPASSMOT_BUFFER_SIZE> _sample_buffer_c;
+    AP_Buffer<float, AP_COMPASSMOT_BUFFER_SIZE> _sample_buffer_rot;
+    AP_Buffer<Vector3f,16> _gyro_buffer;
+
+    float _current;
+    float _gyro_deltat;
+    Quaternion _rot_quat;
+    Matrix3f   _rot_matrix;
+    float _rottotal;
+    uint8_t _i;
+
+    Vector3f _motfactors;
+
+    Vector3f _square_vector(const Vector3f& v) {
+        return Vector3f(v.x*v.x, v.y*v.y, v.z*v.z);
+    }
+
+    Vector3f _sqrt_vector(const Vector3f& v) {
+        return Vector3f(safe_sqrt(v.x),safe_sqrt(v.y),safe_sqrt(v.z));
+    }
+
+    Vector3f _div_vector(const Vector3f& n, const Vector3f& d) {
+        return Vector3f(n.x/d.x,n.y/d.y,n.z/d.z);
+    }
+
+    bool _update();
+    void _clear_samples() {
+        _sample_buffer_m.clear();
+        _sample_buffer_c.clear();
+        _sample_buffer_rot.clear();
+        _rottotal = 0.0f;
+    }
+
+    DataFlash_Class *_DataFlash;
+    bool _logging_started;
+    void write_logging_headers();
+    void log_CMOT(uint8_t i, const Vector3f& mf, const Vector3f& m, const Vector3f& r, float curr, float rot);
+};
+#endif


### PR DESCRIPTION
- Adds in-flight learning of COMPASS_MOT parameters for each compass.
- Adds the CMOT dataflash log message
- Does not affect APM2
- Defaults to log-only, with no parameter setting or saving.