### PR TITLE
Plane: Add new RC RSSI parameters.

### DIFF
--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -130,8 +130,10 @@ public:
         k_param_rtl_autoland,
         k_param_override_channel,
         k_param_stall_prevention,
-        k_param_rssi_range_min, // new, realocate with next k_format_version update
-        
+#if OPTFLOW == ENABLED
+        k_param_optflow,
+#endif
+	   k_param_rssi_range_min, // new, realocate with next k_format_version update
         // 100: Arming parameters
         k_param_arming = 100,
 

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -101,7 +101,7 @@ public:
         k_param_sonar_old, // unused
         k_param_log_bitmask,
         k_param_BoardConfig,
-        k_param_rssi_range,
+        k_param_rssi_range_max, // renamed (before was rssi_range)
         k_param_flapin_channel,
         k_param_flaperon_output,
         k_param_gps,
@@ -130,7 +130,8 @@ public:
         k_param_rtl_autoland,
         k_param_override_channel,
         k_param_stall_prevention,
-
+        k_param_rssi_range_min, // new, realocate with next k_format_version update
+        
         // 100: Arming parameters
         k_param_arming = 100,
 
@@ -449,7 +450,8 @@ public:
     AP_Int8 land_flap_percent;
     AP_Int8 takeoff_flap_percent;
     AP_Int8 rssi_pin;
-    AP_Float rssi_range;             // allows to set max voltage for rssi pin such as 5.0, 3.3 etc.     
+    AP_Float rssi_range_min;             // allows to set max voltage for rssi pin such as 5.0, 3.3 etc.  
+    AP_Float rssi_range_max;             // allows to set min voltage for rssi pin such as 0.5, 1.2 etc.     
     AP_Int8 inverted_flight_ch;             // 0=disabled, 1-8 is channel for inverted flight trigger
     AP_Int8 stick_mixing;
     AP_Float takeoff_throttle_min_speed;

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -450,8 +450,8 @@ public:
     AP_Int8 land_flap_percent;
     AP_Int8 takeoff_flap_percent;
     AP_Int8 rssi_pin;
-    AP_Float rssi_range_min;             // allows to set max voltage for rssi pin such as 5.0, 3.3 etc.  
-    AP_Float rssi_range_max;             // allows to set min voltage for rssi pin such as 0.5, 1.2 etc.     
+    AP_Float rssi_range_min;             // allows to set min voltage for rssi pin such as 0.5, 1.2 etc.  
+    AP_Float rssi_range_max;             // allows to set max voltage for rssi pin such as 5.0, 3.3 etc.     
     AP_Int8 inverted_flight_ch;             // 0=disabled, 1-8 is channel for inverted flight trigger
     AP_Int8 stick_mixing;
     AP_Float takeoff_throttle_min_speed;

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -133,7 +133,8 @@ public:
 #if OPTFLOW == ENABLED
         k_param_optflow,
 #endif
-	   k_param_rssi_range_min, // new, realocate with next k_format_version update
+	   k_param_rssi_range_min, // new, relocate with next k_format_version update
+
         // 100: Arming parameters
         k_param_arming = 100,
 

--- a/ArduPlane/Parameters.pde
+++ b/ArduPlane/Parameters.pde
@@ -896,13 +896,21 @@ const AP_Param::Info var_info[] PROGMEM = {
     // @User: Standard
     GSCALAR(rssi_pin,            "RSSI_PIN",         -1),
 
-    // @Param: RSSI_RANGE
-    // @DisplayName: Receiver RSSI voltage range
-    // @Description: Receiver RSSI voltage range
+    // @Param: RSSI_RANGE_MAX
+    // @DisplayName: RC Receiver RSSI MAX voltage range
+    // @Description: RC Receiver RSSI MAX voltage range
     // @Units: Volt
     // @Values: 3.3:3.3V, 5.0:5V
     // @User: Standard
-    GSCALAR(rssi_range,          "RSSI_RANGE",         5.0),
+    GSCALAR(rssi_range_max,          "RSSI_RANGE_MAX",         5.0),
+    
+    // @Param: RSSI_RANGE_MIN
+    // @DisplayName: RC Receiver RSSI MIN voltage range
+    // @Description: RC Receiver RSSI MIN voltage range
+    // @Units: Volt
+    // @Values: 0.5:0.5V, 1.2:1.2V
+    // @User: Standard
+    GSCALAR(rssi_range_min,          "RSSI_RANGE_MIN",         0.0),
 
     // @Param: INVERTEDFLT_CH
     // @DisplayName: Inverted flight channel

--- a/ArduPlane/sensors.pde
+++ b/ArduPlane/sensors.pde
@@ -80,11 +80,11 @@ static void read_battery(void)
 void read_receiver_rssi(void)
 {
     // avoid divide by zero
-    if (g.rssi_range <= 0) {
+    if ((g.rssi_range_max <= 0) || (g.rssi_range_min >= g.rssi_range_max)) {
         receiver_rssi = 0;
     }else{
         rssi_analog_source->set_pin(g.rssi_pin);
-        float ret = rssi_analog_source->voltage_average() * 255 / g.rssi_range;
+        float ret = ((rssi_analog_source->voltage_average() - g.rssi_range_min) * 255) / (g.rssi_range_max - g.rssi_range_min);
         receiver_rssi = constrain_int16(ret, 0, 255);
     }
 }


### PR DESCRIPTION
To define best RSSI signal intervals is necesary to include max & min RSSI signal values. This can be do for now only with MinimOSD ConfigTool, so conventional GCSs only show raw values. 

Be careful: Enter some nearby values reduce data resolution. But visually, it is best to known when you reach a value near zero than an unit/percent definition of the RSSI readings.

Code compiles with Arduino IDE for Ardupilot and works on legacy APM1.

Hope this time I have did this pull request well...

Dario.