### PR TITLE
AP_InertialSensor: fixed default MPU6000 orientation for PXF

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -299,11 +299,15 @@ bool AP_InertialSensor_MPU6000::update( void )
     hal.scheduler->resume_timer_procs();
 
     gyro *= _gyro_scale / num_samples;
-    _rotate_and_offset_gyro(_gyro_instance, gyro);
-
     accel *= MPU6000_ACCEL_SCALE_1G / num_samples;
-    _rotate_and_offset_accel(_accel_instance, accel);
 
+#if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_PXF
+    gyro.rotate(ROTATION_PITCH_180_YAW_90);
+    accel.rotate(ROTATION_PITCH_180_YAW_90);
+#endif
+    _rotate_and_offset_gyro(_gyro_instance, gyro);
+    _rotate_and_offset_accel(_accel_instance, accel);
+    
     if (_last_filter_hz != _imu.get_filter()) {
         if (_spi_sem->take(10)) {
             _spi->set_bus_speed(AP_HAL::SPIDeviceDriver::SPI_SPEED_LOW);


### PR DESCRIPTION
Fixed default MPU6000 orientation for PXF