### PR TITLE
Plane: Corrected LOGGING_ENABLED when it is configure to DISABLED

### DIFF
--- a/ArduPlane/ArduPlane.pde
+++ b/ArduPlane/ArduPlane.pde
@@ -154,7 +154,6 @@ static void print_flight_mode(AP_HAL::BetterStream *port, uint8_t mode);
 ////////////////////////////////////////////////////////////////////////////////
 // DataFlash
 ////////////////////////////////////////////////////////////////////////////////
-#if LOGGING_ENABLED == ENABLED
 #if CONFIG_HAL_BOARD == HAL_BOARD_APM1
 static DataFlash_APM1 DataFlash;
 #elif CONFIG_HAL_BOARD == HAL_BOARD_APM2
@@ -164,7 +163,6 @@ static DataFlash_File DataFlash(HAL_BOARD_LOG_DIRECTORY);
 #else
 // no dataflash driver
 DataFlash_Empty DataFlash;
-#endif
 #endif
 
 // has a log download started?

--- a/ArduPlane/GCS_Mavlink.pde
+++ b/ArduPlane/GCS_Mavlink.pde
@@ -1084,8 +1084,10 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
                 // run pre_arm_checks and arm_checks and display failures
                 if (arming.arm(AP_Arming::MAVLINK)) {
                     //only log if arming was successful
-                    channel_throttle->enable_out();                        
+                    channel_throttle->enable_out();
+                    #if LOGGING_ENABLED == ENABLED                    
                     Log_Arm_Disarm();
+                    #endif
                     result = MAV_RESULT_ACCEPTED;
                 } else {
                     result = MAV_RESULT_FAILED;
@@ -1098,7 +1100,9 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
                     // reset the mission on disarm
                     mission.stop();
                     //only log if disarming was successful
+                    #if LOGGING_ENABLED == ENABLED                    
                     Log_Arm_Disarm();
+                    #endif
                     result = MAV_RESULT_ACCEPTED;
                 } else {
                     result = MAV_RESULT_FAILED;

--- a/ArduPlane/radio.pde
+++ b/ArduPlane/radio.pde
@@ -113,7 +113,9 @@ static void rudder_arm_check()
             if (arming.arm(AP_Arming::RUDDER)) {
                 channel_throttle->enable_out();                        
                 //only log if arming was successful
+                #if LOGGING_ENABLED == ENABLED
                 Log_Arm_Disarm();
+                #endif
             }                
         }
     } else { 

--- a/ArduPlane/sensors.pde
+++ b/ArduPlane/sensors.pde
@@ -19,9 +19,11 @@ static void init_rangefinder(void)
 static void read_rangefinder(void)
 {
     rangefinder.update();
-
+    
+    #if LOGGING_ENABLED == ENABLED
     if (should_log(MASK_LOG_SONAR))
         Log_Write_Sonar();
+    #endif
 
     rangefinder_height_update();
 }

--- a/ArduPlane/system.pde
+++ b/ArduPlane/system.pde
@@ -672,7 +672,9 @@ static bool should_log(uint32_t mask)
         // we have to set in_mavlink_delay to prevent logging while
         // writing headers
         in_mavlink_delay = true;
+        #if LOGGING_ENABLED == ENABLED
         start_logging();
+        #endif
         in_mavlink_delay = false;
     }
     return ret;


### PR DESCRIPTION
In APM_Config.h, when you try to set "#define LOGGING ENABLED" to disabled, code does not compile properly. 
Adding this changes make it possible.

Code compiles with Arduino IDE for Ardupilot and works great on legacy APM1.

Regards from Spain,
Dario.