### PR TITLE
AC_PosControl: Remove un-needed/unused line.

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -165,7 +165,7 @@ void AC_PosControl::set_target_to_stopping_point_z()
     get_stopping_point_z(_pos_target);
 }
 
-/// get_stopping_point_z - sets stopping_point.z to a reasonable stopping altitude in cm above home
+/// get_stopping_point_z - calculates stopping point based on current position, velocity, vehicle acceleration
 void AC_PosControl::get_stopping_point_z(Vector3f& stopping_point) const
 {
     const float curr_pos_z = _inav.get_altitude();

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -145,7 +145,6 @@ void AC_PosControl::set_alt_target_from_climb_rate(float climb_rate_cms, float d
     // do not let target alt get above limit
     if (_alt_max > 0 && _pos_target.z > _alt_max) {
         _pos_target.z = _alt_max;
-        _limit.pos_up = true;
     }
 
     _vel_desired.z = climb_rate_cms;

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -128,7 +128,7 @@ public:
     /// set_target_to_stopping_point_z - sets altitude target to reasonable stopping altitude in cm above home
     void set_target_to_stopping_point_z();
 
-    /// get_stopping_point_z - sets stopping_point.z to a reasonable stopping altitude in cm above home
+    /// get_stopping_point_z - calculates stopping point based on current position, velocity, vehicle acceleration
     void get_stopping_point_z(Vector3f& stopping_point) const;
 
     /// init_takeoff - initialises target altitude if we are taking off


### PR DESCRIPTION
This line serves no purpose.

_limit.pos_up is shortly after reset to false at the top of pos_to_rate_z() before it is used in anyway. 