### PR TITLE
ArduPlane - crash detection on auto landing

### DIFF
--- a/ArduPlane/ArduPlane.pde
+++ b/ArduPlane/ArduPlane.pde
@@ -1508,6 +1508,8 @@ static void update_flight_stage(void)
             } else {
                 set_flight_stage(AP_SpdHgtControl::FLIGHT_NORMAL);
             }
+        } else {
+            set_flight_stage(AP_SpdHgtControl::FLIGHT_NORMAL);
         }
         SpdHgt_Controller->update_pitch_throttle(relative_target_altitude_cm(),
                                                  target_airspeed_cm,

--- a/ArduPlane/ArduPlane.pde
+++ b/ArduPlane/ArduPlane.pde
@@ -1511,6 +1511,7 @@ static void update_flight_stage(void)
         } else {
             set_flight_stage(AP_SpdHgtControl::FLIGHT_NORMAL);
         }
+
         SpdHgt_Controller->update_pitch_throttle(relative_target_altitude_cm(),
                                                  target_airspeed_cm,
                                                  flight_stage,

--- a/ArduPlane/ArduPlane.pde
+++ b/ArduPlane/ArduPlane.pde
@@ -1500,18 +1500,27 @@ static void update_flight_stage(void)
         if (control_mode==AUTO) {
             if (auto_state.takeoff_complete == false) {
                 set_flight_stage(AP_SpdHgtControl::FLIGHT_TAKEOFF);
-            } else if (mission.get_current_nav_cmd().id == MAV_CMD_NAV_LAND && 
+            } else if (mission.get_current_nav_cmd().id == MAV_CMD_NAV_LAND &&
                        auto_state.land_complete == true) {
                 set_flight_stage(AP_SpdHgtControl::FLIGHT_LAND_FINAL);
             } else if (mission.get_current_nav_cmd().id == MAV_CMD_NAV_LAND) {
-                set_flight_stage(AP_SpdHgtControl::FLIGHT_LAND_APPROACH); 
+                set_flight_stage(AP_SpdHgtControl::FLIGHT_LAND_APPROACH);
+                if (auto_state.land_complete == true) {
+                    set_flight_stage(AP_SpdHgtControl::FLIGHT_LAND_FINAL);
+                }
+                else if (!is_flying()) {
+                    // crash detected. Disable throttle for safety and to protect ESC over-current
+                    gcs_send_text_P(SEVERITY_HIGH, PSTR("CRASH DETECTED!!!"));
+                    auto_state.land_complete = true;
+                    set_flight_stage(AP_SpdHgtControl::FLIGHT_LAND_FINAL);
+                }
+                else {
+                    set_flight_stage(AP_SpdHgtControl::FLIGHT_LAND_APPROACH);
+                }
             } else {
                 set_flight_stage(AP_SpdHgtControl::FLIGHT_NORMAL);
             }
-        } else {
-            set_flight_stage(AP_SpdHgtControl::FLIGHT_NORMAL);
         }
-
         SpdHgt_Controller->update_pitch_throttle(relative_target_altitude_cm(),
                                                  target_airspeed_cm,
                                                  flight_stage,

--- a/ArduPlane/landing.pde
+++ b/ArduPlane/landing.pde
@@ -42,13 +42,14 @@ static bool verify_land()
     // low pass the sink rate to take some of the noise out
     auto_state.land_sink_rate = 0.8f * auto_state.land_sink_rate + 0.2f*sink_rate;
     
-    /* Set land_complete (which starts the flare) under 3 conditions:
+    /* Set land_complete (which starts the flare) under 4 conditions:
        1) we are within LAND_FLARE_ALT meters of the landing altitude
        2) we are within LAND_FLARE_SEC of the landing point vertically
           by the calculated sink rate
        3) we have gone past the landing point and don't have
           rangefinder data (to prevent us keeping throttle on 
           after landing if we've had positive baro drift)
+       4) we have detected a crash before reaching the land waypoint
     */
     if (get_distance(current_loc, next_WP_loc) > 15)
     {

--- a/ArduPlane/landing.pde
+++ b/ArduPlane/landing.pde
@@ -51,10 +51,8 @@ static bool verify_land()
           after landing if we've had positive baro drift)
        4) we have detected a crash before reaching the land waypoint
     */
-    if (get_distance(current_loc, next_WP_loc) > 15)
-    {
-        if (!is_flying())
-        {
+    if (get_distance(current_loc, next_WP_loc) > 15) {
+        if (!is_flying()) {
             if (!auto_state.land_complete) {
                 // if not flying while on approach then we have crashed instead of flared
                 gcs_send_text_P(SEVERITY_HIGH, PSTR("CRASH DETECTED!!!"));


### PR DESCRIPTION
- when on approach during an autoland, check if we are flying. If not, advance us to land_final to flare which disengages the motor. This helps with the scenario of  baro without rangefinder. If the baro drifted so much during flight that the ground is now above the flare sec/alt value then we will hit the ground and never flare which potentially keeps the motor running as it tries to speed up to reach the land waypoint. This is a safety concern as well as a protection of the ESC.