### PR TITLE
EKF Updates and Bugfixes

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -909,6 +909,11 @@ void NavEKF::SelectFlowFusion()
     // if we don't have valid flow measurements and are not using GPS, dead reckon using current velocity vector unless we are in positon hold mode
     if (!flowDataValid && !constPosMode && PV_AidingMode == RELATIVE) {
         constVelMode = true;
+        constPosMode = false; // always clear constant position mode if constant velocity mode is active
+    } else if (flowDataValid) {
+        // clear the constant velocity mode now we have good data
+        constVelMode = false;
+        lastConstVelMode = false;
     }
     // Apply tilt check
     bool tiltOK = (Tnb_flow.c.z > DCM33FlowMin);
@@ -4094,9 +4099,6 @@ void NavEKF::writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRates, V
         flowRadXYcomp[1] = flowStates[0]*flowRadXY[1] + omegaAcrossFlowTime.y;
         // set flag that will trigger observations
         newDataFlow = true;
-        // clear the constant velocity mode now we have good data
-        constVelMode = false;
-        lastConstVelMode = false;
         flowValidMeaTime_ms = imuSampleTime_ms;
     } else {
         newDataFlow = false;

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -2975,9 +2975,8 @@ void NavEKF::FuseOptFlow()
         Kfusion[20] = SK_LOS[0]*(P[20][0]*tempVar[1] + P[20][1]*tempVar[2] - P[20][2]*tempVar[3] + P[20][3]*tempVar[4] + P[20][5]*tempVar[5] - P[20][6]*tempVar[6] - P[20][9]*tempVar[7] + P[20][4]*tempVar[8]);
         Kfusion[21] = SK_LOS[0]*(P[21][0]*tempVar[1] + P[21][1]*tempVar[2] - P[21][2]*tempVar[3] + P[21][3]*tempVar[4] + P[21][5]*tempVar[5] - P[21][6]*tempVar[6] - P[21][9]*tempVar[7] + P[21][4]*tempVar[8]);
         } else {
-            for (uint8_t i = 16; i <= 21; i++) {
-                Kfusion[i] = 0.0f;
-            }
+            memset(&H_LOS[0], 0, sizeof(H_LOS));
+            memset(&Kfusion[0], 0, sizeof(Kfusion));
         }
 
         // calculate variance and innovation for Y observation
@@ -3556,7 +3555,7 @@ bool NavEKF::getPosNED(Vector3f &pos) const
 // return body axis gyro bias estimates in rad/sec
 void NavEKF::getGyroBias(Vector3f &gyroBias) const
 {
-    if (dtIMU == 0) {
+    if (dtIMU < 1e-6f) {
         gyroBias.zero();
         return;
     }
@@ -3618,7 +3617,7 @@ void NavEKF::getIMU1Weighting(float &ret) const
 
 // return the individual Z-accel bias estimates in m/s^2
 void NavEKF::getAccelZBias(float &zbias1, float &zbias2) const {
-    if (dtIMU == 0) {
+    if (dtIMU < 1e-6f) {
         zbias1 = 0;
         zbias2 = 0;
     } else {

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -751,6 +751,7 @@ void NavEKF::SelectVelPosFusion()
             if (vehicleArmed && !useAirspeed() && !assume_zero_sideslip()) {
                 constVelMode = true;
                 constPosMode = false; // always clear constant position mode if constant velocity mode is active
+                PV_AidingMode = NONE;
             }
         }
 

--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -638,9 +638,11 @@ private:
     bool lastConstVelMode;          // last value of holdVelocity
     Vector2f heldVelNE;             // velocity held when no aiding is available
     uint16_t _msecFlowAvg;          // average number of msec between synthetic sideslip measurements
-    uint8_t gpsInhibitMode;         // 1 when GPS useage is being inhibited and only attitude and height data is available
-                                    // 2 when GPS useage is being inhibited and attitude, height, velocity and relative position is available
-                                    // 0 when GPS is being used
+    uint8_t PV_AidingMode;          // Defines the preferred mode for aiding of velocity and position estimates from the INS
+    enum {ABSOLUTE=0,               // GPS aiding is being used (optical flow may also be used) so position estimates are absolute.
+          NONE=1,                   // no aiding is being used so only attitude and height estimates are available. Either constVelMode or constPosMode must be used to constrain tilt drift.
+          RELATIVE=2                // only optical flow aiding is being used so position estimates will be relative
+         };
 
     // states held by optical flow fusion across time steps
     // optical flow X,Y motion compensated rate measurements are fused across two time steps

--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -337,7 +337,7 @@ private:
     Quaternion calcQuatAndFieldStates(float roll, float pitch);
 
     // zero stored variables
-    void ZeroVariables();
+    void InitialiseVariables();
 
     // reset the horizontal position states uing the last GPS measurement
     void ResetPosition(void);
@@ -421,26 +421,34 @@ private:
     AP_Int8 _fallback;              // EKF-to-DCM fallback strictness. 0 = trust EKF more, 1 = fallback more conservatively.
 
     // Tuning parameters
-    AP_Float _gpsNEVelVarAccScale;  // scale factor applied to NE velocity measurement variance due to Vdot
-    AP_Float _gpsDVelVarAccScale;   // scale factor applied to D velocity measurement variance due to Vdot
-    AP_Float _gpsPosVarAccScale;    // scale factor applied to position measurement variance due to Vdot
-    AP_Int16 _msecHgtDelay;         // effective average delay of height measurements rel to (msec)
-    AP_Int16 _msecMagDelay;         // effective average delay of magnetometer measurements rel to IMU (msec)
-    AP_Int16 _msecTasDelay;         // effective average delay of airspeed measurements rel to IMU (msec)
-    AP_Int16 _gpsRetryTimeUseTAS;   // GPS retry time following innovation consistency fail if TAS measurements are used (msec)
-    AP_Int16 _gpsRetryTimeNoTAS;    // GPS retry time following innovation consistency fail if no TAS measurements are used (msec)
-    AP_Int16 _hgtRetryTimeMode0;    // height measurement retry time following innovation consistency fail if GPS fusion mode is = 0 (msec)
-    AP_Int16 _hgtRetryTimeMode12;   // height measurement retry time following innovation consistency fail if GPS fusion mode is > 0 (msec)
-    AP_Int16 _tasRetryTime;         // true airspeed measurement retry time following innovation consistency fail (msec)
-    uint32_t _magFailTimeLimit_ms;  // number of msec before a magnetometer failing innovation consistency checks is declared failed (msec)
-    float _gyroBiasNoiseScaler;     // scale factor applied to gyro bias state process variance when on ground
-    float _magVarRateScale;         // scale factor applied to magnetometer variance due to angular rate
-    uint16_t _msecGpsAvg;           // average number of msec between GPS measurements
-    uint16_t _msecHgtAvg;           // average number of msec between height measurements
-    uint16_t _msecMagAvg;           // average number of msec between magnetometer measurements
-    uint16_t _msecBetaAvg;          // Average number of msec between synthetic sideslip measurements
-    uint16_t _msecBetaMax;          // maximum number of msec between synthetic sideslip measurements
-    float dtVelPos;                 // average of msec between position and velocity corrections
+    const float gpsNEVelVarAccScale     = 0.05f;    // Scale factor applied to NE velocity measurement variance due to manoeuvre acceleration
+    const float gpsDVelVarAccScale      = 0.07f;    // Scale factor applied to vertical velocity measurement variance due to manoeuvre acceleration
+    const float gpsPosVarAccScale       = 0.05f;    // Scale factor applied to horizontal position measurement variance due to manoeuvre acceleration
+    const float msecHgtDelay            = 60;       // Height measurement delay (msec)
+    const uint16_t msecMagDelay         = 40;       // Magnetometer measurement delay (msec)
+    const uint16_t msecTasDelay         = 240;      // Airspeed measurement delay (msec)
+    const uint16_t gpsRetryTimeUseTAS   = 10000;    // GPS retry time with airspeed measurements (msec)
+    const uint16_t gpsRetryTimeNoTAS    = 10000;    // GPS retry time without airspeed measurements (msec)
+    const uint16_t hgtRetryTimeMode0    = 10000;    // Height retry time with vertical velocity measurement (msec)
+    const uint16_t hgtRetryTimeMode12   = 5000;     // Height retry time without vertical velocity measurement (msec)
+    const uint16_t tasRetryTime         = 5000;     // True airspeed timeout and retry interval (msec)
+    const uint32_t magFailTimeLimit_ms  = 10000;    // number of msec before a magnetometer failing innovation consistency checks is declared failed (msec)
+    const float magVarRateScale         = 0.05f;    // scale factor applied to magnetometer variance due to angular rate
+    const float gyroBiasNoiseScaler     = 2.0f;     // scale factor applied to gyro bias state process noise when on ground
+    const uint16_t msecGpsAvg           = 200;      // average number of msec between GPS measurements
+    const uint16_t msecHgtAvg           = 100;      // average number of msec between height measurements
+    const uint16_t msecMagAvg           = 100;      // average number of msec between magnetometer measurements
+    const uint16_t msecBetaAvg          = 100;      // average number of msec between synthetic sideslip measurements
+    const uint16_t msecBetaMax          = 200;      // maximum number of msec between synthetic sideslip measurements
+    const uint16_t msecFlowAvg         = 100;      // average number of msec between optical flow measurements
+    const float dtVelPos                = 0.2;      // number of seconds between position and velocity corrections. This should be a multiple of the imu update interval.
+    const float covTimeStepMax          = 0.07f;    // maximum time (sec) between covariance prediction updates
+    const float covDelAngMax            = 0.05f;    // maximum delta angle between covariance prediction updates
+    const uint32_t TASmsecMax           = 200;      // maximum allowed interval between airspeed measurement updates
+    const float DCM33FlowMin            = 0.71f;    // If Tbn(3,3) is less than this number, optical flow measurements will not be fused as tilt is too high.
+    const float fScaleFactorPnoise      = 1e-10f;   // Process noise added to focal length scale factor state variance at each time step
+    const uint8_t flowTimeDeltaAvg_ms   = 100;      // average interval between optical flow measurements (msec)
+    const uint32_t flowIntervalMax_ms   = 200;      // maximum allowable time between flow fusion events
 
     // Variables
     bool statesInitialised;         // boolean true when filter states have been initialised
@@ -507,8 +515,6 @@ private:
     bool fuseVtasData;              // boolean true when airspeed data is to be fused
     float VtasMeas;                 // true airspeed measurement (m/s)
     state_elements statesAtVtasMeasTime;  // filter states at the effective measurement time
-    const ftype covTimeStepMax;     // maximum time allowed between covariance predictions
-    const ftype covDelAngMax;       // maximum delta angle between covariance predictions
     bool covPredStep;               // boolean set to true when a covariance prediction step has been performed
     bool magFusePerformed;          // boolean set to true when magnetometer fusion has been perfomred in that time step
     bool magFuseRequired;           // boolean set to true when magnetometer fusion will be perfomred in the next time step
@@ -516,7 +522,6 @@ private:
     bool tasFuseStep;               // boolean set to true when airspeed fusion is being performed
     uint32_t TASmsecPrev;           // time stamp of last TAS fusion step
     uint32_t BETAmsecPrev;          // time stamp of last synthetic sideslip fusion step
-    const uint32_t TASmsecMax;      // maximum allowed interval between TAS fusion steps
     uint32_t MAGmsecPrev;           // time stamp of last compass fusion step
     uint32_t HGTmsecPrev;           // time stamp of last height measurement fusion step
     bool inhibitLoadLeveling;       // boolean that turns off delay of fusion to level processor loading
@@ -603,14 +608,11 @@ private:
     uint32_t flowMeaTime_ms;        // time stamp from latest flow measurement (msec)
     uint8_t flowQuality;            // unsigned integer representing quality of optical flow data. 255 is maximum quality.
     uint32_t rngMeaTime_ms;         // time stamp from latest range measurement (msec)
-    float DCM33FlowMin;             // If Tbn(3,3) is less than this number, optical flow measurements will not be fused as tilt is too high.
-    float fScaleFactorPnoise;       // Process noise added to focal length scale factor state variance at each time step
     Vector3f omegaAcrossFlowTime;   // body angular rates averaged across the optical flow sample period
     Matrix3f Tnb_flow;              // transformation matrix from nav to body axes at the middle of the optical flow sample period
     Matrix3f Tbn_flow;              // transformation matrix from body to nav axes at the middle of the optical flow sample period
     float varInnovOptFlow[2];       // optical flow innovations variances (rad/sec)^2
     float innovOptFlow[2];          // optical flow LOS innovations (rad/sec)
-    uint8_t flowTimeDeltaAvg_ms;    // average interval between optical flow measurements (msec)
     float Popt[2][2];               // state covariance matrix
     float flowStates[2];            // flow states [scale factor, terrain position]
     float prevPosN;                 // north position at last measurement
@@ -622,7 +624,6 @@ private:
     float rngMea;                   // range finder measurement (m)
     bool inhibitGndState;           // true when the terrain position state is to remain constant
     uint32_t prevFlowFusionTime_ms; // time the last flow measurement was fused
-    uint32_t flowIntervalMax_ms;    // maximum allowable time between flow fusion events
     bool fScaleInhibit;             // true when the focal length scale factor is to remain constant
     float flowTestRatio[2];         // square of optical flow innovations divided by fail threshold used by main filter where >1.0 is a fail
     float auxFlowTestRatio[2];      // sum of squares of optical flow innovations divided by fail threshold used by aux filter
@@ -637,7 +638,6 @@ private:
     bool constVelMode;              // true when fusing a constant velocity to maintain attitude reference when either optical flow or GPS measurements are lost after arming
     bool lastConstVelMode;          // last value of holdVelocity
     Vector2f heldVelNE;             // velocity held when no aiding is available
-    uint16_t _msecFlowAvg;          // average number of msec between synthetic sideslip measurements
     uint8_t PV_AidingMode;          // Defines the preferred mode for aiding of velocity and position estimates from the INS
     enum {ABSOLUTE=0,               // GPS aiding is being used (optical flow may also be used) so position estimates are absolute.
           NONE=1,                   // no aiding is being used so only attitude and height estimates are available. Either constVelMode or constPosMode must be used to constrain tilt drift.


### PR DESCRIPTION
These updates address the following issues:

1) The code calculating the  EKF solution status summary was hard to follow and had a parenthesis error in the calculation of the absolute position status which had the potential to casue a reporting error under some combinations of inputs. Functional change in reporting status under some input combinations.
https://github.com/priseborough/ardupilot/commit/22bef6e6df3853039ef62a39d81f1eabe983aada

2)  Enumerated variables with clear names have been used instead of numeric types to describe the position and velocity aiding status of the filter. this makes the code easier to read and maintain. No functional change.
https://github.com/priseborough/ardupilot/commit/22bef6e6df3853039ef62a39d81f1eabe983aada

3) The declaration of non user tunable parameters was inconsistent. some were declared using AP param types, others using standard types. some were initialised in the constructor and others were initialised by function call. Also a number of delay and timeout time variables were using signed integer values. These have been changed to unsigned types for consistency. All non user adjustable parameters are now declared as const types. All variables are now initialised by function call to enable an in-flight reset to be used later if required. No functional change.
https://github.com/priseborough/ardupilot/commit/f92b5aae39f1e9c32a7e4669d4e18849a2bfc555

4) The decision to enter constant velocity dead reckoning mode and leave it during optical flow operation was done in two separate places, making it harder to follow and increasing the changes of a coding error during subsequent modifications.
https://github.com/priseborough/ardupilot/commit/e48708bd2b802127d90ada0226fa9538bd230f42

5) Miscellaneous compiler warning messages have been eliminated

6) Constant position and constant velocity mode should never be enabled at the same time. there was one place in code where this condition was not being explicitly enforced.
https://github.com/priseborough/ardupilot/commit/fd606e69497b0656fe5b26de66df56fc40bfa040

These changes have been flight tested on Copter for both normal GPS, no GPS and optical flow only modes of operation.