### PR TITLE
Plane: Fixed differential spoilers support, added elevon offset

### DIFF
--- a/ArduPlane/Attitude.pde
+++ b/ArduPlane/Attitude.pde
@@ -637,6 +637,14 @@ static void channel_output_mixer(uint8_t mixing_type, int16_t &chan1_out, int16_
     c1 = chan1_out - 1500;
     c2 = chan2_out - 1500;
 
+    // apply MIXING_OFFSET to input channels using long-integer version
+    //  of formula:  x = x * (g.mixing_offset/100.0 + 1.0)
+    //  -100 => 2x on 'c1', 100 => 2x on 'c2'
+    if (g.mixing_offset < 0)
+      c1 = (int16_t)(((int32_t)c1) * (-g.mixing_offset+100) / 100);
+    else if (g.mixing_offset > 0)
+      c2 = (int16_t)(((int32_t)c2) * (g.mixing_offset+100) / 100);
+
     v1 = (c1 - c2) * g.mixing_gain;
     v2 = (c1 + c2) * g.mixing_gain;
 
@@ -755,12 +763,6 @@ static void set_servos(void)
         RC_Channel_aux::copy_radio_in_out(RC_Channel_aux::k_aileron_with_input);
         RC_Channel_aux::copy_radio_in_out(RC_Channel_aux::k_elevator_with_input);
 
-        if (g.mix_mode == 0 && g.elevon_output == MIXING_DISABLED) {
-            // set any differential spoilers to follow the elevons in
-            // manual mode. 
-            RC_Channel_aux::set_radio(RC_Channel_aux::k_dspoiler1, channel_roll->radio_out);
-            RC_Channel_aux::set_radio(RC_Channel_aux::k_dspoiler2, channel_pitch->radio_out);
-        }
     } else {
         if (g.mix_mode == 0) {
             // both types of secondary aileron are slaved to the roll servo out
@@ -786,12 +788,15 @@ static void set_servos(void)
 			if (RC_Channel_aux::function_assigned(RC_Channel_aux::k_dspoiler1) && RC_Channel_aux::function_assigned(RC_Channel_aux::k_dspoiler2)) {
 				float ch3 = ch1;
 				float ch4 = ch2;
-				if ( BOOL_TO_SIGN(g.reverse_elevons) * channel_rudder->servo_out < 0) {
-				    ch1 += abs(channel_rudder->servo_out);
-				    ch3 -= abs(channel_rudder->servo_out);
+                   //get rudder value and multiply by DSPOILR_RUD_RATE/100:
+				int16_t ruddVal = (int16_t)((int32_t)(channel_rudder->servo_out) *
+				                                       g.dspoiler_rud_rate / 100);
+				if ( BOOL_TO_SIGN(g.reverse_elevons) * ruddVal < 0) {
+				    ch1 += abs(ruddVal);
+				    ch3 -= abs(ruddVal);
 				} else {
-					ch2 += abs(channel_rudder->servo_out);
-				    ch4 -= abs(channel_rudder->servo_out);
+					ch2 += abs(ruddVal);
+				    ch4 -= abs(ruddVal);
 				}
 				RC_Channel_aux::set_servo_out(RC_Channel_aux::k_dspoiler1, ch3);
 				RC_Channel_aux::set_servo_out(RC_Channel_aux::k_dspoiler2, ch4);
@@ -935,6 +940,34 @@ static void set_servos(void)
         channel_output_mixer(g.vtail_output, channel_pitch->radio_out, channel_rudder->radio_out);
     } else if (g.elevon_output != MIXING_DISABLED) {
         channel_output_mixer(g.elevon_output, channel_pitch->radio_out, channel_roll->radio_out);
+              //if (both) differential spoilers setup then apply rudder
+              // control into splitting the two elevons on the side of
+              // the aircraft where we want to induce additional drag:
+        if (RC_Channel_aux::function_assigned(RC_Channel_aux::k_dspoiler1) &&
+                   RC_Channel_aux::function_assigned(RC_Channel_aux::k_dspoiler2)) {
+            int16_t ch3 = channel_roll->radio_out;    //diff spoiler 1
+            int16_t ch4 = channel_pitch->radio_out;   //diff spoiler 2
+                   //convert rudder-servo output (-4500 to 4500) to PWM
+                   // offset value and multiply by DSPOILR_RUD_RATE/100:
+            int16_t ruddVal = (int16_t)((int32_t)(channel_rudder->servo_out) *
+                                         g.dspoiler_rud_rate / (SERVO_MAX/5));
+            if (ruddVal != 0) {   //if nonzero rudder then apply to spoilers
+                int16_t ch1 = ch3;          //elevon 1
+                int16_t ch2 = ch4;          //elevon 2
+                if (ruddVal > 0) {     //apply rudder to right or left side
+                    ch1 += ruddVal;
+                    ch3 -= ruddVal;
+                } else {
+                    ch2 += ruddVal;
+                    ch4 -= ruddVal;
+                }
+                channel_roll->radio_out = ch1;   //change elevon 1 position
+                channel_pitch->radio_out = ch2;  //change elevon 2 position
+            }
+                   //set positions of differential spoilers:
+            RC_Channel_aux::set_radio(RC_Channel_aux::k_dspoiler1, ch3);
+            RC_Channel_aux::set_radio(RC_Channel_aux::k_dspoiler2, ch4);
+        }
     }
 
     //send throttle to 0 or MIN_PWM if not yet armed

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -130,6 +130,8 @@ public:
         k_param_rtl_autoland,
         k_param_override_channel,
         k_param_stall_prevention,
+        k_param_mixing_offset,
+        k_param_dspoiler_rud_rate,
 #if OPTFLOW == ENABLED
         k_param_optflow,
 #endif
@@ -429,6 +431,8 @@ public:
     AP_Int8 reverse_elevons;
     AP_Int8 reverse_ch1_elevon;
     AP_Int8 reverse_ch2_elevon;
+    AP_Int16 mixing_offset;
+    AP_Int16 dspoiler_rud_rate;
     AP_Int16 num_resets;
     AP_Int32 log_bitmask;
     AP_Int8 reset_switch_chan;

--- a/ArduPlane/Parameters.pde
+++ b/ArduPlane/Parameters.pde
@@ -752,6 +752,22 @@ const AP_Param::Info var_info[] PROGMEM = {
     // @User: User
     GSCALAR(mixing_gain,            "MIXING_GAIN",    0.5f),
 
+    // @Param: MIXING_OFFSET
+    // @DisplayName: Mixing Offset
+    // @Description: The offset for the Vtail and elevon output mixers, as a percentage. This can be used in combination with MIXING_GAIN to configure how the control surfaces respond to input. The response to aileron or elevator input can be increased by setting this parameter to a positive or negative value. A common usage is to enter a positive value to increase the aileron response of the elevons of a flying wing. The default value of zero will leave the aileron-input response equal to the elevator-input response.
+    // @Units: percent
+    // @Range: -1000 1000
+    // @User: User
+    GSCALAR(mixing_offset,          "MIXING_OFFSET",  0),
+
+    // @Param: DSPOILR_RUD_RATE
+    // @DisplayName: Differential spoilers rudder rate
+    // @Description: Sets the amount of deflection that the rudder output will apply to the differential spoilers, as a percentage. The default value of 100 results in full rudder applying full deflection. A value of 0 will result in the differential spoilers exactly following the elevons (no rudder effect).
+    // @Units: percent
+    // @Range: -1000 1000
+    // @User: User
+    GSCALAR(dspoiler_rud_rate,      "DSPOILR_RUD_RATE",  DSPOILR_RUD_RATE_DEFAULT),
+
     // @Param: SYS_NUM_RESETS
     // @DisplayName: Num Resets
     // @Description: Number of APM board resets

--- a/ArduPlane/config.h
+++ b/ArduPlane/config.h
@@ -294,6 +294,10 @@
  # define ELEVON_CH2_REVERSE     DISABLED
 #endif
 
+#ifndef DSPOILR_RUD_RATE_DEFAULT
+ #define DSPOILR_RUD_RATE_DEFAULT 100
+#endif
+
 //////////////////////////////////////////////////////////////////////////////
 // CAMERA TRIGGER AND CONTROL
 //


### PR DESCRIPTION
Fixes ArduPlane differential spoilers when ELEVON_MIXING=0 and ELEVON_OUTPUT>0 (mixing done in flight controller).  All flight modes are supported.  This functionality is used on flying wings with "split elevons" using two servos on each side.  In v3.2 of ArduPlane, differential spoilers are non-operational (see issue #1032).  This patch fixes them so they operate as described in the ArduPlane docs:  http://plane.ardupilot.com/wiki/differential-spoilers

Added parameter:  DSPOILR_RUD_RATE  "Differential spoilers rudder rate"
Sets the amount of deflection that the rudder output will apply to the differential spoilers, as a percentage. The default value of 100 results in full rudder applying full deflection. A value of 0 will result in the differential spoilers exactly following the elevons (no rudder effect).

Added parameter:  MIXING_OFFSET
The offset for the Vtail and elevon output mixers, as a percentage. This can be used in combination with MIXING_GAIN to configure how the control surfaces respond to input. The response to aileron or elevator input can be increased by setting this parameter to a positive or negative value. A common usage is to enter a positive value to increase the aileron response of the elevons of a flying wing. The default value of zero will leave the aileron-input response equal to the elevator-input response.

Notes:  The new parameter DSPOILR_RUD_RATE allows the rudder effect to be "toned down."  Otherwise it can be too easy to apply too much rudder-spoiler control and stall the wing.  The new parameter MIXING_OFFSET allows the elevon mixing on a wing to be tuned so that the "aileron" effect is greater than the "elevator" effect.  Flying wings are usually pitch-sensitive while being difficult to roll, so this tuning is desirable.  I have successfully tested this patch (applied to ArduPlane v3.2 on APM2) in a 47" Popwing, in Manual, Stabilized, and GPS-guided flight modes.

Source and hex files are also posted here:  http://www.etheli.com/APM/ArduPlane_v3.2.0_etMod

--ET