### PR TITLE
ArduPlane: Arming updated to use RC channel objects not RC channels dire...

### DIFF
--- a/ArduPlane/radio.pde
+++ b/ArduPlane/radio.pde
@@ -89,7 +89,7 @@ static void rudder_arm_check()
     }
 
     //if throttle is not down, then pilot cannot rudder arm
-    if (g.rc_3.control_in > 0) {
+    if (channel_throttle->control_in > 0) {
         rudder_arm_timer = 0;
         return;
     }
@@ -101,7 +101,7 @@ static void rudder_arm_check()
     }
 
     // full right rudder starts arming counter
-    if (g.rc_4.control_in > 4000) {
+    if (channel_rudder->control_in > 4000) {
         uint32_t now = millis();
 
         if (rudder_arm_timer == 0 || 


### PR DESCRIPTION
The code had g.rc_3.control_in which would bypass the channel mapping and meant
arming could only occur if the throttle was always mapped to channel 3.
Updated to use the channel mapping object.