### PR TITLE
HAL_PX4: allow 16ch S.BUS output via PX4IO

### DIFF
--- a/libraries/AP_HAL_PX4/RCOutput.cpp
+++ b/libraries/AP_HAL_PX4/RCOutput.cpp
@@ -343,8 +343,8 @@ void PX4RCOutput::_timer_tick(void)
         if (_max_channel <= _servo_count) {
             ::write(_pwm_fd, _period, _max_channel*sizeof(_period[0]));
         } else {
-            // we're using both sets of outputs
-            ::write(_pwm_fd, _period, _servo_count*sizeof(_period[0]));
+            // we're using both sets of outputs, but write all channels to PX4IO to allow >8ch S.BUS out
+            ::write(_pwm_fd, _period, _max_channel*sizeof(_period[0]));
             if (_alt_fd != -1 && _alt_servo_count > 0) {
                 uint8_t n = _max_channel - _servo_count;
                 if (n > _alt_servo_count) {


### PR DESCRIPTION
Allow to output more than 8 channels on Pixhawk's S.BUS out connector. The higher channels are  ignored for output on PWM servo connectors, while forwared to S.BUS out.