### PR TITLE
AP_GPS: Arduplane skips support for NMEA and SIRF on older boards

### DIFF
--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -47,7 +47,7 @@
 /**
  * save flash by skipping NMEA and SIRF support on ArduCopter and ArduPlane on APM1/2 or any frame type on AVR1280 CPUs
  */
-#if HAL_CPU_CLASS < HAL_CPU_CLASS_75 //&& defined(APM_BUILD_DIRECTORY)
+#if HAL_CPU_CLASS < HAL_CPU_CLASS_75 && defined(APM_BUILD_DIRECTORY)
   #if (APM_BUILD_TYPE(APM_BUILD_ArduCopter) || APM_BUILD_TYPE(APM_BUILD_ArduPlane) || defined(__AVR_ATmega1280__))
     #define GPS_SKIP_SIRF_NMEA
   #endif

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -45,10 +45,10 @@
 #endif
 
 /**
- * save flash by skipping NMEA and SIRF support on ArduCopter on APM1/2 or any frame type on AVR1280 CPUs
+ * save flash by skipping NMEA and SIRF support on ArduCopter and ArduPlane on APM1/2 or any frame type on AVR1280 CPUs
  */
-#if HAL_CPU_CLASS < HAL_CPU_CLASS_75 && defined(APM_BUILD_DIRECTORY)
-  #if (APM_BUILD_TYPE(APM_BUILD_ArduCopter) || defined(__AVR_ATmega1280__))
+#if HAL_CPU_CLASS < HAL_CPU_CLASS_75 //&& defined(APM_BUILD_DIRECTORY)
+  #if (APM_BUILD_TYPE(APM_BUILD_ArduCopter) || APM_BUILD_TYPE(APM_BUILD_ArduPlane) || defined(__AVR_ATmega1280__))
     #define GPS_SKIP_SIRF_NMEA
   #endif
 #endif


### PR DESCRIPTION
Hello everyone,

Newest Arduplane code would not fit in nearest future on older boards due an out of flash space, so for gain some kbs (about 4kb) we need to remove some options. Originally APM1 and APM2 kits have been shipped with MTK and UBlox GPS. Rarelly we have used pure NMEA & SIRF GPS units. I have two NMEA GPS connected now to my airplanes, and of course they are in order of flight, so this pull request is not good for me, but... I think if you fly like me, is best to get new code with bugs fixed and new improvements than crash your plane...

Regards from Spain,
Dario.