### PR TITLE
SerialManager and GCS_MAVLink: fix baudrate for telem2 port 

### DIFF
--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -187,13 +187,19 @@ AP_HAL::UARTDriver *AP_SerialManager::find_serial(enum SerialProtocol protocol, 
 }
 
 // find_baudrate - searches available serial ports for the first instance that allows the given protocol
+//  instance should be zero if searching for the first instance, 1 for the second, etc
 //  returns baudrate on success, 0 if a serial port cannot be found
-uint32_t AP_SerialManager::find_baudrate(enum SerialProtocol protocol) const
+uint32_t AP_SerialManager::find_baudrate(enum SerialProtocol protocol, uint8_t instance) const
 {
+    uint8_t found_instance = 0;
+
     // search for matching protocol
     for(uint8_t i=0; i<SERIALMANAGER_NUM_PORTS; i++) {
         if ((enum SerialProtocol)state[i].protocol.get() == protocol) {
-            return map_baudrate(state[i].baud);
+            if (found_instance == instance) {
+                return map_baudrate(state[i].baud);
+            }
+            found_instance++;
         }
     }
 

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -93,8 +93,9 @@ public:
     AP_HAL::UARTDriver *find_serial(enum SerialProtocol protocol, uint8_t instance) const;
 
     // find_baudrate - searches available serial ports for the first instance that allows the given protocol
+    //  instance should be zero if searching for the first instance, 1 for the second, etc
     //  returns the baudrate of that protocol on success, 0 if a serial port cannot be found
-    uint32_t find_baudrate(enum SerialProtocol protocol) const;
+    uint32_t find_baudrate(enum SerialProtocol protocol, uint8_t instance) const;
 
     // get_mavlink_channel - provides the mavlink channel associated with a given protocol (and instance)
     //  instance should be zero if searching for the first instance, 1 for the second, etc

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -102,7 +102,7 @@ GCS_MAVLINK::setup_uart(const AP_SerialManager& serial_manager, AP_SerialManager
     uart->set_flow_control(old_flow_control);
 
     // now change back to desired baudrate
-    uart->begin(serial_manager.find_baudrate(protocol));
+    uart->begin(serial_manager.find_baudrate(protocol, instance));
 
     // and init the gcs instance
     init(uart, mav_chan);


### PR DESCRIPTION
After merging commits made since February, we could no longer exchange MAVLink traffic with companion computer. The companion was connected to telem2 port at 115,200 baud or 1,500,000 baud (as set in `SERIAL2_BAUD`). We updated `SERIAL2_PROTOCOL` to `1` per recent changes, to no avail.

After source inspection, we discovered that `AP_SerialManager::find_baudrate()` does not require the new `instance` argument, and therefore always returns the baud rate for the first-scanned port with matching protocol. Since (in our configuration) the first-scanned port is always the telemetry radio port (defaulting to 57,600 baud), that baud rate is selected for any port. In effect, it appeared that the parameter `SERIAL1_BAUD` was being applied to *all* ports.

The submitted pull request adds the `instance` argument to `AP_SerialManager::find_baudrate()` and replicates logic from `AP_SerialManager::find_serial()` for matching on the correct port instance.