### PR TITLE
AP_NavEKF: Fix bug preventing use of optical flow without GPS

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -720,7 +720,7 @@ void NavEKF::UpdateFilter()
 void NavEKF::SelectVelPosFusion()
 {
     // check for new data, specify which measurements should be used and check data for freshness
-    if (!constPosMode && !constVelMode) {
+    if (PV_AidingMode == AID_ABSOLUTE) {
 
         // check for and read new GPS data
         readGpsData();


### PR DESCRIPTION
This fixes a bug that meant that the EKF would revert back to a basic stabilisation mode in the absence of GPS even if optical flow aiding was being used.