### PR TITLE
Copter: Guided mode that supports position and velocity

### DIFF
--- a/ArduCopter/GCS_Mavlink.pde
+++ b/ArduCopter/GCS_Mavlink.pde
@@ -1328,7 +1328,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
          */
 
         if (!pos_ignore && !vel_ignore && acc_ignore) {
-            guided_set_destination_spline(Vector3f(packet.x * 100.0f, packet.y * 100.0f, -packet.z * 100.0f), Vector3f(packet.vx * 100.0f, packet.vy * 100.0f, -packet.vz * 100.0f));
+            guided_set_destination_posvel(Vector3f(packet.x * 100.0f, packet.y * 100.0f, -packet.z * 100.0f), Vector3f(packet.vx * 100.0f, packet.vy * 100.0f, -packet.vz * 100.0f));
         } else if (pos_ignore && !vel_ignore && acc_ignore) {
             guided_set_velocity(Vector3f(packet.vx * 100.0f, packet.vy * 100.0f, -packet.vz * 100.0f));
         } else if (!pos_ignore && vel_ignore && acc_ignore) {
@@ -1391,7 +1391,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
         }
 
         if (!pos_ignore && !vel_ignore && acc_ignore) {
-            guided_set_destination_spline(pos_ned, Vector3f(packet.vx * 100.0f, packet.vy * 100.0f, -packet.vz * 100.0f));
+            guided_set_destination_posvel(pos_ned, Vector3f(packet.vx * 100.0f, packet.vy * 100.0f, -packet.vz * 100.0f));
         } else if (pos_ignore && !vel_ignore && acc_ignore) {
             guided_set_velocity(Vector3f(packet.vx * 100.0f, packet.vy * 100.0f, -packet.vz * 100.0f));
         } else if (!pos_ignore && vel_ignore && acc_ignore) {

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -188,7 +188,8 @@ enum GuidedMode {
     Guided_TakeOff,
     Guided_WP,
     Guided_Velocity,
-    Guided_Spline
+    Guided_Spline,
+    Guided_PosVel
 };
 
 // RTL states

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -692,27 +692,17 @@ void AC_PosControl::pos_to_rate_xy(bool use_desired_rate, float dt, float ekfNav
             _vel_target.y = _p_pos_xy.kP() * _pos_error.y;
         }
 
-        // decide velocity limit due to position error
-        float vel_max_from_pos_error;
-        if (use_desired_rate) {
-            // if desired velocity (i.e. velocity feed forward) is being used we limit the maximum velocity correction due to position error to 2m/s
-            vel_max_from_pos_error = POSCONTROL_VEL_XY_MAX_FROM_POS_ERR;
-        }else{
-            // if desired velocity is not used, we allow position error to increase speed up to maximum speed
-            vel_max_from_pos_error = _speed_cms;
-        }
-
-        // scale velocity to stays within limits
-        float vel_total = pythagorous2(_vel_target.x, _vel_target.y);
-        if (vel_total > vel_max_from_pos_error) {
-            _vel_target.x = vel_max_from_pos_error * _vel_target.x/vel_total;
-            _vel_target.y = vel_max_from_pos_error * _vel_target.y/vel_total;
-        }
-
         // add desired velocity (i.e. feed forward).
         if (use_desired_rate) {
             _vel_target.x += _vel_desired.x;
             _vel_target.y += _vel_desired.y;
+        }
+
+        // scale velocity within limits
+        float vel_total = pythagorous2(_vel_target.x, _vel_target.y);
+        if (vel_total > _speed_cms) {
+            _vel_target.x = _speed_cms * _vel_target.x/vel_total;
+            _vel_target.y = _speed_cms * _vel_target.y/vel_total;
         }
     }
 }

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -112,6 +112,8 @@ public:
     /// get_speed_xy - allows main code to retrieve target horizontal velocity for wp navigation
     float get_speed_xy() const { return _wp_speed_cms; }
 
+    float get_speed_param() const { return _wp_speed_cms.get(); }
+
     /// get_speed_up - returns target climb speed in cm/s during missions
     float get_speed_up() const { return _wp_speed_up_cms; }
 


### PR DESCRIPTION
There are two ways we could interpret a SET_POSITION_TARGET with a position and velocity:
1. The position target is stationary and the copter is to fly through it at the provided velocity. Useful for path following.
2. The position target is moving at the provided velocity and the copter is to track it. More useful for e.g. followme.

This pull request interprets it as 2. Upon receiving the command, the copter sets the target position to the supplied position target, moves it at the supplied velocity and tries to track it. This is perfect for e.g. followme.