### PR TITLE
ArduPlane - crash detection on landing

### DIFF
--- a/ArduPlane/ArduPlane.pde
+++ b/ArduPlane/ArduPlane.pde
@@ -1500,18 +1500,24 @@ static void update_flight_stage(void)
         if (control_mode==AUTO) {
             if (auto_state.takeoff_complete == false) {
                 set_flight_stage(AP_SpdHgtControl::FLIGHT_TAKEOFF);
-            } else if (mission.get_current_nav_cmd().id == MAV_CMD_NAV_LAND && 
+            } else if (mission.get_current_nav_cmd().id == MAV_CMD_NAV_LAND &&
                        auto_state.land_complete == true) {
                 set_flight_stage(AP_SpdHgtControl::FLIGHT_LAND_FINAL);
             } else if (mission.get_current_nav_cmd().id == MAV_CMD_NAV_LAND) {
-                set_flight_stage(AP_SpdHgtControl::FLIGHT_LAND_APPROACH); 
+                if (auto_state.land_complete == true) {
+                    set_flight_stage(AP_SpdHgtControl::FLIGHT_LAND_FINAL);
+                } else if (!is_flying()) {
+                    // crash detected. Disable throttle for safety and to protect ESC over-current
+                    gcs_send_text_P(SEVERITY_HIGH, PSTR("CRASH DETECTED!!!"));
+                    auto_state.land_complete = true;
+                    set_flight_stage(AP_SpdHgtControl::FLIGHT_LAND_FINAL);
+                } else {
+                    set_flight_stage(AP_SpdHgtControl::FLIGHT_LAND_APPROACH);
+                }
             } else {
                 set_flight_stage(AP_SpdHgtControl::FLIGHT_NORMAL);
             }
-        } else {
-            set_flight_stage(AP_SpdHgtControl::FLIGHT_NORMAL);
         }
-
         SpdHgt_Controller->update_pitch_throttle(relative_target_altitude_cm(),
                                                  target_airspeed_cm,
                                                  flight_stage,


### PR DESCRIPTION
When landing using the LAND waypoint, check for !is_flying() when in FLIGHT_LAND_APPROACH. If we have crashed, move flight stage up so that motor is disabled.
This helps in the case where on long missions the baro drift can push us into the ground well before the flare stage. While crashed and still on approach, this will inhibit the motor and end the mission.