### PR TITLE
Copter: changes to add an optional throttle output filter

### DIFF
--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -128,6 +128,7 @@ public:
         k_param_dcmcheck_thresh,        // deprecated - remove
         k_param_log_bitmask,
         k_param_cli_enabled,            // 61
+        k_param_throttle_filt,          // 62
 
         // 65: AP_Limits Library
         k_param_limits = 65,            // deprecated - remove
@@ -266,7 +267,7 @@ public:
         k_param_rc_9,
         k_param_rc_12,
         k_param_failsafe_gcs,           // 198
-        k_param_rcmap,
+        k_param_rcmap, // 199
 
         //
         // 200: flight modes
@@ -338,6 +339,8 @@ public:
 #if CLI_ENABLED == ENABLED
     AP_Int8         cli_enabled;
 #endif
+
+    AP_Float        throttle_filt;
 
     AP_Int16        rtl_altitude;
     AP_Float        sonar_gain;

--- a/ArduCopter/Parameters.pde
+++ b/ArduCopter/Parameters.pde
@@ -62,6 +62,15 @@ const AP_Param::Info var_info[] PROGMEM = {
     GSCALAR(cli_enabled,    "CLI_ENABLED",    0),
 #endif
 
+    // @Param: PILOT_THR_FILT
+    // @DisplayName: Throttle filter cutoff
+    // @Description: Throttle filter cutoff (Hz) - active whenever altitude control is inactive - 0 to disable
+    // @User: Advanced
+    // @Units: Hz
+    // @Range: 0 10
+    // @Increment: .5
+    GSCALAR(throttle_filt,  "PILOT_THR_FILT",     0),
+
     // @Group: SERIAL
     // @Path: ../libraries/AP_SerialManager/AP_SerialManager.cpp
     GOBJECT(serial_manager, "SERIAL",   AP_SerialManager),

--- a/ArduCopter/control_acro.pde
+++ b/ArduCopter/control_acro.pde
@@ -20,9 +20,7 @@ static void acro_run()
 
     // if motors not running reset angle targets
     if(!motors.armed() || g.rc_3.control_in <= 0) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_out_unstabilized(0,true);
         return;
     }
 

--- a/ArduCopter/control_acro.pde
+++ b/ArduCopter/control_acro.pde
@@ -20,7 +20,7 @@ static void acro_run()
 
     // if motors not running reset angle targets
     if(!motors.armed() || g.rc_3.control_in <= 0) {
-        attitude_control.set_throttle_out_unstabilized(0,true);
+        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
         return;
     }
 
@@ -34,7 +34,7 @@ static void acro_run()
     attitude_control.rate_bf_roll_pitch_yaw(target_roll, target_pitch, target_yaw);
 
     // output pilot's throttle without angle boost
-    attitude_control.set_throttle_out(pilot_throttle_scaled, false);
+    attitude_control.set_throttle_out(pilot_throttle_scaled, false, g.throttle_filt);
 }
 
 

--- a/ArduCopter/control_althold.pde
+++ b/ArduCopter/control_althold.pde
@@ -27,9 +27,7 @@ static void althold_run()
 
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_out_unstabilized(0,true);
         pos_control.set_alt_target_to_current_alt();
         return;
     }
@@ -57,10 +55,7 @@ static void althold_run()
 
     // reset target lean angles and heading while landed
     if (ap.land_complete) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        // move throttle to between minimum and non-takeoff-throttle to keep us on the ground
-        attitude_control.set_throttle_out(get_throttle_pre_takeoff(g.rc_3.control_in), false);
+        attitude_control.set_throttle_out_unstabilized(get_throttle_pre_takeoff(g.rc_3.control_in),true);
         pos_control.set_alt_target_to_current_alt();
     }else{
         // call attitude controller

--- a/ArduCopter/control_althold.pde
+++ b/ArduCopter/control_althold.pde
@@ -27,7 +27,7 @@ static void althold_run()
 
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed) {
-        attitude_control.set_throttle_out_unstabilized(0,true);
+        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
         pos_control.set_alt_target_to_current_alt();
         return;
     }
@@ -55,7 +55,7 @@ static void althold_run()
 
     // reset target lean angles and heading while landed
     if (ap.land_complete) {
-        attitude_control.set_throttle_out_unstabilized(get_throttle_pre_takeoff(g.rc_3.control_in),true);
+        attitude_control.set_throttle_out_unstabilized(get_throttle_pre_takeoff(g.rc_3.control_in),true,g.throttle_filt);
         pos_control.set_alt_target_to_current_alt();
     }else{
         // call attitude controller

--- a/ArduCopter/control_auto.pde
+++ b/ArduCopter/control_auto.pde
@@ -114,9 +114,7 @@ static void auto_takeoff_run()
         // initialise wpnav targets
         wp_nav.shift_wp_origin_to_current_pos();
         // reset attitude control targets
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_out_unstabilized(0,true);
         // tell motors to do a slow start
         motors.slow_start(true);
         return;
@@ -162,9 +160,7 @@ static void auto_wp_run()
     if(!ap.auto_armed) {
         // To-Do: reset waypoint origin to current location because copter is probably on the ground so we don't want it lurching left or right on take-off
         //    (of course it would be better if people just used take-off)
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_out_unstabilized(0,true);
         // tell motors to do a slow start
         motors.slow_start(true);
         return;
@@ -220,9 +216,7 @@ static void auto_spline_run()
     if(!ap.auto_armed) {
         // To-Do: reset waypoint origin to current location because copter is probably on the ground so we don't want it lurching left or right on take-off
         //    (of course it would be better if people just used take-off)
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_out_unstabilized(0,true);
         // tell motors to do a slow start
         motors.slow_start(true);
         return;
@@ -289,9 +283,7 @@ static void auto_land_run()
 
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed || ap.land_complete) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_out_unstabilized(0,true);
         // set target to current position
         wp_nav.init_loiter_target();
         return;
@@ -457,9 +449,7 @@ void auto_loiter_run()
 {
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed || ap.land_complete) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_out_unstabilized(0,true);
         return;
     }
 

--- a/ArduCopter/control_auto.pde
+++ b/ArduCopter/control_auto.pde
@@ -114,7 +114,7 @@ static void auto_takeoff_run()
         // initialise wpnav targets
         wp_nav.shift_wp_origin_to_current_pos();
         // reset attitude control targets
-        attitude_control.set_throttle_out_unstabilized(0,true);
+        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
         // tell motors to do a slow start
         motors.slow_start(true);
         return;
@@ -160,7 +160,7 @@ static void auto_wp_run()
     if(!ap.auto_armed) {
         // To-Do: reset waypoint origin to current location because copter is probably on the ground so we don't want it lurching left or right on take-off
         //    (of course it would be better if people just used take-off)
-        attitude_control.set_throttle_out_unstabilized(0,true);
+        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
         // tell motors to do a slow start
         motors.slow_start(true);
         return;
@@ -216,7 +216,7 @@ static void auto_spline_run()
     if(!ap.auto_armed) {
         // To-Do: reset waypoint origin to current location because copter is probably on the ground so we don't want it lurching left or right on take-off
         //    (of course it would be better if people just used take-off)
-        attitude_control.set_throttle_out_unstabilized(0,true);
+        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
         // tell motors to do a slow start
         motors.slow_start(true);
         return;
@@ -283,7 +283,7 @@ static void auto_land_run()
 
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed || ap.land_complete) {
-        attitude_control.set_throttle_out_unstabilized(0,true);
+        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
         // set target to current position
         wp_nav.init_loiter_target();
         return;
@@ -449,7 +449,7 @@ void auto_loiter_run()
 {
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed || ap.land_complete) {
-        attitude_control.set_throttle_out_unstabilized(0,true);
+        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
         return;
     }
 

--- a/ArduCopter/control_autotune.pde
+++ b/ArduCopter/control_autotune.pde
@@ -256,9 +256,7 @@ static void autotune_run()
     // if not auto armed set throttle to zero and exit immediately
     // this should not actually be possible because of the autotune_init() checks
     if (!ap.auto_armed) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_out_unstabilized(0,true);
         pos_control.set_alt_target_to_current_alt();
         return;
     }
@@ -285,10 +283,8 @@ static void autotune_run()
 
     // reset target lean angles and heading while landed
     if (ap.land_complete) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
         // move throttle to between minimum and non-takeoff-throttle to keep us on the ground
-        attitude_control.set_throttle_out(get_throttle_pre_takeoff(g.rc_3.control_in), false);
+        attitude_control.set_throttle_out_unstabilized(get_throttle_pre_takeoff(g.rc_3.control_in),true);
         pos_control.set_alt_target_to_current_alt();
     }else{
         // check if pilot is overriding the controls

--- a/ArduCopter/control_autotune.pde
+++ b/ArduCopter/control_autotune.pde
@@ -256,7 +256,7 @@ static void autotune_run()
     // if not auto armed set throttle to zero and exit immediately
     // this should not actually be possible because of the autotune_init() checks
     if (!ap.auto_armed) {
-        attitude_control.set_throttle_out_unstabilized(0,true);
+        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
         pos_control.set_alt_target_to_current_alt();
         return;
     }
@@ -284,7 +284,7 @@ static void autotune_run()
     // reset target lean angles and heading while landed
     if (ap.land_complete) {
         // move throttle to between minimum and non-takeoff-throttle to keep us on the ground
-        attitude_control.set_throttle_out_unstabilized(get_throttle_pre_takeoff(g.rc_3.control_in),true);
+        attitude_control.set_throttle_out_unstabilized(get_throttle_pre_takeoff(g.rc_3.control_in),true,g.throttle_filt);
         pos_control.set_alt_target_to_current_alt();
     }else{
         // check if pilot is overriding the controls

--- a/ArduCopter/control_circle.pde
+++ b/ArduCopter/control_circle.pde
@@ -35,9 +35,7 @@ static void circle_run()
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed || ap.land_complete) {
         // To-Do: add some initialisation of position controllers
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_out_unstabilized(0,true);
         pos_control.set_alt_target_to_current_alt();
         return;
     }

--- a/ArduCopter/control_circle.pde
+++ b/ArduCopter/control_circle.pde
@@ -35,7 +35,7 @@ static void circle_run()
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed || ap.land_complete) {
         // To-Do: add some initialisation of position controllers
-        attitude_control.set_throttle_out_unstabilized(0,true);
+        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
         pos_control.set_alt_target_to_current_alt();
         return;
     }

--- a/ArduCopter/control_drift.pde
+++ b/ArduCopter/control_drift.pde
@@ -48,9 +48,7 @@ static void drift_run()
 
     // if not armed or landed and throttle at zero, set throttle to zero and exit immediately
     if(!motors.armed() || (ap.land_complete && ap.throttle_zero)) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_out_unstabilized(0,true);
         return;
     }
 

--- a/ArduCopter/control_drift.pde
+++ b/ArduCopter/control_drift.pde
@@ -48,7 +48,7 @@ static void drift_run()
 
     // if not armed or landed and throttle at zero, set throttle to zero and exit immediately
     if(!motors.armed() || (ap.land_complete && ap.throttle_zero)) {
-        attitude_control.set_throttle_out_unstabilized(0,true);
+        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
         return;
     }
 
@@ -95,7 +95,7 @@ static void drift_run()
     attitude_control.angle_ef_roll_pitch_rate_ef_yaw_smooth(target_roll, target_pitch, target_yaw_rate, get_smoothing_gain());
 
     // output pilot's throttle with angle boost
-    attitude_control.set_throttle_out(get_throttle_assist(vel.z, pilot_throttle_scaled), true);
+    attitude_control.set_throttle_out(get_throttle_assist(vel.z, pilot_throttle_scaled), true, g.throttle_filt);
 }
 
 // get_throttle_assist - return throttle output (range 0 ~ 1000) based on pilot input and z-axis velocity

--- a/ArduCopter/control_flip.pde
+++ b/ArduCopter/control_flip.pde
@@ -218,5 +218,9 @@ static void flip_run()
     }
 
     // output pilot's throttle without angle boost
-    attitude_control.set_throttle_out(throttle_out, false);
+    if (throttle_out == 0.0f) {
+        attitude_control.set_throttle_out_unstabilized(0,false);
+    } else {
+        attitude_control.set_throttle_out(throttle_out, false);
+    }
 }

--- a/ArduCopter/control_flip.pde
+++ b/ArduCopter/control_flip.pde
@@ -219,8 +219,8 @@ static void flip_run()
 
     // output pilot's throttle without angle boost
     if (throttle_out == 0.0f) {
-        attitude_control.set_throttle_out_unstabilized(0,false);
+        attitude_control.set_throttle_out_unstabilized(0,false,g.throttle_filt);
     } else {
-        attitude_control.set_throttle_out(throttle_out, false);
+        attitude_control.set_throttle_out(throttle_out, false, g.throttle_filt);
     }
 }

--- a/ArduCopter/control_guided.pde
+++ b/ArduCopter/control_guided.pde
@@ -161,9 +161,7 @@ static void guided_run()
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed) {
         // To-Do: reset waypoint controller?
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_out_unstabilized(0,true);
         // To-Do: handle take-offs - these may not only be immediately after auto_armed becomes true
         return;
     }
@@ -202,9 +200,7 @@ static void guided_takeoff_run()
         // initialise wpnav targets
         wp_nav.shift_wp_origin_to_current_pos();
         // reset attitude control targets
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_out_unstabilized(0,true);
         // tell motors to do a slow start
         motors.slow_start(true);
         return;

--- a/ArduCopter/control_guided.pde
+++ b/ArduCopter/control_guided.pde
@@ -161,7 +161,7 @@ static void guided_run()
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed) {
         // To-Do: reset waypoint controller?
-        attitude_control.set_throttle_out_unstabilized(0,true);
+        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
         // To-Do: handle take-offs - these may not only be immediately after auto_armed becomes true
         return;
     }
@@ -200,7 +200,7 @@ static void guided_takeoff_run()
         // initialise wpnav targets
         wp_nav.shift_wp_origin_to_current_pos();
         // reset attitude control targets
-        attitude_control.set_throttle_out_unstabilized(0,true);
+        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
         // tell motors to do a slow start
         motors.slow_start(true);
         return;

--- a/ArduCopter/control_land.pde
+++ b/ArduCopter/control_land.pde
@@ -52,9 +52,7 @@ static void land_gps_run()
 
     // if not auto armed or landed set throttle to zero and exit immediately
     if(!ap.auto_armed || ap.land_complete) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_out_unstabilized(0,true);
         wp_nav.init_loiter_target();
 
 #if LAND_REQUIRE_MIN_THROTTLE_TO_DISARM == ENABLED
@@ -127,9 +125,7 @@ static void land_nogps_run()
 
     // if not auto armed or landed set throttle to zero and exit immediately
     if(!ap.auto_armed || ap.land_complete) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_out_unstabilized(0,true);
 #if LAND_REQUIRE_MIN_THROTTLE_TO_DISARM == ENABLED
         // disarm when the landing detector says we've landed and throttle is at minimum
         if (ap.land_complete && (ap.throttle_zero || failsafe.radio)) {

--- a/ArduCopter/control_land.pde
+++ b/ArduCopter/control_land.pde
@@ -52,7 +52,7 @@ static void land_gps_run()
 
     // if not auto armed or landed set throttle to zero and exit immediately
     if(!ap.auto_armed || ap.land_complete) {
-        attitude_control.set_throttle_out_unstabilized(0,true);
+        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
         wp_nav.init_loiter_target();
 
 #if LAND_REQUIRE_MIN_THROTTLE_TO_DISARM == ENABLED
@@ -125,7 +125,7 @@ static void land_nogps_run()
 
     // if not auto armed or landed set throttle to zero and exit immediately
     if(!ap.auto_armed || ap.land_complete) {
-        attitude_control.set_throttle_out_unstabilized(0,true);
+        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
 #if LAND_REQUIRE_MIN_THROTTLE_TO_DISARM == ENABLED
         // disarm when the landing detector says we've landed and throttle is at minimum
         if (ap.land_complete && (ap.throttle_zero || failsafe.radio)) {

--- a/ArduCopter/control_loiter.pde
+++ b/ArduCopter/control_loiter.pde
@@ -35,9 +35,7 @@ static void loiter_run()
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed) {
         wp_nav.init_loiter_target();
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_out_unstabilized(0,true);
         pos_control.set_alt_target_to_current_alt();
         return;
     }
@@ -76,10 +74,8 @@ static void loiter_run()
     // when landed reset targets and output zero throttle
     if (ap.land_complete) {
         wp_nav.init_loiter_target();
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
         // move throttle to between minimum and non-takeoff-throttle to keep us on the ground
-        attitude_control.set_throttle_out(get_throttle_pre_takeoff(g.rc_3.control_in), false);
+        attitude_control.set_throttle_out_unstabilized(get_throttle_pre_takeoff(g.rc_3.control_in),true);
         pos_control.set_alt_target_to_current_alt();
     }else{
         // run loiter controller

--- a/ArduCopter/control_loiter.pde
+++ b/ArduCopter/control_loiter.pde
@@ -35,7 +35,7 @@ static void loiter_run()
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed) {
         wp_nav.init_loiter_target();
-        attitude_control.set_throttle_out_unstabilized(0,true);
+        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
         pos_control.set_alt_target_to_current_alt();
         return;
     }
@@ -75,7 +75,7 @@ static void loiter_run()
     if (ap.land_complete) {
         wp_nav.init_loiter_target();
         // move throttle to between minimum and non-takeoff-throttle to keep us on the ground
-        attitude_control.set_throttle_out_unstabilized(get_throttle_pre_takeoff(g.rc_3.control_in),true);
+        attitude_control.set_throttle_out_unstabilized(get_throttle_pre_takeoff(g.rc_3.control_in),true,g.throttle_filt);
         pos_control.set_alt_target_to_current_alt();
     }else{
         // run loiter controller

--- a/ArduCopter/control_poshold.pde
+++ b/ArduCopter/control_poshold.pde
@@ -156,9 +156,7 @@ static void poshold_run()
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed) {
         wp_nav.init_loiter_target();
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_out_unstabilized(0,true);
         pos_control.set_alt_target_to_current_alt();
         return;
     }
@@ -191,10 +189,8 @@ static void poshold_run()
     // if landed initialise loiter targets, set throttle to zero and exit
     if (ap.land_complete) {
         wp_nav.init_loiter_target();
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
         // move throttle to between minimum and non-takeoff-throttle to keep us on the ground
-        attitude_control.set_throttle_out(get_throttle_pre_takeoff(g.rc_3.control_in), false);
+        attitude_control.set_throttle_out_unstabilized(get_throttle_pre_takeoff(g.rc_3.control_in),true);
         pos_control.set_alt_target_to_current_alt();
         return;
     }else{

--- a/ArduCopter/control_poshold.pde
+++ b/ArduCopter/control_poshold.pde
@@ -156,7 +156,7 @@ static void poshold_run()
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed) {
         wp_nav.init_loiter_target();
-        attitude_control.set_throttle_out_unstabilized(0,true);
+        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
         pos_control.set_alt_target_to_current_alt();
         return;
     }
@@ -190,7 +190,7 @@ static void poshold_run()
     if (ap.land_complete) {
         wp_nav.init_loiter_target();
         // move throttle to between minimum and non-takeoff-throttle to keep us on the ground
-        attitude_control.set_throttle_out_unstabilized(get_throttle_pre_takeoff(g.rc_3.control_in),true);
+        attitude_control.set_throttle_out_unstabilized(get_throttle_pre_takeoff(g.rc_3.control_in),true,g.throttle_filt);
         pos_control.set_alt_target_to_current_alt();
         return;
     }else{

--- a/ArduCopter/control_rtl.pde
+++ b/ArduCopter/control_rtl.pde
@@ -134,9 +134,7 @@ static void rtl_climb_return_run()
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed) {
         // reset attitude control targets
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_out_unstabilized(0,true);
         // To-Do: re-initialise wpnav targets
         return;
     }
@@ -192,9 +190,7 @@ static void rtl_loiterathome_run()
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed) {
         // reset attitude control targets
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_out_unstabilized(0,true);
         // To-Do: re-initialise wpnav targets
         return;
     }
@@ -263,9 +259,7 @@ static void rtl_descent_run()
 
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_out_unstabilized(0,true);
         // set target to current position
         wp_nav.init_loiter_target();
         return;
@@ -327,9 +321,7 @@ static void rtl_land_run()
     float target_yaw_rate = 0;
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed || ap.land_complete) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_out_unstabilized(0,true);
         // set target to current position
         wp_nav.init_loiter_target();
 

--- a/ArduCopter/control_rtl.pde
+++ b/ArduCopter/control_rtl.pde
@@ -134,7 +134,7 @@ static void rtl_climb_return_run()
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed) {
         // reset attitude control targets
-        attitude_control.set_throttle_out_unstabilized(0,true);
+        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
         // To-Do: re-initialise wpnav targets
         return;
     }
@@ -190,7 +190,7 @@ static void rtl_loiterathome_run()
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed) {
         // reset attitude control targets
-        attitude_control.set_throttle_out_unstabilized(0,true);
+        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
         // To-Do: re-initialise wpnav targets
         return;
     }
@@ -259,7 +259,7 @@ static void rtl_descent_run()
 
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed) {
-        attitude_control.set_throttle_out_unstabilized(0,true);
+        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
         // set target to current position
         wp_nav.init_loiter_target();
         return;
@@ -321,7 +321,7 @@ static void rtl_land_run()
     float target_yaw_rate = 0;
     // if not auto armed set throttle to zero and exit immediately
     if(!ap.auto_armed || ap.land_complete) {
-        attitude_control.set_throttle_out_unstabilized(0,true);
+        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
         // set target to current position
         wp_nav.init_loiter_target();
 

--- a/ArduCopter/control_sport.pde
+++ b/ArduCopter/control_sport.pde
@@ -26,9 +26,7 @@ static void sport_run()
 
     // if not armed or throttle at zero, set throttle to zero and exit immediately
     if(!motors.armed() || g.rc_3.control_in <= 0) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_out_unstabilized(0,true);
         pos_control.set_alt_target_to_current_alt();
         return;
     }
@@ -77,10 +75,8 @@ static void sport_run()
 
     // reset target lean angles and heading while landed
     if (ap.land_complete) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
         // move throttle to between minimum and non-takeoff-throttle to keep us on the ground
-        attitude_control.set_throttle_out(get_throttle_pre_takeoff(g.rc_3.control_in), false);
+        attitude_control.set_throttle_out_unstabilized(get_throttle_pre_takeoff(g.rc_3.control_in),true);
         pos_control.set_alt_target_to_current_alt();
     }else{
 

--- a/ArduCopter/control_sport.pde
+++ b/ArduCopter/control_sport.pde
@@ -26,7 +26,7 @@ static void sport_run()
 
     // if not armed or throttle at zero, set throttle to zero and exit immediately
     if(!motors.armed() || g.rc_3.control_in <= 0) {
-        attitude_control.set_throttle_out_unstabilized(0,true);
+        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
         pos_control.set_alt_target_to_current_alt();
         return;
     }
@@ -76,7 +76,7 @@ static void sport_run()
     // reset target lean angles and heading while landed
     if (ap.land_complete) {
         // move throttle to between minimum and non-takeoff-throttle to keep us on the ground
-        attitude_control.set_throttle_out_unstabilized(get_throttle_pre_takeoff(g.rc_3.control_in),true);
+        attitude_control.set_throttle_out_unstabilized(get_throttle_pre_takeoff(g.rc_3.control_in),true,g.throttle_filt);
         pos_control.set_alt_target_to_current_alt();
     }else{
 

--- a/ArduCopter/control_stabilize.pde
+++ b/ArduCopter/control_stabilize.pde
@@ -25,9 +25,7 @@ static void stabilize_run()
 
     // if not armed or throttle at zero, set throttle to zero and exit immediately
     if(!motors.armed() || g.rc_3.control_in <= 0) {
-        attitude_control.relax_bf_rate_controller();
-        attitude_control.set_yaw_target_to_current_heading();
-        attitude_control.set_throttle_out(0, false);
+        attitude_control.set_throttle_out_unstabilized(0,true);
         return;
     }
 

--- a/ArduCopter/control_stabilize.pde
+++ b/ArduCopter/control_stabilize.pde
@@ -25,7 +25,7 @@ static void stabilize_run()
 
     // if not armed or throttle at zero, set throttle to zero and exit immediately
     if(!motors.armed() || g.rc_3.control_in <= 0) {
-        attitude_control.set_throttle_out_unstabilized(0,true);
+        attitude_control.set_throttle_out_unstabilized(0,true,g.throttle_filt);
         return;
     }
 
@@ -48,5 +48,5 @@ static void stabilize_run()
     // body-frame rate controller is run directly from 100hz loop
 
     // output pilot's throttle
-    attitude_control.set_throttle_out(pilot_throttle_scaled, true);
+    attitude_control.set_throttle_out(pilot_throttle_scaled, true, g.throttle_filt);
 }

--- a/ArduCopter/heli_control_acro.pde
+++ b/ArduCopter/heli_control_acro.pde
@@ -49,7 +49,7 @@ static void heli_acro_run()
     }
 
     // output pilot's throttle without angle boost
-    attitude_control.set_throttle_out(g.rc_3.control_in, false);
+    attitude_control.set_throttle_out(g.rc_3.control_in, false, g.throttle_filt);
 }
 
 // get_pilot_desired_yaw_rate - transform pilot's yaw input into a desired yaw angle rate

--- a/ArduCopter/heli_control_stabilize.pde
+++ b/ArduCopter/heli_control_stabilize.pde
@@ -54,7 +54,7 @@ static void heli_stabilize_run()
     attitude_control.angle_ef_roll_pitch_rate_ef_yaw_smooth(target_roll, target_pitch, target_yaw_rate, get_smoothing_gain());
 
     // output pilot's throttle - note that TradHeli does not used angle-boost
-    attitude_control.set_throttle_out(pilot_throttle_scaled, false);
+    attitude_control.set_throttle_out(pilot_throttle_scaled, false, g.throttle_filt);
 }
 
 #endif  //HELI_FRAME

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -708,6 +708,7 @@ void AC_AttitudeControl::accel_limiting(bool enable_limits)
  // provide 0 to cut motors
 void AC_AttitudeControl::set_throttle_out(float throttle_out, bool apply_angle_boost)
 {
+    _motors.set_stabilizing(true);
     if (apply_angle_boost) {
         _motors.set_throttle(get_angle_boost(throttle_out));
     }else{
@@ -715,6 +716,18 @@ void AC_AttitudeControl::set_throttle_out(float throttle_out, bool apply_angle_b
         // clear angle_boost for logging purposes
         _angle_boost = 0;
     }
+}
+
+// outputs a throttle to all motors evenly with no attitude stabilization
+void AC_AttitudeControl::set_throttle_out_unstabilized(float throttle_in, bool reset_attitude_control)
+{
+    if (reset_attitude_control) {
+        relax_bf_rate_controller();
+        set_yaw_target_to_current_heading();
+    }
+    _motors.set_stabilizing(false);
+    _motors.set_throttle(throttle_in);
+    _angle_boost = 0;
 }
 
 // get_angle_boost - returns a throttle including compensation for roll/pitch angle

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -706,7 +706,7 @@ void AC_AttitudeControl::accel_limiting(bool enable_limits)
 
  // set_throttle_out - to be called by upper throttle controllers when they wish to provide throttle output directly to motors
  // provide 0 to cut motors
-void AC_AttitudeControl::set_throttle_out(int16_t throttle_out, bool apply_angle_boost)
+void AC_AttitudeControl::set_throttle_out(float throttle_out, bool apply_angle_boost)
 {
     if (apply_angle_boost) {
         _motors.set_throttle(get_angle_boost(throttle_out));
@@ -719,10 +719,10 @@ void AC_AttitudeControl::set_throttle_out(int16_t throttle_out, bool apply_angle
 
 // get_angle_boost - returns a throttle including compensation for roll/pitch angle
 // throttle value should be 0 ~ 1000
-int16_t AC_AttitudeControl::get_angle_boost(int16_t throttle_pwm)
+float AC_AttitudeControl::get_angle_boost(float throttle_pwm)
 {
     float temp = _ahrs.cos_pitch() * _ahrs.cos_roll();
-    int16_t throttle_out;
+    float throttle_out;
 
     temp = constrain_float(temp, 0.5f, 1.0f);
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -706,9 +706,10 @@ void AC_AttitudeControl::accel_limiting(bool enable_limits)
 
  // set_throttle_out - to be called by upper throttle controllers when they wish to provide throttle output directly to motors
  // provide 0 to cut motors
-void AC_AttitudeControl::set_throttle_out(float throttle_out, bool apply_angle_boost)
+void AC_AttitudeControl::set_throttle_out(float throttle_out, bool apply_angle_boost, float filter_cutoff)
 {
     _motors.set_stabilizing(true);
+    _motors.set_throttle_filter_cutoff(filter_cutoff);
     if (apply_angle_boost) {
         _motors.set_throttle(get_boosted_throttle(throttle_out));
     }else{
@@ -719,12 +720,13 @@ void AC_AttitudeControl::set_throttle_out(float throttle_out, bool apply_angle_b
 }
 
 // outputs a throttle to all motors evenly with no attitude stabilization
-void AC_AttitudeControl::set_throttle_out_unstabilized(float throttle_in, bool reset_attitude_control)
+void AC_AttitudeControl::set_throttle_out_unstabilized(float throttle_in, bool reset_attitude_control, float filter_cutoff)
 {
     if (reset_attitude_control) {
         relax_bf_rate_controller();
         set_yaw_target_to_current_heading();
     }
+    _motors.set_throttle_filter_cutoff(filter_cutoff);
     _motors.set_stabilizing(false);
     _motors.set_throttle(throttle_in);
     _angle_boost = 0;

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -174,8 +174,10 @@ public:
     //
 
      // set_throttle_out - to be called by upper throttle controllers when they wish to provide throttle output directly to motors
-     // provide 0 to cut motors
      void set_throttle_out(float throttle_pwm, bool apply_angle_boost);
+
+     // outputs a throttle to all motors evenly with no stabilization
+     void set_throttle_out_unstabilized(float throttle_in, bool reset_attitude_control);
 
      // angle_boost - accessor for angle boost so it can be logged
      int16_t angle_boost() const { return _angle_boost; }

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -233,8 +233,8 @@ protected:
     // throttle methods
     //
 
-    // get_angle_boost - calculate total body frame throttle required to produce the given earth frame throttle
-    virtual float get_angle_boost(float throttle_pwm);
+    // calculate total body frame throttle required to produce the given earth frame throttle
+    virtual float get_boosted_throttle(float throttle_in);
 
     // references to external libraries
     const AP_AHRS&      _ahrs;

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -175,7 +175,7 @@ public:
 
      // set_throttle_out - to be called by upper throttle controllers when they wish to provide throttle output directly to motors
      // provide 0 to cut motors
-     void set_throttle_out(int16_t throttle_pwm, bool apply_angle_boost);
+     void set_throttle_out(float throttle_pwm, bool apply_angle_boost);
 
      // angle_boost - accessor for angle boost so it can be logged
      int16_t angle_boost() const { return _angle_boost; }
@@ -232,7 +232,7 @@ protected:
     //
 
     // get_angle_boost - calculate total body frame throttle required to produce the given earth frame throttle
-    virtual int16_t get_angle_boost(int16_t throttle_pwm);
+    virtual float get_angle_boost(float throttle_pwm);
 
     // references to external libraries
     const AP_AHRS&      _ahrs;

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -174,10 +174,10 @@ public:
     //
 
      // set_throttle_out - to be called by upper throttle controllers when they wish to provide throttle output directly to motors
-     void set_throttle_out(float throttle_pwm, bool apply_angle_boost);
+     void set_throttle_out(float throttle_pwm, bool apply_angle_boost, float filt_cutoff);
 
      // outputs a throttle to all motors evenly with no stabilization
-     void set_throttle_out_unstabilized(float throttle_in, bool reset_attitude_control);
+     void set_throttle_out_unstabilized(float throttle_in, bool reset_attitude_control, float filt_cutoff);
 
      // angle_boost - accessor for angle boost so it can be logged
      int16_t angle_boost() const { return _angle_boost; }

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
@@ -377,13 +377,13 @@ float AC_AttitudeControl_Heli::rate_bf_to_motor_yaw(float rate_target_cds)
 // throttle functions
 //
 
-// get_angle_boost - returns a throttle including compensation for roll/pitch angle
+// returns a throttle including compensation for roll/pitch angle
 // throttle value should be 0 ~ 1000
-int16_t AC_AttitudeControl_Heli::get_angle_boost(int16_t throttle_pwm)
+float AC_AttitudeControl_Heli::get_boosted_throttle(float throttle_in)
 {
     // no angle boost for trad helis
     _angle_boost = 0;
-    return throttle_pwm;
+    return throttle_in;
 }
 
 // update_feedforward_filter_rate - Sets LPF cutoff frequency

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.h
@@ -73,8 +73,8 @@ private:
     // throttle methods
     //
 
-    // get_angle_boost - calculate total body frame throttle required to produce the given earth frame throttle
-    virtual int16_t get_angle_boost(int16_t throttle_pwm);
+    // calculate total body frame throttle required to produce the given earth frame throttle
+    float get_boosted_throttle(float throttle_in);
     
     
     // LPF filters to act on Rate Feedforward terms to linearize output.

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -74,7 +74,6 @@ void AC_PosControl::set_dt(float delta_sec)
 
     // update rate z-axis velocity error and accel error filters
     _vel_error_filter.set_cutoff_frequency(_dt,POSCONTROL_VEL_ERROR_CUTOFF_FREQ);
-    _accel_error_filter.set_cutoff_frequency(_dt,POSCONTROL_ACCEL_ERROR_CUTOFF_FREQ);
 }
 
 /// set_dt_xy - sets time delta in seconds for horizontal controller (i.e. 50hz = 0.02)
@@ -354,11 +353,10 @@ void AC_PosControl::accel_to_throttle(float accel_target_z)
     if (_flags.reset_accel_to_throttle) {
         // Reset Filter
         _accel_error.z = 0;
-        _accel_error_filter.reset(0);
         _flags.reset_accel_to_throttle = false;
     } else {
-        // calculate accel error and Filter with fc = 2 Hz
-        _accel_error.z = _accel_error_filter.apply(accel_target_z - z_accel_meas);
+        // calculate accel error
+        _accel_error.z = accel_target_z - z_accel_meas;
     }
 
     // set input to PID
@@ -382,7 +380,7 @@ void AC_PosControl::accel_to_throttle(float accel_target_z)
     float thr_out = p+i+d+_throttle_hover;
 
     // send throttle to attitude controller with angle boost
-    _attitude_control.set_throttle_out(thr_out, true);
+    _attitude_control.set_throttle_out(thr_out, true, POSCONTROL_THROTTLE_CUTOFF_FREQ);
 }
 
 ///

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -335,7 +335,6 @@ void AC_PosControl::rate_to_accel_z()
 
     // consolidate and constrain target acceleration
     desired_accel = _accel_feedforward.z + p;
-    desired_accel = constrain_int32(desired_accel, -32000, 32000);
 
     // set target for accel based throttle controller
     accel_to_throttle(desired_accel);
@@ -346,7 +345,7 @@ void AC_PosControl::rate_to_accel_z()
 void AC_PosControl::accel_to_throttle(float accel_target_z)
 {
     float z_accel_meas;         // actual acceleration
-    int32_t p,i,d;              // used to capture pid values for logging
+    float p,i,d;              // used to capture pid values for logging
 
     // Calculate Earth Frame Z acceleration
     z_accel_meas = -(_ahrs.get_accel_ef_blended().z + GRAVITY_MSS) * 100.0f;
@@ -359,7 +358,7 @@ void AC_PosControl::accel_to_throttle(float accel_target_z)
         _flags.reset_accel_to_throttle = false;
     } else {
         // calculate accel error and Filter with fc = 2 Hz
-        _accel_error.z = _accel_error_filter.apply(constrain_float(accel_target_z - z_accel_meas, -32000, 32000));
+        _accel_error.z = _accel_error_filter.apply(accel_target_z - z_accel_meas);
     }
 
     // set input to PID
@@ -380,7 +379,7 @@ void AC_PosControl::accel_to_throttle(float accel_target_z)
     // get d term
     d = _pid_accel_z.get_d();
 
-    int16_t thr_out = (int16_t)p+i+d+_throttle_hover;
+    float thr_out = p+i+d+_throttle_hover;
 
     // send throttle to attitude controller with angle boost
     _attitude_control.set_throttle_out(thr_out, true);

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -380,8 +380,7 @@ void AC_PosControl::accel_to_throttle(float accel_target_z)
     // get d term
     d = _pid_accel_z.get_d();
 
-    // ensure throttle is above zero (or motors lib will stop stabilizing)
-    int16_t thr_out = max((int16_t)p+i+d+_throttle_hover,1);
+    int16_t thr_out = (int16_t)p+i+d+_throttle_hover;
 
     // send throttle to attitude controller with angle boost
     _attitude_control.set_throttle_out(thr_out, true);

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -39,7 +39,7 @@
 #define POSCONTROL_ACTIVE_TIMEOUT_MS            200    // position controller is considered active if it has been called within the past 0.2 seconds
 
 #define POSCONTROL_VEL_ERROR_CUTOFF_FREQ        4.0f    // 4hz low-pass filter on velocity error
-#define POSCONTROL_ACCEL_ERROR_CUTOFF_FREQ      2.0f    // 2hz low-pass filter on accel error
+#define POSCONTROL_THROTTLE_CUTOFF_FREQ      2.0f    // 2hz low-pass filter on accel error
 #define POSCONTROL_JERK_LIMIT_CMSSS             1700.0f // 17m/s/s/s jerk limit on horizontal acceleration
 #define POSCONTROL_ACCEL_FILTER_HZ              5.0f    // 5hz low-pass filter on acceleration
 
@@ -370,7 +370,6 @@ private:
     float       _alt_max;               // max altitude - should be updated from the main code with altitude limit from fence
     float       _distance_to_target;    // distance to position target - for reporting only
     LowPassFilterFloat _vel_error_filter;   // low-pass-filter on z-axis velocity error
-    LowPassFilterFloat _accel_error_filter; // low-pass-filter on z-axis accelerometer error
 
     Vector2f    _accel_target_jerk_limited; // acceleration target jerk limited to 100deg/s/s
     Vector2f    _accel_target_filtered;     // acceleration target filtered with 5hz low pass filter

--- a/libraries/AP_Motors/AP_MotorsCoax.cpp
+++ b/libraries/AP_Motors/AP_MotorsCoax.cpp
@@ -123,15 +123,63 @@ void AP_MotorsCoax::output_min()
     hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]), _rc_throttle.radio_min);
 }
 
-// output_armed - sends commands to the motors
-void AP_MotorsCoax::output_armed()
+void AP_MotorsCoax::output_armed_not_stabilizing()
+{
+    int16_t out_min = _rc_throttle.radio_min + _min_throttle;
+    int16_t motor_out;
+
+    int16_t min_thr = rel_pwm_to_thr_range(_spin_when_armed_ramped);
+
+    // initialize limits flags
+    limit.roll_pitch = true;
+    limit.yaw = true;
+    limit.throttle_lower = false;
+    limit.throttle_upper = false;
+
+    if (_rc_throttle.servo_out <= min_thr) {
+        _rc_throttle.servo_out = min_thr;
+        limit.throttle_lower = true;
+    }
+    if (_rc_throttle.servo_out >= _max_throttle) {
+        _rc_throttle.servo_out = _max_throttle;
+        limit.throttle_upper = true;
+    }
+
+    _rc_throttle.calc_pwm();
+
+    motor_out = _rc_throttle.radio_out;
+
+    _servo1.servo_out = 0;
+    _servo1.calc_pwm();
+
+    _servo2.servo_out = 0;
+    _servo2.calc_pwm();
+
+    if (motor_out >= out_min) {
+        motor_out = apply_thrust_curve_and_volt_scaling(motor_out, out_min, _rc_throttle.radio_max);
+    }
+
+    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]), _servo1.radio_out);
+    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]), _servo2.radio_out);
+    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]), motor_out);
+    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]), motor_out);
+}
+
+// sends commands to the motors
+// TODO pull code that is common to output_armed_not_stabilizing into helper functions
+void AP_MotorsCoax::output_armed_stabilizing()
 {
     int16_t out_min = _rc_throttle.radio_min + _min_throttle;
     int16_t motor_out[4];
 
-    // Throttle is 0 to 1000 only
-    if (_rc_throttle.servo_out <= 0) {
-        _rc_throttle.servo_out = 0;
+    // initialize limits flags
+    limit.roll_pitch = false;
+    limit.yaw = false;
+    limit.throttle_lower = false;
+    limit.throttle_upper = false;
+
+    if (_rc_throttle.servo_out <= _min_throttle) {
+        _rc_throttle.servo_out = _min_throttle;
         limit.throttle_lower = true;
     }
     if (_rc_throttle.servo_out >= _max_throttle) {
@@ -143,44 +191,27 @@ void AP_MotorsCoax::output_armed()
     _rc_throttle.calc_pwm();
     _rc_yaw.calc_pwm();
 
-    // if we are not sending a throttle output, we cut the motors
-    if(_rc_throttle.servo_out == 0) {
-        // range check spin_when_armed
-        if (_spin_when_armed < 0) {
-            _spin_when_armed = 0;
-        }
-        if (_spin_when_armed > _min_throttle) {
-            _spin_when_armed = _min_throttle;
-        }
-        motor_out[AP_MOTORS_MOT_3] = _rc_throttle.radio_min + _spin_when_armed;
-        motor_out[AP_MOTORS_MOT_4] = _rc_throttle.radio_min + _spin_when_armed;
-    }else{
+    // motors
+    motor_out[AP_MOTORS_MOT_3] = _rev_yaw*_rc_yaw.pwm_out + _rc_throttle.radio_out;
+    motor_out[AP_MOTORS_MOT_4] = -_rev_yaw*_rc_yaw.pwm_out +_rc_throttle.radio_out;
 
-        // check if throttle is below limit
-        if (_rc_throttle.servo_out <= _min_throttle) {  // perhaps being at min throttle itself is not a problem, only being under is
-            limit.throttle_lower = true;
-            _rc_throttle.servo_out = _min_throttle;
-            _rc_throttle.calc_pwm();    // recalculate radio.out
-        }
+    // TODO: set limits.roll_pitch and limits.yaw
 
-        // motors
-        motor_out[AP_MOTORS_MOT_3] = _rev_yaw*_rc_yaw.pwm_out + _rc_throttle.radio_out;
-        motor_out[AP_MOTORS_MOT_4] = -_rev_yaw*_rc_yaw.pwm_out +_rc_throttle.radio_out;
-        // front
-        _servo1.servo_out = _rev_roll*_rc_roll.servo_out;
-        // right
-        _servo2.servo_out = _rev_pitch*_rc_pitch.servo_out;
-		_servo1.calc_pwm();
-		_servo2.calc_pwm();
+    // front
+    _servo1.servo_out = _rev_roll*_rc_roll.servo_out;
+    // right
+    _servo2.servo_out = _rev_pitch*_rc_pitch.servo_out;
 
-		// adjust for thrust curve and voltage scaling
-        motor_out[AP_MOTORS_MOT_3] = apply_thrust_curve_and_volt_scaling(motor_out[AP_MOTORS_MOT_3], out_min, _rc_throttle.radio_max);
-        motor_out[AP_MOTORS_MOT_4] = apply_thrust_curve_and_volt_scaling(motor_out[AP_MOTORS_MOT_4], out_min, _rc_throttle.radio_max);
+    _servo1.calc_pwm();
+    _servo2.calc_pwm();
 
-        // ensure motors don't drop below a minimum value and stop
-        motor_out[AP_MOTORS_MOT_3] = max(motor_out[AP_MOTORS_MOT_3],    out_min);
-        motor_out[AP_MOTORS_MOT_4] = max(motor_out[AP_MOTORS_MOT_4],    out_min);
-    }
+    // adjust for thrust curve and voltage scaling
+    motor_out[AP_MOTORS_MOT_3] = apply_thrust_curve_and_volt_scaling(motor_out[AP_MOTORS_MOT_3], out_min, _rc_throttle.radio_max);
+    motor_out[AP_MOTORS_MOT_4] = apply_thrust_curve_and_volt_scaling(motor_out[AP_MOTORS_MOT_4], out_min, _rc_throttle.radio_max);
+
+    // ensure motors don't drop below a minimum value and stop
+    motor_out[AP_MOTORS_MOT_3] = max(motor_out[AP_MOTORS_MOT_3],    out_min);
+    motor_out[AP_MOTORS_MOT_4] = max(motor_out[AP_MOTORS_MOT_4],    out_min);
 
     // send output to each motor
     hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]), _servo1.radio_out);
@@ -202,7 +233,7 @@ void AP_MotorsCoax::output_disarmed()
 void AP_MotorsCoax::output_test(uint8_t motor_seq, int16_t pwm)
 {
     // exit immediately if not armed
-    if (!_flags.armed) {
+    if (!armed()) {
         return;
     }
 

--- a/libraries/AP_Motors/AP_MotorsCoax.h
+++ b/libraries/AP_Motors/AP_MotorsCoax.h
@@ -60,8 +60,9 @@ public:
 
 protected:
     // output - sends commands to the motors
-    virtual void        output_armed();
-    virtual void        output_disarmed();
+    void                output_armed_stabilizing();
+    void                output_armed_not_stabilizing();
+    void                output_disarmed();
 
     AP_Int8             _rev_roll;      // REV Roll feedback
     AP_Int8             _rev_pitch;     // REV pitch feedback

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -280,7 +280,7 @@ void AP_MotorsHeli::output_min()
 void AP_MotorsHeli::output_test(uint8_t motor_seq, int16_t pwm)
 {
     // exit immediately if not armed
-    if (!_flags.armed) {
+    if (!armed()) {
         return;
     }
 
@@ -375,8 +375,14 @@ uint16_t AP_MotorsHeli::get_motor_mask()
 // protected methods
 //
 
-// output_armed - sends commands to the motors
-void AP_MotorsHeli::output_armed()
+void AP_MotorsHeli::output_armed_not_stabilizing()
+{
+    // call output_armed_stabilizing
+    output_armed_stabilizing();
+}
+
+// sends commands to the motors
+void AP_MotorsHeli::output_armed_stabilizing()
 {
     // if manual override (i.e. when setting up swash), pass pilot commands straight through to swash
     if (_servo_manual == 1) {
@@ -401,7 +407,7 @@ void AP_MotorsHeli::output_armed()
 void AP_MotorsHeli::output_disarmed()
 {
     // for helis - armed or disarmed we allow servos to move
-    output_armed();
+    output_armed_stabilizing();
 }
 
 //

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -208,8 +208,9 @@ public:
 protected:
 
     // output - sends commands to the motors
-    void output_armed();
-    void output_disarmed();
+    void                output_armed_stabilizing();
+    void                output_armed_not_stabilizing();
+    void                output_disarmed();
 
 private:
 

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -118,9 +118,61 @@ uint16_t AP_MotorsMatrix::get_motor_mask()
     return mask;
 }
 
+void AP_MotorsMatrix::output_armed_not_stabilizing()
+{
+    int8_t i;
+    int16_t motor_out[AP_MOTORS_MAX_NUM_MOTORS];    // final outputs sent to the motors
+    int16_t out_min_pwm = _rc_throttle.radio_min + _min_throttle;      // minimum pwm value we can send to the motors
+    int16_t out_max_pwm = _rc_throttle.radio_max;                      // maximum pwm value we can send to the motors
+
+    // initialize limits flags
+    limit.roll_pitch = true;
+    limit.yaw = true;
+    limit.throttle_lower = false;
+    limit.throttle_upper = false;
+
+    int16_t min_thr = rel_pwm_to_thr_range(_spin_when_armed_ramped);
+
+    if (_rc_throttle.servo_out <= min_thr) {
+        _rc_throttle.servo_out = min_thr;
+        limit.throttle_lower = true;
+    }
+
+    if (_rc_throttle.servo_out >= _hover_out) {
+        _rc_throttle.servo_out = _hover_out;
+        limit.throttle_upper = true;
+    }
+
+    _rc_throttle.calc_pwm();
+
+    // set output throttle
+    for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i]) {
+            motor_out[i] = _rc_throttle.radio_out;
+        }
+    }
+
+    if(_rc_throttle.radio_out >= out_min_pwm) {
+        // apply thrust curve and voltage scaling
+        for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
+            if (motor_enabled[i]) {
+                motor_out[i] = apply_thrust_curve_and_volt_scaling(motor_out[i], out_min_pwm, out_max_pwm);
+            }
+        }
+    }
+
+    // send output to each motor
+    for( i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++ ) {
+        if( motor_enabled[i] ) {
+            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[i]), motor_out[i]);
+        }
+    }
+}
+
 // output_armed - sends commands to the motors
 // includes new scaling stability patch
-void AP_MotorsMatrix::output_armed()
+// TODO pull code that is common to output_armed_not_stabilizing into helper functions
+void AP_MotorsMatrix::output_armed_stabilizing()
 {
     int8_t i;
     int16_t out_min_pwm = _rc_throttle.radio_min + _min_throttle;      // minimum pwm value we can send to the motors
@@ -137,7 +189,7 @@ void AP_MotorsMatrix::output_armed()
     int16_t yaw_allowed;    // amount of yaw we can fit in
     int16_t thr_adj;        // the difference between the pilot's desired throttle and out_best_thr_pwm (the throttle that is actually provided)
 
-    // initialize limits flag
+    // initialize limits flags
     limit.roll_pitch = false;
     limit.yaw = false;
     limit.throttle_lower = false;
@@ -145,8 +197,8 @@ void AP_MotorsMatrix::output_armed()
 
     // Throttle is 0 to 1000 only
     // To-Do: we should not really be limiting this here because we don't "own" this _rc_throttle object
-    if (_rc_throttle.servo_out <= 0) {
-        _rc_throttle.servo_out = 0;
+    if (_rc_throttle.servo_out <= _min_throttle) {
+        _rc_throttle.servo_out = _min_throttle;
         limit.throttle_lower = true;
     }
     if (_rc_throttle.servo_out >= _max_throttle) {
@@ -160,169 +212,139 @@ void AP_MotorsMatrix::output_armed()
     _rc_throttle.calc_pwm();
     _rc_yaw.calc_pwm();
 
-    // if we are not sending a throttle output, we cut the motors
-    if (_rc_throttle.servo_out == 0) {
-        // range check spin_when_armed
-        if (_spin_when_armed_ramped < 0) {
-             _spin_when_armed_ramped = 0;
-        }
-        if (_spin_when_armed_ramped > _min_throttle) {
-            _spin_when_armed_ramped = _min_throttle;
-        }
-        for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
-            // spin motors at minimum
-            if (motor_enabled[i]) {
-                motor_out[i] = _rc_throttle.radio_min + _spin_when_armed_ramped;
+    // calculate roll and pitch for each motor
+    // set rpy_low and rpy_high to the lowest and highest values of the motors
+    for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i]) {
+            rpy_out[i] = _rc_roll.pwm_out * _roll_factor[i] * get_voltage_comp_gain() +
+                            _rc_pitch.pwm_out * _pitch_factor[i] * get_voltage_comp_gain();
+
+            // record lowest roll pitch command
+            if (rpy_out[i] < rpy_low) {
+                rpy_low = rpy_out[i];
+            }
+            // record highest roll pich command
+            if (rpy_out[i] > rpy_high) {
+                rpy_high = rpy_out[i];
             }
         }
+    }
 
-        // Every thing is limited
+    // calculate throttle that gives most possible room for yaw (range 1000 ~ 2000) which is the lower of:
+    //      1. mid throttle - average of highest and lowest motor (this would give the maximum possible room margin above the highest motor and below the lowest)
+    //      2. the higher of:
+    //            a) the pilot's throttle input
+    //            b) the mid point between the pilot's input throttle and hover-throttle
+    //      Situation #2 ensure we never increase the throttle above hover throttle unless the pilot has commanded this.
+    //      Situation #2b allows us to raise the throttle above what the pilot commanded but not so far that it would actually cause the copter to rise.
+    //      We will choose #1 (the best throttle for yaw control) if that means reducing throttle to the motors (i.e. we favour reducing throttle *because* it provides better yaw control)
+    //      We will choose #2 (a mix of pilot and hover throttle) only when the throttle is quite low.  We favour reducing throttle instead of better yaw control because the pilot has commanded it
+    int16_t motor_mid = (rpy_low+rpy_high)/2;
+    out_best_thr_pwm = min(out_mid_pwm - motor_mid, max(_rc_throttle.radio_out, _rc_throttle.radio_out*max(0,1.0f-_throttle_low_comp)+get_hover_throttle_as_pwm()*_throttle_low_comp));
+
+    // calculate amount of yaw we can fit into the throttle range
+    // this is always equal to or less than the requested yaw from the pilot or rate controller
+    yaw_allowed = min(out_max_pwm - out_best_thr_pwm, out_best_thr_pwm - out_min_pwm) - (rpy_high-rpy_low)/2;
+    yaw_allowed = max(yaw_allowed, _yaw_headroom);
+
+    if (_rc_yaw.pwm_out >= 0) {
+        // if yawing right
+        if (yaw_allowed > _rc_yaw.pwm_out * get_voltage_comp_gain()) {
+            yaw_allowed = _rc_yaw.pwm_out * get_voltage_comp_gain(); // to-do: this is bad form for yaw_allows to change meaning to become the amount that we are going to output
+        }else{
+            limit.yaw = true;
+        }
+    }else{
+        // if yawing left
+        yaw_allowed = -yaw_allowed;
+        if (yaw_allowed < _rc_yaw.pwm_out * get_voltage_comp_gain()) {
+            yaw_allowed = _rc_yaw.pwm_out * get_voltage_comp_gain(); // to-do: this is bad form for yaw_allows to change meaning to become the amount that we are going to output
+        }else{
+            limit.yaw = true;
+        }
+    }
+
+    // add yaw to intermediate numbers for each motor
+    rpy_low = 0;
+    rpy_high = 0;
+    for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i]) {
+            rpy_out[i] =    rpy_out[i] +
+                            yaw_allowed * _yaw_factor[i];
+
+            // record lowest roll+pitch+yaw command
+            if( rpy_out[i] < rpy_low ) {
+                rpy_low = rpy_out[i];
+            }
+            // record highest roll+pitch+yaw command
+            if( rpy_out[i] > rpy_high) {
+                rpy_high = rpy_out[i];
+            }
+        }
+    }
+
+    // check everything fits
+    thr_adj = _rc_throttle.radio_out - out_best_thr_pwm;
+
+    // calculate upper and lower limits of thr_adj
+    int16_t thr_adj_max = max(out_max_pwm-(out_best_thr_pwm+rpy_high),0);
+
+    // if we are increasing the throttle (situation #2 above)..
+    if (thr_adj > 0) {
+        // increase throttle as close as possible to requested throttle
+        // without going over out_max_pwm
+        if (thr_adj > thr_adj_max){
+            thr_adj = thr_adj_max;
+            // we haven't even been able to apply full throttle command
+            limit.throttle_upper = true;
+        }
+    }else if(thr_adj < 0){
+        // decrease throttle as close as possible to requested throttle
+        // without going under out_min_pwm or over out_max_pwm
+        // earlier code ensures we can't break both boundaries
+        int16_t thr_adj_min = min(out_min_pwm-(out_best_thr_pwm+rpy_low),0);
+        if (thr_adj > thr_adj_max) {
+            thr_adj = thr_adj_max;
+            limit.throttle_upper = true;
+        }
+        if (thr_adj < thr_adj_min) {
+            thr_adj = thr_adj_min;
+        }
+    }
+
+    // do we need to reduce roll, pitch, yaw command
+    // earlier code does not allow both limit's to be passed simultaneously with abs(_yaw_factor)<1
+    if ((rpy_low+out_best_thr_pwm)+thr_adj < out_min_pwm){
+        rpy_scale = (float)(out_min_pwm-thr_adj-out_best_thr_pwm)/rpy_low;
+        // we haven't even been able to apply full roll, pitch and minimal yaw without scaling
         limit.roll_pitch = true;
         limit.yaw = true;
+    }else if((rpy_high+out_best_thr_pwm)+thr_adj > out_max_pwm){
+        rpy_scale = (float)(out_max_pwm-thr_adj-out_best_thr_pwm)/rpy_high;
+        // we haven't even been able to apply full roll, pitch and minimal yaw without scaling
+        limit.roll_pitch = true;
+        limit.yaw = true;
+    }
 
-    } else {
-
-        // check if throttle is below limit
-        if (_rc_throttle.servo_out <= _min_throttle) {  // perhaps being at min throttle itself is not a problem, only being under is
-            limit.throttle_lower = true;
-            _rc_throttle.servo_out = _min_throttle;
-            _rc_throttle.calc_pwm();    // recalculate radio.out
+    // add scaled roll, pitch, constrained yaw and throttle for each motor
+    for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i]) {
+            motor_out[i] = out_best_thr_pwm+thr_adj +
+                            rpy_scale*rpy_out[i];
         }
+    }
 
-        // calculate roll and pitch for each motor
-        // set rpy_low and rpy_high to the lowest and highest values of the motors
-        for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
-            if (motor_enabled[i]) {
-                rpy_out[i] = _rc_roll.pwm_out * _roll_factor[i] * get_voltage_comp_gain() +
-                             _rc_pitch.pwm_out * _pitch_factor[i] * get_voltage_comp_gain();
-
-                // record lowest roll pitch command
-                if (rpy_out[i] < rpy_low) {
-                    rpy_low = rpy_out[i];
-                }
-                // record highest roll pich command
-                if (rpy_out[i] > rpy_high) {
-                    rpy_high = rpy_out[i];
-                }
-            }
+    // apply thrust curve and voltage scaling
+    for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i]) {
+            motor_out[i] = apply_thrust_curve_and_volt_scaling(motor_out[i], out_min_pwm, out_max_pwm);
         }
+    }
 
-        // calculate throttle that gives most possible room for yaw (range 1000 ~ 2000) which is the lower of:
-        //      1. mid throttle - average of highest and lowest motor (this would give the maximum possible room margin above the highest motor and below the lowest)
-        //      2. the higher of:
-        //            a) the pilot's throttle input
-        //            b) the mid point between the pilot's input throttle and hover-throttle
-        //      Situation #2 ensure we never increase the throttle above hover throttle unless the pilot has commanded this.
-        //      Situation #2b allows us to raise the throttle above what the pilot commanded but not so far that it would actually cause the copter to rise.
-        //      We will choose #1 (the best throttle for yaw control) if that means reducing throttle to the motors (i.e. we favour reducing throttle *because* it provides better yaw control)
-        //      We will choose #2 (a mix of pilot and hover throttle) only when the throttle is quite low.  We favour reducing throttle instead of better yaw control because the pilot has commanded it
-        int16_t motor_mid = (rpy_low+rpy_high)/2;
-        out_best_thr_pwm = min(out_mid_pwm - motor_mid, max(_rc_throttle.radio_out, _rc_throttle.radio_out*max(0,1.0f-_throttle_low_comp)+get_hover_throttle_as_pwm()*_throttle_low_comp));
-
-        // calculate amount of yaw we can fit into the throttle range
-        // this is always equal to or less than the requested yaw from the pilot or rate controller
-        yaw_allowed = min(out_max_pwm - out_best_thr_pwm, out_best_thr_pwm - out_min_pwm) - (rpy_high-rpy_low)/2;
-        yaw_allowed = max(yaw_allowed, _yaw_headroom);
-
-        if (_rc_yaw.pwm_out >= 0) {
-            // if yawing right
-            if (yaw_allowed > _rc_yaw.pwm_out * get_voltage_comp_gain()) {
-                yaw_allowed = _rc_yaw.pwm_out * get_voltage_comp_gain(); // to-do: this is bad form for yaw_allows to change meaning to become the amount that we are going to output
-            }else{
-                limit.yaw = true;
-            }
-        }else{
-            // if yawing left
-            yaw_allowed = -yaw_allowed;
-            if (yaw_allowed < _rc_yaw.pwm_out * get_voltage_comp_gain()) {
-                yaw_allowed = _rc_yaw.pwm_out * get_voltage_comp_gain(); // to-do: this is bad form for yaw_allows to change meaning to become the amount that we are going to output
-            }else{
-                limit.yaw = true;
-            }
-        }
-
-        // add yaw to intermediate numbers for each motor
-        rpy_low = 0;
-        rpy_high = 0;
-        for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
-            if (motor_enabled[i]) {
-                rpy_out[i] =    rpy_out[i] +
-                                yaw_allowed * _yaw_factor[i];
-
-                // record lowest roll+pitch+yaw command
-                if( rpy_out[i] < rpy_low ) {
-                    rpy_low = rpy_out[i];
-                }
-                // record highest roll+pitch+yaw command
-                if( rpy_out[i] > rpy_high) {
-                    rpy_high = rpy_out[i];
-                }
-            }
-        }
-
-        // check everything fits
-        thr_adj = _rc_throttle.radio_out - out_best_thr_pwm;
-
-        // calculate upper and lower limits of thr_adj
-        int16_t thr_adj_max = max(out_max_pwm-(out_best_thr_pwm+rpy_high),0);
-
-        // if we are increasing the throttle (situation #2 above)..
-        if (thr_adj > 0) {
-            // increase throttle as close as possible to requested throttle
-            // without going over out_max_pwm
-            if (thr_adj > thr_adj_max){
-                thr_adj = thr_adj_max;
-                // we haven't even been able to apply full throttle command
-                limit.throttle_upper = true;
-            }
-        }else if(thr_adj < 0){
-            // decrease throttle as close as possible to requested throttle
-            // without going under out_min_pwm or over out_max_pwm
-            // earlier code ensures we can't break both boundaries
-            int16_t thr_adj_min = min(out_min_pwm-(out_best_thr_pwm+rpy_low),0);
-            if (thr_adj > thr_adj_max) {
-                thr_adj = thr_adj_max;
-                limit.throttle_upper = true;
-            }
-            if (thr_adj < thr_adj_min) {
-                thr_adj = thr_adj_min;
-            }
-        }
-
-        // do we need to reduce roll, pitch, yaw command
-        // earlier code does not allow both limit's to be passed simultaneously with abs(_yaw_factor)<1
-        if ((rpy_low+out_best_thr_pwm)+thr_adj < out_min_pwm){
-            rpy_scale = (float)(out_min_pwm-thr_adj-out_best_thr_pwm)/rpy_low;
-            // we haven't even been able to apply full roll, pitch and minimal yaw without scaling
-            limit.roll_pitch = true;
-            limit.yaw = true;
-        }else if((rpy_high+out_best_thr_pwm)+thr_adj > out_max_pwm){
-            rpy_scale = (float)(out_max_pwm-thr_adj-out_best_thr_pwm)/rpy_high;
-            // we haven't even been able to apply full roll, pitch and minimal yaw without scaling
-            limit.roll_pitch = true;
-            limit.yaw = true;
-        }
-
-        // add scaled roll, pitch, constrained yaw and throttle for each motor
-        for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
-            if (motor_enabled[i]) {
-                motor_out[i] = out_best_thr_pwm+thr_adj +
-                               rpy_scale*rpy_out[i];
-            }
-        }
-
-        // apply thrust curve and voltage scaling
-        for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
-            if (motor_enabled[i]) {
-                motor_out[i] = apply_thrust_curve_and_volt_scaling(motor_out[i], out_min_pwm, out_max_pwm);
-            }
-        }
-
-        // clip motor output if required (shouldn't be)
-        for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
-            if (motor_enabled[i]) {
-                motor_out[i] = constrain_int16(motor_out[i], out_min_pwm, out_max_pwm);
-            }
+    // clip motor output if required (shouldn't be)
+    for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i]) {
+            motor_out[i] = constrain_int16(motor_out[i], out_min_pwm, out_max_pwm);
         }
     }
 
@@ -347,7 +369,7 @@ void AP_MotorsMatrix::output_disarmed()
 void AP_MotorsMatrix::output_test(uint8_t motor_seq, int16_t pwm)
 {
     // exit immediately if not armed
-    if (!_flags.armed) {
+    if (!armed()) {
         return;
     }
 

--- a/libraries/AP_Motors/AP_MotorsMatrix.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix.h
@@ -67,7 +67,8 @@ public:
 
 protected:
     // output - sends commands to the motors
-    void                output_armed();
+    void                output_armed_stabilizing();
+    void                output_armed_not_stabilizing();
     void                output_disarmed();
 
     // add_motor using raw roll, pitch, throttle and yaw factors

--- a/libraries/AP_Motors/AP_MotorsMatrix.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix.h
@@ -67,8 +67,8 @@ public:
 
 protected:
     // output - sends commands to the motors
-    virtual void        output_armed();
-    virtual void        output_disarmed();
+    void                output_armed();
+    void                output_disarmed();
 
     // add_motor using raw roll, pitch, throttle and yaw factors
     void                add_motor_raw(int8_t motor_num, float roll_fac, float pitch_fac, float yaw_fac, uint8_t testing_order);

--- a/libraries/AP_Motors/AP_MotorsSingle.h
+++ b/libraries/AP_Motors/AP_MotorsSingle.h
@@ -61,8 +61,9 @@ public:
 
 protected:
     // output - sends commands to the motors
-    virtual void        output_armed();
-    virtual void        output_disarmed();
+    void                output_armed_stabilizing();
+    void                output_armed_not_stabilizing();
+    void                output_disarmed();
 
     AP_Int8             _rev_roll;      // REV Roll feedback
     AP_Int8             _rev_pitch;     // REV pitch feedback

--- a/libraries/AP_Motors/AP_MotorsTri.h
+++ b/libraries/AP_Motors/AP_MotorsTri.h
@@ -47,8 +47,9 @@ public:
 
 protected:
     // output - sends commands to the motors
-    virtual void        output_armed();
-    virtual void        output_disarmed();
+    void                output_armed_stabilizing();
+    void                output_armed_not_stabilizing();
+    void                output_disarmed();
 
     RC_Channel&         _rc_tail;       // REV parameter used from this channel to determine direction of tail servo movement
 };

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -93,14 +93,6 @@ const AP_Param::GroupInfo AP_Motors::var_info[] PROGMEM = {
     // @User: Advanced
     AP_GROUPINFO("CURR_MAX", 12, AP_Motors, _batt_current_max, AP_MOTORS_CURR_MAX_DEFAULT),
 
-    // @Param: THR_FILT
-    // @DisplayName: Throttle output filter
-    // @Description: Frequency cutoff (in hz) of throttle output filter
-    // @Range: 2 5
-    // @Units: Hz
-    // @User: Advanced
-    AP_GROUPINFO("THR_FILT", 13, AP_Motors, _throttle_filt_hz, 0.0f),
-
     AP_GROUPEND
 };
 
@@ -138,7 +130,8 @@ AP_Motors::AP_Motors(RC_Channel& rc_roll, RC_Channel& rc_pitch, RC_Channel& rc_t
     _batt_voltage_filt.set_cutoff_frequency(1.0f/_loop_rate,AP_MOTORS_BATT_VOLT_FILT_HZ);
     _batt_voltage_filt.reset(1.0f);
 
-    _throttle_filter.set_cutoff_frequency(1.0f/_loop_rate,_throttle_filt_hz);
+    // setup throttle filtering
+    _throttle_filter.set_cutoff_frequency(1.0f/_loop_rate,0.0f);
     _throttle_filter.reset(0.0f);
 };
 
@@ -220,10 +213,6 @@ void AP_Motors::slow_start(bool true_false)
 // update the throttle input filter
 void AP_Motors::update_throttle_filter()
 {
-    if (_throttle_filter.get_cutoff_frequency() != _throttle_filt_hz) {
-        _throttle_filter.set_cutoff_frequency(1.0f/_loop_rate,_throttle_filt_hz);
-    }
-
     if (armed()) {
         _throttle_filter.apply(_throttle_in);
     } else {

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -121,7 +121,7 @@ public:
     void                set_roll(int16_t roll_in) { _rc_roll.servo_out = roll_in; };                    // range -4500 ~ 4500
     void                set_pitch(int16_t pitch_in) { _rc_pitch.servo_out = pitch_in; };                // range -4500 ~ 4500
     void                set_yaw(int16_t yaw_in) { _rc_yaw.servo_out = yaw_in; };                        // range -4500 ~ 4500
-    void                set_throttle(int16_t throttle_in) { _rc_throttle.servo_out = throttle_in; };    // range 0 ~ 1000
+    void                set_throttle(int16_t throttle_in) { _throttle_in = throttle_in; };    // range 0 ~ 1000
 
     // accessors for roll, pitch, yaw and throttle inputs to motors
     int16_t             get_roll() const { return _rc_roll.servo_out; }
@@ -198,6 +198,9 @@ protected:
     virtual void        output_armed()=0;
     virtual void        output_disarmed()=0;
 
+    // update the throttle input filter
+    void                update_throttle_filter();
+
     // update_max_throttle - updates the limits on _max_throttle for slow_start and current limiting flag
     void                update_max_throttle();
 
@@ -239,6 +242,7 @@ protected:
     AP_Float            _batt_voltage_max;      // maximum voltage used to scale lift
     AP_Float            _batt_voltage_min;      // minimum voltage used to scale lift
     AP_Float            _batt_current_max;      // current over which maximum throttle is limited
+    AP_Float            _throttle_filt_hz;       // throttle output filter time constant in hz
 
     // internal variables
     RC_Channel&         _rc_roll;               // roll input in from users is held in servo_out
@@ -264,5 +268,7 @@ protected:
     int16_t             _batt_timer;            // timer used in battery resistance calcs
     float               _lift_max;              // maximum lift ratio from battery voltage
     float               _throttle_limit;        // ratio of throttle limit between hover and maximum
+    float               _throttle_in;           // last throttle input from set_throttle caller
+    LowPassFilterFloat  _throttle_filter;       // throttle input filter
 };
 #endif  // __AP_MOTORS_CLASS_H__

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -130,6 +130,8 @@ public:
     int16_t             get_yaw() const { return _rc_yaw.servo_out; }
     int16_t             get_throttle_out() const { return _rc_throttle.servo_out; }
 
+    void                set_throttle_filter_cutoff(float filt_hz) { _throttle_filter.set_cutoff_frequency(1.0f/_loop_rate,filt_hz); }
+
     // output - sends commands to the motors
     void                output();
 
@@ -247,7 +249,6 @@ protected:
     AP_Float            _batt_voltage_max;      // maximum voltage used to scale lift
     AP_Float            _batt_voltage_min;      // minimum voltage used to scale lift
     AP_Float            _batt_current_max;      // current over which maximum throttle is limited
-    AP_Float            _throttle_filt_hz;       // throttle output filter time constant in hz
 
     // internal variables
     RC_Channel&         _rc_roll;               // roll input in from users is held in servo_out

--- a/mk/targets.mk
+++ b/mk/targets.mk
@@ -64,7 +64,7 @@ empty: all
 %-nologging: EXTRAFLAGS += "-DLOGGING_ENABLED=DISABLED "
 
 # cope with copter and hil targets
-FRAMES = quad tri hexa y6 octa octa-quad heli single obc nologging
+FRAMES = quad tri hexa y6 octa octa-quad heli single coax obc nologging
 BOARDS = apm1 apm2 apm2beta apm1-1280 px4 px4-v1 px4-v2 sitl flymaple linux vrbrain vrbrain-v40 vrbrain-v45 vrbrainv-50 vrbrain-v51 vrbrain-v52 vrubrain-v51 vrubrain-v52 vrhero-v10 erle pxf navio bbbmini
 
 define frame_template


### PR DESCRIPTION
These changes:

- add an optional throttle filter into the AP_Motors class, intended to prevent batteries with over-current protection from triggering in flight
- eliminate integers from the AC_PosControl and AC_AttitudeControl levels of the throttle output chain, replacing them with floats
- eliminate constraints that could cause issues by introducing nonlinearities between the alt-hold controller and throttle output filter
- introduce a flag in AP_Motors that specifies if the copter should be stabilizing, in order to prevent a zero or negative throttle demand from the alt-hold controller from causing stabilization to stop
- add a new function set_throttle_out_unstabilized to AC_AttitudeControl, which allows the caller to output an arbitrary throttle to all motors without stabilizing, optionally resetting the attitude controller
- modify copter to use the new throttle interface appropriately