### PR TITLE
Vagrant: bash gets confused if you pass in .sh files from windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+
+# bash gets confused if you pass in .sh files from windows
+# This breaks Vagrant for some users.
+*.sh text eol=lf
+
+


### PR DESCRIPTION
This change prevents git from adding carriage returns to .sh files