### PR TITLE
ArduCopter: Add Lost copter sound as an Aux Channel Option

### DIFF
--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -65,6 +65,7 @@ enum aux_sw_func {
     AUXSW_RETRACT_MOUNT,           // Retract Mount
     AUXSW_RELAY,                   // Relay pin on/off (only supports first relay)
     AUXSW_LANDING_GEAR,            // Landing gear controller
+    AUXSW_LOST_COPTER_SOUND,       // Play lost copter sound
 };
 
 // Frame types

--- a/ArduCopter/switches.pde
+++ b/ArduCopter/switches.pde
@@ -535,6 +535,19 @@ static void do_aux_switch_function(int8_t ch_function, uint8_t ch_flag)
         }
         break;    
 
+    case AUXSW_LOST_COPTER_SOUND:
+        ::printf("Lost Copter Sound Case\n");
+        switch (ch_flag) {
+            case AUX_SWITCH_HIGH:
+                ::printf("SW High\n");
+                AP_Notify::flags.lost_copter = TRUE;
+                break;
+            case AUX_SWITCH_LOW:
+                ::printf("SW Low\n");
+                AP_Notify::flags.lost_copter = FALSE;
+                break;
+        }
+        break;
     }
 }
 

--- a/ArduCopter/switches.pde
+++ b/ArduCopter/switches.pde
@@ -536,14 +536,11 @@ static void do_aux_switch_function(int8_t ch_function, uint8_t ch_flag)
         break;    
 
     case AUXSW_LOST_COPTER_SOUND:
-        ::printf("Lost Copter Sound Case\n");
         switch (ch_flag) {
             case AUX_SWITCH_HIGH:
-                ::printf("SW High\n");
                 AP_Notify::flags.lost_copter = TRUE;
                 break;
             case AUX_SWITCH_LOW:
-                ::printf("SW Low\n");
                 AP_Notify::flags.lost_copter = FALSE;
                 break;
         }

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -72,6 +72,7 @@ public:
 
         // additional flags
         uint32_t external_leds      : 1;    // 1 if external LEDs are enabled (normally only used for copter)
+        uint32_t lost_copter        : 1;    // 1 when lost copter tone is requested (normally only used for copter)
     };
 
     /// notify_events_type - bitmask of active events.

--- a/libraries/AP_Notify/ToneAlarm_PX4.cpp
+++ b/libraries/AP_Notify/ToneAlarm_PX4.cpp
@@ -230,6 +230,18 @@ void ToneAlarm_PX4::update()
             play_tone(AP_NOTIFY_PX4_TONE_LOUD_ATTENTION_NEEDED);
         }
     }
+
+
+    if (flags.lost_copter != AP_Notify::flags.lost_copter) {
+        flags.lost_copter = AP_Notify::flags.lost_copter;
+        if(flags.lost_copter) {
+            ::printf("AP_Notify Flag: %d\n", AP_Notify::flags.lost_copter);
+            play_tone(AP_NOTIFY_PX4_TONE_LOUD_LOST_COPTER_CTS);
+        }else{
+            stop_cont_tone();
+        }
+    }
+
 }
 
 #endif // CONFIG_HAL_BOARD == HAL_BOARD_PX4

--- a/libraries/AP_Notify/ToneAlarm_PX4.cpp
+++ b/libraries/AP_Notify/ToneAlarm_PX4.cpp
@@ -235,7 +235,6 @@ void ToneAlarm_PX4::update()
     if (flags.lost_copter != AP_Notify::flags.lost_copter) {
         flags.lost_copter = AP_Notify::flags.lost_copter;
         if(flags.lost_copter) {
-            ::printf("AP_Notify Flag: %d\n", AP_Notify::flags.lost_copter);
             play_tone(AP_NOTIFY_PX4_TONE_LOUD_LOST_COPTER_CTS);
         }else{
             stop_cont_tone();

--- a/libraries/AP_Notify/ToneAlarm_PX4.h
+++ b/libraries/AP_Notify/ToneAlarm_PX4.h
@@ -54,6 +54,7 @@ private:
         uint8_t parachute_release     : 1;    // 1 if parachute is being released
         uint8_t pre_arm_check         : 1;    // 0 = failing checks, 1 = passed
         uint8_t failsafe_radio        : 1;    // 1 if radio failsafe
+        uint8_t lost_copter           : 1;    // 1 if lost copter tone requested
     } flags;
 
     int8_t _cont_tone_playing;


### PR DESCRIPTION
This pull requests adds an Aux Switch option to play the lost copter tone. This is very useful for FPV racing quads. I am getting an error in the console "tune error" when stopping the continuous tone. There may be an issue with the stop_cont_tone() function. @jschall could you please take a look and see if I am using this function incorrectly? I only see it used in one other case so there may be an issue when multiple continuous tones are requested.