### PR TITLE
added octa-quad target for SITL, fixed octa motor order

### DIFF
--- a/Tools/autotest/pysim/multicopter.py
+++ b/Tools/autotest/pysim/multicopter.py
@@ -58,14 +58,25 @@ def build_motors(frame):
             Motor(180,  True,  2),
             Motor(45,   False, 3),
             Motor(135,  False, 4),
-            Motor(-45,  False, 7),
-            Motor(-135, False, 8),
-            Motor(270,  True, 10),
-            Motor(90,   True, 11),
+            Motor(-45,  False, 5),
+            Motor(-135, False, 6),
+            Motor(270,  True,  7),
+            Motor(90,   True,  8),
             ]
         if frame == 'octax':
             for i in range(8):
                 motors[i].angle += 22.5
+    elif frame in ["octa-quad"]:
+        motors = [
+            Motor(  45, False, 1),
+            Motor( -45, True,  2),
+            Motor(-135, False, 3),
+            Motor( 135, True,  4),
+            Motor( -45, False, 5),
+            Motor(  45, True,  6),
+            Motor( 135, False, 7),
+            Motor(-135, True,  8),
+            ]
     else:
         raise RuntimeError("Unknown multicopter frame type '%s'" % frame)
 

--- a/Tools/autotest/sim_vehicle.sh
+++ b/Tools/autotest/sim_vehicle.sh
@@ -183,6 +183,10 @@ case $FRAME in
     octa)
 	BUILD_TARGET="sitl-octa"
         EXTRA_SIM="--frame=octa"
+  ;;
+    octa-quad)
+  BUILD_TARGET="sitl-octa-quad"
+        EXTRA_SIM="--frame=octa-quad"
 	;;
     elevon*)
         EXTRA_PARM="param set ELEVON_OUTPUT 4;"


### PR DESCRIPTION
Seems octas were a little behind in SITL-land, octa-quad (x8) was missing, and the existing octa target had a weird motor ordering