### PR TITLE
PX4IO: sbus1_output

### DIFF
--- a/mk/PX4/ROMFS/init.d/rc.APM
+++ b/mk/PX4/ROMFS/init.d/rc.APM
@@ -173,8 +173,7 @@ then
     then
         echo "Setting up sbus1 output
         px4io sbus1_out
-     fi
-fi
+    fi
 else
     echo "No PX4IO board found"
     echo "No PX4IO board found" >> $logfile

--- a/mk/PX4/ROMFS/init.d/rc.APM
+++ b/mk/PX4/ROMFS/init.d/rc.APM
@@ -7,6 +7,7 @@
 # To enable mkblctrl_+ startup add a /fs/microsd/APM/mkblctrl_+ file
 # To enable mkblctrl_x startup add a /fs/microsd/APM/mkblctrl_x file
 # To enable PWM on FMUv1 on ttyS1 add a /fs/microsd/APM/AUXPWM.en file
+# To enable SBUS1 output on px4io add a /fs/microsd/APM/sbus1_out file
 
 set deviceA /dev/ttyACM0
 
@@ -168,6 +169,12 @@ then
                tone_alarm MNGGG
         fi
     fi
+    if [ -f /fs/microsd/APM/sbus1_out ]
+    then
+        echo "Setting up sbus1 output
+        px4io sbus1_out
+     fi
+fi
 else
     echo "No PX4IO board found"
     echo "No PX4IO board found" >> $logfile


### PR DESCRIPTION
Provide a way to turn on the px4io sbus1_out. PX4Firmware now has pulled the upstream support for sbus1 output.

I'm flying this with the pending ArduPlane beta compiled with the current PX4Firmware version.