### PR TITLE
Copter: 90-atan2(-x,y) is the same as atan2(y,x)

### DIFF
--- a/ArduCopter/position_vector.pde
+++ b/ArduCopter/position_vector.pde
@@ -38,7 +38,7 @@ Vector3f pv_location_to_vector_with_default(const Location& loc, const Vector3f&
 // pv_get_bearing_cd - return bearing in centi-degrees between two positions
 float pv_get_bearing_cd(const Vector3f &origin, const Vector3f &destination)
 {
-    float bearing = 9000 + fast_atan2(-(destination.x-origin.x), destination.y-origin.y) * DEGX100;
+    float bearing = fast_atan2(destination.y-origin.y, destination.x-origin.x) * DEGX100;
     if (bearing < 0) {
         bearing += 36000;
     }

--- a/libraries/AC_WPNav/AC_Circle.cpp
+++ b/libraries/AC_WPNav/AC_Circle.cpp
@@ -246,7 +246,7 @@ void AC_Circle::init_start_angle(bool use_heading)
             _angle = wrap_PI(_ahrs.yaw-PI);
         } else {
             // get bearing from circle center to vehicle in radians
-            float bearing_rad = ToRad(90) + fast_atan2(-(curr_pos.x-_center.x), curr_pos.y-_center.y);
+            float bearing_rad = fast_atan2(curr_pos.y-_center.y,curr_pos.x-_center.x);
             _angle = wrap_PI(bearing_rad);
         }
     }


### PR DESCRIPTION
    from math import *
    from numpy import linspace

    def test_atan2(y,x):
        ret = pi/2+atan2(-x,y)
        if ret < -pi:
            ret += 2*pi
        if ret > pi:
            ret -= 2*pi
        return ret

    for x in linspace(-1,1,100):
        for y in linspace(-1,1,100):
            difference = abs(test_atan2(y,x)-atan2(y,x))
            if difference > 1.0e-15:
                print difference