### PR TITLE
ArduPlane: Snooze Lidar

### DIFF
--- a/ArduPlane/Parameters.pde
+++ b/ArduPlane/Parameters.pde
@@ -991,8 +991,8 @@ const AP_Param::Info var_info[] PROGMEM = {
 
     // @Param: RNGFND_LANDING
     // @DisplayName: Enable rangefinder for landing
-    // @Description: This enables the use of a rangefinder for automatic landing. The rangefinder will be used both on the landing approach and for final flare
-    // @Values: 0:Disabled,1:Enabled
+    // @Description: This enables the use of a rangefinder for automatic landing. The rangefinder will be used both on the landing approach and for final flare when enabled. Snooze will power-down the rangefinder when not landing to conserve power if you have a STOP_PIN defined.
+    // @Values: 0:Disabled,1:Enabled,2:EnabledWithSnooze
     // @User: Standard
     GSCALAR(rangefinder_landing,    "RNGFND_LANDING",   0),
 

--- a/ArduPlane/sensors.pde
+++ b/ArduPlane/sensors.pde
@@ -11,6 +11,9 @@ static void init_barometer(void)
 static void init_rangefinder(void)
 {
     rangefinder.init();
+
+    bool powerDownOnBoot = (g.rangefinder_landing == 2);
+    rangefinder.SetPoweredDown(powerDownOnBoot);
 }
 
 /*
@@ -18,6 +21,21 @@ static void init_rangefinder(void)
  */
 static void read_rangefinder(void)
 {
+    bool powerDown = false;
+
+    if (g.rangefinder_landing == 2) {
+        powerDown = (mission.get_current_nav_cmd().id != MAV_CMD_NAV_LAND);
+    }
+
+    if (rangefinder.SetPoweredDown(powerDown)) {
+        if (powerDown) {
+            gcs_send_text_P(SEVERITY_LOW, PSTR("Rangefinder Powered Down"));
+        }
+        else {
+            gcs_send_text_P(SEVERITY_LOW, PSTR("Rangefinder Powered Up"));
+        }
+    }
+
     rangefinder.update();
 
     if (should_log(MASK_LOG_SONAR))

--- a/ArduPlane/sensors.pde
+++ b/ArduPlane/sensors.pde
@@ -24,7 +24,9 @@ static void read_rangefinder(void)
     bool powerDown = false;
 
     if (g.rangefinder_landing == 2) {
-        powerDown = (mission.get_current_nav_cmd().id != MAV_CMD_NAV_LAND);
+        // power up if landing and also below 20m above the max range
+        powerDown = (mission.get_current_nav_cmd().id != MAV_CMD_NAV_LAND) ||
+                    (adjusted_altitude_cm() > rangefinder.max_distance_cm() + 200);
     }
 
     if (rangefinder.SetPoweredDown(powerDown)) {

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PX4_PWM.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PX4_PWM.h
@@ -35,6 +35,8 @@ public:
     // update state
     void update(void);
 
+    bool SetPoweredDown(bool powerDown);
+
 private:
     int _fd;
     uint64_t _last_timestamp;

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -88,7 +88,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] PROGMEM = {
     // @Values: 0:No,1:Yes
     AP_GROUPINFO("_RMETRIC", 9, RangeFinder, _ratiometric[0], 1),
 
-    // @Param: RNGFND_PWRRNG
+    // @Param: _PWRRNG
     // @DisplayName: Powersave range
     // @Description: This parameter sets the estimated terrain distance in meters above which the sensor will be put into a power saving mode (if available). A value of zero means power saving is not enabled
     // @Units: meters
@@ -103,8 +103,6 @@ const AP_Param::GroupInfo RangeFinder::var_info[] PROGMEM = {
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("_GNDCLEAR", 11, RangeFinder, _ground_clearance_cm[0], RANGEFINDER_GROUND_CLEARANCE_CM_DEFAULT),
-
-    // 10..12 left for future expansion
 
 #if RANGEFINDER_MAX_INSTANCES > 1
     // @Param: 2_TYPE
@@ -212,6 +210,17 @@ void RangeFinder::init(void)
         state[i].status = RangeFinder_NotConnected;
         state[i].range_valid_count = 0;
     }
+}
+
+bool RangeFinder::SetPoweredDown(bool powerDown)
+{
+    bool success = false;
+    for (uint8_t i=0; i<num_instances; i++) {
+        if (drivers[i] != NULL) {
+            success |= drivers[i]->SetPoweredDown(powerDown);
+        }
+    }
+    return success;
 }
 
 /*

--- a/libraries/AP_RangeFinder/RangeFinder.h
+++ b/libraries/AP_RangeFinder/RangeFinder.h
@@ -77,6 +77,8 @@ public:
         bool                   pre_arm_check;   // true if sensor has passed pre-arm checks
         uint16_t               pre_arm_distance_min;    // min distance captured during pre-arm checks
         uint16_t               pre_arm_distance_max;    // max distance captured during pre-arm checks
+        bool                   healthy;     // sensor is communicating correctly
+        bool                   poweredDown;  // powered up or powered down
     };
 
     // parameters for each instance
@@ -107,6 +109,8 @@ public:
     // 10Hz from main loop
     void update(void);
     
+    bool SetPoweredDown(bool powerDown);
+
 #define _RangeFinder_STATE(instance) state[instance]
 
     uint16_t distance_cm(uint8_t instance) const {

--- a/libraries/AP_RangeFinder/RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/RangeFinder_Backend.h
@@ -38,6 +38,8 @@ public:
     bool out_of_range(void) const {
         return ranger._powersave_range > 0 && ranger.estimated_terrain_height > ranger._powersave_range;
     }
+    
+    virtual bool SetPoweredDown(bool powerDown) { return false; };
 
 protected:
 


### PR DESCRIPTION
ArduPlane: Snooze Lidar

- Allow ability to snooze lidar by powering it down when not landing by using a new value of RNGFND_LANDING=2. This will require a STOP_PIN to be defined.
- PX4 only