### PR TITLE
EKF Updates and Bugfixes

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -909,6 +909,11 @@ void NavEKF::SelectFlowFusion()
     // if we don't have valid flow measurements and are not using GPS, dead reckon using current velocity vector unless we are in positon hold mode
     if (!flowDataValid && !constPosMode && PV_AidingMode == RELATIVE) {
         constVelMode = true;
+        constPosMode = false; // always clear constant position mode if constant velocity mode is active
+    } else if (flowDataValid) {
+        // clear the constant velocity mode now we have good data
+        constVelMode = false;
+        lastConstVelMode = false;
     }
     // Apply tilt check
     bool tiltOK = (Tnb_flow.c.z > DCM33FlowMin);
@@ -4094,9 +4099,6 @@ void NavEKF::writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRates, V
         flowRadXYcomp[1] = flowStates[0]*flowRadXY[1] + omegaAcrossFlowTime.y;
         // set flag that will trigger observations
         newDataFlow = true;
-        // clear the constant velocity mode now we have good data
-        constVelMode = false;
-        lastConstVelMode = false;
         flowValidMeaTime_ms = imuSampleTime_ms;
     } else {
         newDataFlow = false;

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -2975,9 +2975,8 @@ void NavEKF::FuseOptFlow()
         Kfusion[20] = SK_LOS[0]*(P[20][0]*tempVar[1] + P[20][1]*tempVar[2] - P[20][2]*tempVar[3] + P[20][3]*tempVar[4] + P[20][5]*tempVar[5] - P[20][6]*tempVar[6] - P[20][9]*tempVar[7] + P[20][4]*tempVar[8]);
         Kfusion[21] = SK_LOS[0]*(P[21][0]*tempVar[1] + P[21][1]*tempVar[2] - P[21][2]*tempVar[3] + P[21][3]*tempVar[4] + P[21][5]*tempVar[5] - P[21][6]*tempVar[6] - P[21][9]*tempVar[7] + P[21][4]*tempVar[8]);
         } else {
-            for (uint8_t i = 16; i <= 21; i++) {
-                Kfusion[i] = 0.0f;
-            }
+            memset(&H_LOS[0], 0, sizeof(H_LOS));
+            memset(&Kfusion[0], 0, sizeof(Kfusion));
         }
 
         // calculate variance and innovation for Y observation
@@ -3556,7 +3555,7 @@ bool NavEKF::getPosNED(Vector3f &pos) const
 // return body axis gyro bias estimates in rad/sec
 void NavEKF::getGyroBias(Vector3f &gyroBias) const
 {
-    if (dtIMU == 0) {
+    if (dtIMU < 1e-6f) {
         gyroBias.zero();
         return;
     }
@@ -3618,7 +3617,7 @@ void NavEKF::getIMU1Weighting(float &ret) const
 
 // return the individual Z-accel bias estimates in m/s^2
 void NavEKF::getAccelZBias(float &zbias1, float &zbias2) const {
-    if (dtIMU == 0) {
+    if (dtIMU < 1e-6f) {
         zbias1 = 0;
         zbias2 = 0;
     } else {

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -751,6 +751,7 @@ void NavEKF::SelectVelPosFusion()
             if (vehicleArmed && !useAirspeed() && !assume_zero_sideslip()) {
                 constVelMode = true;
                 constPosMode = false; // always clear constant position mode if constant velocity mode is active
+                PV_AidingMode = NONE;
             }
         }
 

--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -638,9 +638,11 @@ private:
     bool lastConstVelMode;          // last value of holdVelocity
     Vector2f heldVelNE;             // velocity held when no aiding is available
     uint16_t _msecFlowAvg;          // average number of msec between synthetic sideslip measurements
-    uint8_t gpsInhibitMode;         // 1 when GPS useage is being inhibited and only attitude and height data is available
-                                    // 2 when GPS useage is being inhibited and attitude, height, velocity and relative position is available
-                                    // 0 when GPS is being used
+    uint8_t PV_AidingMode;          // Defines the preferred mode for aiding of velocity and position estimates from the INS
+    enum {ABSOLUTE=0,               // GPS aiding is being used (optical flow may also be used) so position estimates are absolute.
+          NONE=1,                   // no aiding is being used so only attitude and height estimates are available. Either constVelMode or constPosMode must be used to constrain tilt drift.
+          RELATIVE=2                // only optical flow aiding is being used so position estimates will be relative
+         };
 
     // states held by optical flow fusion across time steps
     // optical flow X,Y motion compensated rate measurements are fused across two time steps


### PR DESCRIPTION
These updates address the following issues:

1) Enumerated variables with clear names have been used instead of numeric types to describe the position and velocity aiding status of the filter. this makes the code easier to read and maintain. Maintainability enhancement, no functional change.

2) Constant position and constant velocity mode should never be enabled at the same time. there was one place in code where this condition was not being explicitly enforced. Fixes potential bug.

3) The decision to enter constant velocity dead reckoning mode and leave it during optical flow operation was done in two separate places, making it harder to follow and increasing the changes of a coding error during subsequent modifications. Maintainability enhancement, no functional change.

3) The declaration of non user tunable parameters was inconsistent. some were declared using AP param types, others using standard types. some were initialised in the constructor and others were initialised by function call. Also a number of delay and timeout time variables were using signed integer values. These have been changed to unsigned types for consistency. All non user adjustable parameters are now declared as const types. All variables are now initialised by function call to enable an in-flight reset to be used later if required. Maintainability enhancement, no functional change.

5) The code calculating the EKF solution status summary was hard to follow and had a parenthesis error in the calculation of the absolute position status which had the potential to cause a reporting error under some combinations of inputs. Fixes potential bug.

6) Miscellaneous compiler warning messages have been eliminated. Maintainability enhancement, no functional change.

