### PR TITLE
SITL: Numerous improvements to vagrant image and easier SITL for mac/win

### DIFF
--- a/Tools/autotest/run_cmd.sh
+++ b/Tools/autotest/run_cmd.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# This is a helper script for run_in_terminal_window.sh.  I'm not sure why Ardupilot.elf exits if not run from inside of a script
+echo running $*
+( $* )
+echo cmd exited

--- a/Tools/autotest/run_in_terminal_window.sh
+++ b/Tools/autotest/run_in_terminal_window.sh
@@ -13,8 +13,14 @@ elif [ -x /usr/bin/konsole ]; then
   /usr/bin/konsole --hold -e $*
 elif [ -x /usr/bin/gnome-terminal ]; then
   /usr/bin/gnome-terminal -e "$*"
+elif [ -n "$STY" ]; then
+  # We are running inside of screen, try to start it there
+  /usr/bin/screen -X screen -t $name $*
 else
-  echo "ERROR: Please install xterm"
-  exit 1
+  filename="/tmp/$name.log"
+  echo "Window access not found, logging to $filename"
+  cmd="$1"
+  shift
+  ( run_cmd.sh $cmd $* &>$filename < /dev/null ) &
 fi
 exit 0

--- a/Tools/autotest/sim_vehicle.sh
+++ b/Tools/autotest/sim_vehicle.sh
@@ -210,6 +210,10 @@ pushd $autotest/../../$VEHICLE || {
     usage
     exit 1
 }
+if [ ! -f $autotest/../../config.mk ]; then
+    echo Generating a default configuration
+    make configure
+fi
 if [ $CLEAN_BUILD == 1 ]; then
     make clean
 fi
@@ -321,6 +325,11 @@ fi
 options=""
 if [ $START_HIL == 0 ]; then
 options="--master $MAVLINK_PORT --sitl $SIMOUT_PORT"
+fi
+
+# If running inside of a vagrant guest, then we probably want to forward our mavlink out to the containing host OS
+if [ $USER == "vagrant" ]; then
+options="$options --out 10.0.2.2:14550"
 fi
 options="$options --out 127.0.0.1:14550 --out 127.0.0.1:14551"
 extra_cmd1=""

--- a/Tools/vagrant/README.md
+++ b/Tools/vagrant/README.md
@@ -7,6 +7,8 @@ This README is mean't to be the instructions on how to run this.
 
 Windows, OS-X and Linux are supported.  [Download](https://www.vagrantup.com/downloads.html) and install per their instructions.
 
+If you are on Windows you will want to [install](https://www.virtualbox.org/wiki/Downloads) VirtualBox prior to installing Vagrant.
+
 ## Start a vagrant instance
 
 * Change the current directory to be any directory inside this source tree and run "vagrant up".  It will start running the instance

--- a/Tools/vagrant/README.md
+++ b/Tools/vagrant/README.md
@@ -1,0 +1,34 @@
+# Vagrant for SITL and ardupilot development
+
+We support a vagrant container for _easily_ running SITL (software in the loop simulator) and compling Ardupilot code.
+This README is mean't to be the instructions on how to run this.
+
+## Install vagrant for your platform
+
+Windows, OS-X and Linux are supported.  [Download](https://www.vagrantup.com/downloads.html) and install per their instructions.
+
+## Start a vagrant instance
+
+* Change the current directory to be any directory inside this source tree and run "vagrant up".  It will start running the instance
+in a VM (the initial time you run this command it will likely need to fetch many things).  All the files in this directory tree will
+magically appear inside the running instance at /vagrant.  
+
+## Start running SITL
+
+In your vagrant shell run:
+<pre>
+vagrant ssh -c "sim_vehicle.sh -j 2"
+</pre>
+This will build the Ardupilot code if needed and then run the simulator.  The mavlink prompt allows you to monitor vehicle state.  To exit
+the simulation just press control-d to exit the mavlink shell.
+
+## Run mission planner or mavproxy in your main OS
+
+You can now connect to the running simulator from your main OS.  Just connect to UDP port 14550, either from mission planner or mavproxy. 
+The mavproxy command is "mavproxy.py --master=127.0.0.1:14550"
+
+## Shutting down the simulator
+
+* When you are done with the simulator, just press ctrl-d in the vagrant ssh window to exit the special mavproxy that is gluing everything together.
+* Run "vagrant suspend" to stop the running VM.  When you need it again just run "vagrant up" to resume.
+

--- a/Tools/vagrant/initvagrant.sh
+++ b/Tools/vagrant/initvagrant.sh
@@ -9,10 +9,19 @@ sudo apt-get -y install dos2unix python-wxgtk2.8 python-scipy python-matplotlib 
 sudo pip install pymavlink MAVProxy
 
 echo "source /vagrant/Tools/vagrant/shellinit.sh" >>/home/vagrant/.profile
+rm /home/vagrant/.screenrc
 ln -s /vagrant/Tools/vagrant/screenrc /home/vagrant/.screenrc
 
-echo "NOTE: Currently this vagrant file only support simulating copters and rovers, adding support for plane would be straightforward,"
-echo "just add JSB sim per Tridge's instructions (and send in a pull-request)"
+# build JSB sim
+pushd /tmp
+rm -rf jsbsim
+git clone git://github.com/tridge/jsbsim.git
+sudo apt-get install libtool automake autoconf libexpat1-dev
+cd jsbsim
+./autogen.sh
+make -j2
+sudo make install
+popd
 
-# 
+# Now you can run
 # vagrant ssh -c "screen -d -R"

--- a/Tools/vagrant/initvagrant.sh
+++ b/Tools/vagrant/initvagrant.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e 
+
+echo "Initial setup of SITL-vagrant instance."
+sudo apt-get -y update
+sudo apt-get -y install dos2unix python-wxgtk2.8 python-scipy python-matplotlib python-opencv python-pip g++ g++-4.7 gawk git ccache  python-serial python-wxgtk2.8 python-lxml screen
+
+sudo pip install pymavlink MAVProxy
+
+echo "source /vagrant/Tools/vagrant/shellinit.sh" >>/home/vagrant/.profile
+ln -s /vagrant/Tools/vagrant/screenrc /home/vagrant/.screenrc
+
+echo "NOTE: Currently this vagrant file only support simulating copters and rovers, adding support for plane would be straightforward,"
+echo "just add JSB sim per Tridge's instructions (and send in a pull-request)"
+
+# 
+# vagrant ssh -c "screen -d -R"

--- a/Tools/vagrant/screenrc
+++ b/Tools/vagrant/screenrc
@@ -1,0 +1,10 @@
+altscreen on
+term screen-256color
+bind ',' prev
+bind '.' next
+#
+#change the hardstatus settings to give an window list at the bottom of the
+#screen, with the time and date and with the current window highlighted
+hardstatus alwayslastline
+#hardstatus string '%{= kG}%-Lw%{= kW}%50> %n%f* %t%{= kG}%+Lw%< %{= kG}%-=%c:%s%{-}'
+hardstatus string '%{= kG}[ %{G}%H %{g}][%= %{= kw}%?%-Lw%?%{r}(%{W}%n*%f%t%?(%u)%?%{r})%{w}%?%+Lw%?%?%= %{g}][%{B} %m-%d %{W}%c %{g}]'

--- a/Tools/vagrant/shellinit.sh
+++ b/Tools/vagrant/shellinit.sh
@@ -1,0 +1,11 @@
+# Init that is run every time a new session starts up
+
+export APMROOT=/vagrant
+export PATH=$APMROOT/Tools/autotest:$PATH
+
+cd $APMROOT/ArduCopter
+
+echo "Ardupilot environment ready.  Run 'sim_vehicle.sh' to start simulating an arducopter instance."
+echo "or run 'make sitl' to just do a test build."
+echo "NOTE: This vagrant build environment isn't currently intended for building PX4 loads, but if someone wants"
+echo "to add that ability it wouldn't be too difficult."

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,15 +1,35 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-Vagrant::Config.run do |config|
-  config.vm.box = "ubuntu-12.04-32bit"
-  config.vm.box_url = "http://files.vagrantup.com/precise32.box"
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
 
-  config.vm.share_folder("ardupilot", "/home/vagrant/ardupilot", ".")
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  # Allow symlinks
-  config.vm.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/cross-compiler", "1"]
-  # Otherwise the compile will go into swap, making things slow
-  config.vm.customize ["modifyvm", :id, "--memory", "2048"]
+  config.vm.box = "ubuntu/trusty32"
+  # push.app = "geeksville/ardupilot-sitl"
+
+  # Allow symlinks - I think this is no longer needed
+  # config.vm.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/cross-compiler", "1"]
+
+  # The following forwarding is not necessary (or possible), because our sim_vehicle.sh is smart enough to send packets
+  # out to the containing OS
+  # config.vm.network "forwarded_port", guest: 14550, host: 14550, protocol: "udp"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "virtualbox" do |vb|
+      # Don't boot with headless mode
+      #   vb.gui = true
+      #
+      #   # Use VBoxManage to customize the VM. For example to change memory:
+      vb.customize ["modifyvm", :id, "--memory", "2048"]
+      vb.customize ["modifyvm", :id, "--ioapic", "on"]
+      vb.customize ["modifyvm", :id, "--cpus", "2"]
+  end
+
+  config.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"  
 end
 


### PR DESCRIPTION
For full instructions/notes see Tools/vagrant/README.md

Notes:
* Old Vagrantfile updated to run faster and self init with our various
build dependancies.
* The sim_vehicle.sh script will now implicitly configure if necessary
* run_in_terminal_window.sh is now smart enough to use Screen sessions.  Or
if those are not available to warn the user but run the command with logging
going to a file in /tmp.