### PR TITLE
ArduPlane: port INITIAL_MODE param from rover

### DIFF
--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -271,6 +271,7 @@ public:
         k_param_flight_mode4,
         k_param_flight_mode5,
         k_param_flight_mode6,
+        k_param_initial_mode,
 
         //
         // 220: Waypoint data
@@ -403,6 +404,7 @@ public:
     AP_Int8 flight_mode4;
     AP_Int8 flight_mode5;
     AP_Int8 flight_mode6;
+    AP_Int8 initial_mode;
 
     // Navigational maneuvering limits
     //

--- a/ArduPlane/Parameters.pde
+++ b/ArduPlane/Parameters.pde
@@ -596,6 +596,13 @@ const AP_Param::Info var_info[] PROGMEM = {
     // @User: Standard
     GSCALAR(flight_mode6,           "FLTMODE6",       FLIGHT_MODE_6),
 
+    // @Param: INITIAL_MODE
+    // @DisplayName: Initial driving mode
+    // @Description: This selects the mode to start in on boot. This is useful for when you want to start in AUTO mode on boot without a receiver.
+    // @Values: 0:Manual,1:CIRCLE,2:STABILIZE,3:TRAINING,4:ACRO,5:FBWA,6:FBWB,7:CRUISE,8:AUTOTUNE,10:Auto,11:RTL,12:Loiter,15:Guided
+    // @User: Advanced
+    GSCALAR(initial_mode,        "INITIAL_MODE",     MANUAL),
+
     // @Param: LIM_ROLL_CD
     // @DisplayName: Maximum Bank Angle
     // @Description: The maximum commanded bank angle in either direction

--- a/ArduPlane/system.pde
+++ b/ArduPlane/system.pde
@@ -218,7 +218,7 @@ static void init_ardupilot()
     // choose the nav controller
     set_nav_controller();
 
-    set_mode(MANUAL);
+    set_mode((FlightMode)g.initial_mode.get());
 
     // set the correct flight mode
     // ---------------------------


### PR DESCRIPTION
added INITIAL_MODE which is the mode we boot up into. Default is MANUAL. This is useful when flying without a RX or if you have a RX that outputs zeros without a detected Txmtr. This is a port from rover.