### PR TITLE
Plane: Never trigger fence breach in LAND_FINAL flight stage.

### DIFF
--- a/ArduPlane/geofence.pde
+++ b/ArduPlane/geofence.pde
@@ -290,6 +290,11 @@ static void geofence_check(bool altitude_check_only)
     uint8_t breach_type = FENCE_BREACH_NONE;
     struct Location loc;
 
+    // Never trigger a fence breach in the final stage of landing
+    if (flight_stage == AP_SpdHgtControl::FLIGHT_LAND_FINAL) {
+        return;
+    }
+
     if (geofence_check_minalt()) {
         outside = true;
         breach_type = FENCE_BREACH_MINALT;


### PR DESCRIPTION
After a plane has reached the LAND_FINAL flight stage we should probably assume we are close to the ground.  A fence breach at this time could cause the plane to veer at very low altitude.

This becomes much more of an issue when considering:  https://github.com/diydrones/ardupilot/pull/2079 -- which only disables the floor during landing.  This is a Good Thing in case the plane goes haywire while still on approach and is nice and high.  However, once the plane is low enough the fence shouldn't ever breach.