### PR TITLE
mk: add 'upload' target to copy fresh ELF to Linux board using SCP

### DIFF
--- a/mk/board_linux.mk
+++ b/mk/board_linux.mk
@@ -6,3 +6,4 @@ include $(MK_DIR)/find_tools.mk
 OPTFLAGS = -O0
 LIBS = -lm -lpthread -lrt
 include $(MK_DIR)/board_native.mk
+include $(MK_DIR)/upload_firmware.mk

--- a/mk/upload_firmware.mk
+++ b/mk/upload_firmware.mk
@@ -1,0 +1,11 @@
+ifneq ($(BOARD_LINUX_HOST),)
+upload: $(SKETCHELF).timestamp-upload
+
+$(SKETCHELF).timestamp-upload: $(SKETCHELF)
+	scp $(SKETCHELF) $(BOARD_LINUX_HOST):
+	touch $@
+else
+upload:
+	@echo Check your config.mk: BOARD_LINUX_HOST should be defined to upload firmware
+	exit 1
+endif


### PR DESCRIPTION
`make pxf upload` builds elf and copy it to target
device using scp.

Target hostname should be specified in BOARD_LINUX_HOST variable