### PR TITLE
Ekf opt flow logging

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -4517,7 +4517,7 @@ void  NavEKF::getFilterStatus(uint8_t &status) const
     bool doingNormalGpsNav = !posTimeout && (PV_AidingMode == AID_ABSOLUTE);
     bool notDeadReckoning = !constVelMode && !constPosMode;
     bool someVertRefData = (!velTimeout && (_fusionModeGPS == 0)) || !hgtTimeout;
-    bool someHorizRefData = !(velTimeout && posTimeout && tasTimeout);
+    bool someHorizRefData = !(velTimeout && posTimeout && tasTimeout) || doingFlowNav;
     status = (!state.quat.is_nan()<<0 | // attitude valid (we need a better check)
               (someHorizRefData && notDeadReckoning)<<1 | // horizontal velocity estimate valid
               someVertRefData<<2 | // vertical velocity estimate valid

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -3668,16 +3668,17 @@ bool NavEKF::getHAGL(float &HAGL) const
 }
 
 // return data for debugging optical flow fusion
-void NavEKF::getFlowDebug(float &scaleFactor, float &gndPos, float &flowInnovX, float &flowInnovY, float &augFlowInnovX, float &augFlowInnovY, float &rngInnov, float &range) const
+void NavEKF::getFlowDebug(float &scaleFactor, float &estHAGL, float &flowInnovX, float &flowInnovY, float &flowVarX, float &flowVarY, float &rngInnov, float &range, float &gndOffsetErr) const
 {
     scaleFactor = flowStates[0];
-    gndPos = flowStates[1];
+    estHAGL = flowStates[1] - state.position.z;
     flowInnovX = innovOptFlow[0];
     flowInnovY = innovOptFlow[1];
-    augFlowInnovX = auxFlowObsInnov[0];
-    augFlowInnovY = auxFlowObsInnov[1];
+    flowVarX = flowTestRatio[0];
+    flowVarY = flowTestRatio[1];
     rngInnov = innovRng;
     range = rngMea;
+    gndOffsetErr = sqrtf(Popt[1][1]); // note Popt[1][1] is constrained to be non-negative in RunAuxiliaryEKF()
 }
 
 // calculate whether the flight vehicle is on the ground or flying from height, airspeed and GPS speed

--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -171,7 +171,7 @@ public:
     void  writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRates, Vector2f &rawGyroRates, uint32_t &msecFlowMeas, uint8_t &rangeHealth, float &rawSonarRange);
 
     // return data for debugging optical flow fusion
-    void getFlowDebug(float &scaleFactor, float &gndPos, float &flowInnovX, float &flowInnovY, float &augFlowInnovX, float &augFlowInnovY, float &rngInnov, float &range) const;
+    void getFlowDebug(float &scaleFactor, float &gndPos, float &flowInnovX, float &flowInnovY, float &flowVarX, float &flowVarY, float &rngInnov, float &range, float &gndOffsetErr) const;
 
     /*
     return the filter fault status as a bitmasked integer

--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -607,7 +607,7 @@ private:
     uint32_t flowValidMeaTime_ms;   // time stamp from latest valid flow measurement (msec)
     uint32_t flowMeaTime_ms;        // time stamp from latest flow measurement (msec)
     uint8_t flowQuality;            // unsigned integer representing quality of optical flow data. 255 is maximum quality.
-    uint32_t rngMeaTime_ms;         // time stamp from latest range measurement (msec)
+    uint32_t gndHgtValidTime_ms;    // time stamp from last terrain offset state update (msec)
     Vector3f omegaAcrossFlowTime;   // body angular rates averaged across the optical flow sample period
     Matrix3f Tnb_flow;              // transformation matrix from nav to body axes at the middle of the optical flow sample period
     Matrix3f Tbn_flow;              // transformation matrix from body to nav axes at the middle of the optical flow sample period

--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -354,12 +354,13 @@ struct PACKED log_EKF5 {
     uint32_t time_ms;
     int16_t FIX;
     int16_t FIY;
-    int16_t AFIX;
-    int16_t AFIY;
-    int16_t gndPos;
+    uint8_t normInnovFX;
+    uint8_t normInnovFY;
+    uint16_t estHAGL;
     uint8_t scaler;
     int16_t RI;
-    uint16_t range;
+    uint16_t meaRng;
+    uint16_t errHAGL;
 };
 
 struct PACKED log_Cmd {
@@ -531,7 +532,7 @@ struct PACKED log_Esc {
     { LOG_ESC8_MSG, sizeof(log_Esc), \
       "ESC8",  "Icccc", "TimeMS,RPM,Volt,Curr,Temp" }, \
     { LOG_EKF5_MSG, sizeof(log_EKF5), \
-      "EKF5","IhhhhcBcC","TimeMS,FIX,FIY,AFIX,AFIY,gndPos,fScaler,RI,rng" }
+      "EKF5","IhhBBCBcCC","TimeMS,FIX,FIY,SFX,SFY,estHAGL,fScaler,RI,meaRng,errHAGL" }
 
 #if HAL_CPU_CLASS >= HAL_CPU_CLASS_75
 #define LOG_COMMON_STRUCTURES LOG_BASE_STRUCTURES, LOG_EXTRA_STRUCTURES

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -1009,23 +1009,25 @@ void DataFlash_Class::Log_Write_EKF(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
     // Write fifth EKF packet
     if (optFlowEnabled) {
         float fscale;
-        float gndPos;
+        float estHAGL;
         float flowInnovX, flowInnovY;
-        float augFlowInnovX, augFlowInnovY;
+        float flowVarX, flowVarY;
         float rngInnov;
         float range;
-        ahrs.get_NavEKF().getFlowDebug(fscale, gndPos, flowInnovX, flowInnovY, augFlowInnovX, augFlowInnovY, rngInnov, range);
+        float gndOffsetErr;
+        ahrs.get_NavEKF().getFlowDebug(fscale, estHAGL, flowInnovX, flowInnovY, flowVarX, flowVarY, rngInnov, range, gndOffsetErr);
         struct log_EKF5 pkt5 = {
             LOG_PACKET_HEADER_INIT(LOG_EKF5_MSG),
             time_ms : hal.scheduler->millis(),
             FIX : (int16_t)(1000*flowInnovX),
             FIY : (int16_t)(1000*flowInnovY),
-            AFIX : (int16_t)(1000*augFlowInnovX),
-            AFIY : (int16_t)(1000*augFlowInnovY),
-            gndPos : (int16_t)(100*gndPos),
+            normInnovFX : min((uint8_t)(100*flowVarX),255),
+            normInnovFY : min((uint8_t)(100*flowVarY),255),
+            estHAGL : (uint16_t)(100*estHAGL),
             scaler: (uint8_t)(100*fscale),
             RI : (int16_t)(100*rngInnov),
-            range : (uint16_t)(100*range)
+            meaRng : (uint16_t)(100*range),
+            errHAGL : (uint16_t)(100*gndOffsetErr)
          };
         WriteBlock(&pkt5, sizeof(pkt5));
     }


### PR DESCRIPTION
This update adds logging of the estimate height above ground and its 1-Sigma error estimate in addition to replacing the auxiliary filter innovations with the normalised innovation variances (as a percentage) from the main filter.

It also corrects an error in the solution status reporting that is logged (bit not currently used) that caused the velocity validity to reported as false when using optical flow only.

A timeout has been added to terrain offset validity so that the status does not toggle rapidly due to short duration dropouts in valid range finder data.