### PR TITLE
fix serial manager baud rates

### DIFF
--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -188,12 +188,17 @@ AP_HAL::UARTDriver *AP_SerialManager::find_serial(enum SerialProtocol protocol, 
 
 // find_baudrate - searches available serial ports for the first instance that allows the given protocol
 //  returns baudrate on success, 0 if a serial port cannot be found
-uint32_t AP_SerialManager::find_baudrate(enum SerialProtocol protocol) const
+uint32_t AP_SerialManager::find_baudrate(enum SerialProtocol protocol, uint8_t instance) const
 {
+    uint8_t found_instance = 0;
+
     // search for matching protocol
     for(uint8_t i=0; i<SERIALMANAGER_NUM_PORTS; i++) {
-        if ((enum SerialProtocol)state[i].protocol.get() == protocol) {
-            return map_baudrate(state[i].baud);
+        if (protocol_match(protocol, (enum SerialProtocol)state[i].protocol.get())) {
+            if (found_instance == instance) {
+                return map_baudrate(state[i].baud);
+            }
+            found_instance++;
         }
     }
 

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -94,7 +94,7 @@ public:
 
     // find_baudrate - searches available serial ports for the first instance that allows the given protocol
     //  returns the baudrate of that protocol on success, 0 if a serial port cannot be found
-    uint32_t find_baudrate(enum SerialProtocol protocol) const;
+    uint32_t find_baudrate(enum SerialProtocol protocol, uint8_t instance) const;
 
     // get_mavlink_channel - provides the mavlink channel associated with a given protocol (and instance)
     //  instance should be zero if searching for the first instance, 1 for the second, etc

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -102,7 +102,7 @@ GCS_MAVLINK::setup_uart(const AP_SerialManager& serial_manager, AP_SerialManager
     uart->set_flow_control(old_flow_control);
 
     // now change back to desired baudrate
-    uart->begin(serial_manager.find_baudrate(protocol));
+    uart->begin(serial_manager.find_baudrate(protocol, instance));
 
     // and init the gcs instance
     init(uart, mav_chan);


### PR DESCRIPTION
This fixes a bug that caused AP_SerialManager::find_baudrate to always return the first MAVLink UART's baudrate.