### PR TITLE
Rover: Add new RC RSSI parameters.

### DIFF
--- a/APMrover2/Parameters.h
+++ b/APMrover2/Parameters.h
@@ -55,7 +55,6 @@ public:
         k_param_serial1_baud,
         k_param_serial2_baud,
 
-
         // 110: Telemetry control
         //
         k_param_gcs0 = 110, // stream rates for uartA
@@ -77,6 +76,8 @@ public:
         k_param_steering_learn, // unused
         k_param_NavEKF,  // Extended Kalman Filter Inertial Navigation Group
         k_param_mission, // mission library
+        k_param_rssi_range_max, // new         
+        k_param_rssi_range_min, // new        
 
         // 140: battery controls
         k_param_battery_monitoring = 140,   // deprecated, can be deleted
@@ -221,7 +222,9 @@ public:
 
     // sensor parameters
     AP_Int8	    compass_enabled; 
-
+    AP_Float    rssi_range_min;             // allows to set min voltage for rssi pin such as 0.5, 1.2 etc.  
+    AP_Float    rssi_range_max;             // allows to set max voltage for rssi pin such as 5.0, 3.3 etc.
+    
     // navigation parameters
     //
     AP_Float    speed_cruise;

--- a/APMrover2/Parameters.pde
+++ b/APMrover2/Parameters.pde
@@ -42,6 +42,22 @@ const AP_Param::Info var_info[] PROGMEM = {
     // @User: Standard
     GSCALAR(rssi_pin,            "RSSI_PIN",         -1),
 
+    // @Param: RSSI_RANGE_MAX
+    // @DisplayName: RC Receiver RSSI MAX voltage range
+    // @Description: RC Receiver RSSI MAX voltage range
+    // @Units: Volt
+    // @Values: 3.3:3.3V, 5.0:5V
+    // @User: Standard
+    GSCALAR(rssi_range_max,          "RSSI_RANGE_MAX",         5.0),
+    
+    // @Param: RSSI_RANGE_MIN
+    // @DisplayName: RC Receiver RSSI MIN voltage range
+    // @Description: RC Receiver RSSI MIN voltage range
+    // @Units: Volt
+    // @Values: 0.5:0.5V, 1.2:1.2V
+    // @User: Standard
+    GSCALAR(rssi_range_min,          "RSSI_RANGE_MIN",         0.0),
+    
     // @Param: SYSID_THIS_MAV
     // @DisplayName: MAVLink system ID
     // @Description: ID used in MAVLink protocol to identify this vehicle

--- a/APMrover2/sensors.pde
+++ b/APMrover2/sensors.pde
@@ -23,9 +23,14 @@ static void read_battery(void)
 // RC_CHANNELS_SCALED message
 void read_receiver_rssi(void)
 {
-    rssi_analog_source->set_pin(g.rssi_pin);
-    float ret = rssi_analog_source->voltage_average() * 50;
-    receiver_rssi = constrain_int16(ret, 0, 255);
+    // avoid divide by zero
+    if ((g.rssi_range_max <= 0) || (g.rssi_range_min >= g.rssi_range_max)) {
+        receiver_rssi = 0;
+    }else{
+        rssi_analog_source->set_pin(g.rssi_pin);
+        float ret = ((rssi_analog_source->voltage_average() - g.rssi_range_min) * 255) / (g.rssi_range_max - g.rssi_range_min);
+        receiver_rssi = constrain_int16(ret, 0, 255);
+    }
 }
 
 // read the sonars


### PR DESCRIPTION
Same changes as in pull requests #1603 & #1604, but this time for
Rover...

To define best RSSI signal intervals is necesary to include max & min RSSI signal values. This can be do for now only with MinimOSD ConfigTool, so conventional GCSs only show raw values. 

Be careful: Enter some nearby values reduce data resolution. But visually, it is best to known when you reach a value near zero than an unit/percent definition of the RSSI readings.

Code compiles with Arduino IDE for Ardupilot and works on legacy APM1.

Dario.
