### PR TITLE
Copter: changes to alt-hold and throttle control chain

### DIFF
--- a/ArduCopter/control_acro.pde
+++ b/ArduCopter/control_acro.pde
@@ -22,7 +22,7 @@ static void acro_run()
     if(!motors.armed() || g.rc_3.control_in <= 0) {
         attitude_control.relax_bf_rate_controller();
         attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_zero();
         return;
     }
 

--- a/ArduCopter/control_acro.pde
+++ b/ArduCopter/control_acro.pde
@@ -20,9 +20,7 @@ static void acro_run()
 
     // if motors not running reset angle targets
     if(!motors.armed() || g.rc_3.control_in <= 0) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_zero();
+        attitude_control.set_throttle_out_pre_takeoff(0);
         return;
     }
 

--- a/ArduCopter/control_althold.pde
+++ b/ArduCopter/control_althold.pde
@@ -27,9 +27,7 @@ static void althold_run()
 
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_zero();
+        attitude_control.set_throttle_out_pre_takeoff(0);
         pos_control.set_alt_target_to_current_alt();
         return;
     }
@@ -57,10 +55,7 @@ static void althold_run()
 
     // reset target lean angles and heading while landed
     if (ap.land_complete) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        // move throttle to between minimum and non-takeoff-throttle to keep us on the ground
-        attitude_control.set_throttle_out(get_throttle_pre_takeoff(g.rc_3.control_in), false);
+        attitude_control.set_throttle_out_pre_takeoff(get_throttle_pre_takeoff(g.rc_3.control_in));
         pos_control.set_alt_target_to_current_alt();
     }else{
         // call attitude controller

--- a/ArduCopter/control_althold.pde
+++ b/ArduCopter/control_althold.pde
@@ -29,7 +29,7 @@ static void althold_run()
     if(!ap.auto_armed) {
         attitude_control.relax_bf_rate_controller();
         attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_zero();
         pos_control.set_alt_target_to_current_alt();
         return;
     }

--- a/ArduCopter/control_auto.pde
+++ b/ArduCopter/control_auto.pde
@@ -114,9 +114,7 @@ static void auto_takeoff_run()
         // initialise wpnav targets
         wp_nav.shift_wp_origin_to_current_pos();
         // reset attitude control targets
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_zero();
+        attitude_control.set_throttle_out_pre_takeoff(0);
         // tell motors to do a slow start
         motors.slow_start(true);
         return;
@@ -162,9 +160,7 @@ static void auto_wp_run()
     if(!ap.auto_armed) {
         // To-Do: reset waypoint origin to current location because copter is probably on the ground so we don't want it lurching left or right on take-off
         //    (of course it would be better if people just used take-off)
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_zero();
+        attitude_control.set_throttle_out_pre_takeoff(0);
         // tell motors to do a slow start
         motors.slow_start(true);
         return;
@@ -220,9 +216,7 @@ static void auto_spline_run()
     if(!ap.auto_armed) {
         // To-Do: reset waypoint origin to current location because copter is probably on the ground so we don't want it lurching left or right on take-off
         //    (of course it would be better if people just used take-off)
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_zero();
+        attitude_control.set_throttle_out_pre_takeoff(0);
         // tell motors to do a slow start
         motors.slow_start(true);
         return;
@@ -289,9 +283,7 @@ static void auto_land_run()
 
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed || ap.land_complete) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_zero();
+        attitude_control.set_throttle_out_pre_takeoff(0);
         // set target to current position
         wp_nav.init_loiter_target();
         return;
@@ -457,9 +449,7 @@ void auto_loiter_run()
 {
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed || ap.land_complete) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_zero();
+        attitude_control.set_throttle_out_pre_takeoff(0);
         return;
     }
 

--- a/ArduCopter/control_auto.pde
+++ b/ArduCopter/control_auto.pde
@@ -116,7 +116,7 @@ static void auto_takeoff_run()
         // reset attitude control targets
         attitude_control.relax_bf_rate_controller();
         attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_zero();
         // tell motors to do a slow start
         motors.slow_start(true);
         return;
@@ -164,7 +164,7 @@ static void auto_wp_run()
         //    (of course it would be better if people just used take-off)
         attitude_control.relax_bf_rate_controller();
         attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_zero();
         // tell motors to do a slow start
         motors.slow_start(true);
         return;
@@ -222,7 +222,7 @@ static void auto_spline_run()
         //    (of course it would be better if people just used take-off)
         attitude_control.relax_bf_rate_controller();
         attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_zero();
         // tell motors to do a slow start
         motors.slow_start(true);
         return;
@@ -291,7 +291,7 @@ static void auto_land_run()
     if(!ap.auto_armed || ap.land_complete) {
         attitude_control.relax_bf_rate_controller();
         attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_zero();
         // set target to current position
         wp_nav.init_loiter_target();
         return;
@@ -459,7 +459,7 @@ void auto_loiter_run()
     if(!ap.auto_armed || ap.land_complete) {
         attitude_control.relax_bf_rate_controller();
         attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_zero();
         return;
     }
 

--- a/ArduCopter/control_autotune.pde
+++ b/ArduCopter/control_autotune.pde
@@ -258,7 +258,7 @@ static void autotune_run()
     if (!ap.auto_armed) {
         attitude_control.relax_bf_rate_controller();
         attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_zero();
         pos_control.set_alt_target_to_current_alt();
         return;
     }

--- a/ArduCopter/control_autotune.pde
+++ b/ArduCopter/control_autotune.pde
@@ -256,9 +256,7 @@ static void autotune_run()
     // if not auto armed set throttle to zero and exit immediately
     // this should not actually be possible because of the autotune_init() checks
     if (!ap.auto_armed) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_zero();
+        attitude_control.set_throttle_out_pre_takeoff(0);
         pos_control.set_alt_target_to_current_alt();
         return;
     }
@@ -285,10 +283,8 @@ static void autotune_run()
 
     // reset target lean angles and heading while landed
     if (ap.land_complete) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
         // move throttle to between minimum and non-takeoff-throttle to keep us on the ground
-        attitude_control.set_throttle_out(get_throttle_pre_takeoff(g.rc_3.control_in), false);
+        attitude_control.set_throttle_out_pre_takeoff(get_throttle_pre_takeoff(g.rc_3.control_in));
         pos_control.set_alt_target_to_current_alt();
     }else{
         // check if pilot is overriding the controls

--- a/ArduCopter/control_circle.pde
+++ b/ArduCopter/control_circle.pde
@@ -35,9 +35,7 @@ static void circle_run()
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed || ap.land_complete) {
         // To-Do: add some initialisation of position controllers
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_zero();
+        attitude_control.set_throttle_out_pre_takeoff(0);
         pos_control.set_alt_target_to_current_alt();
         return;
     }

--- a/ArduCopter/control_circle.pde
+++ b/ArduCopter/control_circle.pde
@@ -37,7 +37,7 @@ static void circle_run()
         // To-Do: add some initialisation of position controllers
         attitude_control.relax_bf_rate_controller();
         attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_zero();
         pos_control.set_alt_target_to_current_alt();
         return;
     }

--- a/ArduCopter/control_drift.pde
+++ b/ArduCopter/control_drift.pde
@@ -50,7 +50,7 @@ static void drift_run()
     if(!motors.armed() || (ap.land_complete && ap.throttle_zero)) {
         attitude_control.relax_bf_rate_controller();
         attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_zero();
         return;
     }
 

--- a/ArduCopter/control_drift.pde
+++ b/ArduCopter/control_drift.pde
@@ -48,9 +48,7 @@ static void drift_run()
 
     // if not armed or landed and throttle at zero, set throttle to zero and exit immediately
     if(!motors.armed() || (ap.land_complete && ap.throttle_zero)) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_zero();
+        attitude_control.set_throttle_out_pre_takeoff(0);
         return;
     }
 

--- a/ArduCopter/control_flip.pde
+++ b/ArduCopter/control_flip.pde
@@ -218,5 +218,9 @@ static void flip_run()
     }
 
     // output pilot's throttle without angle boost
-    attitude_control.set_throttle_out(throttle_out, false);
+    if (throttle_out == 0.0f) {
+        attitude_control.set_throttle_zero();
+    } else {
+        attitude_control.set_throttle_out(throttle_out, false);
+    }
 }

--- a/ArduCopter/control_guided.pde
+++ b/ArduCopter/control_guided.pde
@@ -161,9 +161,7 @@ static void guided_run()
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed) {
         // To-Do: reset waypoint controller?
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_zero();
+        attitude_control.set_throttle_out_pre_takeoff(0);
         // To-Do: handle take-offs - these may not only be immediately after auto_armed becomes true
         return;
     }
@@ -202,9 +200,7 @@ static void guided_takeoff_run()
         // initialise wpnav targets
         wp_nav.shift_wp_origin_to_current_pos();
         // reset attitude control targets
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_zero();
+        attitude_control.set_throttle_out_pre_takeoff(0);
         // tell motors to do a slow start
         motors.slow_start(true);
         return;

--- a/ArduCopter/control_guided.pde
+++ b/ArduCopter/control_guided.pde
@@ -163,7 +163,7 @@ static void guided_run()
         // To-Do: reset waypoint controller?
         attitude_control.relax_bf_rate_controller();
         attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_zero();
         // To-Do: handle take-offs - these may not only be immediately after auto_armed becomes true
         return;
     }
@@ -204,7 +204,7 @@ static void guided_takeoff_run()
         // reset attitude control targets
         attitude_control.relax_bf_rate_controller();
         attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_zero();
         // tell motors to do a slow start
         motors.slow_start(true);
         return;

--- a/ArduCopter/control_land.pde
+++ b/ArduCopter/control_land.pde
@@ -52,9 +52,7 @@ static void land_gps_run()
 
     // if not auto armed or landed set throttle to zero and exit immediately
     if(!ap.auto_armed || ap.land_complete) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_zero();
+        attitude_control.set_throttle_out_pre_takeoff(0);
         wp_nav.init_loiter_target();
 
 #if LAND_REQUIRE_MIN_THROTTLE_TO_DISARM == ENABLED
@@ -127,9 +125,7 @@ static void land_nogps_run()
 
     // if not auto armed or landed set throttle to zero and exit immediately
     if(!ap.auto_armed || ap.land_complete) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_zero();
+        attitude_control.set_throttle_out_pre_takeoff(0);
 #if LAND_REQUIRE_MIN_THROTTLE_TO_DISARM == ENABLED
         // disarm when the landing detector says we've landed and throttle is at minimum
         if (ap.land_complete && (ap.throttle_zero || failsafe.radio)) {

--- a/ArduCopter/control_land.pde
+++ b/ArduCopter/control_land.pde
@@ -54,7 +54,7 @@ static void land_gps_run()
     if(!ap.auto_armed || ap.land_complete) {
         attitude_control.relax_bf_rate_controller();
         attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_zero();
         wp_nav.init_loiter_target();
 
 #if LAND_REQUIRE_MIN_THROTTLE_TO_DISARM == ENABLED
@@ -129,7 +129,7 @@ static void land_nogps_run()
     if(!ap.auto_armed || ap.land_complete) {
         attitude_control.relax_bf_rate_controller();
         attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_zero();
 #if LAND_REQUIRE_MIN_THROTTLE_TO_DISARM == ENABLED
         // disarm when the landing detector says we've landed and throttle is at minimum
         if (ap.land_complete && (ap.throttle_zero || failsafe.radio)) {

--- a/ArduCopter/control_loiter.pde
+++ b/ArduCopter/control_loiter.pde
@@ -35,9 +35,7 @@ static void loiter_run()
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed) {
         wp_nav.init_loiter_target();
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_zero();
+        attitude_control.set_throttle_out_pre_takeoff(0);
         pos_control.set_alt_target_to_current_alt();
         return;
     }
@@ -76,10 +74,8 @@ static void loiter_run()
     // when landed reset targets and output zero throttle
     if (ap.land_complete) {
         wp_nav.init_loiter_target();
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
         // move throttle to between minimum and non-takeoff-throttle to keep us on the ground
-        attitude_control.set_throttle_out(get_throttle_pre_takeoff(g.rc_3.control_in), false);
+        attitude_control.set_throttle_out_pre_takeoff(get_throttle_pre_takeoff(g.rc_3.control_in));
         pos_control.set_alt_target_to_current_alt();
     }else{
         // run loiter controller

--- a/ArduCopter/control_loiter.pde
+++ b/ArduCopter/control_loiter.pde
@@ -37,7 +37,7 @@ static void loiter_run()
         wp_nav.init_loiter_target();
         attitude_control.relax_bf_rate_controller();
         attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_zero();
         pos_control.set_alt_target_to_current_alt();
         return;
     }

--- a/ArduCopter/control_poshold.pde
+++ b/ArduCopter/control_poshold.pde
@@ -158,7 +158,7 @@ static void poshold_run()
         wp_nav.init_loiter_target();
         attitude_control.relax_bf_rate_controller();
         attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_zero();
         pos_control.set_alt_target_to_current_alt();
         return;
     }

--- a/ArduCopter/control_poshold.pde
+++ b/ArduCopter/control_poshold.pde
@@ -156,9 +156,7 @@ static void poshold_run()
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed) {
         wp_nav.init_loiter_target();
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_zero();
+        attitude_control.set_throttle_out_pre_takeoff(0);
         pos_control.set_alt_target_to_current_alt();
         return;
     }
@@ -191,10 +189,8 @@ static void poshold_run()
     // if landed initialise loiter targets, set throttle to zero and exit
     if (ap.land_complete) {
         wp_nav.init_loiter_target();
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
         // move throttle to between minimum and non-takeoff-throttle to keep us on the ground
-        attitude_control.set_throttle_out(get_throttle_pre_takeoff(g.rc_3.control_in), false);
+        attitude_control.set_throttle_out_pre_takeoff(get_throttle_pre_takeoff(g.rc_3.control_in));
         pos_control.set_alt_target_to_current_alt();
         return;
     }else{

--- a/ArduCopter/control_rtl.pde
+++ b/ArduCopter/control_rtl.pde
@@ -136,7 +136,7 @@ static void rtl_climb_return_run()
         // reset attitude control targets
         attitude_control.relax_bf_rate_controller();
         attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_zero();
         // To-Do: re-initialise wpnav targets
         return;
     }
@@ -194,7 +194,7 @@ static void rtl_loiterathome_run()
         // reset attitude control targets
         attitude_control.relax_bf_rate_controller();
         attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_zero();
         // To-Do: re-initialise wpnav targets
         return;
     }
@@ -265,7 +265,7 @@ static void rtl_descent_run()
     if(!ap.auto_armed) {
         attitude_control.relax_bf_rate_controller();
         attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_zero();
         // set target to current position
         wp_nav.init_loiter_target();
         return;
@@ -329,7 +329,7 @@ static void rtl_land_run()
     if(!ap.auto_armed || ap.land_complete) {
         attitude_control.relax_bf_rate_controller();
         attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_zero();
         // set target to current position
         wp_nav.init_loiter_target();
 

--- a/ArduCopter/control_rtl.pde
+++ b/ArduCopter/control_rtl.pde
@@ -134,9 +134,7 @@ static void rtl_climb_return_run()
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed) {
         // reset attitude control targets
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_zero();
+        attitude_control.set_throttle_out_pre_takeoff(0);
         // To-Do: re-initialise wpnav targets
         return;
     }
@@ -192,9 +190,7 @@ static void rtl_loiterathome_run()
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed) {
         // reset attitude control targets
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_zero();
+        attitude_control.set_throttle_out_pre_takeoff(0);
         // To-Do: re-initialise wpnav targets
         return;
     }
@@ -263,9 +259,7 @@ static void rtl_descent_run()
 
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_zero();
+        attitude_control.set_throttle_out_pre_takeoff(0);
         // set target to current position
         wp_nav.init_loiter_target();
         return;
@@ -327,9 +321,7 @@ static void rtl_land_run()
     float target_yaw_rate = 0;
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed || ap.land_complete) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_zero();
+        attitude_control.set_throttle_out_pre_takeoff(0);
         // set target to current position
         wp_nav.init_loiter_target();
 

--- a/ArduCopter/control_sport.pde
+++ b/ArduCopter/control_sport.pde
@@ -26,9 +26,7 @@ static void sport_run()
 
     // if not armed or throttle at zero, set throttle to zero and exit immediately
     if(!motors.armed() || g.rc_3.control_in <= 0) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_zero();
+        attitude_control.set_throttle_out_pre_takeoff(0);
         pos_control.set_alt_target_to_current_alt();
         return;
     }
@@ -77,10 +75,8 @@ static void sport_run()
 
     // reset target lean angles and heading while landed
     if (ap.land_complete) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
         // move throttle to between minimum and non-takeoff-throttle to keep us on the ground
-        attitude_control.set_throttle_out(get_throttle_pre_takeoff(g.rc_3.control_in), false);
+        attitude_control.set_throttle_out_pre_takeoff(get_throttle_pre_takeoff(g.rc_3.control_in));
         pos_control.set_alt_target_to_current_alt();
     }else{
 

--- a/ArduCopter/control_sport.pde
+++ b/ArduCopter/control_sport.pde
@@ -28,7 +28,7 @@ static void sport_run()
     if(!motors.armed() || g.rc_3.control_in <= 0) {
         attitude_control.relax_bf_rate_controller();
         attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_zero();
         pos_control.set_alt_target_to_current_alt();
         return;
     }

--- a/ArduCopter/control_stabilize.pde
+++ b/ArduCopter/control_stabilize.pde
@@ -27,7 +27,7 @@ static void stabilize_run()
     if(!motors.armed() || g.rc_3.control_in <= 0) {
         attitude_control.relax_bf_rate_controller();
         attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_zero();
         return;
     }
 

--- a/ArduCopter/control_stabilize.pde
+++ b/ArduCopter/control_stabilize.pde
@@ -25,9 +25,7 @@ static void stabilize_run()
 
     // if not armed or throttle at zero, set throttle to zero and exit immediately
     if(!motors.armed() || g.rc_3.control_in <= 0) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_zero();
+        attitude_control.set_throttle_out_pre_takeoff(0);
         return;
     }
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -706,7 +706,7 @@ void AC_AttitudeControl::accel_limiting(bool enable_limits)
 
  // set_throttle_out - to be called by upper throttle controllers when they wish to provide throttle output directly to motors
  // provide 0 to cut motors
-void AC_AttitudeControl::set_throttle_out(int16_t throttle_out, bool apply_angle_boost)
+void AC_AttitudeControl::set_throttle_out(float throttle_out, bool apply_angle_boost)
 {
     if (apply_angle_boost) {
         _motors.set_throttle(get_angle_boost(throttle_out));
@@ -719,10 +719,10 @@ void AC_AttitudeControl::set_throttle_out(int16_t throttle_out, bool apply_angle
 
 // get_angle_boost - returns a throttle including compensation for roll/pitch angle
 // throttle value should be 0 ~ 1000
-int16_t AC_AttitudeControl::get_angle_boost(int16_t throttle_pwm)
+float AC_AttitudeControl::get_angle_boost(float throttle_pwm)
 {
     float temp = _ahrs.cos_pitch() * _ahrs.cos_roll();
-    int16_t throttle_out;
+    float throttle_out;
 
     temp = constrain_float(temp, 0.5f, 1.0f);
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -709,12 +709,18 @@ void AC_AttitudeControl::accel_limiting(bool enable_limits)
 void AC_AttitudeControl::set_throttle_out(float throttle_out, bool apply_angle_boost)
 {
     if (apply_angle_boost) {
+        _motors.set_stabilize(true);
         _motors.set_throttle(get_angle_boost(throttle_out));
     }else{
+        _motors.set_stabilize(true);
         _motors.set_throttle(throttle_out);
         // clear angle_boost for logging purposes
         _angle_boost = 0;
     }
+}
+
+void AC_AttitudeControl::set_throttle_zero() {
+    _motors.set_stabilize(false);
 }
 
 // get_angle_boost - returns a throttle including compensation for roll/pitch angle

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -704,23 +704,33 @@ void AC_AttitudeControl::accel_limiting(bool enable_limits)
 // throttle functions
 //
 
- // set_throttle_out - to be called by upper throttle controllers when they wish to provide throttle output directly to motors
- // provide 0 to cut motors
-void AC_AttitudeControl::set_throttle_out(float throttle_out, bool apply_angle_boost)
+// set_throttle_out - to be called by upper throttle controllers when they wish to provide throttle output directly to motors
+// provide 0 to cut motors
+void AC_AttitudeControl::set_throttle_out(float throttle_in, bool apply_angle_boost)
 {
+    float throttle_out = throttle_in;
     if (apply_angle_boost) {
-        _motors.set_stabilize(true);
-        _motors.set_throttle(get_angle_boost(throttle_out));
-    }else{
-        _motors.set_stabilize(true);
-        _motors.set_throttle(throttle_out);
-        // clear angle_boost for logging purposes
-        _angle_boost = 0;
+        // inverted_factor is 1 for tilt angles below 60 degrees
+        // reduces as a function of angle beyond 60 degrees
+        // becomes zero at 90 degrees
+        float min_throttle = _motors.throttle_min();
+        float cos_tilt = _ahrs.cos_pitch() * _ahrs.cos_roll();
+        float inverted_factor = constrain_float(2.0f*cos_tilt, 0.0f, 1.0f);
+        float boost_factor = 1.0f/constrain_float(cos_tilt, 0.5f, 1.0f);
+
+        throttle_out = (throttle_in-min_throttle)*inverted_factor*boost_factor + min_throttle;
     }
+    _angle_boost = throttle_out - throttle_in;
+
+    _motors.set_stabilize(true);
+    _motors.set_throttle(throttle_out);
 }
 
-void AC_AttitudeControl::set_throttle_zero() {
+void AC_AttitudeControl::set_throttle_zero()
+{
+    _angle_boost = 0.0f;
     _motors.set_stabilize(false);
+    _motors.set_throttle(0.0f);
 }
 
 // outputs a throttle to all motors evenly with no stabilization
@@ -733,28 +743,6 @@ void AC_AttitudeControl::set_throttle_out_pre_takeoff(float throttle_in)
     } else {
         set_throttle_out(throttle_in, false);
     }
-}
-
-// get_angle_boost - returns a throttle including compensation for roll/pitch angle
-// throttle value should be 0 ~ 1000
-float AC_AttitudeControl::get_angle_boost(float throttle_pwm)
-{
-    float temp = _ahrs.cos_pitch() * _ahrs.cos_roll();
-    float throttle_out;
-
-    temp = constrain_float(temp, 0.5f, 1.0f);
-
-    // reduce throttle if we go inverted
-    temp = constrain_float(9000-max(labs(_ahrs.roll_sensor),labs(_ahrs.pitch_sensor)), 0, 3000) / (3000 * temp);
-
-    // apply scale and constrain throttle
-    // To-Do: move throttle_min and throttle_max into the AP_Vehicles class?
-    throttle_out = constrain_float((float)(throttle_pwm-_motors.throttle_min()) * temp + _motors.throttle_min(), _motors.throttle_min(), 1000);
-
-    // record angle boost for logging
-    _angle_boost = throttle_out - throttle_pwm;
-
-    return throttle_out;
 }
 
 // sqrt_controller - response based on the sqrt of the error instead of the more common linear response

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -723,6 +723,18 @@ void AC_AttitudeControl::set_throttle_zero() {
     _motors.set_stabilize(false);
 }
 
+// outputs a throttle to all motors evenly with no stabilization
+void AC_AttitudeControl::set_throttle_out_pre_takeoff(float throttle_in)
+{
+    relax_bf_rate_controller();
+    set_yaw_target_to_current_heading();
+    if (throttle_in == 0.0f) {
+        set_throttle_zero();
+    } else {
+        set_throttle_out(throttle_in, false);
+    }
+}
+
 // get_angle_boost - returns a throttle including compensation for roll/pitch angle
 // throttle value should be 0 ~ 1000
 float AC_AttitudeControl::get_angle_boost(float throttle_pwm)

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -726,6 +726,7 @@ void AC_AttitudeControl::set_throttle_out(float throttle_in, bool apply_angle_bo
     _motors.set_throttle(throttle_out);
 }
 
+// set_throttle_zero - outputs a warning spin at MOT_SPIN_ARMED
 void AC_AttitudeControl::set_throttle_zero()
 {
     _angle_boost = 0.0f;
@@ -733,7 +734,9 @@ void AC_AttitudeControl::set_throttle_zero()
     _motors.set_throttle(0.0f);
 }
 
-// outputs a throttle to all motors evenly with no stabilization
+// set_throttle_out_pre_takeoff - resets integrators, yaw and rate targets
+// outputs a warning spin at the specified throttle
+// calling with zero throttle means MOT_SPIN_ARMED
 void AC_AttitudeControl::set_throttle_out_pre_takeoff(float throttle_in)
 {
     relax_bf_rate_controller();

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -175,7 +175,7 @@ public:
 
      // set_throttle_out - to be called by upper throttle controllers when they wish to provide throttle output directly to motors
      // provide 0 to cut motors
-     void set_throttle_out(int16_t throttle_pwm, bool apply_angle_boost);
+     void set_throttle_out(float throttle_pwm, bool apply_angle_boost);
 
      // angle_boost - accessor for angle boost so it can be logged
      int16_t angle_boost() const { return _angle_boost; }
@@ -232,7 +232,7 @@ protected:
     //
 
     // get_angle_boost - calculate total body frame throttle required to produce the given earth frame throttle
-    virtual int16_t get_angle_boost(int16_t throttle_pwm);
+    virtual float get_angle_boost(float throttle_pwm);
 
     // references to external libraries
     const AP_AHRS&      _ahrs;

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -181,8 +181,8 @@ public:
      // outputs a throttle to all motors evenly with no stabilization
      void set_throttle_out_pre_takeoff(float throttle_in);
 
-     // angle_boost - accessor for angle boost so it can be logged
-     int16_t angle_boost() const { return _angle_boost; }
+    // angle_boost - accessor for angle boost so it can be logged
+    int16_t angle_boost() const { return _angle_boost; }
 
     //
     // helper functions
@@ -230,13 +230,6 @@ protected:
     float rate_bf_to_motor_roll(float rate_target_cds);
     float rate_bf_to_motor_pitch(float rate_target_cds);
     virtual float rate_bf_to_motor_yaw(float rate_target_cds);
-
-    //
-    // throttle methods
-    //
-
-    // get_angle_boost - calculate total body frame throttle required to produce the given earth frame throttle
-    virtual float get_angle_boost(float throttle_pwm);
 
     // references to external libraries
     const AP_AHRS&      _ahrs;

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -178,6 +178,9 @@ public:
 
      void set_throttle_zero();
 
+     // outputs a throttle to all motors evenly with no stabilization
+     void set_throttle_out_pre_takeoff(float throttle_in);
+
      // angle_boost - accessor for angle boost so it can be logged
      int16_t angle_boost() const { return _angle_boost; }
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -234,6 +234,13 @@ protected:
     float rate_bf_to_motor_pitch(float rate_target_cds);
     virtual float rate_bf_to_motor_yaw(float rate_target_cds);
 
+    //
+    // throttle methods
+    //
+
+    // get_angle_boost - calculate total body frame throttle required to produce the given earth frame throttle
+    virtual float get_boosted_throttle(float throttle_in);
+
     // references to external libraries
     const AP_AHRS&      _ahrs;
     const AP_Vehicle::MultiCopter &_aparm;

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -173,13 +173,16 @@ public:
     // throttle functions
     //
 
-     // set_throttle_out - to be called by upper throttle controllers when they wish to provide throttle output directly to motors
-     void set_throttle_out(float throttle_pwm, bool apply_angle_boost);
+    // set_throttle_out - to be called by upper throttle controllers when they wish to provide throttle output directly to motors
+    void set_throttle_out(float throttle_out, bool apply_angle_boost);
 
-     void set_throttle_zero();
+    // set_throttle_zero - outputs a warning spin at MOT_SPIN_ARMED
+    void set_throttle_zero();
 
-     // outputs a throttle to all motors evenly with no stabilization
-     void set_throttle_out_pre_takeoff(float throttle_in);
+    // resets integrators, yaw and rate targets
+    // outputs a warning spin at the specified throttle
+    // calling with zero throttle means MOT_SPIN_ARMED
+    void set_throttle_out_pre_takeoff(float throttle_out);
 
     // angle_boost - accessor for angle boost so it can be logged
     int16_t angle_boost() const { return _angle_boost; }

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -174,8 +174,9 @@ public:
     //
 
      // set_throttle_out - to be called by upper throttle controllers when they wish to provide throttle output directly to motors
-     // provide 0 to cut motors
      void set_throttle_out(float throttle_pwm, bool apply_angle_boost);
+
+     void set_throttle_zero();
 
      // angle_boost - accessor for angle boost so it can be logged
      int16_t angle_boost() const { return _angle_boost; }

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
@@ -377,13 +377,13 @@ float AC_AttitudeControl_Heli::rate_bf_to_motor_yaw(float rate_target_cds)
 // throttle functions
 //
 
-// get_angle_boost - returns a throttle including compensation for roll/pitch angle
+// returns a throttle including compensation for roll/pitch angle
 // throttle value should be 0 ~ 1000
-int16_t AC_AttitudeControl_Heli::get_angle_boost(int16_t throttle_pwm)
+float AC_AttitudeControl_Heli::get_boosted_throttle(float throttle_in)
 {
     // no angle boost for trad helis
     _angle_boost = 0;
-    return throttle_pwm;
+    return throttle_in;
 }
 
 // update_feedforward_filter_rate - Sets LPF cutoff frequency

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.h
@@ -73,8 +73,8 @@ private:
     // throttle methods
     //
 
-    // get_angle_boost - calculate total body frame throttle required to produce the given earth frame throttle
-    virtual int16_t get_angle_boost(int16_t throttle_pwm);
+    // calculate total body frame throttle required to produce the given earth frame throttle
+    float get_boosted_throttle(float throttle_in);
     
     
     // LPF filters to act on Rate Feedforward terms to linearize output.

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -380,8 +380,7 @@ void AC_PosControl::accel_to_throttle(float accel_target_z)
     // get d term
     d = _pid_accel_z.get_d();
 
-    // ensure throttle is above zero (or motors lib will stop stabilizing)
-    int16_t thr_out = max((int16_t)p+i+d+_throttle_hover,1);
+    int16_t thr_out = (int16_t)p+i+d+_throttle_hover;
 
     // send throttle to attitude controller with angle boost
     _attitude_control.set_throttle_out(thr_out, true);

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -346,7 +346,7 @@ void AC_PosControl::rate_to_accel_z()
 void AC_PosControl::accel_to_throttle(float accel_target_z)
 {
     float z_accel_meas;         // actual acceleration
-    int32_t p,i,d;              // used to capture pid values for logging
+    float p,i,d;              // used to capture pid values for logging
 
     // Calculate Earth Frame Z acceleration
     z_accel_meas = -(_ahrs.get_accel_ef_blended().z + GRAVITY_MSS) * 100.0f;
@@ -380,7 +380,7 @@ void AC_PosControl::accel_to_throttle(float accel_target_z)
     // get d term
     d = _pid_accel_z.get_d();
 
-    int16_t thr_out = (int16_t)p+i+d+_throttle_hover;
+    float thr_out = p+i+d+_throttle_hover;
 
     // send throttle to attitude controller with angle boost
     _attitude_control.set_throttle_out(thr_out, true);

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -335,7 +335,6 @@ void AC_PosControl::rate_to_accel_z()
 
     // consolidate and constrain target acceleration
     desired_accel = _accel_feedforward.z + p;
-    desired_accel = constrain_int32(desired_accel, -32000, 32000);
 
     // set target for accel based throttle controller
     accel_to_throttle(desired_accel);
@@ -359,7 +358,7 @@ void AC_PosControl::accel_to_throttle(float accel_target_z)
         _flags.reset_accel_to_throttle = false;
     } else {
         // calculate accel error and Filter with fc = 2 Hz
-        _accel_error.z = _accel_error_filter.apply(constrain_float(accel_target_z - z_accel_meas, -32000, 32000));
+        _accel_error.z = _accel_error_filter.apply(accel_target_z - z_accel_meas);
     }
 
     // set input to PID

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -192,149 +192,149 @@ void AP_MotorsMatrix::output_armed()
     // if we are not sending a throttle output, we cut the motors
     if (_rc_throttle.servo_out == 0) {
         output_warning_spin();
-    } else {
+        return;
+    }
 
-        // check if throttle is below limit
-        if (_rc_throttle.servo_out <= _min_throttle) {  // perhaps being at min throttle itself is not a problem, only being under is
-            limit.throttle_lower = true;
-            _rc_throttle.servo_out = _min_throttle;
-            _rc_throttle.calc_pwm();    // recalculate radio.out
-        }
+    // check if throttle is below limit
+    if (_rc_throttle.servo_out <= _min_throttle) {  // perhaps being at min throttle itself is not a problem, only being under is
+        limit.throttle_lower = true;
+        _rc_throttle.servo_out = _min_throttle;
+        _rc_throttle.calc_pwm();    // recalculate radio.out
+    }
 
-        // calculate roll and pitch for each motor
-        // set rpy_low and rpy_high to the lowest and highest values of the motors
-        for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
-            if (motor_enabled[i]) {
-                rpy_out[i] = _rc_roll.pwm_out * _roll_factor[i] * get_voltage_comp_gain() +
-                             _rc_pitch.pwm_out * _pitch_factor[i] * get_voltage_comp_gain();
+    // calculate roll and pitch for each motor
+    // set rpy_low and rpy_high to the lowest and highest values of the motors
+    for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i]) {
+            rpy_out[i] = _rc_roll.pwm_out * _roll_factor[i] * get_voltage_comp_gain() +
+                            _rc_pitch.pwm_out * _pitch_factor[i] * get_voltage_comp_gain();
 
-                // record lowest roll pitch command
-                if (rpy_out[i] < rpy_low) {
-                    rpy_low = rpy_out[i];
-                }
-                // record highest roll pich command
-                if (rpy_out[i] > rpy_high) {
-                    rpy_high = rpy_out[i];
-                }
+            // record lowest roll pitch command
+            if (rpy_out[i] < rpy_low) {
+                rpy_low = rpy_out[i];
+            }
+            // record highest roll pich command
+            if (rpy_out[i] > rpy_high) {
+                rpy_high = rpy_out[i];
             }
         }
+    }
 
-        // calculate throttle that gives most possible room for yaw (range 1000 ~ 2000) which is the lower of:
-        //      1. mid throttle - average of highest and lowest motor (this would give the maximum possible room margin above the highest motor and below the lowest)
-        //      2. the higher of:
-        //            a) the pilot's throttle input
-        //            b) the mid point between the pilot's input throttle and hover-throttle
-        //      Situation #2 ensure we never increase the throttle above hover throttle unless the pilot has commanded this.
-        //      Situation #2b allows us to raise the throttle above what the pilot commanded but not so far that it would actually cause the copter to rise.
-        //      We will choose #1 (the best throttle for yaw control) if that means reducing throttle to the motors (i.e. we favour reducing throttle *because* it provides better yaw control)
-        //      We will choose #2 (a mix of pilot and hover throttle) only when the throttle is quite low.  We favour reducing throttle instead of better yaw control because the pilot has commanded it
-        int16_t motor_mid = (rpy_low+rpy_high)/2;
-        out_best_thr_pwm = min(out_mid_pwm - motor_mid, max(_rc_throttle.radio_out, _rc_throttle.radio_out*max(0,1.0f-_throttle_low_comp)+get_hover_throttle_as_pwm()*_throttle_low_comp));
+    // calculate throttle that gives most possible room for yaw (range 1000 ~ 2000) which is the lower of:
+    //      1. mid throttle - average of highest and lowest motor (this would give the maximum possible room margin above the highest motor and below the lowest)
+    //      2. the higher of:
+    //            a) the pilot's throttle input
+    //            b) the mid point between the pilot's input throttle and hover-throttle
+    //      Situation #2 ensure we never increase the throttle above hover throttle unless the pilot has commanded this.
+    //      Situation #2b allows us to raise the throttle above what the pilot commanded but not so far that it would actually cause the copter to rise.
+    //      We will choose #1 (the best throttle for yaw control) if that means reducing throttle to the motors (i.e. we favour reducing throttle *because* it provides better yaw control)
+    //      We will choose #2 (a mix of pilot and hover throttle) only when the throttle is quite low.  We favour reducing throttle instead of better yaw control because the pilot has commanded it
+    int16_t motor_mid = (rpy_low+rpy_high)/2;
+    out_best_thr_pwm = min(out_mid_pwm - motor_mid, max(_rc_throttle.radio_out, _rc_throttle.radio_out*max(0,1.0f-_throttle_low_comp)+get_hover_throttle_as_pwm()*_throttle_low_comp));
 
-        // calculate amount of yaw we can fit into the throttle range
-        // this is always equal to or less than the requested yaw from the pilot or rate controller
-        yaw_allowed = min(out_max_pwm - out_best_thr_pwm, out_best_thr_pwm - out_min_pwm) - (rpy_high-rpy_low)/2;
-        yaw_allowed = max(yaw_allowed, _yaw_headroom);
+    // calculate amount of yaw we can fit into the throttle range
+    // this is always equal to or less than the requested yaw from the pilot or rate controller
+    yaw_allowed = min(out_max_pwm - out_best_thr_pwm, out_best_thr_pwm - out_min_pwm) - (rpy_high-rpy_low)/2;
+    yaw_allowed = max(yaw_allowed, _yaw_headroom);
 
-        if (_rc_yaw.pwm_out >= 0) {
-            // if yawing right
-            if (yaw_allowed > _rc_yaw.pwm_out * get_voltage_comp_gain()) {
-                yaw_allowed = _rc_yaw.pwm_out * get_voltage_comp_gain(); // to-do: this is bad form for yaw_allows to change meaning to become the amount that we are going to output
-            }else{
-                limit.yaw = true;
-            }
+    if (_rc_yaw.pwm_out >= 0) {
+        // if yawing right
+        if (yaw_allowed > _rc_yaw.pwm_out * get_voltage_comp_gain()) {
+            yaw_allowed = _rc_yaw.pwm_out * get_voltage_comp_gain(); // to-do: this is bad form for yaw_allows to change meaning to become the amount that we are going to output
         }else{
-            // if yawing left
-            yaw_allowed = -yaw_allowed;
-            if (yaw_allowed < _rc_yaw.pwm_out * get_voltage_comp_gain()) {
-                yaw_allowed = _rc_yaw.pwm_out * get_voltage_comp_gain(); // to-do: this is bad form for yaw_allows to change meaning to become the amount that we are going to output
-            }else{
-                limit.yaw = true;
-            }
-        }
-
-        // add yaw to intermediate numbers for each motor
-        rpy_low = 0;
-        rpy_high = 0;
-        for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
-            if (motor_enabled[i]) {
-                rpy_out[i] =    rpy_out[i] +
-                                yaw_allowed * _yaw_factor[i];
-
-                // record lowest roll+pitch+yaw command
-                if( rpy_out[i] < rpy_low ) {
-                    rpy_low = rpy_out[i];
-                }
-                // record highest roll+pitch+yaw command
-                if( rpy_out[i] > rpy_high) {
-                    rpy_high = rpy_out[i];
-                }
-            }
-        }
-
-        // check everything fits
-        thr_adj = _rc_throttle.radio_out - out_best_thr_pwm;
-
-        // calculate upper and lower limits of thr_adj
-        int16_t thr_adj_max = max(out_max_pwm-(out_best_thr_pwm+rpy_high),0);
-
-        // if we are increasing the throttle (situation #2 above)..
-        if (thr_adj > 0) {
-            // increase throttle as close as possible to requested throttle
-            // without going over out_max_pwm
-            if (thr_adj > thr_adj_max){
-                thr_adj = thr_adj_max;
-                // we haven't even been able to apply full throttle command
-                limit.throttle_upper = true;
-            }
-        }else if(thr_adj < 0){
-            // decrease throttle as close as possible to requested throttle
-            // without going under out_min_pwm or over out_max_pwm
-            // earlier code ensures we can't break both boundaries
-            int16_t thr_adj_min = min(out_min_pwm-(out_best_thr_pwm+rpy_low),0);
-            if (thr_adj > thr_adj_max) {
-                thr_adj = thr_adj_max;
-                limit.throttle_upper = true;
-            }
-            if (thr_adj < thr_adj_min) {
-                thr_adj = thr_adj_min;
-            }
-        }
-
-        // do we need to reduce roll, pitch, yaw command
-        // earlier code does not allow both limit's to be passed simultaneously with abs(_yaw_factor)<1
-        if ((rpy_low+out_best_thr_pwm)+thr_adj < out_min_pwm){
-            rpy_scale = (float)(out_min_pwm-thr_adj-out_best_thr_pwm)/rpy_low;
-            // we haven't even been able to apply full roll, pitch and minimal yaw without scaling
-            limit.roll_pitch = true;
-            limit.yaw = true;
-        }else if((rpy_high+out_best_thr_pwm)+thr_adj > out_max_pwm){
-            rpy_scale = (float)(out_max_pwm-thr_adj-out_best_thr_pwm)/rpy_high;
-            // we haven't even been able to apply full roll, pitch and minimal yaw without scaling
-            limit.roll_pitch = true;
             limit.yaw = true;
         }
+    }else{
+        // if yawing left
+        yaw_allowed = -yaw_allowed;
+        if (yaw_allowed < _rc_yaw.pwm_out * get_voltage_comp_gain()) {
+            yaw_allowed = _rc_yaw.pwm_out * get_voltage_comp_gain(); // to-do: this is bad form for yaw_allows to change meaning to become the amount that we are going to output
+        }else{
+            limit.yaw = true;
+        }
+    }
 
-        // add scaled roll, pitch, constrained yaw and throttle for each motor
-        for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
-            if (motor_enabled[i]) {
-                motor_out[i] = out_best_thr_pwm+thr_adj +
-                               rpy_scale*rpy_out[i];
+    // add yaw to intermediate numbers for each motor
+    rpy_low = 0;
+    rpy_high = 0;
+    for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i]) {
+            rpy_out[i] =    rpy_out[i] +
+                            yaw_allowed * _yaw_factor[i];
+
+            // record lowest roll+pitch+yaw command
+            if( rpy_out[i] < rpy_low ) {
+                rpy_low = rpy_out[i];
+            }
+            // record highest roll+pitch+yaw command
+            if( rpy_out[i] > rpy_high) {
+                rpy_high = rpy_out[i];
             }
         }
+    }
 
-        // apply thrust curve and voltage scaling
-        for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
-            if (motor_enabled[i]) {
-                motor_out[i] = apply_thrust_curve_and_volt_scaling(motor_out[i], out_min_pwm, out_max_pwm);
-            }
+    // check everything fits
+    thr_adj = _rc_throttle.radio_out - out_best_thr_pwm;
+
+    // calculate upper and lower limits of thr_adj
+    int16_t thr_adj_max = max(out_max_pwm-(out_best_thr_pwm+rpy_high),0);
+
+    // if we are increasing the throttle (situation #2 above)..
+    if (thr_adj > 0) {
+        // increase throttle as close as possible to requested throttle
+        // without going over out_max_pwm
+        if (thr_adj > thr_adj_max){
+            thr_adj = thr_adj_max;
+            // we haven't even been able to apply full throttle command
+            limit.throttle_upper = true;
         }
+    }else if(thr_adj < 0){
+        // decrease throttle as close as possible to requested throttle
+        // without going under out_min_pwm or over out_max_pwm
+        // earlier code ensures we can't break both boundaries
+        int16_t thr_adj_min = min(out_min_pwm-(out_best_thr_pwm+rpy_low),0);
+        if (thr_adj > thr_adj_max) {
+            thr_adj = thr_adj_max;
+            limit.throttle_upper = true;
+        }
+        if (thr_adj < thr_adj_min) {
+            thr_adj = thr_adj_min;
+        }
+    }
 
-        // clip motor output if required (shouldn't be)
-        for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
-            if (motor_enabled[i]) {
-                motor_out[i] = constrain_int16(motor_out[i], out_min_pwm, out_max_pwm);
-            }
+    // do we need to reduce roll, pitch, yaw command
+    // earlier code does not allow both limit's to be passed simultaneously with abs(_yaw_factor)<1
+    if ((rpy_low+out_best_thr_pwm)+thr_adj < out_min_pwm){
+        rpy_scale = (float)(out_min_pwm-thr_adj-out_best_thr_pwm)/rpy_low;
+        // we haven't even been able to apply full roll, pitch and minimal yaw without scaling
+        limit.roll_pitch = true;
+        limit.yaw = true;
+    }else if((rpy_high+out_best_thr_pwm)+thr_adj > out_max_pwm){
+        rpy_scale = (float)(out_max_pwm-thr_adj-out_best_thr_pwm)/rpy_high;
+        // we haven't even been able to apply full roll, pitch and minimal yaw without scaling
+        limit.roll_pitch = true;
+        limit.yaw = true;
+    }
+
+    // add scaled roll, pitch, constrained yaw and throttle for each motor
+    for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i]) {
+            motor_out[i] = out_best_thr_pwm+thr_adj +
+                            rpy_scale*rpy_out[i];
+        }
+    }
+
+    // apply thrust curve and voltage scaling
+    for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i]) {
+            motor_out[i] = apply_thrust_curve_and_volt_scaling(motor_out[i], out_min_pwm, out_max_pwm);
+        }
+    }
+
+    // clip motor output if required (shouldn't be)
+    for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i]) {
+            motor_out[i] = constrain_int16(motor_out[i], out_min_pwm, out_max_pwm);
         }
     }
 

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -190,7 +190,7 @@ void AP_MotorsMatrix::output_armed()
     _rc_yaw.calc_pwm();
 
     // if we are not sending a throttle output, we cut the motors
-    if (_rc_throttle.servo_out == 0) {
+    if (!_stabilize) {
         output_warning_spin();
         return;
     }

--- a/libraries/AP_Motors/AP_MotorsMatrix.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix.h
@@ -69,6 +69,7 @@ protected:
     // output - sends commands to the motors
     virtual void        output_armed();
     virtual void        output_disarmed();
+    void                output_warning_spin();
 
     // add_motor using raw roll, pitch, throttle and yaw factors
     void                add_motor_raw(int8_t motor_num, float roll_fac, float pitch_fac, float yaw_fac, uint8_t testing_order);

--- a/libraries/AP_Motors/AP_MotorsMatrix.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix.h
@@ -20,7 +20,8 @@ public:
 
     /// Constructor
     AP_MotorsMatrix(RC_Channel& rc_roll, RC_Channel& rc_pitch, RC_Channel& rc_throttle, RC_Channel& rc_yaw, uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) :
-        AP_Motors(rc_roll, rc_pitch, rc_throttle, rc_yaw, loop_rate, speed_hz)
+        AP_Motors(rc_roll, rc_pitch, rc_throttle, rc_yaw, loop_rate, speed_hz),
+        _throttle_out(0.0f)
     {};
 
     // init
@@ -65,6 +66,8 @@ public:
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
     virtual uint16_t    get_motor_mask();
 
+    void set_throttle(float throttle);
+
 protected:
     // output - sends commands to the motors
     virtual void        output_armed();
@@ -78,6 +81,8 @@ protected:
     float               _pitch_factor[AP_MOTORS_MAX_NUM_MOTORS]; // each motors contribution to pitch
     float               _yaw_factor[AP_MOTORS_MAX_NUM_MOTORS];  // each motors contribution to yaw (normally 1 or -1)
     uint8_t             _test_order[AP_MOTORS_MAX_NUM_MOTORS];  // order of the motors in the test sequence
+
+    float _throttle_out;
 };
 
 #endif  // AP_MOTORSMATRIX

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -99,7 +99,7 @@ const AP_Param::GroupInfo AP_Motors::var_info[] PROGMEM = {
     // @Range: 0 5
     // @Units: Hz
     // @User: Advanced
-    AP_GROUPINFO("THR_FILT", 13, AP_Motors, _throttle_filter, 2.0f),
+    AP_GROUPINFO("THR_FILT", 13, AP_Motors, _throttle_filter, 0.0f),
 
     AP_GROUPEND
 };

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -93,6 +93,14 @@ const AP_Param::GroupInfo AP_Motors::var_info[] PROGMEM = {
     // @User: Advanced
     AP_GROUPINFO("CURR_MAX", 12, AP_Motors, _batt_current_max, AP_MOTORS_CURR_MAX_DEFAULT),
 
+    // @Param: THR_FILT
+    // @DisplayName: Throttle output filter
+    // @Description: Frequency cutoff (in hz) of throttle output filter
+    // @Range: 0 5
+    // @Units: Hz
+    // @User: Advanced
+    AP_GROUPINFO("THR_FILT", 13, AP_Motors, _throttle_filter, 2.0f),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -117,7 +117,8 @@ AP_Motors::AP_Motors(RC_Channel& rc_roll, RC_Channel& rc_pitch, RC_Channel& rc_t
     _batt_resistance(0.0f),
     _batt_timer(0),
     _lift_max(1.0f),
-    _throttle_limit(1.0f)
+    _throttle_limit(1.0f),
+    _stabilize(false)
 {
     AP_Param::setup_object_defaults(this, var_info);
 

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -122,6 +122,7 @@ public:
     void                set_pitch(int16_t pitch_in) { _rc_pitch.servo_out = pitch_in; };                // range -4500 ~ 4500
     void                set_yaw(int16_t yaw_in) { _rc_yaw.servo_out = yaw_in; };                        // range -4500 ~ 4500
     void                set_throttle(int16_t throttle_in) { _rc_throttle.servo_out = throttle_in; };    // range 0 ~ 1000
+    void                set_stabilize(bool stabilize) { _stabilize = stabilize; }
 
     // accessors for roll, pitch, yaw and throttle inputs to motors
     int16_t             get_roll() { return _rc_roll.servo_out; }
@@ -267,5 +268,6 @@ protected:
     int16_t             _batt_timer;            // timer used in battery resistance calcs
     float               _lift_max;              // maximum lift ratio from battery voltage
     float               _throttle_limit;        // ratio of throttle limit between hover and maximum
+    bool                _stabilize;             // specifies whether the copter should be stabilizing
 };
 #endif  // __AP_MOTORS_CLASS_H__

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -121,7 +121,7 @@ public:
     void                set_roll(int16_t roll_in) { _rc_roll.servo_out = roll_in; };                    // range -4500 ~ 4500
     void                set_pitch(int16_t pitch_in) { _rc_pitch.servo_out = pitch_in; };                // range -4500 ~ 4500
     void                set_yaw(int16_t yaw_in) { _rc_yaw.servo_out = yaw_in; };                        // range -4500 ~ 4500
-    void                set_throttle(int16_t throttle_in) { _rc_throttle.servo_out = throttle_in; };    // range 0 ~ 1000
+    virtual void        set_throttle(float throttle_in) { _rc_throttle.servo_out = constrain_float(throttle_in,-32000,32000); };    // range 0 ~ 1000
     void                set_stabilize(bool stabilize) { _stabilize = stabilize; }
 
     // accessors for roll, pitch, yaw and throttle inputs to motors
@@ -243,6 +243,7 @@ protected:
     AP_Float            _batt_voltage_max;      // maximum voltage used to scale lift
     AP_Float            _batt_voltage_min;      // minimum voltage used to scale lift
     AP_Float            _batt_current_max;      // current over which maximum throttle is limited
+    AP_Float            _throttle_filter;       // throttle output filter time constant in hz
 
     // internal variables
     RC_Channel&         _rc_roll;               // roll input in from users is held in servo_out

--- a/libraries/AP_Motors/examples/AP_Motors_test/AP_Motors_test.pde
+++ b/libraries/AP_Motors/examples/AP_Motors_test/AP_Motors_test.pde
@@ -172,6 +172,7 @@ void stability_test()
 
     // arm motors
     motors.armed(true);
+    motors.set_stabilize(true);
 
     // run stability test
     for (int16_t i=0; i < testing_array_rows; i++) {
@@ -206,6 +207,7 @@ void stability_test()
     motors.set_roll(0);
     motors.set_yaw(0);
     motors.set_throttle(0);
+    motors.set_stabilize(false);
     motors.armed(false);
 
     hal.console->println("finished test.");


### PR DESCRIPTION
These changes:
- add an optional throttle filter into the AP_Motors class, intended to prevent batteries with over-current protection from triggering in flight
- eliminates integers from the AC_PosControl and AC_AttitudeControl levels of the throttle output chain, replacing them with floats
- eliminates constraints that could cause issues by introducing nonlinearities between the alt-hold controller and throttle output filter
- introduces a flag in AP_Motors that specifies if the copter should be stabilizing, in order to prevent a zero or negative throttle demand from the alt-hold controller from causing stabilization to stop
- sets that flag appropriately in AC_AttitudeControl, which required introducing a new function set_throttle_zero in order to stop stabilization
- added a new function set_throttle_out_pre_takeoff, which allows the caller to output an arbitrary throttle to all motors without stabilizing
- modified copter to use these new functions appropriately