### PR TITLE
ardupilot: add ArduPlane/test to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ ArduCopter/Debug/
 ArduCopter/terrain/*.DAT
 ArduCopter/test.ArduCopter/
 ArduCopter/test/*
+ArduPlane/test/*
 ArduPlane/terrain/*.DAT
 ArduPlane/test.ArduPlane/
 APMrover2/test.APMrover2/


### PR DESCRIPTION
add ArduPlane/test/* to gitignore so that the ArduPlane SITL example (--aircraft test) won't show flight logs as changes. ArduCopter already has this.