### PR TITLE
Copter: Add new RC RSSI parameters.

### DIFF
--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -102,7 +102,7 @@ public:
         k_param_battery,
         k_param_fs_batt_mah,
         k_param_angle_rate_max,         // remove
-        k_param_rssi_range,
+        k_param_rssi_range_max,         // renamed (before was rssi_range)
         k_param_rc_feel_rp,
         k_param_NavEKF,                 // Extended Kalman Filter Inertial Navigation Group
         k_param_mission,                // mission library
@@ -124,6 +124,7 @@ public:
         k_param_optflow,
         k_param_dcmcheck_thresh,        // 59
         k_param_log_bitmask,
+        k_param_rssi_range_min,         // new, realocate with next k_format_version update        
 
         // 65: AP_Limits Library
         k_param_limits = 65,            // deprecated - remove
@@ -346,7 +347,8 @@ public:
     AP_Int16        rtl_alt_final;
 
     AP_Int8         rssi_pin;
-    AP_Float        rssi_range;                 // allows to set max voltage for rssi pin such as 5.0, 3.3 etc. 
+    AP_Float        rssi_range_min;             // allows to set min voltage for rssi pin such as 0.5, 1.2 etc.  
+    AP_Float        rssi_range_max;             // allows to set max voltage for rssi pin such as 5.0, 3.3 etc. 
     AP_Int8         wp_yaw_behavior;            // controls how the autopilot controls yaw during missions
     AP_Int8         rc_feel_rp;                 // controls vehicle response to user input with 0 being extremely soft and 100 begin extremely crisp
 

--- a/ArduCopter/Parameters.pde
+++ b/ArduCopter/Parameters.pde
@@ -187,13 +187,21 @@ const AP_Param::Info var_info[] PROGMEM = {
     // @User: Standard
     GSCALAR(rssi_pin,            "RSSI_PIN",         -1),
 
-    // @Param: RSSI_RANGE
-    // @DisplayName: Receiver RSSI voltage range
-    // @Description: Receiver RSSI voltage range
+    // @Param: RSSI_RANGE_MAX
+    // @DisplayName: RC Receiver RSSI MAX voltage range
+    // @Description: RC Receiver RSSI MAX voltage range
     // @Units: Volt
-    // @Values: 3.3:3.3V, 5:5V
+    // @Values: 3.3:3.3V, 5.0:5V
     // @User: Standard
-    GSCALAR(rssi_range,          "RSSI_RANGE",         5.0f),
+    GSCALAR(rssi_range_max,          "RSSI_RANGE_MAX",         5.0),
+    
+    // @Param: RSSI_RANGE_MIN
+    // @DisplayName: RC Receiver RSSI MIN voltage range
+    // @Description: RC Receiver RSSI MIN voltage range
+    // @Units: Volt
+    // @Values: 0.5:0.5V, 1.2:1.2V
+    // @User: Standard
+    GSCALAR(rssi_range_min,          "RSSI_RANGE_MIN",         0.0),
 
     // @Param: WP_YAW_BEHAVIOR
     // @DisplayName: Yaw behaviour during missions

--- a/ArduCopter/sensors.pde
+++ b/ArduCopter/sensors.pde
@@ -161,11 +161,11 @@ static void read_battery(void)
 void read_receiver_rssi(void)
 {
     // avoid divide by zero
-    if (g.rssi_range <= 0) {
+    if ((g.rssi_range_max <= 0) || (g.rssi_range_min >= g.rssi_range_max)) {
         receiver_rssi = 0;
     }else{
         rssi_analog_source->set_pin(g.rssi_pin);
-        float ret = rssi_analog_source->voltage_average() * 255 / g.rssi_range;
+        float ret = ((rssi_analog_source->voltage_average() - g.rssi_range_min) * 255) / (g.rssi_range_max - g.rssi_range_min);
         receiver_rssi = constrain_int16(ret, 0, 255);
     }
 }


### PR DESCRIPTION
To define best RSSI signal intervals is necesary to include max & min RSSI signal values. This can be do for now only with MinimOSD ConfigTool, so conventional GCSs only show raw values. 

Be careful: Enter some nearby values reduce data resolution. But visually, it is best to known when you reach a value near zero than an unit/percent definition of the RSSI readings.

I can not compile code because I only have legacys APM1. Sketch is too big for Arduino IDE.

Hope this time I have did this pull request well...

Dario.
