### PR TITLE
AP_InertialSensor: fix accel calibration

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -508,8 +508,12 @@ bool AP_InertialSensor::calibrate_accel(AP_InertialSensor_UserInteract* interact
             goto failed;
         }
 
-        // clear out any existing samples from ins
-        update();
+        // wait 100ms for ins filter to rise
+        for (uint8_t k=0; k<10; k++) {
+            wait_for_sample();
+            update();
+            hal.scheduler->delay(10);
+        }
 
         uint8_t num_samples = 0;
         while (num_samples < 32) {

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -518,7 +518,7 @@ bool AP_InertialSensor::calibrate_accel(AP_InertialSensor_UserInteract* interact
         }
 
         uint32_t num_samples = 0;
-        while (num_samples < 1000/update_dt_milliseconds) {
+        while (num_samples < 400/update_dt_milliseconds) {
             wait_for_sample();
             // read samples from ins
             update();

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -508,15 +508,17 @@ bool AP_InertialSensor::calibrate_accel(AP_InertialSensor_UserInteract* interact
             goto failed;
         }
 
+        const uint8_t update_dt_milliseconds = (uint8_t)(1000.0f/get_sample_rate()+0.5f);
+
         // wait 100ms for ins filter to rise
-        for (uint8_t k=0; k<10; k++) {
+        for (uint8_t k=0; k<100/update_dt_milliseconds; k++) {
             wait_for_sample();
             update();
-            hal.scheduler->delay(10);
+            hal.scheduler->delay(update_dt_milliseconds);
         }
 
-        uint8_t num_samples = 0;
-        while (num_samples < 32) {
+        uint32_t num_samples = 0;
+        while (num_samples < 1000/update_dt_milliseconds) {
             wait_for_sample();
             // read samples from ins
             update();
@@ -534,7 +536,7 @@ bool AP_InertialSensor::calibrate_accel(AP_InertialSensor_UserInteract* interact
                     goto failed;
                 }
             }
-            hal.scheduler->delay(10);
+            hal.scheduler->delay(update_dt_milliseconds);
             num_samples++;
         }
         for (uint8_t k=0; k<num_accels; k++) {

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -518,7 +518,13 @@ bool AP_InertialSensor::calibrate_accel(AP_InertialSensor_UserInteract* interact
             update();
             // capture sample
             for (uint8_t k=0; k<num_accels; k++) {
-                samples[k][i] += get_accel(k);
+                Vector3f samp;
+                if(get_delta_velocity(k,samp)) {
+                    samp /= _delta_velocity_dt[k];
+                } else {
+                    samp = get_accel(k);
+                }
+                samples[k][i] += samp;
                 if (!get_accel_health(k)) {
                     interact->printf_P(PSTR("accel[%u] not healthy"), (unsigned)k);
                     goto failed;

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -125,8 +125,12 @@ public:
         if(_delta_velocity_valid[i]) delta_velocity = _delta_velocity[i];
         return _delta_velocity_valid[i];
     }
-
     bool get_delta_velocity(Vector3f &delta_velocity) const { return get_delta_velocity(_primary_accel, delta_velocity); }
+
+    float get_delta_velocity_dt(uint8_t i) const {
+        return _delta_velocity_dt[i];
+    }
+    float get_delta_velocity() const { return get_delta_velocity_dt(_primary_accel); }
 
     /// Fetch the current accelerometer values
     ///
@@ -250,6 +254,7 @@ private:
     // Most recent accelerometer reading
     Vector3f _accel[INS_MAX_INSTANCES];
     Vector3f _delta_velocity[INS_MAX_INSTANCES];
+    float _delta_velocity_dt[INS_MAX_INSTANCES];
     bool _delta_velocity_valid[INS_MAX_INSTANCES];
 
     // Most recent gyro reading

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -57,10 +57,11 @@ void AP_InertialSensor_Backend::_publish_gyro(uint8_t instance, const Vector3f &
     }
 }
 
-void AP_InertialSensor_Backend::_publish_delta_velocity(uint8_t instance, const Vector3f &delta_velocity)
+void AP_InertialSensor_Backend::_publish_delta_velocity(uint8_t instance, const Vector3f &delta_velocity, float dt)
 {
     // publish delta velocity
     _imu._delta_velocity[instance] = delta_velocity;
+    _imu._delta_velocity_dt[instance] = dt;
     _imu._delta_velocity_valid[instance] = true;
 }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -64,7 +64,7 @@ protected:
     void _rotate_and_correct_accel(uint8_t instance, Vector3f &accel);
     void _rotate_and_correct_gyro(uint8_t instance, Vector3f &gyro);
 
-    void _publish_delta_velocity(uint8_t instance, const Vector3f &delta_velocity);
+    void _publish_delta_velocity(uint8_t instance, const Vector3f &delta_velocity, float dt);
     void _publish_delta_angle(uint8_t instance, const Vector3f &delta_angle);
 
     // rotate gyro vector, offset and publish

--- a/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
@@ -28,6 +28,7 @@ AP_InertialSensor_PX4::AP_InertialSensor_PX4(AP_InertialSensor &imu) :
     for (uint8_t i=0; i<INS_MAX_INSTANCES; i++) {
         _delta_angle_accumulator[i].zero();
         _delta_velocity_accumulator[i].zero();
+        _delta_velocity_dt[i] = 0.0f;
     }
 }
 
@@ -210,7 +211,7 @@ bool AP_InertialSensor_PX4::update(void)
         // so we only want to do this if we have new data from it
         if (_last_accel_timestamp[k] != _last_accel_update_timestamp[k]) {
             _publish_accel(_accel_instance[k], accel, false);
-            _publish_delta_velocity(_accel_instance[k], _delta_velocity_accumulator[k]);
+            _publish_delta_velocity(_accel_instance[k], _delta_velocity_accumulator[k], _delta_velocity_dt[k]);
             _last_accel_update_timestamp[k] = _last_accel_timestamp[k];
         }
     }
@@ -229,6 +230,7 @@ bool AP_InertialSensor_PX4::update(void)
     for (uint8_t i=0; i<INS_MAX_INSTANCES; i++) {
         _delta_angle_accumulator[i].zero();
         _delta_velocity_accumulator[i].zero();
+        _delta_velocity_dt[i] = 0.0f;
     }
 
     if (_last_accel_filter_hz != _accel_filter_cutoff()) {
@@ -263,6 +265,7 @@ void AP_InertialSensor_PX4::_new_accel_sample(uint8_t i, accel_report &accel_rep
 
     // integrate delta velocity accumulator
     _delta_velocity_accumulator[i] += delVel;
+    _delta_velocity_dt[i] += dt;
 
     // save last timestamp
     _last_accel_timestamp[i] = accel_report.timestamp;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_PX4.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_PX4.h
@@ -78,6 +78,7 @@ private:
 
     Vector3f _delta_angle_accumulator[INS_MAX_INSTANCES];
     Vector3f _delta_velocity_accumulator[INS_MAX_INSTANCES];
+    float _delta_velocity_dt[INS_MAX_INSTANCES];
     Vector3f _last_delAng[INS_MAX_INSTANCES];
     Vector3f _last_gyro[INS_MAX_INSTANCES];
 


### PR DESCRIPTION
This fixes an unintended consequence of the inertial sensor changes in which the accel filter stops updating between accel samples, which causes it to screw up the accel calibration as was still settling while the accel cal was collecting a sample.