### PR TITLE
ArduPlane: Disarm On Land param

### DIFF
--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -73,6 +73,7 @@ public:
         k_param_reset_mission_chan,
         k_param_land_flare_alt,
         k_param_land_flare_sec,
+        k_param_land_disarm_delay,
         k_param_crosstrack_min_distance, // unused
         k_param_rudder_steer, // unused
         k_param_throttle_nudge,
@@ -430,6 +431,7 @@ public:
     AP_Int32 RTL_altitude_cm;
     AP_Float land_flare_alt;
     AP_Float land_flare_sec;
+    AP_Int16 land_disarm_delay;
     AP_Int32 min_gndspeed_cm;
     AP_Int16 pitch_trim_cd;
     AP_Int16 FBWB_min_altitude_cm;

--- a/ArduPlane/Parameters.pde
+++ b/ArduPlane/Parameters.pde
@@ -223,6 +223,14 @@ const AP_Param::Info var_info[] PROGMEM = {
     // @User: Advanced
     GSCALAR(land_flare_sec,          "LAND_FLARE_SEC",  2.0),
 
+    // @Param: LAND_DISARM_DELY
+    // @DisplayName: Landing disarm delay
+    // @Description: After a landing has occur using a LAND waypoint, automatically disarm after this many seconds have passed. Use 0 to not disarm.
+    // @Units: seconds
+    // @Increment: 1
+    // @User: Advanced
+    GSCALAR(land_disarm_delay,       "LAND_DISARM_DELY",  0),
+
 	// @Param: NAV_CONTROLLER
 	// @DisplayName: Navigation controller selection
 	// @Description: Which navigation controller to enable. Currently the only navigation controller available is L1. From time to time other experimental conrtrollers will be added which are selected using this parameter.


### PR DESCRIPTION
After a landing has occur using a LAND waypoint, automatically disarm after this many seconds have passed. Use 0 to not disarm. This is checked once per second to minimize demand on resource. The param is called "LAND_DISARM_DELY" note the spelling of DELY due to constrained string size