### PR TITLE
AP_InertialSensor: add high-rate IMU sampling and delta angle accumulation

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -247,6 +247,8 @@ AP_InertialSensor::AP_InertialSensor() :
         _accel_error_count[i] = 0;
         _gyro_error_count[i] = 0;
     }
+    memset(_delta_velocity_valid,0,sizeof(_delta_velocity_valid));
+    memset(_delta_angle_valid,0,sizeof(_delta_angle_valid));
 }
 
 
@@ -1002,6 +1004,8 @@ void AP_InertialSensor::update(void)
             // _publish_accel()
             _gyro_healthy[i] = false;
             _accel_healthy[i] = false;
+            _delta_velocity_valid[i] = false;
+            _delta_angle_valid[i] = false;
         }
         for (uint8_t i=0; i<_backend_count; i++) {
             _backends[i]->update();

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -998,8 +998,8 @@ void AP_InertialSensor::update(void)
     if (!_hil_mode) {
         for (uint8_t i=0; i<INS_MAX_INSTANCES; i++) {
             // mark sensors unhealthy and let update() in each backend
-            // mark them healthy via _rotate_and_offset_gyro() and
-            // _rotate_and_offset_accel() 
+            // mark them healthy via _publish_gyro() and
+            // _publish_accel()
             _gyro_healthy[i] = false;
             _accel_healthy[i] = false;
         }

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -116,6 +116,23 @@ public:
     const Vector3f &get_gyro_offsets(uint8_t i) const { return _gyro_offset[i]; }
     const Vector3f &get_gyro_offsets(void) const { return get_gyro_offsets(_primary_gyro); }
 
+    //get delta angle if available
+    bool get_delta_angle(uint8_t i, Vector3f &delta_angle) const {
+        if(_delta_angle_valid[i]) delta_angle = _delta_angle[i];
+        return _delta_angle_valid[i];
+    }
+
+    bool get_delta_angle(Vector3f &delta_angle) const { return get_delta_angle(_primary_gyro, delta_angle); }
+
+
+    //get delta velocity if available
+    bool get_delta_velocity(uint8_t i, Vector3f &delta_velocity) const {
+        if(_delta_velocity_valid[i]) delta_velocity = _delta_velocity[i];
+        return _delta_velocity_valid[i];
+    }
+
+    bool get_delta_velocity(Vector3f &delta_velocity) const { return get_delta_velocity(_primary_accel, delta_velocity); }
+
     /// Fetch the current accelerometer values
     ///
     /// @returns	vector of current accelerations in m/s/s
@@ -236,9 +253,13 @@ private:
     
     // Most recent accelerometer reading
     Vector3f _accel[INS_MAX_INSTANCES];
+    Vector3f _delta_velocity[INS_MAX_INSTANCES];
+    bool _delta_velocity_valid[INS_MAX_INSTANCES];
 
     // Most recent gyro reading
     Vector3f _gyro[INS_MAX_INSTANCES];
+    Vector3f _delta_angle[INS_MAX_INSTANCES];
+    bool _delta_angle_valid[INS_MAX_INSTANCES];
 
     // product id
     AP_Int16 _product_id;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -12,7 +12,7 @@ AP_InertialSensor_Backend::AP_InertialSensor_Backend(AP_InertialSensor &imu) :
 /*
   rotate gyro vector and add the gyro offset
  */
-void AP_InertialSensor_Backend::_rotate_and_offset_gyro(uint8_t instance, const Vector3f &gyro)
+void AP_InertialSensor_Backend::_publish_gyro(uint8_t instance, const Vector3f &gyro)
 {
     _imu._gyro[instance] = gyro;
     _imu._gyro[instance].rotate(_imu._board_orientation);
@@ -23,7 +23,7 @@ void AP_InertialSensor_Backend::_rotate_and_offset_gyro(uint8_t instance, const 
 /*
   rotate accel vector, scale and add the accel offset
  */
-void AP_InertialSensor_Backend::_rotate_and_offset_accel(uint8_t instance, const Vector3f &accel)
+void AP_InertialSensor_Backend::_publish_accel(uint8_t instance, const Vector3f &accel)
 {
     _imu._accel[instance] = accel;
     _imu._accel[instance].rotate(_imu._board_orientation);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -61,14 +61,17 @@ protected:
     // access to frontend
     AP_InertialSensor &_imu;
 
-    // rotate gyro vector and offset
-    void _rotate_and_offset_gyro(uint8_t instance, const Vector3f &gyro);
+    void _rotate_and_correct_accel(uint8_t instance, Vector3f &accel);
+    void _rotate_and_correct_gyro(uint8_t instance, Vector3f &gyro);
+
+    void _publish_delta_velocity(uint8_t instance, const Vector3f &delta_velocity);
+    void _publish_delta_angle(uint8_t instance, const Vector3f &delta_angle);
 
     // rotate gyro vector, offset and publish
-    void _publish_gyro(uint8_t instance, const Vector3f &gyro);
+    void _publish_gyro(uint8_t instance, const Vector3f &gyro, bool rotate_and_correct = true);
 
     // rotate accel vector, scale, offset and publish
-    void _publish_accel(uint8_t instance, const Vector3f &accel);
+    void _publish_accel(uint8_t instance, const Vector3f &accel, bool rotate_and_correct = true);
 
     // set accelerometer error_count
     void _set_accel_error_count(uint8_t instance, uint32_t error_count);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -36,7 +36,7 @@ public:
     /* 
      * Update the sensor data. Called by the frontend to transfer
      * accumulated sensor readings to the frontend structure via the
-     * _rotate_and_offset_gyro() and _rotate_and_offset_accel() functions
+     * _publish_gyro() and _publish_accel() functions
      */
     virtual bool update() = 0;
 
@@ -64,8 +64,11 @@ protected:
     // rotate gyro vector and offset
     void _rotate_and_offset_gyro(uint8_t instance, const Vector3f &gyro);
 
-    // rotate accel vector, scale and offset
-    void _rotate_and_offset_accel(uint8_t instance, const Vector3f &accel);
+    // rotate gyro vector, offset and publish
+    void _publish_gyro(uint8_t instance, const Vector3f &gyro);
+
+    // rotate accel vector, scale, offset and publish
+    void _publish_accel(uint8_t instance, const Vector3f &accel);
 
     // set accelerometer error_count
     void _set_accel_error_count(uint8_t instance, uint32_t error_count);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Flymaple.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Flymaple.cpp
@@ -67,12 +67,8 @@ AP_InertialSensor_Flymaple::AP_InertialSensor_Flymaple(AP_InertialSensor &imu) :
     AP_InertialSensor_Backend(imu),
     _have_gyro_sample(false),
     _have_accel_sample(false),
-    _accel_filter_x(raw_sample_rate_hz, 10),
-    _accel_filter_y(raw_sample_rate_hz, 10),
-    _accel_filter_z(raw_sample_rate_hz, 10),
-    _gyro_filter_x(raw_sample_rate_hz, 10),
-    _gyro_filter_y(raw_sample_rate_hz, 10),
-    _gyro_filter_z(raw_sample_rate_hz, 10),
+    _accel_filter(raw_sample_rate_hz, 10),
+    _gyro_filter(raw_sample_rate_hz, 10),
     _last_gyro_timestamp(0),
     _last_accel_timestamp(0)
 {}
@@ -167,12 +163,8 @@ void AP_InertialSensor_Flymaple::_set_filter_frequency(uint8_t filter_hz)
     if (filter_hz == 0)
         filter_hz = _default_filter_hz;
 
-    _accel_filter_x.set_cutoff_frequency(raw_sample_rate_hz, filter_hz);
-    _accel_filter_y.set_cutoff_frequency(raw_sample_rate_hz, filter_hz);
-    _accel_filter_z.set_cutoff_frequency(raw_sample_rate_hz, filter_hz);
-    _gyro_filter_x.set_cutoff_frequency(raw_sample_rate_hz, filter_hz);
-    _gyro_filter_y.set_cutoff_frequency(raw_sample_rate_hz, filter_hz);
-    _gyro_filter_z.set_cutoff_frequency(raw_sample_rate_hz, filter_hz);
+    _accel_filter.set_cutoff_frequency(raw_sample_rate_hz, filter_hz);
+    _gyro_filter.set_cutoff_frequency(raw_sample_rate_hz, filter_hz);
 }
 
 
@@ -239,9 +231,7 @@ void AP_InertialSensor_Flymaple::_accumulate(void)
         int16_t y = -((((int16_t)buffer[1]) << 8) | buffer[0]);    // chip X axis
         int16_t x = -((((int16_t)buffer[3]) << 8) | buffer[2]);    // chip Y axis
         int16_t z = -((((int16_t)buffer[5]) << 8) | buffer[4]);    // chip Z axis
-        _accel_filtered = Vector3f(_accel_filter_x.apply(x),
-                                   _accel_filter_y.apply(y),
-                                   _accel_filter_z.apply(z));
+        _accel_filtered = _accel_filter.apply(Vector3f(x,y,z));
         _have_accel_sample = true;
         _last_accel_timestamp = now;
     }
@@ -256,9 +246,7 @@ void AP_InertialSensor_Flymaple::_accumulate(void)
         int16_t y = -((((int16_t)buffer[0]) << 8) | buffer[1]);    // chip X axis
         int16_t x = -((((int16_t)buffer[2]) << 8) | buffer[3]);    // chip Y axis
         int16_t z = -((((int16_t)buffer[4]) << 8) | buffer[5]);    // chip Z axis
-        _gyro_filtered = Vector3f(_gyro_filter_x.apply(x),
-                                  _gyro_filter_y.apply(y),
-                                  _gyro_filter_z.apply(z));
+        _gyro_filtered = _gyro_filter.apply(Vector3f(x,y,z));
         _have_gyro_sample = true;
         _last_gyro_timestamp = now;
     }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Flymaple.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Flymaple.cpp
@@ -182,11 +182,11 @@ bool AP_InertialSensor_Flymaple::update(void)
 
     // Adjust for chip scaling to get m/s/s
     accel *= FLYMAPLE_ACCELEROMETER_SCALE_M_S;
-    _rotate_and_offset_accel(_accel_instance, accel);
+    _publish_accel(_accel_instance, accel);
 
     // Adjust for chip scaling to get radians/sec
     gyro *= FLYMAPLE_GYRO_SCALE_R_S;
-    _rotate_and_offset_gyro(_gyro_instance, gyro);
+    _publish_gyro(_gyro_instance, gyro);
 
     if (_last_filter_hz != _imu.get_filter()) {
         _set_filter_frequency(_imu.get_filter());

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Flymaple.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Flymaple.h
@@ -38,12 +38,8 @@ private:
 
     void _set_filter_frequency(uint8_t filter_hz);
     // Low Pass filters for gyro and accel 
-    LowPassFilter2p _accel_filter_x;
-    LowPassFilter2p _accel_filter_y;
-    LowPassFilter2p _accel_filter_z;
-    LowPassFilter2p _gyro_filter_x;
-    LowPassFilter2p _gyro_filter_y;
-    LowPassFilter2p _gyro_filter_z;
+    LowPassFilter2pVector3f _accel_filter;
+    LowPassFilter2pVector3f _gyro_filter;
 
     uint8_t _gyro_instance;
     uint8_t _accel_instance;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.cpp
@@ -251,11 +251,11 @@ bool AP_InertialSensor_L3G4200D::update(void)
 
     // Adjust for chip scaling to get m/s/s
     accel *= ADXL345_ACCELEROMETER_SCALE_M_S;
-    _rotate_and_offset_accel(_accel_instance, accel);
+    _publish_accel(_accel_instance, accel);
 
     // Adjust for chip scaling to get radians/sec
     gyro *= L3G4200D_GYRO_SCALE_R_S;
-    _rotate_and_offset_gyro(_gyro_instance, gyro);
+    _publish_gyro(_gyro_instance, gyro);
 
     if (_last_filter_hz != _imu.get_filter()) {
         _set_filter_frequency(_imu.get_filter());

--- a/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.cpp
@@ -115,12 +115,8 @@ AP_InertialSensor_L3G4200D::AP_InertialSensor_L3G4200D(AP_InertialSensor &imu) :
     AP_InertialSensor_Backend(imu),
     _have_gyro_sample(false),
     _have_accel_sample(false),
-    _accel_filter_x(800, 10),
-    _accel_filter_y(800, 10),
-    _accel_filter_z(800, 10),
-    _gyro_filter_x(800, 10),
-    _gyro_filter_y(800, 10),
-    _gyro_filter_z(800, 10)
+    _accel_filter(800, 10),
+    _gyro_filter(800, 10),
 {}
 
 bool AP_InertialSensor_L3G4200D::_init_sensor(void) 
@@ -235,12 +231,8 @@ void AP_InertialSensor_L3G4200D::_set_filter_frequency(uint8_t filter_hz)
     if (filter_hz == 0)
         filter_hz = _default_filter_hz;
 
-    _accel_filter_x.set_cutoff_frequency(800, filter_hz);
-    _accel_filter_y.set_cutoff_frequency(800, filter_hz);
-    _accel_filter_z.set_cutoff_frequency(800, filter_hz);
-    _gyro_filter_x.set_cutoff_frequency(800, filter_hz);
-    _gyro_filter_y.set_cutoff_frequency(800, filter_hz);
-    _gyro_filter_z.set_cutoff_frequency(800, filter_hz);
+    _accel_filter.set_cutoff_frequency(800, filter_hz);
+    _gyro_filter.set_cutoff_frequency(800, filter_hz);
 }
 
 /*
@@ -308,9 +300,7 @@ void AP_InertialSensor_L3G4200D::_accumulate(void)
         if (hal.i2c->readRegisters(L3G4200D_I2C_ADDRESS, L3G4200D_REG_XL | L3G4200D_REG_AUTO_INCREMENT, 
                                    sizeof(buffer), (uint8_t *)&buffer[0][0]) == 0) {
             for (uint8_t i=0; i<num_samples_available; i++) {
-                _gyro_filtered = Vector3f(_gyro_filter_x.apply(buffer[i][0]), 
-                                          _gyro_filter_y.apply(-buffer[i][1]), 
-                                          _gyro_filter_z.apply(-buffer[i][2]));
+                _gyro_filtered = _gyro_filter.apply(Vector3f(buffer[i][0], -buffer[i][1], -buffer[i][2]));
                 _have_gyro_sample = true;
             }
         }
@@ -330,9 +320,7 @@ void AP_InertialSensor_L3G4200D::_accumulate(void)
                                            sizeof(buffer[0]), num_samples_available,
                                            (uint8_t *)&buffer[0][0]) == 0) {
             for (uint8_t i=0; i<num_samples_available; i++) {
-                _accel_filtered = Vector3f(_accel_filter_x.apply(buffer[i][0]),
-                                           _accel_filter_y.apply(-buffer[i][1]),
-                                           _accel_filter_z.apply(-buffer[i][2]));
+                _accel_filtered = _accel_filter.apply(Vector3f(buffer[i][0], -buffer[i][1], -buffer[i][2]));
                 _have_accel_sample = true;
             }
         }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.h
@@ -43,12 +43,8 @@ private:
     void _set_filter_frequency(uint8_t filter_hz);
 
     // Low Pass filters for gyro and accel 
-    LowPassFilter2p _accel_filter_x;
-    LowPassFilter2p _accel_filter_y;
-    LowPassFilter2p _accel_filter_z;
-    LowPassFilter2p _gyro_filter_x;
-    LowPassFilter2p _gyro_filter_y;
-    LowPassFilter2p _gyro_filter_z;
+    LowPassFilter2pVector3f _accel_filter;
+    LowPassFilter2pVector3f _gyro_filter;
 
     // gyro and accel instances
     uint8_t _gyro_instance;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -295,10 +295,10 @@ bool AP_InertialSensor_MPU6000::update( void )
     hal.scheduler->resume_timer_procs();
 
     gyro *= _gyro_scale / num_samples;
-    _rotate_and_offset_gyro(_gyro_instance, gyro);
+    _publish_gyro(_gyro_instance, gyro);
 
     accel *= MPU6000_ACCEL_SCALE_1G / num_samples;
-    _rotate_and_offset_accel(_accel_instance, accel);
+    _publish_accel(_accel_instance, accel);
 
     if (_last_filter_hz != _imu.get_filter()) {
         if (_spi_sem->take(10)) {

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -181,12 +181,8 @@ AP_InertialSensor_MPU6000::AP_InertialSensor_MPU6000(AP_InertialSensor &imu) :
     _last_filter_hz(0),
     _error_count(0),
 #if MPU6000_FAST_SAMPLING
-    _accel_filter_x(1000, 15),
-    _accel_filter_y(1000, 15),
-    _accel_filter_z(1000, 15),
-    _gyro_filter_x(1000, 15),
-    _gyro_filter_y(1000, 15),
-    _gyro_filter_z(1000, 15),    
+    _accel_filter(1000, 15),
+    _gyro_filter(1000, 15),
 #else
     _sample_count(0),
     _accel_sum(),
@@ -376,13 +372,13 @@ void AP_InertialSensor_MPU6000::_read_data_transaction() {
 
 #define int16_val(v, idx) ((int16_t)(((uint16_t)v[2*idx] << 8) | v[2*idx+1]))
 #if MPU6000_FAST_SAMPLING
-    _accel_filtered = Vector3f(_accel_filter_x.apply(int16_val(rx.v, 1)), 
-                               _accel_filter_y.apply(int16_val(rx.v, 0)), 
-                               _accel_filter_z.apply(-int16_val(rx.v, 2)));
+    _accel_filtered = _accel_filter.apply(Vector3f(int16_val(rx.v, 1),
+                                                   int16_val(rx.v, 0),
+                                                   -int16_val(rx.v, 2)));
 
-    _gyro_filtered = Vector3f(_gyro_filter_x.apply(int16_val(rx.v, 5)), 
-                              _gyro_filter_y.apply(int16_val(rx.v, 4)), 
-                              _gyro_filter_z.apply(-int16_val(rx.v, 6)));
+    _gyro_filtered = _gyro_filter.apply(Vector3f(int16_val(rx.v, 5),
+                                                 int16_val(rx.v, 4),
+                                                 -int16_val(rx.v, 6)));
 #else
     _accel_sum.x += int16_val(rx.v, 1);
     _accel_sum.y += int16_val(rx.v, 0);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.h
@@ -80,12 +80,8 @@ private:
     Vector3f _gyro_filtered;
 
     // Low Pass filters for gyro and accel 
-    LowPassFilter2p _accel_filter_x;
-    LowPassFilter2p _accel_filter_y;
-    LowPassFilter2p _accel_filter_z;
-    LowPassFilter2p _gyro_filter_x;
-    LowPassFilter2p _gyro_filter_y;
-    LowPassFilter2p _gyro_filter_z;
+    LowPassFilter2pVector3f _accel_filter;
+    LowPassFilter2pVector3f _gyro_filter;
 #else
     // accumulation in timer - must be read with timer disabled
     // the sum of the values since last read

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9150.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9150.cpp
@@ -1101,10 +1101,10 @@ bool AP_InertialSensor_MPU9150::update(void)
     hal.scheduler->resume_timer_procs();
 
     accel *= MPU9150_ACCEL_SCALE_2G;
-    _rotate_and_offset_accel(_accel_instance, accel);
+    _publish_accel(_accel_instance, accel);
 
     gyro *= MPU9150_GYRO_SCALE_2000;
-    _rotate_and_offset_gyro(_gyro_instance, gyro);
+    _publish_gyro(_gyro_instance, gyro);
 
     if (_last_filter_hz != _imu.get_filter()) {
         _set_filter_frequency(_imu.get_filter());

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9150.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9150.cpp
@@ -327,12 +327,8 @@ static struct gyro_state_s st = {
 AP_InertialSensor_MPU9150::AP_InertialSensor_MPU9150(AP_InertialSensor &imu) :
     AP_InertialSensor_Backend(imu),
     _have_sample_available(false),
-    _accel_filter_x(800, 10),
-    _accel_filter_y(800, 10),
-    _accel_filter_z(800, 10),
-    _gyro_filter_x(800, 10),
-    _gyro_filter_y(800, 10),
-    _gyro_filter_z(800, 10)
+    _accel_filter(800, 10),
+    _gyro_filter(800, 10),
 {
 }
 
@@ -361,12 +357,8 @@ void AP_InertialSensor_MPU9150::_set_filter_frequency(uint8_t filter_hz)
     if (filter_hz == 0)
         filter_hz = _default_filter_hz;
 
-    _accel_filter_x.set_cutoff_frequency(800, filter_hz);
-    _accel_filter_y.set_cutoff_frequency(800, filter_hz);
-    _accel_filter_z.set_cutoff_frequency(800, filter_hz);
-    _gyro_filter_x.set_cutoff_frequency(800, filter_hz);
-    _gyro_filter_y.set_cutoff_frequency(800, filter_hz);
-    _gyro_filter_z.set_cutoff_frequency(800, filter_hz);
+    _accel_filter.set_cutoff_frequency(800, filter_hz);
+    _gyro_filter.set_cutoff_frequency(800, filter_hz);
 }
 
 /**
@@ -1087,15 +1079,9 @@ void AP_InertialSensor_MPU9150::_accumulate(void)
 
         // TODO Revisit why AP_InertialSensor_L3G4200D uses a minus sign in the y and z component. Maybe this
         //  is because the sensor is placed in the bottom side of the board?
-        _accel_filtered = Vector3f(
-            _accel_filter_x.apply(accel_x), 
-            _accel_filter_y.apply(accel_y), 
-            _accel_filter_z.apply(accel_z));
-        
-        _gyro_filtered = Vector3f(
-            _gyro_filter_x.apply(gyro_x), 
-            _gyro_filter_y.apply(gyro_y), 
-            _gyro_filter_z.apply(gyro_z));
+        _accel_filtered = _accel_filter.apply(Vector3f(accel_x, accel_y, accel_z));
+
+        _gyro_filtered = _gyro_filter.apply(Vector3f(gyro_x, gyro_y, gyro_z));
 
         _have_sample_available = true;
     }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9150.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9150.h
@@ -52,12 +52,8 @@ private:
     void _set_filter_frequency(uint8_t filter_hz);
 
     // Low Pass filters for gyro and accel 
-    LowPassFilter2p _accel_filter_x;
-    LowPassFilter2p _accel_filter_y;
-    LowPassFilter2p _accel_filter_z;
-    LowPassFilter2p _gyro_filter_x;
-    LowPassFilter2p _gyro_filter_y;
-    LowPassFilter2p _gyro_filter_z;
+    LowPassFilter2pVector3f _accel_filter;
+    LowPassFilter2pVector3f _gyro_filter;
 
     uint8_t _gyro_instance;
     uint8_t _accel_instance;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
@@ -175,12 +175,8 @@ AP_InertialSensor_MPU9250::AP_InertialSensor_MPU9250(AP_InertialSensor &imu) :
 	AP_InertialSensor_Backend(imu),
     _last_filter_hz(-1),
     _shared_data_idx(0),
-    _accel_filter_x(1000, 15),
-    _accel_filter_y(1000, 15),
-    _accel_filter_z(1000, 15),
-    _gyro_filter_x(1000, 15),
-    _gyro_filter_y(1000, 15),
-    _gyro_filter_z(1000, 15),
+    _accel_filter(1000, 15),
+    _gyro_filter(1000, 15),
     _have_sample_available(false)
 {
 }
@@ -341,13 +337,13 @@ void AP_InertialSensor_MPU9250::_read_data_transaction()
 
 #define int16_val(v, idx) ((int16_t)(((uint16_t)v[2*idx] << 8) | v[2*idx+1]))
 
-    Vector3f _accel_filtered = Vector3f(_accel_filter_x.apply(int16_val(rx.v, 1)), 
-                                        _accel_filter_y.apply(int16_val(rx.v, 0)), 
-                                        _accel_filter_z.apply(-int16_val(rx.v, 2)));
+    Vector3f _accel_filtered = _accel_filter.apply(Vector3f(int16_val(rx.v, 1),
+                                                   int16_val(rx.v, 0),
+                                                   -int16_val(rx.v, 2)));
 
-    Vector3f _gyro_filtered = Vector3f(_gyro_filter_x.apply(int16_val(rx.v, 5)), 
-                                       _gyro_filter_y.apply(int16_val(rx.v, 4)), 
-                                       _gyro_filter_z.apply(-int16_val(rx.v, 6)));
+    Vector3f _gyro_filtered = _gyro_filter.apply(Vector3f(int16_val(rx.v, 5),
+                                                 int16_val(rx.v, 4),
+                                                 -int16_val(rx.v, 6)));
     // update the shared buffer
     uint8_t idx = _shared_data_idx ^ 1;
     _shared_data[idx]._accel_filtered = _accel_filtered;
@@ -395,13 +391,9 @@ void AP_InertialSensor_MPU9250::_set_filter(uint8_t filter_hz)
         filter_hz = _default_filter_hz;
     }
 
-    _accel_filter_x.set_cutoff_frequency(1000, filter_hz);
-    _accel_filter_y.set_cutoff_frequency(1000, filter_hz);
-    _accel_filter_z.set_cutoff_frequency(1000, filter_hz);
+    _accel_filter.set_cutoff_frequency(1000, filter_hz);
 
-    _gyro_filter_x.set_cutoff_frequency(1000, filter_hz);
-    _gyro_filter_y.set_cutoff_frequency(1000, filter_hz);
-    _gyro_filter_z.set_cutoff_frequency(1000, filter_hz);    
+    _gyro_filter.set_cutoff_frequency(1000, filter_hz);
 }
 
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
@@ -289,8 +289,8 @@ bool AP_InertialSensor_MPU9250::update( void )
     gyro.rotate(ROTATION_ROLL_180);
 #endif
 
-    _rotate_and_offset_gyro(_gyro_instance, gyro);
-    _rotate_and_offset_accel(_accel_instance, accel);
+    _publish_gyro(_gyro_instance, gyro);
+    _publish_accel(_accel_instance, accel);
 
     if (_last_filter_hz != _imu.get_filter()) {
         _set_filter(_imu.get_filter());

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.h
@@ -60,12 +60,8 @@ private:
     volatile uint8_t _shared_data_idx;
 
     // Low Pass filters for gyro and accel 
-    LowPassFilter2p _accel_filter_x;
-    LowPassFilter2p _accel_filter_y;
-    LowPassFilter2p _accel_filter_z;
-    LowPassFilter2p _gyro_filter_x;
-    LowPassFilter2p _gyro_filter_y;
-    LowPassFilter2p _gyro_filter_z;
+    LowPassFilter2pVector3f _accel_filter;
+    LowPassFilter2pVector3f _gyro_filter;
 
     // do we currently have a sample pending?
     bool _have_sample_available;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Oilpan.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Oilpan.cpp
@@ -104,14 +104,14 @@ bool AP_InertialSensor_Oilpan::update()
     v(_sensor_signs[0] * ( adc_values[0] - OILPAN_RAW_GYRO_OFFSET ) * _gyro_gain_x,
       _sensor_signs[1] * ( adc_values[1] - OILPAN_RAW_GYRO_OFFSET ) * _gyro_gain_y,
       _sensor_signs[2] * ( adc_values[2] - OILPAN_RAW_GYRO_OFFSET ) * _gyro_gain_z);
-    _rotate_and_offset_gyro(_gyro_instance, v);
+    _publish_gyro(_gyro_instance, v);
 
     // copy accels to frontend
     v(_sensor_signs[3] * (adc_values[3] - OILPAN_RAW_ACCEL_OFFSET),
       _sensor_signs[4] * (adc_values[4] - OILPAN_RAW_ACCEL_OFFSET),
       _sensor_signs[5] * (adc_values[5] - OILPAN_RAW_ACCEL_OFFSET));
     v *= OILPAN_ACCEL_SCALE_1G;
-    _rotate_and_offset_accel(_accel_instance, v);
+    _publish_accel(_accel_instance, v);
 
     return true;
 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
@@ -243,6 +243,22 @@ void AP_InertialSensor_PX4::_new_accel_sample(uint8_t i, accel_report &accel_rep
 
     // report error count
     _set_accel_error_count(frontend_instance, accel_report.error_count);
+
+#ifdef AP_INERTIALSENSOR_PX4_DEBUG
+    _accel_dt_max[i] = max(_accel_dt_max[i],dt);
+
+    _accel_meas_count[i] ++;
+
+    if(_accel_meas_count[i] >= 10000) {
+        uint32_t tnow = hal.scheduler->micros();
+
+        ::printf("a%d %.2f Hz max %.8f s\n", frontend_instance, 10000.0/((tnow-_accel_meas_count_start_us[i])*1.0e-6f),_accel_dt_max[i]);
+
+        _accel_meas_count_start_us[i] = tnow;
+        _accel_meas_count[i] = 0;
+        _accel_dt_max[i] = 0;
+    }
+#endif // AP_INERTIALSENSOR_PX4_DEBUG
 }
 
 void AP_InertialSensor_PX4::_new_gyro_sample(uint8_t i, gyro_report &gyro_report)
@@ -285,6 +301,21 @@ void AP_InertialSensor_PX4::_new_gyro_sample(uint8_t i, gyro_report &gyro_report
 
     // report error count
     _set_gyro_error_count(_gyro_instance[i], gyro_report.error_count);
+#ifdef AP_INERTIALSENSOR_PX4_DEBUG
+    _gyro_dt_max[i] = max(_gyro_dt_max[i],dt);
+
+    _gyro_meas_count[i] ++;
+
+    if(_gyro_meas_count[i] >= 10000) {
+        uint32_t tnow = hal.scheduler->micros();
+
+        ::printf("g%d %.2f Hz max %.8f s\n", frontend_instance, 10000.0f/((tnow-_gyro_meas_count_start_us[i])*1.0e-6f), _gyro_dt_max[i]);
+
+        _gyro_meas_count_start_us[i] = tnow;
+        _gyro_meas_count[i] = 0;
+        _gyro_dt_max[i] = 0;
+    }
+#endif // AP_INERTIALSENSOR_PX4_DEBUG
 }
 
 void AP_InertialSensor_PX4::_get_sample()

--- a/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
@@ -107,20 +107,20 @@ bool AP_InertialSensor_PX4::update(void)
 
     for (uint8_t k=0; k<_num_accel_instances; k++) {
         Vector3f accel = _accel_in[k];
-        // calling _rotate_and_offset_accel sets the sensor healthy,
+        // calling _publish_accel sets the sensor healthy,
         // so we only want to do this if we have new data from it
         if (_last_accel_timestamp[k] != _last_accel_update_timestamp[k]) {
-            _rotate_and_offset_accel(_accel_instance[k], accel);
+            _publish_accel(_accel_instance[k], accel);
             _last_accel_update_timestamp[k] = _last_accel_timestamp[k];
         }
     }
 
     for (uint8_t k=0; k<_num_gyro_instances; k++) {
         Vector3f gyro = _gyro_in[k];
-        // calling _rotate_and_offset_accel sets the sensor healthy,
+        // calling _publish_accel sets the sensor healthy,
         // so we only want to do this if we have new data from it
         if (_last_gyro_timestamp[k] != _last_gyro_update_timestamp[k]) {
-            _rotate_and_offset_gyro(_gyro_instance[k], gyro);
+            _publish_gyro(_gyro_instance[k], gyro);
             _last_gyro_update_timestamp[k] = _last_gyro_timestamp[k];
         }
     }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_PX4.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_PX4.h
@@ -47,6 +47,9 @@ private:
     void _new_accel_sample(uint8_t i, accel_report &accel_report);
     void _new_gyro_sample(uint8_t i, gyro_report &gyro_report);
 
+    bool _get_gyro_sample(uint8_t i, struct gyro_report &gyro_report);
+    bool _get_accel_sample(uint8_t i, struct accel_report &accel_report);
+
     // support for updating filter at runtime
     uint8_t _last_filter_hz;
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_PX4.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_PX4.h
@@ -13,6 +13,9 @@
 #include <uORB/uORB.h>
 #include <uORB/topics/sensor_combined.h>
 
+#include <Filter.h>
+#include <LowPassFilter2p.h>
+
 class AP_InertialSensor_PX4 : public AP_InertialSensor_Backend
 {
 public:
@@ -41,9 +44,11 @@ private:
     uint64_t _last_get_sample_timestamp;
     uint64_t _last_sample_timestamp;
 
+    void _new_accel_sample(uint8_t i, accel_report &accel_report);
+    void _new_gyro_sample(uint8_t i, gyro_report &gyro_report);
+
     // support for updating filter at runtime
     uint8_t _last_filter_hz;
-    uint8_t _default_filter_hz;
 
     void _set_filter_frequency(uint8_t filter_hz);
 
@@ -58,6 +63,15 @@ private:
     // from the backend indexes
     uint8_t _accel_instance[INS_MAX_INSTANCES];
     uint8_t _gyro_instance[INS_MAX_INSTANCES];
+
+    // Low Pass filters for gyro and accel
+    LowPassFilter2pVector3f _accel_filter[INS_MAX_INSTANCES];
+    LowPassFilter2pVector3f _gyro_filter[INS_MAX_INSTANCES];
+
+    Vector3f _delta_angle_accumulator[INS_MAX_INSTANCES];
+    Vector3f _delta_velocity_accumulator[INS_MAX_INSTANCES];
+    Vector3f _last_delAng[INS_MAX_INSTANCES];
+    Vector3f _last_gyro[INS_MAX_INSTANCES];
 };
 #endif // CONFIG_HAL_BOARD
 #endif // __AP_INERTIAL_SENSOR_PX4_H__

--- a/libraries/AP_InertialSensor/AP_InertialSensor_PX4.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_PX4.h
@@ -75,6 +75,17 @@ private:
     Vector3f _delta_velocity_accumulator[INS_MAX_INSTANCES];
     Vector3f _last_delAng[INS_MAX_INSTANCES];
     Vector3f _last_gyro[INS_MAX_INSTANCES];
+
+#ifdef AP_INERTIALSENSOR_PX4_DEBUG
+    uint32_t _gyro_meas_count[INS_MAX_INSTANCES];
+    uint32_t _accel_meas_count[INS_MAX_INSTANCES];
+
+    uint32_t _gyro_meas_count_start_us[INS_MAX_INSTANCES];
+    uint32_t _accel_meas_count_start_us[INS_MAX_INSTANCES];
+
+    float _gyro_dt_max[INS_MAX_INSTANCES];
+    float _accel_dt_max[INS_MAX_INSTANCES];
+#endif // AP_INERTIALSENSOR_PX4_DEBUG
 };
 #endif // CONFIG_HAL_BOARD
 #endif // __AP_INERTIAL_SENSOR_PX4_H__

--- a/libraries/AP_InertialSensor/examples/coning.py
+++ b/libraries/AP_InertialSensor/examples/coning.py
@@ -1,0 +1,334 @@
+#!/usr/bin/python
+
+from math import *
+from pymavlink.rotmat import Vector3, Matrix3
+from numpy import linspace
+from visual import *
+
+class Quat:
+    def __init__(self,w=1.0,x=0.0,y=0.0,z=0.0):
+        self.w = w
+        self.x = x
+        self.y = y
+        self.z = z
+
+    def to_euler(self):
+        roll = (atan2(2.0*(self.w*self.x + self.y*self.z), 1 - 2.0*(self.x*self.x + self.y*self.y)))
+        pitch = asin(2.0*(self.w*self.y - self.z*self.x))
+        yaw = atan2(2.0*(self.w*self.z + self.x*self.y), 1 - 2.0*(self.y*self.y + self.z*self.z))
+        return Vector3(roll,pitch,yaw)
+
+    def from_euler(self,euler):
+        #(roll,pitch,yaw)
+        cr2 = cos(euler[0]*0.5)
+        cp2 = cos(euler[1]*0.5)
+        cy2 = cos(euler[2]*0.5)
+        sr2 = sin(euler[0]*0.5)
+        sp2 = sin(euler[1]*0.5)
+        sy2 = sin(euler[2]*0.5)
+
+        self.w = cr2*cp2*cy2 + sr2*sp2*sy2
+        self.x = sr2*cp2*cy2 - cr2*sp2*sy2
+        self.y = cr2*sp2*cy2 + sr2*cp2*sy2
+        self.z = cr2*cp2*sy2 - sr2*sp2*cy2
+        return self
+
+    def from_axis_angle(self, vec):
+        theta = vec.length()
+        if theta == 0:
+            self.w = 1.0
+            self.x = 0.0
+            self.y = 0.0
+            self.z = 0.0
+            return
+
+        vec_normalized = vec.normalized()
+
+        st2 = sin(theta/2.0)
+        self.w = cos(theta/2.0)
+        self.x = vec_normalized.x * st2
+        self.y = vec_normalized.y * st2
+        self.z = vec_normalized.z * st2
+
+    def rotate(self, vec):
+        r = Quat()
+        r.from_axis_angle(vec)
+        q = self * r
+        self.w = q.w
+        self.x = q.x
+        self.y = q.y
+        self.z = q.z
+
+    def to_axis_angle(self):
+        l = sqrt(self.x**2+self.y**2+self.z**2)
+
+        (x,y,z) = (self.x,self.y,self.z)
+        if l != 0:
+            temp = 2.0*atan2(l,self.w)
+            if temp > pi:
+                temp -= 2*pi
+            elif temp < -pi:
+                temp += 2*pi
+            (x,y,z) = (temp*x/l,temp*y/l,temp*z/l)
+        return Vector3(x,y,z)
+
+    def to_rotation_matrix(self):
+        m = Matrix3()
+        yy = self.y**2
+        yz = self.y * self.z
+        xx = self.x**2
+        xy = self.x * self.y
+        xz = self.x * self.z
+        wx = self.w * self.x
+        wy = self.w * self.y
+        wz = self.w * self.z
+        zz = self.z**2
+
+        m.a.x = 1.0-2.0*(yy + zz)
+        m.a.y =   2.0*(xy - wz)
+        m.a.z =   2.0*(xz + wy)
+        m.b.x =   2.0*(xy + wz)
+        m.b.y = 1.0-2.0*(xx + zz)
+        m.b.z =   2.0*(yz - wx)
+        m.c.x =   2.0*(xz - wy)
+        m.c.y =   2.0*(yz + wx)
+        m.c.z = 1.0-2.0*(xx + yy)
+        return m
+
+    def inverse(self):
+        return Quat(self.w,-self.x,-self.y,-self.z)
+
+    def __mul__(self,operand):
+        ret = Quat()
+        w1=self.w
+        x1=self.x
+        y1=self.y
+        z1=self.z
+        w2=operand.w
+        x2=operand.x
+        y2=operand.y
+        z2=operand.z
+
+        ret.w = w1*w2 - x1*x2 - y1*y2 - z1*z2
+        ret.x = w1*x2 + x1*w2 + y1*z2 - z1*y2
+        ret.y = w1*y2 - x1*z2 + y1*w2 + z1*x2
+        ret.z = w1*z2 + x1*y2 - y1*x2 + z1*w2
+        return ret
+
+    def __str__(self):
+        return "Quat(%f, %f, %f, %f)" % (self.w,self.x,self.y,self.z)
+
+def vpy_vec(vec):
+    return vector(vec.y, -vec.z, -vec.x)
+
+def update_arrows(q,x,y,z):
+    m = q.to_rotation_matrix().transposed()
+    x.axis = vpy_vec(m*Vector3(1,0,0))
+    x.up = vpy_vec(m*Vector3(0,1,0))
+    y.axis = vpy_vec(m*Vector3(0,1,0))
+    y.up = vpy_vec(m*Vector3(1,0,0))
+    z.axis = vpy_vec(m*Vector3(0,0,1))
+    z.up = vpy_vec(m*Vector3(1,0,0))
+
+class Attitude:
+    def __init__(self,reference=False):
+        self.labels = []
+        self.xarrows = []
+        self.yarrows = []
+        self.zarrows = []
+        self.q = Quat()
+        self.reference = reference
+        self.update_arrows()
+
+    def add_arrows(self, arrowpos = Vector3(0,0,0), labeltext=None):
+        if labeltext is not None:
+            self.labels.append(label(pos = vpy_vec(arrowpos), text=labeltext))
+
+        sw = .005 if self.reference else .05
+
+        self.xarrows.append(arrow(pos=vpy_vec(arrowpos),color=color.red,opacity=1,shaftwidth=sw))
+        self.yarrows.append(arrow(pos=vpy_vec(arrowpos),color=color.green,opacity=1,shaftwidth=sw))
+        self.zarrows.append(arrow(pos=vpy_vec(arrowpos),color=color.blue,opacity=1,shaftwidth=sw))
+        self.update_arrows()
+
+    def rotate(self, vec):
+        self.q.rotate(vec)
+
+    def update_arrows(self):
+        m = self.q.to_rotation_matrix().transposed()
+        sl = 1.1 if self.reference else 1.0
+        for i in self.xarrows:
+            i.axis = vpy_vec(m*Vector3(sl,0,0))
+            i.up = vpy_vec(m*Vector3(0,1,0))
+        for i in self.yarrows:
+            i.axis = vpy_vec(m*Vector3(0,sl,0))
+            i.up = vpy_vec(m*Vector3(1,0,0))
+        for i in self.zarrows:
+            i.axis = vpy_vec(m*Vector3(0,0,sl))
+            i.up = vpy_vec(m*Vector3(1,0,0))
+        for i in self.labels:
+            i.xoffset = scene.width*0.07
+            i.yoffset = scene.width*0.1
+
+class Tian_integrator:
+    def __init__(self, integrate_separately=True):
+        self.alpha = Vector3(0,0,0)
+        self.beta = Vector3(0,0,0)
+        self.last_alpha = Vector3(0,0,0)
+        self.last_delta_alpha = Vector3(0,0,0)
+        self.last_sample = Vector3(0,0,0)
+        self.integrate_separately = integrate_separately
+
+    def add_sample(self, sample, dt):
+        delta_alpha = (self.last_sample+sample)*0.5*dt
+        self.alpha += delta_alpha
+        delta_beta = 0.5 * (self.last_alpha + (1.0/6.0)*self.last_delta_alpha)%delta_alpha
+
+        if self.integrate_separately:
+            self.beta += delta_beta
+        else:
+            self.alpha += delta_beta
+
+        self.last_alpha = self.alpha
+        self.last_delta_alpha = delta_alpha
+        self.last_sample = sample
+
+    def pop_delta_angles(self):
+        ret = self.alpha + self.beta
+        self.alpha.zero()
+        self.beta.zero()
+        return ret
+
+filter2p_1khz_30hz_data = {}
+def filter2p_1khz_30hz(sample, key):
+    global filter2p_1khz_30hz_data
+    if not key in filter2p_1khz_30hz_data:
+        filter2p_1khz_30hz_data[key] = (0.0,0.0)
+    (delay_element_1, delay_element_2) = filter2p_1khz_30hz_data[key]
+    sample_freq = 1000
+    cutoff_freq = 30
+    fr = sample_freq/cutoff_freq
+    ohm = tan(pi/fr)
+    c = 1.0+2.0*cos(pi/4.0)*ohm + ohm**2
+    b0 = ohm**2/c
+    b1 = 2.0*b0
+    b2 = b0
+    a1 = 2.0*(ohm**2-1.0)/c
+    a2 = (1.0-2.0*cos(pi/4.0)*ohm+ohm**2)/c
+
+    delay_element_0 = sample - delay_element_1 * a1 - delay_element_2 * a2
+    output = delay_element_0 * b0 + delay_element_1 * b1 + delay_element_2 * b2
+
+    filter2p_1khz_30hz_data[key] = (delay_element_0, delay_element_1)
+
+    return output
+
+def filter2p_1khz_30hz_vector3(sample, key):
+    ret = Vector3()
+    ret.x = filter2p_1khz_30hz(sample.x, "vec3f"+key+"x")
+    ret.y = filter2p_1khz_30hz(sample.y, "vec3f"+key+"y")
+    ret.z = filter2p_1khz_30hz(sample.z, "vec3f"+key+"z")
+    return ret
+
+
+reference_attitude = Attitude(True)
+uncorrected_attitude_low = Attitude()
+uncorrected_attitude_high = Attitude()
+corrected_attitude = Attitude()
+corrected_attitude_combined = Attitude()
+
+corrected_attitude_integrator = Tian_integrator()
+corrected_attitude_integrator_combined = Tian_integrator(integrate_separately = False)
+
+reference_attitude.add_arrows(Vector3(0,-3,0))
+uncorrected_attitude_low.add_arrows(Vector3(0,-3,0), "no correction\nlow rate integration\n30hz software LPF @ 1khz\n(ardupilot 2015-02-18)")
+
+reference_attitude.add_arrows(Vector3(0,-1,0))
+uncorrected_attitude_high.add_arrows(Vector3(0,-1,0), "no correction\nhigh rate integration")
+
+reference_attitude.add_arrows(Vector3(0,1,0))
+corrected_attitude.add_arrows(Vector3(0,1,0), "Tian et al\nseparate integration")
+
+reference_attitude.add_arrows(Vector3(0,3,0))
+corrected_attitude_combined.add_arrows(Vector3(0,3,0), "Tian et al\ncombined_integration\n(proposed patch)")
+
+#scene.scale = (0.3,0.3,0.3)
+scene.fov = 0.001
+scene.forward = (-0.5, -0.5, -1)
+
+coning_frequency_hz = 50
+coning_magnitude_rad_s = 2
+label_text = (
+    "coning motion frequency %f hz\n"
+    "coning motion peak amplitude %f deg/s\n"
+    "thin arrows are reference attitude"
+    ) % (coning_frequency_hz, degrees(coning_magnitude_rad_s))
+label(pos = vpy_vec(Vector3(0,0,2)), text=label_text)
+
+t = 0.0
+dt_10000 = 0.0001
+dt_1000 = 0.001
+dt_333 = 0.003
+
+accumulated_delta_angle = Vector3(0,0,0)
+last_gyro_10000 = Vector3(0,0,0)
+last_gyro_1000 = Vector3(0,0,0)
+last_filtered_gyro_333 = Vector3(0,0,0)
+filtered_gyro = Vector3(0,0,0)
+
+while True:
+    rate(66)
+    for i in range(5):
+        for j in range(3):
+            for k in range(10):
+                #vvvvvvvvvv 10 kHz vvvvvvvvvv#
+
+                #compute angular rate at current time
+                gyro = Vector3(sin(t*coning_frequency_hz*2*pi), cos(t*coning_frequency_hz*2*pi),0)*coning_magnitude_rad_s
+
+                #integrate reference attitude
+                reference_attitude.rotate((gyro+last_gyro_10000) * dt_10000 * 0.5)
+
+                #increment time
+                t += dt_10000
+                last_gyro_10000 = gyro
+
+            #vvvvvvvvvv 1 kHz vvvvvvvvvv#
+
+            #update filter for sim 1
+            filtered_gyro = filter2p_1khz_30hz_vector3(gyro, "1")
+
+            #update integrator for sim 2
+            accumulated_delta_angle += (gyro+last_gyro_1000) * dt_1000 * 0.5
+
+            #update integrator for sim 3
+            corrected_attitude_integrator.add_sample(gyro, dt_1000)
+
+            #update integrator for sim 4
+            corrected_attitude_integrator_combined.add_sample(gyro, dt_1000)
+
+            last_gyro_1000 = gyro
+
+        #vvvvvvvvvv 333 Hz vvvvvvvvvv#
+
+        #update sim 1 (leftmost)
+        uncorrected_attitude_low.rotate((filtered_gyro+last_filtered_gyro_333) * dt_333 * 0.5)
+
+        #update sim 2
+        uncorrected_attitude_high.rotate(accumulated_delta_angle)
+        accumulated_delta_angle.zero()
+
+        #update sim 3
+        corrected_attitude.rotate(corrected_attitude_integrator.pop_delta_angles())
+
+        #update sim 4 (rightmost)
+        corrected_attitude_combined.rotate(corrected_attitude_integrator_combined.pop_delta_angles())
+
+        last_filtered_gyro_333 = filtered_gyro
+
+    #vvvvvvvvvv 66 Hz vvvvvvvvvv#
+    reference_attitude.update_arrows()
+    corrected_attitude.update_arrows()
+    corrected_attitude_combined.update_arrows()
+    uncorrected_attitude_low.update_arrows()
+    uncorrected_attitude_high.update_arrows()

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -1107,7 +1107,11 @@ void NavEKF::UpdateStrapdownEquationsNED()
 
     // apply corrections for earths rotation rate and coning errors
     // % * - and + operators have been overloaded
-    correctedDelAng   = correctedDelAng - prevTnb * earthRateNED*dtIMU + (prevDelAng % correctedDelAng) * 8.333333e-2f;
+    if (haveDeltaAngles) {
+        correctedDelAng   = correctedDelAng - prevTnb * earthRateNED*dtIMU;
+    } else {
+        correctedDelAng   = correctedDelAng - prevTnb * earthRateNED*dtIMU + (prevDelAng % correctedDelAng) * 8.333333e-2f;
+    }
 
     // save current measurements
     prevDelAng = correctedDelAng;
@@ -3915,45 +3919,50 @@ void NavEKF::ConstrainStates()
 // update IMU delta angle and delta velocity measurements
 void NavEKF::readIMUData()
 {
-    Vector3f angRate;   // angular rate vector in XYZ body axes measured by the IMU (rad/s)
-    Vector3f accel1;    // acceleration vector in XYZ body axes measured by IMU1 (m/s^2)
-    Vector3f accel2;    // acceleration vector in XYZ body axes measured by IMU2 (m/s^2)
+    const AP_InertialSensor &ins = _ahrs->get_ins();
+
+    // limit IMU delta time to prevent numerical problems elsewhere
+    dtIMU = constrain_float(ins.get_delta_time(), 0.001f, 1.0f);
 
     // the imu sample time is sued as a common time reference throughout the filter
     imuSampleTime_ms = hal.scheduler->millis();
 
-    // limit IMU delta time to prevent numerical problems elsewhere
-    dtIMU = constrain_float(_ahrs->get_ins().get_delta_time(), 0.001f, 1.0f);
+    bool dual_ins = ins.get_accel_health(0) && ins.get_accel_health(1);
+    haveDeltaAngles = true;
 
-    // get accel and gyro data from dual sensors if healthy
-    if (_ahrs->get_ins().get_accel_health(0) && _ahrs->get_ins().get_accel_health(1)) {
-        accel1 = _ahrs->get_ins().get_accel(0);
-        accel2 = _ahrs->get_ins().get_accel(1);
+    if (dual_ins) {
+        Vector3f dAngIMU1;
+        Vector3f dAngIMU2;
+
+        if(!ins.get_delta_velocity(0,dVelIMU1)) {
+            dVelIMU1 = ins.get_accel(0) * dtIMU;
+        }
+
+        if(!ins.get_delta_velocity(1,dVelIMU2)) {
+            dVelIMU2 = ins.get_accel(1) * dtIMU;
+        }
+
+        if(!ins.get_delta_angle(0, dAngIMU1)) {
+            haveDeltaAngles = false;
+            dAngIMU1 = ins.get_gyro(0) * dtIMU;
+        }
+
+        if(!ins.get_delta_angle(1, dAngIMU2)) {
+            haveDeltaAngles = false;
+            dAngIMU2 = ins.get_gyro(1) * dtIMU;
+        }
+        dAngIMU = (dAngIMU1+dAngIMU2) * 0.5f;
     } else {
-        accel1 = _ahrs->get_ins().get_accel();
-        accel2 = accel1;
-    }
+        if(!ins.get_delta_velocity(dVelIMU1)) {
+            dVelIMU1 = ins.get_accel() * dtIMU;
+        }
+        dVelIMU2 = dVelIMU1;
 
-    // average the available gyro sensors
-    angRate.zero();
-    uint8_t gyro_count = 0;
-    for (uint8_t i = 0; i<_ahrs->get_ins().get_gyro_count(); i++) {
-        if (_ahrs->get_ins().get_gyro_health(i)) {
-            angRate += _ahrs->get_ins().get_gyro(i);
-            gyro_count++;
+        if(!ins.get_delta_angle(dAngIMU)) {
+            haveDeltaAngles = false;
+            dAngIMU = ins.get_gyro() * dtIMU;
         }
     }
-    if (gyro_count != 0) {
-        angRate /= gyro_count;
-    }
-
-    // trapezoidal integration
-    dAngIMU     = (angRate + lastAngRate) * dtIMU * 0.5f;
-    lastAngRate = angRate;
-    dVelIMU1    = (accel1 + lastAccel1) * dtIMU * 0.5f;
-    lastAccel1  = accel1;
-    dVelIMU2    = (accel2 + lastAccel2) * dtIMU * 0.5f;
-    lastAccel2  = accel2;
 }
 
 // check for new valid GPS data and update stored measurement if available
@@ -4412,6 +4421,7 @@ void NavEKF::InitialiseVariables()
     inhibitMagStates = true;
     gndOffsetValid =  false;
     flowXfailed = false;
+    haveDeltaAngles = false;
     validOrigin = false;
 }
 

--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -665,6 +665,8 @@ private:
     bool gndOffsetValid;            // true when the ground offset state can still be considered valid
     bool flowXfailed;               // true when the X optical flow measurement has failed the innovation consistency check
 
+    bool haveDeltaAngles;
+
     // states held by optical flow fusion across time steps
     // optical flow X,Y motion compensated rate measurements are fused across two time steps
     // to level computational load as this can be an expensive operation

--- a/libraries/Filter/LowPassFilter2p.h
+++ b/libraries/Filter/LowPassFilter2p.h
@@ -17,42 +17,106 @@
 
 #ifndef LOWPASSFILTER2P_H
 #define LOWPASSFILTER2P_H
+#include <stdio.h>
 
-/// @file	LowPassFilter.h
-/// @brief	A class to implement a second order low pass filter 
+/// @file   LowPassFilter2p.h
+/// @brief  A class to implement a second order low pass filter
 /// Author: Leonard Hall <LeonardTHall@gmail.com>
+
+class DigitalBiquadFilter
+{
+public:
+    DigitalBiquadFilter() :
+    _delay_element_1(0.0f),
+    _delay_element_2(0.0f){}
+
+    struct biquad_params {
+        float cutoff_freq;
+        float sample_freq;
+        float a1;
+        float a2;
+        float b0;
+        float b1;
+        float b2;
+    };
+
+    float apply(float sample, const struct biquad_params params);
+
+    void reset() { _delay_element_1 = _delay_element_2 = 0.0f; }
+
+    static void compute_params(float sample_freq, float cutoff_freq, biquad_params &ret);
+
+private:
+    float _delay_element_1;
+    float _delay_element_2;
+};
 
 class LowPassFilter2p
 {
 public:
+    LowPassFilter2p() { memset(&_params, 0, sizeof(_params)); }
     // constructor
     LowPassFilter2p(float sample_freq, float cutoff_freq) {
         // set initial parameters
         set_cutoff_frequency(sample_freq, cutoff_freq);
-        _delay_element_1 = _delay_element_2 = 0;
     }
 
     // change parameters
-    void set_cutoff_frequency(float sample_freq, float cutoff_freq);
-
-    // apply - Add a new raw value to the filter 
-    // and retrieve the filtered result
-    float apply(float sample);
+    void set_cutoff_frequency(float sample_freq, float cutoff_freq) {
+        DigitalBiquadFilter::compute_params(sample_freq, cutoff_freq, _params);
+    }
 
     // return the cutoff frequency
     float get_cutoff_freq(void) const {
-        return _cutoff_freq;
+        return _params.cutoff_freq;
+    }
+
+    float get_sample_freq(void) const {
+        return _params.sample_freq;
+    }
+
+protected:
+    struct DigitalBiquadFilter::biquad_params _params;
+};
+
+class LowPassFilter2pfloat : public LowPassFilter2p
+{
+public:
+    LowPassFilter2pfloat() :
+    LowPassFilter2p() {}
+
+    LowPassFilter2pfloat(float sample_freq, float cutoff_freq):
+    LowPassFilter2p(sample_freq,cutoff_freq) {}
+
+    float apply(float sample) {
+        return _filter.apply(sample, _params);
+    }
+private:
+    DigitalBiquadFilter _filter;
+};
+
+class LowPassFilter2pVector3f : public LowPassFilter2p
+{
+public:
+    LowPassFilter2pVector3f() :
+    LowPassFilter2p() {}
+
+    LowPassFilter2pVector3f(float sample_freq, float cutoff_freq) :
+    LowPassFilter2p(sample_freq,cutoff_freq) {}
+
+    Vector3f apply(const Vector3f &sample) {
+        Vector3f ret;
+        ret.x = _filter_x.apply(sample.x, _params);
+        ret.y = _filter_y.apply(sample.y, _params);
+        ret.z = _filter_z.apply(sample.z, _params);
+        return ret;
     }
 
 private:
-    float           _cutoff_freq; 
-    float           _a1;
-    float           _a2;
-    float           _b0;
-    float           _b1;
-    float           _b2;
-    float           _delay_element_1;        // buffered sample -1
-    float           _delay_element_2;        // buffered sample -2
+    DigitalBiquadFilter _filter_x;
+    DigitalBiquadFilter _filter_y;
+    DigitalBiquadFilter _filter_z;
 };
+
 
 #endif // LOWPASSFILTER2P_H

--- a/libraries/Filter/examples/LowPassFilter2p/LowPassFilter2p.pde
+++ b/libraries/Filter/examples/LowPassFilter2p/LowPassFilter2p.pde
@@ -18,7 +18,7 @@
 const AP_HAL::HAL& hal = AP_HAL_BOARD_DRIVER;
 
 // craete an instance with 800Hz sample rate and 30Hz cutoff
-static LowPassFilter2p low_pass_filter(800, 30);
+static LowPassFilter2pfloat low_pass_filter(800, 30);
 
 // setup routine
 static void setup()


### PR DESCRIPTION
- Splits LowPassFilter2p into LowPassFilter2pfloat and LowPassFilter2pVector3
- InertialSensor frontend now optionally provides a delta-angle and delta-velocity measurement
- InertialSensor_PX4 backend now configures sensors for maximum sample rate, minimal hardware filtering, and no software filtering
- InertialSensor_PX4 backend now integrates delta velocities and angles at full IMU rate
- InertialSensor_PX4 backend now uses the [Tian et al method](http://www.sage.unsw.edu.au/snap/publications/tian_etal2010b.pdf) to accumulate coning-corrected delta angles at full IMU rate

Depends on PX4Firmware PR 31: https://github.com/diydrones/PX4Firmware/pull/31
see libraries/AP_InertialSensor/examples/coning.py (depends on vpython, pymavlink)