### PR TITLE
Plane: Beep/Chirp after a land to help find in tall grass

### DIFF
--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -135,6 +135,7 @@ public:
         k_param_trim_rc_at_start,
         k_param_hil_mode,
         k_param_land_disarm_delay,
+        k_param_land_beep,
 
         // 100: Arming parameters
         k_param_arming = 100,
@@ -439,6 +440,7 @@ public:
     AP_Int32 RTL_altitude_cm;
     AP_Float land_flare_alt;
     AP_Int8 land_disarm_delay;
+    AP_Int8 land_beep;
     AP_Int32 min_gndspeed_cm;
     AP_Int16 pitch_trim_cd;
     AP_Int16 FBWB_min_altitude_cm;

--- a/ArduPlane/Parameters.pde
+++ b/ArduPlane/Parameters.pde
@@ -241,6 +241,13 @@ const AP_Param::Info var_info[] PROGMEM = {
     // @User: Advanced
     GSCALAR(land_disarm_delay,       "LAND_DISARMDELAY",  0),
 
+    // @Param: LAND_BEEP
+    // @DisplayName: Beep after landing
+    // @Description: When landing in tall grass it is sometimes hard to find the aircraft. When enabled (non-zero) it will make a chirp sound once per second.
+    // @Values: 0:Off,1:On,2:On_After_Land,3:On_After_Land_MuteViaModeChange
+    // @User: Advanced
+    GSCALAR(land_beep,       "LAND_BEEP",  0),
+
 	// @Param: NAV_CONTROLLER
 	// @DisplayName: Navigation controller selection
 	// @Description: Which navigation controller to enable. Currently the only navigation controller available is L1. From time to time other experimental conrtrollers will be added which are selected using this parameter.

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -195,4 +195,12 @@ enum {
     ATT_CONTROL_APMCONTROL = 1
 };
 
+enum {
+    LAND_BEEP_OFF = 0,
+    LAND_BEEP_ON = 1, // always on, useful for testing or just to know what it sounds like
+    LAND_BEEP_ON_AFTER_LAND = 2,
+    LAND_BEEP_ON_AFTER_LAND_MUTE_VIA_MODE_CHANGE = 3,
+};
+
+
 #endif // _DEFINES_H

--- a/ArduPlane/landing.pde
+++ b/ArduPlane/landing.pde
@@ -62,6 +62,12 @@ static bool verify_land()
                 gcs_send_text_fmt(PSTR("Flare %.1fm sink=%.2f speed=%.1f"), 
                                   height, auto_state.land_sink_rate, gps.ground_speed());
             }
+
+            // start beeping/chirping so it's easier to find the aircraft in tall grass
+            if ((g.land_beep == LAND_BEEP_ON_AFTER_LAND) ||
+                (g.land_beep == LAND_BEEP_ON_AFTER_LAND_MUTE_VIA_MODE_CHANGE)) {
+                AP_Notify::flags.landed = 1;
+            }
         }
         auto_state.land_complete = true;
 

--- a/ArduPlane/system.pde
+++ b/ArduPlane/system.pde
@@ -422,6 +422,11 @@ static void set_mode(enum FlightMode mode)
     pitchController.reset_I();
     yawController.reset_I();    
     steerController.reset_I();    
+
+    // mute landed chirp
+    if (g.land_beep == LAND_BEEP_ON_AFTER_LAND_MUTE_VIA_MODE_CHANGE) {
+        AP_Notify::flags.landed = 0;
+    }
 }
 
 /*

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -69,6 +69,7 @@ public:
         uint32_t parachute_release  : 1;    // 1 if parachute is being released
         uint32_t ekf_bad            : 1;    // 1 if ekf is reporting problems
         uint32_t autopilot_mode     : 1;    // 1 if vehicle is in an autopilot flight mode (only used by OreoLEDs)
+        uint32_t landed             : 1;    // 1 if vehicle has landed/crash, helpful for finding aircraft in tall grass
 
         // additional flags
         uint32_t external_leds      : 1;    // 1 if external LEDs are enabled (normally only used for copter)

--- a/libraries/AP_Notify/ToneAlarm_PX4.cpp
+++ b/libraries/AP_Notify/ToneAlarm_PX4.cpp
@@ -34,6 +34,11 @@
 
 extern const AP_HAL::HAL& hal;
 
+/*
+ * PX4 play tone descriptions can be found at the top of:
+ * PX4Firmware/src/drivers/stm32/tone_alarm/tone_alarm.cpp
+ */
+
 const ToneAlarm_PX4::Tone ToneAlarm_PX4::_tones[] {
     #define AP_NOTIFY_PX4_TONE_QUIET_NEG_FEEDBACK 0
     { "MFT200L4<<<B#A#2", false },
@@ -63,6 +68,8 @@ const ToneAlarm_PX4::Tone ToneAlarm_PX4::_tones[] {
     { "MBT200>B#1", true },
     #define AP_NOTIFY_PX4_TONE_LOUD_BATTERY_ALERT_CTS 13
     { "MBNT255>B#8B#8B#8B#8B#8B#8B#8B#8B#8B#8B#8B#8B#8B#8B#8B#8", true },
+    #define AP_NOTIFY_PX4_TONE_LOUD_LANDED 14
+    { "MBT255 A64 B64 G16 T32 P2", true },
 };
 
 bool ToneAlarm_PX4::init()
@@ -228,6 +235,18 @@ void ToneAlarm_PX4::update()
         if (flags.parachute_release) {
             // parachute release warning tune
             play_tone(AP_NOTIFY_PX4_TONE_LOUD_ATTENTION_NEEDED);
+        }
+    }
+
+    // check if landed
+    if (flags.landed != AP_Notify::flags.landed) {
+        flags.landed = AP_Notify::flags.landed;
+        if (flags.landed) {
+            // landed chirp, play forever until user stops/reboot it
+            play_tone(AP_NOTIFY_PX4_TONE_LOUD_LANDED);
+        }
+        else {
+            stop_cont_tone();
         }
     }
 }

--- a/libraries/AP_Notify/ToneAlarm_PX4.h
+++ b/libraries/AP_Notify/ToneAlarm_PX4.h
@@ -54,6 +54,7 @@ private:
         uint8_t parachute_release     : 1;    // 1 if parachute is being released
         uint8_t pre_arm_check         : 1;    // 0 = failing checks, 1 = passed
         uint8_t failsafe_radio        : 1;    // 1 if radio failsafe
+        uint8_t landed                : 1;    // 1 if landed and chirping
     } flags;
 
     int8_t _cont_tone_playing;


### PR DESCRIPTION
ArduPlane: added LAND_BEEP

- Helpful for landing in tall grass and can not see aircraft directly, this is an audible beep/chirp
- Has 4 modes: 0:Off,1:On (always),2:On_After_Land,3:On_After_Land_MuteViaModeChange

The #1 "On" option means the beep is on, always. That mean it beeps allll the time. Useful to hear the beep when testing so you know what to listen for, but otherwise this option should be set to 2 or 3.

Also, it will auto-mute after you pick up the aircraft.. or kick it.