### PR TITLE
Plane: Reactivate CLI on older boards 

### DIFF
--- a/ArduPlane/config.h
+++ b/ArduPlane/config.h
@@ -475,9 +475,7 @@
 #endif
 
 // use this for CLI options
-#ifndef CLI_LOGS_ENABLED
- # define CLI_LOGS_ENABLED ENABLED
-#endif
+// Logs option is defined by LOGGING_ENABLED
 
 #ifndef CLI_SETUP_ENABLED
 #if HAL_CPU_CLASS > HAL_CPU_CLASS_16

--- a/ArduPlane/config.h
+++ b/ArduPlane/config.h
@@ -469,13 +469,29 @@
  # define SCALING_SPEED          15.0
 #endif
 
-// use this to completely disable the CLI. We now default the CLI to
-// off on smaller boards.
+// use this to completely disable the CLI.
 #ifndef CLI_ENABLED
-#if HAL_CPU_CLASS > HAL_CPU_CLASS_16
  # define CLI_ENABLED ENABLED
-#else
- # define CLI_ENABLED DISABLE
+#endif
+
+// use this for CLI options
+#ifndef CLI_LOGS_ENABLED
+ # define CLI_LOGS_ENABLED ENABLED
+#endif
+
+#ifndef CLI_SETUP_ENABLED
+#if HAL_CPU_CLASS > HAL_CPU_CLASS_16
+ # define CLI_SETUP_ENABLED ENABLED
+#else 
+ # define CLI_SETUP_ENABLED DISABLED
+#endif
+#endif
+
+#ifndef CLI_TEST_ENABLED
+#if HAL_CPU_CLASS > HAL_CPU_CLASS_16
+ # define CLI_TEST_ENABLED ENABLED
+#else 
+ # define CLI_TEST_ENABLED DISABLED
 #endif
 #endif
 

--- a/ArduPlane/setup.pde
+++ b/ArduPlane/setup.pde
@@ -33,6 +33,7 @@ static const struct Menu::command setup_menu_commands[] PROGMEM = {
     {"erase",                       setup_erase},
 };
 
+#if CLI_SETUP_ENABLED == ENABLED
 // Create the setup menu object.
 MENU(setup_menu, "setup", setup_menu_commands);
 
@@ -52,6 +53,7 @@ setup_mode(uint8_t argc, const Menu::arg *argv)
     setup_menu.run();
     return 0;
 }
+#endif // CLI_SETUP_ENABLED
 
 // Print the current configuration.
 // Called by the setup menu 'show' command.

--- a/ArduPlane/system.pde
+++ b/ArduPlane/system.pde
@@ -21,8 +21,12 @@ static int8_t   main_menu_help(uint8_t argc, const Menu::arg *argv)
 {
     cliSerial->printf_P(PSTR("Commands:\n"
                          "  logs        log readback/setup mode\n"
+                    #if CLI_SETUP_ENABLED == ENABLED                
                          "  setup       setup mode\n"
+                    #endif
+                    #if CLI_TEST_ENABLED == ENABLED         
                          "  test        test mode\n"
+                    #endif                         
                          "  reboot      reboot to flight mode\n"
                          "\n"));
     return(0);
@@ -33,8 +37,12 @@ static const struct Menu::command main_menu_commands[] PROGMEM = {
 //   command		function called
 //   =======        ===============
     {"logs",                process_logs},
+#if CLI_SETUP_ENABLED == ENABLED    
     {"setup",               setup_mode},
+#endif
+#if CLI_TEST_ENABLED == ENABLED
     {"test",                test_mode},
+#endif    
     {"reboot",              reboot_board},
     {"help",                main_menu_help},
 };

--- a/ArduPlane/test.pde
+++ b/ArduPlane/test.pde
@@ -65,6 +65,7 @@ static const struct Menu::command test_menu_commands[] PROGMEM = {
 
 };
 
+#if CLI_TEST_ENABLED == ENABLED
 // A Macro to create the Menu
 MENU(test_menu, "test", test_menu_commands);
 
@@ -80,6 +81,7 @@ static void print_hit_enter()
 {
     cliSerial->printf_P(PSTR("Hit Enter to exit.\n\n"));
 }
+#endif // CLI_TEST_ENABLED
 
 static int8_t
 test_radio_pwm(uint8_t argc, const Menu::arg *argv)


### PR DESCRIPTION
Downloading logs trough Mavlink sometimes result in a corrupted file or it takes too many time for download.
With some restrictions and new defines on Config.h we can use CLI on older boards.

Code compiles with Arduino IDE for Ardupilot and works great on legacy APM1.

Regards from Spain,
Dario.


