### PR TITLE
AP_Math: Move simple math function implementations to header for better compile time optimization

### DIFF
--- a/libraries/AP_Math/AP_Math.cpp
+++ b/libraries/AP_Math/AP_Math.cpp
@@ -118,50 +118,5 @@ enum Rotation rotation_combination(enum Rotation r1, enum Rotation r2, bool *fou
 }
 #endif
 
-// constrain a value
-float constrain_float(float amt, float low, float high) 
-{
-	// the check for NaN as a float prevents propogation of
-	// floating point errors through any function that uses
-	// constrain_float(). The normal float semantics already handle -Inf
-	// and +Inf
-	if (isnan(amt)) {
-		return (low+high)*0.5f;
-	}
-	return ((amt)<(low)?(low):((amt)>(high)?(high):(amt)));
-}
 
-// constrain a int16_t value
-int16_t constrain_int16(int16_t amt, int16_t low, int16_t high) {
-	return ((amt)<(low)?(low):((amt)>(high)?(high):(amt)));
-}
 
-// constrain a int32_t value
-int32_t constrain_int32(int32_t amt, int32_t low, int32_t high) {
-	return ((amt)<(low)?(low):((amt)>(high)?(high):(amt)));
-}
-
-// degrees -> radians
-float radians(float deg) {
-	return deg * DEG_TO_RAD;
-}
-
-// radians -> degrees
-float degrees(float rad) {
-	return rad * RAD_TO_DEG;
-}
-
-// square
-float sq(float v) {
-	return v*v;
-}
-
-// 2D vector length
-float pythagorous2(float a, float b) {
-	return sqrtf(sq(a)+sq(b));
-}
-
-// 3D vector length
-float pythagorous3(float a, float b, float c) {
-	return sqrtf(sq(a)+sq(b)+sq(c));
-}

--- a/libraries/AP_Math/AP_Math.cpp
+++ b/libraries/AP_Math/AP_Math.cpp
@@ -118,5 +118,54 @@ enum Rotation rotation_combination(enum Rotation r1, enum Rotation r2, bool *fou
 }
 #endif
 
+#if HAL_CPU_CLASS < HAL_CPU_CLASS_75
+// constrain a value
+// constrain a value
+float constrain_float(float amt, float low, float high)
+{
+  // the check for NaN as a float prevents propogation of
+  // floating point errors through any function that uses
+  // constrain_float(). The normal float semantics already handle -Inf
+  // and +Inf
+  if (isnan(amt)) {
+    return (low+high)*0.5f;
+  }
+  return ((amt)<(low)?(low):((amt)>(high)?(high):(amt)));
+}
+// constrain a int16_t value
+int16_t constrain_int16(int16_t amt, int16_t low, int16_t high) {
+  return ((amt)<(low)?(low):((amt)>(high)?(high):(amt)));
+}
 
+// constrain a int32_t value
+int32_t constrain_int32(int32_t amt, int32_t low, int32_t high) {
+  return ((amt)<(low)?(low):((amt)>(high)?(high):(amt)));
+}
+
+// degrees -> radians
+float radians(float deg) {
+  return deg * DEG_TO_RAD;
+}
+
+// radians -> degrees
+float degrees(float rad) {
+  return rad * RAD_TO_DEG;
+}
+
+// square
+float sq(float v) {
+  return v*v;
+}
+
+// 2D vector length
+float pythagorous2(float a, float b) {
+  return sqrtf(sq(a)+sq(b));
+}
+
+// 3D vector length
+float pythagorous3(float a, float b, float c) {
+  return sqrtf(sq(a)+sq(b)+sq(c));
+}
+
+#endif
 

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -166,22 +166,52 @@ void wgsecef2llh(const Vector3d &ecef, Vector3d &llh);
 #endif
 
 // constrain a value
-float   constrain_float(float amt, float low, float high);
-int16_t constrain_int16(int16_t amt, int16_t low, int16_t high);
-int32_t constrain_int32(int32_t amt, int32_t low, int32_t high);
+// constrain a value
+inline float constrain_float(float amt, float low, float high)
+{
+	// the check for NaN as a float prevents propogation of
+	// floating point errors through any function that uses
+	// constrain_float(). The normal float semantics already handle -Inf
+	// and +Inf
+	if (isnan(amt)) {
+		return (low+high)*0.5f;
+	}
+	return ((amt)<(low)?(low):((amt)>(high)?(high):(amt)));
+}
+// constrain a int16_t value
+inline int16_t constrain_int16(int16_t amt, int16_t low, int16_t high) {
+	return ((amt)<(low)?(low):((amt)>(high)?(high):(amt)));
+}
+
+// constrain a int32_t value
+inline int32_t constrain_int32(int32_t amt, int32_t low, int32_t high) {
+	return ((amt)<(low)?(low):((amt)>(high)?(high):(amt)));
+}
 
 // degrees -> radians
-float radians(float deg);
+inline float radians(float deg) {
+	return deg * DEG_TO_RAD;
+}
 
 // radians -> degrees
-float degrees(float rad);
+inline float degrees(float rad) {
+	return rad * RAD_TO_DEG;
+}
 
 // square
-float sq(float v);
+inline float sq(float v) {
+	return v*v;
+}
 
-// sqrt of sum of squares
-float pythagorous2(float a, float b);
-float pythagorous3(float a, float b, float c);
+// 2D vector length
+inline float pythagorous2(float a, float b) {
+	return sqrtf(sq(a)+sq(b));
+}
+
+// 3D vector length
+inline float pythagorous3(float a, float b, float c) {
+	return sqrtf(sq(a)+sq(b)+sq(c));
+}
 
 #ifdef radians
 #error "Build is including Arduino base headers"

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -20,6 +20,14 @@
 #include "polygon.h"
 #include "edc.h"
 
+#ifdef __AVR__
+//do not inline functions on avr hardware
+//since this increases code size
+#define INLINE static inline __attribute((noinline))
+#else
+#define INLINE static inline
+#endif
+
 #ifndef M_PI_F
  #define M_PI_F 3.141592653589793f
 #endif
@@ -167,7 +175,7 @@ void wgsecef2llh(const Vector3d &ecef, Vector3d &llh);
 
 // constrain a value
 // constrain a value
-inline float constrain_float(float amt, float low, float high)
+INLINE float constrain_float(float amt, float low, float high)
 {
 	// the check for NaN as a float prevents propogation of
 	// floating point errors through any function that uses
@@ -179,37 +187,37 @@ inline float constrain_float(float amt, float low, float high)
 	return ((amt)<(low)?(low):((amt)>(high)?(high):(amt)));
 }
 // constrain a int16_t value
-inline int16_t constrain_int16(int16_t amt, int16_t low, int16_t high) {
+INLINE int16_t constrain_int16(int16_t amt, int16_t low, int16_t high) {
 	return ((amt)<(low)?(low):((amt)>(high)?(high):(amt)));
 }
 
 // constrain a int32_t value
-inline int32_t constrain_int32(int32_t amt, int32_t low, int32_t high) {
+INLINE int32_t constrain_int32(int32_t amt, int32_t low, int32_t high) {
 	return ((amt)<(low)?(low):((amt)>(high)?(high):(amt)));
 }
 
 // degrees -> radians
-inline float radians(float deg) {
+INLINE float radians(float deg) {
 	return deg * DEG_TO_RAD;
 }
 
 // radians -> degrees
-inline float degrees(float rad) {
+INLINE float degrees(float rad) {
 	return rad * RAD_TO_DEG;
 }
 
 // square
-inline float sq(float v) {
+INLINE float sq(float v) {
 	return v*v;
 }
 
 // 2D vector length
-inline float pythagorous2(float a, float b) {
+INLINE float pythagorous2(float a, float b) {
 	return sqrtf(sq(a)+sq(b));
 }
 
 // 3D vector length
-inline float pythagorous3(float a, float b, float c) {
+INLINE float pythagorous3(float a, float b, float c) {
 	return sqrtf(sq(a)+sq(b)+sq(c));
 }
 
@@ -221,6 +229,6 @@ inline float pythagorous3(float a, float b, float c) {
 #define max(a,b) ((a)>(b)?(a):(b))
 #define min(a,b) ((a)<(b)?(a):(b))
 
-
+#undef INLINE
 #endif // AP_MATH_H
 

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -20,14 +20,6 @@
 #include "polygon.h"
 #include "edc.h"
 
-#ifdef __AVR__
-//do not inline functions on avr hardware
-//since this increases code size
-#define INLINE static inline __attribute((noinline))
-#else
-#define INLINE static inline
-#endif
-
 #ifndef M_PI_F
  #define M_PI_F 3.141592653589793f
 #endif
@@ -173,9 +165,20 @@ void wgsllh2ecef(const Vector3d &llh, Vector3d &ecef);
 void wgsecef2llh(const Vector3d &ecef, Vector3d &llh);
 #endif
 
+#if HAL_CPU_CLASS < HAL_CPU_CLASS_75
+float constrain_float(float amt, float low, float high);
+int16_t constrain_int16(int16_t amt, int16_t low, int16_t high);
+int16_t constrain_int16(int16_t amt, int16_t low, int16_t high);
+int32_t constrain_int32(int32_t amt, int32_t low, int32_t high);
+float radians(float deg);
+float degrees(float rad);
+float sq(float v);
+float pythagorous2(float a, float b);
+float pythagorous3(float a, float b, float c);
+#else
 // constrain a value
 // constrain a value
-INLINE float constrain_float(float amt, float low, float high)
+inline float constrain_float(float amt, float low, float high)
 {
 	// the check for NaN as a float prevents propogation of
 	// floating point errors through any function that uses
@@ -187,39 +190,41 @@ INLINE float constrain_float(float amt, float low, float high)
 	return ((amt)<(low)?(low):((amt)>(high)?(high):(amt)));
 }
 // constrain a int16_t value
-INLINE int16_t constrain_int16(int16_t amt, int16_t low, int16_t high) {
+inline int16_t constrain_int16(int16_t amt, int16_t low, int16_t high) {
 	return ((amt)<(low)?(low):((amt)>(high)?(high):(amt)));
 }
 
 // constrain a int32_t value
-INLINE int32_t constrain_int32(int32_t amt, int32_t low, int32_t high) {
+inline int32_t constrain_int32(int32_t amt, int32_t low, int32_t high) {
 	return ((amt)<(low)?(low):((amt)>(high)?(high):(amt)));
 }
 
 // degrees -> radians
-INLINE float radians(float deg) {
+inline float radians(float deg) {
 	return deg * DEG_TO_RAD;
 }
 
 // radians -> degrees
-INLINE float degrees(float rad) {
+inline float degrees(float rad) {
 	return rad * RAD_TO_DEG;
 }
 
 // square
-INLINE float sq(float v) {
+inline float sq(float v) {
 	return v*v;
 }
 
 // 2D vector length
-INLINE float pythagorous2(float a, float b) {
+inline float pythagorous2(float a, float b) {
 	return sqrtf(sq(a)+sq(b));
 }
 
 // 3D vector length
-INLINE float pythagorous3(float a, float b, float c) {
+inline float pythagorous3(float a, float b, float c) {
 	return sqrtf(sq(a)+sq(b)+sq(c));
 }
+
+#endif
 
 #ifdef radians
 #error "Build is including Arduino base headers"


### PR DESCRIPTION
Functions like sq() are better moved to the header file as inline.
Compiler can then optimize these out when used in code, this saves cpu
cycles with stack push, pop during function calls.

Also it significantly reduced code size (Cortex-M3 build with NavEKF enabled)

Before:
```
 text	   data	    bss	    dec	    hex	
 450272	   3492	  28784	 482548	  75cf4
```
After:
```
text	   data	    bss	    dec	    hex	
410552	   3492	  28780	 442824	  6c1c8
```