### PR TITLE
Copter: set ahrs home from EKF origin

### DIFF
--- a/ArduCopter/ArduCopter.pde
+++ b/ArduCopter/ArduCopter.pde
@@ -963,6 +963,9 @@ static void fast_loop()
 
     // run the attitude controllers
     update_flight_mode();
+
+    // update home from EKF if necessary
+    update_home_from_EKF();
 }
 
 // rc_loops - reads user input from transmitter/receiver
@@ -1175,9 +1178,6 @@ static void update_GPS(void)
     if (gps_updated) {
         // set system time if necessary
         set_system_time_from_GPS();
-
-        // update home from GPS location if necessary
-        update_home_from_EKF();
 
         // check gps base position (used for RTK only)
         check_gps_base_pos();

--- a/ArduCopter/ArduCopter.pde
+++ b/ArduCopter/ArduCopter.pde
@@ -1177,7 +1177,7 @@ static void update_GPS(void)
         set_system_time_from_GPS();
 
         // update home from GPS location if necessary
-        update_home_from_GPS();
+        update_home_from_EKF();
 
         // check gps base position (used for RTK only)
         check_gps_base_pos();

--- a/ArduCopter/commands.pde
+++ b/ArduCopter/commands.pde
@@ -74,15 +74,13 @@ static bool set_home(const Location& loc)
         scaleLongUp   = 1.0f/scaleLongDown;
         // record home is set
         set_home_state(HOME_SET_NOT_LOCKED);
-    }
 
-    // To-Do: doing the stuff below constantly while armed could lead to lots of logging or performance hit?
-
-    // log new home position which mission library will pull from ahrs
-    if (should_log(MASK_LOG_CMD)) {
-        AP_Mission::Mission_Command temp_cmd;
-        if (mission.read_cmd_from_storage(0, temp_cmd)) {
-            Log_Write_Cmd(temp_cmd);
+        // log new home position which mission library will pull from ahrs
+        if (should_log(MASK_LOG_CMD)) {
+            AP_Mission::Mission_Command temp_cmd;
+            if (mission.read_cmd_from_storage(0, temp_cmd)) {
+                Log_Write_Cmd(temp_cmd);
+            }
         }
     }
 

--- a/ArduCopter/commands.pde
+++ b/ArduCopter/commands.pde
@@ -7,44 +7,26 @@
  *   HOME_SET_AND_LOCKED    = home has been set by user, cannot be moved except by user initiated do-set-home command
  */
 
-static uint8_t ground_start_count = 10;     // counter used to grab at least 10 reads before accepting a GPS location as home location
-
-// checks if we should update ahrs/RTL home position from GPS
-static void update_home_from_GPS()
+// checks if we should update ahrs/RTL home position from the EKF
+static void update_home_from_EKF()
 {
-    // exit immediately if counter has run down and home already set
-    if (ground_start_count == 0 && ap.home_state != HOME_UNSET) {
+    // exit immediately if home already set
+    if (ap.home_state != HOME_UNSET) {
         return;
     }
 
-    // if counter has not run down
-    if (ground_start_count > 0) {
-
-        // reset counter if we do not have GPS lock
-        if (gps.status() < AP_GPS::GPS_OK_FIX_3D) {
-            ground_start_count = 10;
-
-        // count down for 10 consecutive locks
-        } else {
-           ground_start_count--;
-        }
-
-        return;
-    }
-
-    // move home to current gps location (this will set home_state to HOME_SET)
-    set_home(gps.location());
+    // move home to current ekf location (this will set home_state to HOME_SET)
+    set_home_to_current_location();
 }
 
 // set_home_to_current_location - set home to current GPS location
 static bool set_home_to_current_location() {
-    // exit with failure if we haven't had 10 good GPS position
-    if (ground_start_count > 0) {
-        return false;
+    // get current location from EKF
+    Location temp_loc;
+    if (inertial_nav.get_location(temp_loc)) {
+        return set_home(temp_loc);
     }
-
-    // set home to latest gps location
-    return set_home(gps.location());
+    return false;
 }
 
 // set_home_to_current_location_and_lock - set home to current location and lock so it cannot be moved

--- a/ArduCopter/inertia.pde
+++ b/ArduCopter/inertia.pde
@@ -10,6 +10,11 @@ static void read_inertia()
 // read_inertial_altitude - pull altitude and climb rate from inertial nav library
 static void read_inertial_altitude()
 {
+    // exit immediately if we do not have an altitude estimate or home is not set
+    if (!inertial_nav.get_filter_status().flags.vert_pos || (ap.home_state == HOME_UNSET)) {
+        return;
+    }
+
     // with inertial nav we can update the altitude and climb rate at 50hz
     current_loc.alt = pv_alt_above_home(inertial_nav.get_altitude());
     current_loc.flags.relative_alt = true;

--- a/ArduCopter/motors.pde
+++ b/ArduCopter/motors.pde
@@ -156,9 +156,6 @@ static bool init_arm_motors(bool arming_from_gcs)
         did_ground_start = true;
     }
 
-    // fast baro calibration to reset ground pressure
-    init_barometer(false);
-
     // go back to normal AHRS gains
     ahrs.set_fast_gains(false);
 

--- a/libraries/AP_InertialNav/AP_InertialNav.h
+++ b/libraries/AP_InertialNav/AP_InertialNav.h
@@ -62,6 +62,12 @@ public:
     virtual const Vector3f&    get_position() const = 0;
 
     /**
+     * get_llh - updates the provided location with the latest calculated location including absolute altitude
+     *  returns true on success (i.e. the EKF knows it's latest position), false on failure
+     */
+    virtual bool get_location(struct Location &loc) const = 0;
+
+    /**
      * get_latitude - returns the latitude of the current position estimation in 100 nano degrees (i.e. degree value multiplied by 10,000,000)
      * @return
      */

--- a/libraries/AP_InertialNav/AP_InertialNav_NavEKF.cpp
+++ b/libraries/AP_InertialNav/AP_InertialNav_NavEKF.cpp
@@ -63,6 +63,15 @@ const Vector3f &AP_InertialNav_NavEKF::get_position(void) const
 }
 
 /**
+ * get_location - updates the provided location with the latest calculated locatoin
+ *  returns true on success (i.e. the EKF knows it's latest position), false on failure
+ */
+bool AP_InertialNav_NavEKF::get_location(struct Location &loc) const
+{
+    return _ahrs_ekf.get_NavEKF().getLLH(loc);
+}
+
+/**
  * get_latitude - returns the latitude of the current position estimation in 100 nano degrees (i.e. degree value multiplied by 10,000,000)
  */
 int32_t AP_InertialNav_NavEKF::get_latitude() const

--- a/libraries/AP_InertialNav/AP_InertialNav_NavEKF.h
+++ b/libraries/AP_InertialNav/AP_InertialNav_NavEKF.h
@@ -49,6 +49,12 @@ public:
     const Vector3f&    get_position() const;
 
     /**
+     * get_llh - updates the provided location with the latest calculated location including absolute altitude
+     *  returns true on success (i.e. the EKF knows it's latest position), false on failure
+     */
+    bool get_location(struct Location &loc) const;
+
+    /**
      * get_latitude - returns the latitude of the current position estimation in 100 nano degrees (i.e. degree value multiplied by 10,000,000)
      */
     int32_t     get_latitude() const;


### PR DESCRIPTION
This should resolve the large relative altitude error we see sometimes when the AHRS home alt and EKF origin alt are very different.

This is for Jon and Paul to review before we push to master