### PR TITLE
ESC output refactor

### DIFF
--- a/ArduCopter/ArduCopter.pde
+++ b/ArduCopter/ArduCopter.pde
@@ -422,16 +422,30 @@ static struct {
  #error Unrecognised frame type
 #endif
 
+static AP_Actuator_PWM output1(CH_1);
+static AP_Actuator_PWM output2(CH_2);
+static AP_Actuator_PWM output3(CH_3);
+static AP_Actuator_PWM output4(CH_4);
+static AP_Actuator_PWM output5(CH_5);
+static AP_Actuator_PWM output6(CH_6);
+static AP_Actuator_PWM output7(CH_7);
+static AP_Actuator_PWM output8(CH_8);
+
+static AP_Actuator_Channel* outputs[8] = {
+    &output1, &output2, &output3, &output4,
+    &output5, &output6, &output7, &output8,
+};
+
 #if FRAME_CONFIG == HELI_FRAME  // helicopter constructor requires more arguments
-static MOTOR_CLASS motors(g.rc_1, g.rc_2, g.rc_3, g.rc_4, g.rc_7, g.rc_8, g.heli_servo_1, g.heli_servo_2, g.heli_servo_3, g.heli_servo_4, MAIN_LOOP_RATE);
+static MOTOR_CLASS motors(g.rc_1, g.rc_2, g.rc_3, g.rc_4, g.rc_7, g.rc_8, g.heli_servo_1, g.heli_servo_2, g.heli_servo_3, g.heli_servo_4, outputs, MAIN_LOOP_RATE);
 #elif FRAME_CONFIG == TRI_FRAME  // tri constructor requires additional rc_7 argument to allow tail servo reversing
-static MOTOR_CLASS motors(g.rc_1, g.rc_2, g.rc_3, g.rc_4, g.rc_7, MAIN_LOOP_RATE);
+static MOTOR_CLASS motors(g.rc_1, g.rc_2, g.rc_3, g.rc_4, g.rc_7, outputs, MAIN_LOOP_RATE);
 #elif FRAME_CONFIG == SINGLE_FRAME  // single constructor requires extra servos for flaps
-static MOTOR_CLASS motors(g.rc_1, g.rc_2, g.rc_3, g.rc_4, g.single_servo_1, g.single_servo_2, g.single_servo_3, g.single_servo_4, MAIN_LOOP_RATE);
+static MOTOR_CLASS motors(g.rc_1, g.rc_2, g.rc_3, g.rc_4, g.single_servo_1, g.single_servo_2, g.single_servo_3, g.single_servo_4, outputs, MAIN_LOOP_RATE);
 #elif FRAME_CONFIG == COAX_FRAME  // single constructor requires extra servos for flaps
-static MOTOR_CLASS motors(g.rc_1, g.rc_2, g.rc_3, g.rc_4, g.single_servo_1, g.single_servo_2, MAIN_LOOP_RATE);
+static MOTOR_CLASS motors(g.rc_1, g.rc_2, g.rc_3, g.rc_4, g.single_servo_1, g.single_servo_2, outputs, MAIN_LOOP_RATE);
 #else
-static MOTOR_CLASS motors(g.rc_1, g.rc_2, g.rc_3, g.rc_4, MAIN_LOOP_RATE);
+static MOTOR_CLASS motors(g.rc_1, g.rc_2, g.rc_3, g.rc_4, outputs, MAIN_LOOP_RATE);
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libraries/AP_Motors/AP_Actuator_Channel.h
+++ b/libraries/AP_Motors/AP_Actuator_Channel.h
@@ -1,0 +1,24 @@
+// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+
+#ifndef __AP_ACTUATOR_CHANNEL_H__
+#define __AP_ACTUATOR_CHANNEL_H__
+
+#include <AP_Common.h>
+
+class AP_Actuator_Channel {
+public:
+    /* Output active/highZ control */
+    virtual void enable_ch() = 0;
+    virtual void disable_ch() = 0;
+
+    /* Set the value the actuator is driven with */
+    virtual void write(int16_t value) = 0;
+
+    /* Set output frequency (1/period) if using PWM or similar */
+    virtual void set_freq(uint16_t freq_hz) = 0;
+
+    /* Does the channel support reverse thrust (ESCs only) */
+    virtual bool capability_reverse() const { return false; }
+};
+
+#endif

--- a/libraries/AP_Motors/AP_Actuator_PWM.cpp
+++ b/libraries/AP_Motors/AP_Actuator_PWM.cpp
@@ -1,0 +1,36 @@
+// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <AP_HAL.h>
+#include "AP_Actuator_PWM.h"
+
+extern const AP_HAL::HAL &hal;
+
+void AP_Actuator_PWM::enable_ch() {
+    hal.rcout->enable_ch(ch);
+}
+
+void AP_Actuator_PWM::disable_ch() {
+    hal.rcout->disable_ch(ch);
+}
+
+void AP_Actuator_PWM::write(int16_t value) {
+    hal.rcout->write(ch, value);
+}
+
+void AP_Actuator_PWM::set_freq(uint16_t freq_hz) {
+    hal.rcout->set_freq((uint32_t) 1 << ch, freq_hz);
+}

--- a/libraries/AP_Motors/AP_Actuator_PWM.h
+++ b/libraries/AP_Motors/AP_Actuator_PWM.h
@@ -1,0 +1,26 @@
+// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+
+#ifndef __AP_ACTUATOR_PWM_H__
+#define __AP_ACTUATOR_PWM_H__
+
+#include "AP_Actuator_Channel.h"
+
+class AP_Actuator_PWM : public AP_Actuator_Channel {
+public:
+    AP_Actuator_PWM(uint8_t _ch) : ch(_ch) {}
+
+    /* Output active/highZ control */
+    void enable_ch();
+    void disable_ch();
+
+    /* Set the value the actuator is driven with */
+    void write(int16_t value);
+
+    /* Set output frequency (1/period) */
+    void set_freq(uint16_t freq_hz);
+
+protected:
+    uint8_t ch;
+};
+
+#endif

--- a/libraries/AP_Motors/AP_Motors.h
+++ b/libraries/AP_Motors/AP_Motors.h
@@ -14,5 +14,6 @@
 #include "AP_MotorsHeli.h"
 #include "AP_MotorsSingle.h"
 #include "AP_MotorsCoax.h"
+#include "AP_Actuator_PWM.h"
 
 #endif // __AP_MOTORS_H__

--- a/libraries/AP_Motors/AP_MotorsCoax.cpp
+++ b/libraries/AP_Motors/AP_MotorsCoax.cpp
@@ -91,36 +91,32 @@ void AP_MotorsCoax::set_update_rate( uint16_t speed_hz )
     _speed_hz = speed_hz;
 
     // set update rate for the two motors
-    uint32_t mask2 =
-        1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]) |
-        1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]) ;
-    hal.rcout->set_freq(mask2, _speed_hz);
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3])]->set_freq(_speed_hz);
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])]->set_freq(_speed_hz);
 
     // set update rate for the two servos
-    uint32_t mask =
-      1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]) |
-      1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]) ;
-    hal.rcout->set_freq(mask, _servo_speed);
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])]->set_freq(_servo_speed);
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])]->set_freq(_servo_speed);
 }
 
 // enable - starts allowing signals to be sent to motors
 void AP_MotorsCoax::enable()
 {
     // enable output channels
-    hal.rcout->enable_ch(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]));
-    hal.rcout->enable_ch(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]));
-    hal.rcout->enable_ch(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]));
-    hal.rcout->enable_ch(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]));
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])]->enable_ch();
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])]->enable_ch();
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3])]->enable_ch();
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])]->enable_ch();
 }
 
 // output_min - sends minimum values out to the motor and trim values to the servos
 void AP_MotorsCoax::output_min()
 {
     // send minimum value to each motor
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]), _servo1.radio_trim);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]), _servo2.radio_trim);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]), _rc_throttle.radio_min);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]), _rc_throttle.radio_min);
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])]->write(_servo1.radio_trim);
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])]->write(_servo2.radio_trim);
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3])]->write(_rc_throttle.radio_min);
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])]->write(_rc_throttle.radio_min);
 }
 
 // output_armed - sends commands to the motors
@@ -183,10 +179,10 @@ void AP_MotorsCoax::output_armed()
     }
 
     // send output to each motor
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]), _servo1.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]), _servo2.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]), motor_out[AP_MOTORS_MOT_3]);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]), motor_out[AP_MOTORS_MOT_4]);
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])]->write(_servo1.radio_out);
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])]->write(_servo2.radio_out);
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3])]->write(motor_out[AP_MOTORS_MOT_3]);
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])]->write(motor_out[AP_MOTORS_MOT_4]);
 }
 
 // output_disarmed - sends commands to the motors
@@ -210,19 +206,19 @@ void AP_MotorsCoax::output_test(uint8_t motor_seq, int16_t pwm)
     switch (motor_seq) {
         case 1:
             // flap servo 1
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]), pwm);
+            _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])]->write(pwm);
             break;
         case 2:
             // flap servo 2
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]), pwm);
+            _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])]->write(pwm);
             break;
         case 3:
             // motor 1
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]), pwm);
+            _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3])]->write(pwm);
             break;
         case 4:
             // motor 2
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]), pwm);
+            _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])]->write(pwm);
             break;
         default:
             // do nothing

--- a/libraries/AP_Motors/AP_MotorsCoax.cpp
+++ b/libraries/AP_Motors/AP_MotorsCoax.cpp
@@ -91,32 +91,32 @@ void AP_MotorsCoax::set_update_rate( uint16_t speed_hz )
     _speed_hz = speed_hz;
 
     // set update rate for the two motors
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3])]->set_freq(_speed_hz);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])]->set_freq(_speed_hz);
+    _rc_out[AP_MOTORS_MOT_3]->set_freq(_speed_hz);
+    _rc_out[AP_MOTORS_MOT_4]->set_freq(_speed_hz);
 
     // set update rate for the two servos
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])]->set_freq(_servo_speed);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])]->set_freq(_servo_speed);
+    _rc_out[AP_MOTORS_MOT_1]->set_freq(_servo_speed);
+    _rc_out[AP_MOTORS_MOT_2]->set_freq(_servo_speed);
 }
 
 // enable - starts allowing signals to be sent to motors
 void AP_MotorsCoax::enable()
 {
     // enable output channels
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])]->enable_ch();
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])]->enable_ch();
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3])]->enable_ch();
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])]->enable_ch();
+    _rc_out[AP_MOTORS_MOT_1]->enable_ch();
+    _rc_out[AP_MOTORS_MOT_2]->enable_ch();
+    _rc_out[AP_MOTORS_MOT_3]->enable_ch();
+    _rc_out[AP_MOTORS_MOT_4]->enable_ch();
 }
 
 // output_min - sends minimum values out to the motor and trim values to the servos
 void AP_MotorsCoax::output_min()
 {
     // send minimum value to each motor
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])]->write(_servo1.radio_trim);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])]->write(_servo2.radio_trim);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3])]->write(_rc_throttle.radio_min);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])]->write(_rc_throttle.radio_min);
+    _rc_out[AP_MOTORS_MOT_1]->write(_servo1.radio_trim);
+    _rc_out[AP_MOTORS_MOT_2]->write(_servo2.radio_trim);
+    _rc_out[AP_MOTORS_MOT_3]->write(_rc_throttle.radio_min);
+    _rc_out[AP_MOTORS_MOT_4]->write(_rc_throttle.radio_min);
 }
 
 // output_armed - sends commands to the motors
@@ -179,10 +179,10 @@ void AP_MotorsCoax::output_armed()
     }
 
     // send output to each motor
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])]->write(_servo1.radio_out);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])]->write(_servo2.radio_out);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3])]->write(motor_out[AP_MOTORS_MOT_3]);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])]->write(motor_out[AP_MOTORS_MOT_4]);
+    _rc_out[AP_MOTORS_MOT_1]->write(_servo1.radio_out);
+    _rc_out[AP_MOTORS_MOT_2]->write(_servo2.radio_out);
+    _rc_out[AP_MOTORS_MOT_3]->write(motor_out[AP_MOTORS_MOT_3]);
+    _rc_out[AP_MOTORS_MOT_4]->write(motor_out[AP_MOTORS_MOT_4]);
 }
 
 // output_disarmed - sends commands to the motors
@@ -206,19 +206,19 @@ void AP_MotorsCoax::output_test(uint8_t motor_seq, int16_t pwm)
     switch (motor_seq) {
         case 1:
             // flap servo 1
-            _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])]->write(pwm);
+            _rc_out[AP_MOTORS_MOT_1]->write(pwm);
             break;
         case 2:
             // flap servo 2
-            _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])]->write(pwm);
+            _rc_out[AP_MOTORS_MOT_2]->write(pwm);
             break;
         case 3:
             // motor 1
-            _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3])]->write(pwm);
+            _rc_out[AP_MOTORS_MOT_3]->write(pwm);
             break;
         case 4:
             // motor 2
-            _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])]->write(pwm);
+            _rc_out[AP_MOTORS_MOT_4]->write(pwm);
             break;
         default:
             // do nothing

--- a/libraries/AP_Motors/AP_MotorsCoax.h
+++ b/libraries/AP_Motors/AP_MotorsCoax.h
@@ -25,8 +25,8 @@ class AP_MotorsCoax : public AP_Motors {
 public:
 
     /// Constructor
-    AP_MotorsCoax( RC_Channel& rc_roll, RC_Channel& rc_pitch, RC_Channel& rc_throttle, RC_Channel& rc_yaw, RC_Channel& servo1, RC_Channel& servo2, uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) :
-        AP_Motors(rc_roll, rc_pitch, rc_throttle, rc_yaw, loop_rate, speed_hz),
+    AP_MotorsCoax( RC_Channel& rc_roll, RC_Channel& rc_pitch, RC_Channel& rc_throttle, RC_Channel& rc_yaw, RC_Channel& servo1, RC_Channel& servo2, AP_Actuator_Channel* rc_out[], uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) :
+        AP_Motors(rc_roll, rc_pitch, rc_throttle, rc_yaw, rc_out, loop_rate, speed_hz),
         _servo1(servo1),
         _servo2(servo2)
     {

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -240,20 +240,20 @@ void AP_MotorsHeli::set_update_rate( uint16_t speed_hz )
     _speed_hz = speed_hz;
 
     // setup fast channels
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])]->set_freq(_speed_hz);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])]->set_freq(_speed_hz);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3])]->set_freq(_speed_hz);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])]->set_freq(_speed_hz);
+    _rc_out[AP_MOTORS_MOT_1]->set_freq(_speed_hz);
+    _rc_out[AP_MOTORS_MOT_2]->set_freq(_speed_hz);
+    _rc_out[AP_MOTORS_MOT_3]->set_freq(_speed_hz);
+    _rc_out[AP_MOTORS_MOT_4]->set_freq(_speed_hz);
 }
 
 // enable - starts allowing signals to be sent to motors
 void AP_MotorsHeli::enable()
 {
     // enable output channels
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])]->enable_ch();    // swash servo 1
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])]->enable_ch();    // swash servo 2
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3])]->enable_ch();    // swash servo 3
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])]->enable_ch();    // yaw
+    _rc_out[AP_MOTORS_MOT_1]->enable_ch();    // swash servo 1
+    _rc_out[AP_MOTORS_MOT_2]->enable_ch();    // swash servo 2
+    _rc_out[AP_MOTORS_MOT_3]->enable_ch();    // swash servo 3
+    _rc_out[AP_MOTORS_MOT_4]->enable_ch();    // yaw
     _rc_out[AP_MOTORS_HELI_AUX]->enable_ch();                               // output for gyro gain or direct drive variable pitch tail motor
     _rc_out[AP_MOTORS_HELI_RSC]->enable_ch();                               // output for main rotor esc
 }
@@ -286,22 +286,22 @@ void AP_MotorsHeli::output_test(uint8_t motor_seq, int16_t pwm)
     switch (motor_seq) {
         case 1:
             // swash servo 1
-            _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])]->write(pwm);
+            _rc_out[AP_MOTORS_MOT_1]->write(pwm);
             break;
         case 2:
             // swash servo 2
-            _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])]->write(pwm);
+            _rc_out[AP_MOTORS_MOT_2]->write(pwm);
             break;
         case 3:
             // swash servo 3
-            _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3])]->write(pwm);
+            _rc_out[AP_MOTORS_MOT_3]->write(pwm);
             break;
         case 4:
             // external gyro & tail servo
             if (_tail_type == AP_MOTORS_HELI_TAILTYPE_SERVO_EXTGYRO) {
                 write_aux(_ext_gyro_gain);
             }
-            _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])]->write(pwm);
+            _rc_out[AP_MOTORS_MOT_4]->write(pwm);
             break;
         case 5:
             // main rotor
@@ -624,10 +624,10 @@ void AP_MotorsHeli::move_swash(int16_t roll_out, int16_t pitch_out, int16_t coll
     _servo_4.calc_pwm();
 
     // actually move the servos
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])]->write(_servo_1.radio_out);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])]->write(_servo_2.radio_out);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3])]->write(_servo_3.radio_out);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])]->write(_servo_4.radio_out);
+    _rc_out[AP_MOTORS_MOT_1]->write(_servo_1.radio_out);
+    _rc_out[AP_MOTORS_MOT_2]->write(_servo_2.radio_out);
+    _rc_out[AP_MOTORS_MOT_3]->write(_servo_3.radio_out);
+    _rc_out[AP_MOTORS_MOT_4]->write(_servo_4.radio_out);
 
     // output gain to exernal gyro
     if (_tail_type == AP_MOTORS_HELI_TAILTYPE_SERVO_EXTGYRO) {

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -97,9 +97,10 @@ public:
                    RC_Channel&      swash_servo_2,
                    RC_Channel&      swash_servo_3,
                    RC_Channel&      yaw_servo,
+                   AP_Actuator_Channel* rc_out[],
                    uint16_t         loop_rate,
                    uint16_t         speed_hz = AP_MOTORS_HELI_SPEED_DEFAULT) :
-        AP_Motors(rc_roll, rc_pitch, rc_throttle, rc_yaw, loop_rate, speed_hz),
+        AP_Motors(rc_roll, rc_pitch, rc_throttle, rc_yaw, rc_out, loop_rate, speed_hz),
         _servo_aux(servo_aux),
         _servo_rsc(servo_rotor),
         _servo_1(swash_servo_1),

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -21,8 +21,8 @@
 #define AP_MOTORS_HELI_SPEED_ANALOG_SERVOS      125     // update rate for analog servos
 
 // TradHeli Aux Function Output Channels
-#define AP_MOTORS_HELI_AUX                      CH_7
-#define AP_MOTORS_HELI_RSC                      CH_8
+#define AP_MOTORS_HELI_AUX                      6
+#define AP_MOTORS_HELI_RSC                      7
 
 // servo position defaults
 #define AP_MOTORS_HELI_SERVO1_POS               -60

--- a/libraries/AP_Motors/AP_MotorsHexa.h
+++ b/libraries/AP_Motors/AP_MotorsHexa.h
@@ -16,7 +16,7 @@ class AP_MotorsHexa : public AP_MotorsMatrix {
 public:
 
     /// Constructor
-    AP_MotorsHexa(RC_Channel& rc_roll, RC_Channel& rc_pitch, RC_Channel& rc_throttle, RC_Channel& rc_yaw, uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) : AP_MotorsMatrix(rc_roll, rc_pitch, rc_throttle, rc_yaw, loop_rate, speed_hz) {
+    AP_MotorsHexa(RC_Channel& rc_roll, RC_Channel& rc_pitch, RC_Channel& rc_throttle, RC_Channel& rc_yaw, AP_Actuator_Channel* rc_out[], uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) : AP_MotorsMatrix(rc_roll, rc_pitch, rc_throttle, rc_yaw, rc_out, loop_rate, speed_hz) {
     };
 
     // setup_motors - configures the motors for a hexa

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -48,7 +48,7 @@ void AP_MotorsMatrix::set_update_rate( uint16_t speed_hz )
     // check each enabled motor
     for( i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++ ) {
         if( motor_enabled[i] ) {
-            _rc_out[pgm_read_byte(&_motor_to_channel_map[i])]->set_freq(_speed_hz);
+            _rc_out[i]->set_freq(_speed_hz);
         }
     }
 }
@@ -79,7 +79,7 @@ void AP_MotorsMatrix::enable()
     // enable output channels
     for( i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++ ) {
         if( motor_enabled[i] ) {
-            _rc_out[pgm_read_byte(&_motor_to_channel_map[i])]->enable_ch();
+            _rc_out[i]->enable_ch();
         }
     }
 }
@@ -98,7 +98,7 @@ void AP_MotorsMatrix::output_min()
     // fill the motor_out[] array for HIL use and send minimum value to each motor
     for( i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++ ) {
         if( motor_enabled[i] ) {
-            _rc_out[pgm_read_byte(&_motor_to_channel_map[i])]->write(_rc_throttle.radio_min);
+            _rc_out[i]->write(_rc_throttle.radio_min);
         }
     }
 }
@@ -327,7 +327,7 @@ void AP_MotorsMatrix::output_armed()
     // send output to each motor
     for( i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++ ) {
         if( motor_enabled[i] ) {
-            _rc_out[pgm_read_byte(&_motor_to_channel_map[i])]->write(motor_out[i]);
+            _rc_out[i]->write(motor_out[i]);
         }
     }
 }
@@ -353,7 +353,7 @@ void AP_MotorsMatrix::output_test(uint8_t motor_seq, int16_t pwm)
     for (uint8_t i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
         if (motor_enabled[i] && _test_order[i] == motor_seq) {
             // turn on this motor
-            _rc_out[pgm_read_byte(&_motor_to_channel_map[i])]->write(pwm);
+            _rc_out[i]->write(pwm);
         }
     }
 }
@@ -378,7 +378,8 @@ void AP_MotorsMatrix::add_motor_raw(int8_t motor_num, float roll_fac, float pitc
         _test_order[motor_num] = testing_order;
 
         // disable this channel from being used by RC_Channel_aux
-        RC_Channel_aux::disable_aux_channel(pgm_read_byte(&_motor_to_channel_map[motor_num]));
+        // TODO: check if channel is a hardware PWM channel and use get_ch if so
+        RC_Channel_aux::disable_aux_channel(motor_num);
     }
 }
 

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -46,13 +46,11 @@ void AP_MotorsMatrix::set_update_rate( uint16_t speed_hz )
     _speed_hz = speed_hz;
 
     // check each enabled motor
-    uint32_t mask = 0;
     for( i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++ ) {
         if( motor_enabled[i] ) {
-		mask |= 1U << pgm_read_byte(&_motor_to_channel_map[i]);
+            _rc_out[pgm_read_byte(&_motor_to_channel_map[i])]->set_freq(_speed_hz);
         }
     }
-    hal.rcout->set_freq( mask, _speed_hz );
 }
 
 // set frame orientation (normally + or X)
@@ -81,7 +79,7 @@ void AP_MotorsMatrix::enable()
     // enable output channels
     for( i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++ ) {
         if( motor_enabled[i] ) {
-            hal.rcout->enable_ch(pgm_read_byte(&_motor_to_channel_map[i]));
+            _rc_out[pgm_read_byte(&_motor_to_channel_map[i])]->enable_ch();
         }
     }
 }
@@ -100,7 +98,7 @@ void AP_MotorsMatrix::output_min()
     // fill the motor_out[] array for HIL use and send minimum value to each motor
     for( i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++ ) {
         if( motor_enabled[i] ) {
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[i]), _rc_throttle.radio_min);
+            _rc_out[pgm_read_byte(&_motor_to_channel_map[i])]->write(_rc_throttle.radio_min);
         }
     }
 }
@@ -329,7 +327,7 @@ void AP_MotorsMatrix::output_armed()
     // send output to each motor
     for( i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++ ) {
         if( motor_enabled[i] ) {
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[i]), motor_out[i]);
+            _rc_out[pgm_read_byte(&_motor_to_channel_map[i])]->write(motor_out[i]);
         }
     }
 }
@@ -355,7 +353,7 @@ void AP_MotorsMatrix::output_test(uint8_t motor_seq, int16_t pwm)
     for (uint8_t i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
         if (motor_enabled[i] && _test_order[i] == motor_seq) {
             // turn on this motor
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[i]), pwm);
+            _rc_out[pgm_read_byte(&_motor_to_channel_map[i])]->write(pwm);
         }
     }
 }
@@ -380,7 +378,7 @@ void AP_MotorsMatrix::add_motor_raw(int8_t motor_num, float roll_fac, float pitc
         _test_order[motor_num] = testing_order;
 
         // disable this channel from being used by RC_Channel_aux
-        RC_Channel_aux::disable_aux_channel(_motor_to_channel_map[motor_num]);
+        RC_Channel_aux::disable_aux_channel(pgm_read_byte(&_motor_to_channel_map[motor_num]));
     }
 }
 

--- a/libraries/AP_Motors/AP_MotorsMatrix.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix.h
@@ -19,8 +19,8 @@ class AP_MotorsMatrix : public AP_Motors {
 public:
 
     /// Constructor
-    AP_MotorsMatrix(RC_Channel& rc_roll, RC_Channel& rc_pitch, RC_Channel& rc_throttle, RC_Channel& rc_yaw, uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) :
-        AP_Motors(rc_roll, rc_pitch, rc_throttle, rc_yaw, loop_rate, speed_hz)
+    AP_MotorsMatrix(RC_Channel& rc_roll, RC_Channel& rc_pitch, RC_Channel& rc_throttle, RC_Channel& rc_yaw, AP_Actuator_Channel* rc_out[], uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) :
+        AP_Motors(rc_roll, rc_pitch, rc_throttle, rc_yaw, rc_out, loop_rate, speed_hz)
     {};
 
     // init

--- a/libraries/AP_Motors/AP_MotorsOcta.h
+++ b/libraries/AP_Motors/AP_MotorsOcta.h
@@ -16,7 +16,7 @@ class AP_MotorsOcta : public AP_MotorsMatrix {
 public:
 
     /// Constructor
-    AP_MotorsOcta(RC_Channel& rc_roll, RC_Channel& rc_pitch, RC_Channel& rc_throttle, RC_Channel& rc_yaw, uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) : AP_MotorsMatrix(rc_roll, rc_pitch, rc_throttle, rc_yaw, loop_rate, speed_hz) {
+    AP_MotorsOcta(RC_Channel& rc_roll, RC_Channel& rc_pitch, RC_Channel& rc_throttle, RC_Channel& rc_yaw, AP_Actuator_Channel* rc_out[], uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) : AP_MotorsMatrix(rc_roll, rc_pitch, rc_throttle, rc_yaw, rc_out, loop_rate, speed_hz) {
     };
 
     // setup_motors - configures the motors for an octa

--- a/libraries/AP_Motors/AP_MotorsOctaQuad.h
+++ b/libraries/AP_Motors/AP_MotorsOctaQuad.h
@@ -16,7 +16,7 @@ class AP_MotorsOctaQuad : public AP_MotorsMatrix {
 public:
 
     /// Constructor
-    AP_MotorsOctaQuad(RC_Channel& rc_roll, RC_Channel& rc_pitch, RC_Channel& rc_throttle, RC_Channel& rc_yaw, uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) : AP_MotorsMatrix(rc_roll, rc_pitch, rc_throttle, rc_yaw, loop_rate, speed_hz) {
+    AP_MotorsOctaQuad(RC_Channel& rc_roll, RC_Channel& rc_pitch, RC_Channel& rc_throttle, RC_Channel& rc_yaw, AP_Actuator_Channel* rc_out[], uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) : AP_MotorsMatrix(rc_roll, rc_pitch, rc_throttle, rc_yaw, rc_out, loop_rate, speed_hz) {
     };
 
     // setup_motors - configures the motors for a quad

--- a/libraries/AP_Motors/AP_MotorsQuad.h
+++ b/libraries/AP_Motors/AP_MotorsQuad.h
@@ -16,7 +16,7 @@ class AP_MotorsQuad : public AP_MotorsMatrix {
 public:
 
     /// Constructor
-    AP_MotorsQuad(RC_Channel& rc_roll, RC_Channel& rc_pitch, RC_Channel& rc_throttle, RC_Channel& rc_yaw, uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) : AP_MotorsMatrix(rc_roll, rc_pitch, rc_throttle, rc_yaw, loop_rate, speed_hz) {
+    AP_MotorsQuad(RC_Channel& rc_roll, RC_Channel& rc_pitch, RC_Channel& rc_throttle, RC_Channel& rc_yaw, AP_Actuator_Channel* rc_out[], uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) : AP_MotorsMatrix(rc_roll, rc_pitch, rc_throttle, rc_yaw, rc_out, loop_rate, speed_hz) {
     };
 
     // setup_motors - configures the motors for a quad

--- a/libraries/AP_Motors/AP_MotorsSingle.cpp
+++ b/libraries/AP_Motors/AP_MotorsSingle.cpp
@@ -97,36 +97,34 @@ void AP_MotorsSingle::set_update_rate( uint16_t speed_hz )
     _speed_hz = speed_hz;
 
     // set update rate for the 3 motors (but not the servo on channel 7)
-    uint32_t mask = 
-	    1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]) |
-	    1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]) |
-	    1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]) |
-		1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]) ;
-    hal.rcout->set_freq(mask, _servo_speed);
-	uint32_t mask2 = 1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_7]);
-	hal.rcout->set_freq(mask2, _speed_hz);
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])]->set_freq(_servo_speed);
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])]->set_freq(_servo_speed);
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3])]->set_freq(_servo_speed);
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])]->set_freq(_servo_speed);
+
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_7])]->set_freq(_speed_hz);
 }
 
 // enable - starts allowing signals to be sent to motors
 void AP_MotorsSingle::enable()
 {
     // enable output channels
-    hal.rcout->enable_ch(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]));
-    hal.rcout->enable_ch(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]));
-    hal.rcout->enable_ch(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]));
-    hal.rcout->enable_ch(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]));
-	hal.rcout->enable_ch(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_7]));
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])]->enable_ch();
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])]->enable_ch();
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3])]->enable_ch();
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])]->enable_ch();
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_7])]->enable_ch();
 }
 
 // output_min - sends minimum values out to the motor and trim values to the servos
 void AP_MotorsSingle::output_min()
 {
     // send minimum value to each motor
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]), _servo1.radio_trim);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]), _servo2.radio_trim);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]), _servo3.radio_trim);
-	hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]), _servo4.radio_trim);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_7]), _rc_throttle.radio_min);
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])]->write(_servo1.radio_trim);
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])]->write(_servo2.radio_trim);
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3])]->write(_servo3.radio_trim);
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])]->write(_servo4.radio_trim);
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_7])]->write(_rc_throttle.radio_min);
 }
 
 // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
@@ -200,12 +198,12 @@ void AP_MotorsSingle::output_armed()
     _servo3.calc_pwm();
     _servo4.calc_pwm();
 
-    // send output to each motor
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]), _servo1.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]), _servo2.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]), _servo3.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]), _servo4.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_7]), motor_out);
+    // send output to each actuator
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])]->write(_servo1.radio_out);
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])]->write(_servo2.radio_out);
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3])]->write(_servo3.radio_out);
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])]->write(_servo4.radio_out);
+    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_7])]->write(motor_out);
 }
 
 // output_disarmed - sends commands to the motors
@@ -229,23 +227,23 @@ void AP_MotorsSingle::output_test(uint8_t motor_seq, int16_t pwm)
     switch (motor_seq) {
         case 1:
             // flap servo 1
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]), pwm);
+            _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])]->write(pwm);
             break;
         case 2:
             // flap servo 2
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]), pwm);
+            _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])]->write(pwm);
             break;
         case 3:
             // flap servo 3
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]), pwm);
+            _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3])]->write(pwm);
             break;
         case 4:
             // flap servo 4
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]), pwm);
+            _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])]->write(pwm);
             break;
         case 5:
             // spin main motor
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_7]), pwm);
+            _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_7])]->write(pwm);
             break;
         default:
             // do nothing

--- a/libraries/AP_Motors/AP_MotorsSingle.cpp
+++ b/libraries/AP_Motors/AP_MotorsSingle.cpp
@@ -97,34 +97,34 @@ void AP_MotorsSingle::set_update_rate( uint16_t speed_hz )
     _speed_hz = speed_hz;
 
     // set update rate for the 3 motors (but not the servo on channel 7)
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])]->set_freq(_servo_speed);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])]->set_freq(_servo_speed);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3])]->set_freq(_servo_speed);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])]->set_freq(_servo_speed);
+    _rc_out[AP_MOTORS_MOT_1]->set_freq(_servo_speed);
+    _rc_out[AP_MOTORS_MOT_2]->set_freq(_servo_speed);
+    _rc_out[AP_MOTORS_MOT_3]->set_freq(_servo_speed);
+    _rc_out[AP_MOTORS_MOT_4]->set_freq(_servo_speed);
 
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_7])]->set_freq(_speed_hz);
+    _rc_out[AP_MOTORS_MOT_7]->set_freq(_speed_hz);
 }
 
 // enable - starts allowing signals to be sent to motors
 void AP_MotorsSingle::enable()
 {
     // enable output channels
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])]->enable_ch();
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])]->enable_ch();
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3])]->enable_ch();
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])]->enable_ch();
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_7])]->enable_ch();
+    _rc_out[AP_MOTORS_MOT_1]->enable_ch();
+    _rc_out[AP_MOTORS_MOT_2]->enable_ch();
+    _rc_out[AP_MOTORS_MOT_3]->enable_ch();
+    _rc_out[AP_MOTORS_MOT_4]->enable_ch();
+    _rc_out[AP_MOTORS_MOT_7]->enable_ch();
 }
 
 // output_min - sends minimum values out to the motor and trim values to the servos
 void AP_MotorsSingle::output_min()
 {
     // send minimum value to each motor
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])]->write(_servo1.radio_trim);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])]->write(_servo2.radio_trim);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3])]->write(_servo3.radio_trim);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])]->write(_servo4.radio_trim);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_7])]->write(_rc_throttle.radio_min);
+    _rc_out[AP_MOTORS_MOT_1]->write(_servo1.radio_trim);
+    _rc_out[AP_MOTORS_MOT_2]->write(_servo2.radio_trim);
+    _rc_out[AP_MOTORS_MOT_3]->write(_servo3.radio_trim);
+    _rc_out[AP_MOTORS_MOT_4]->write(_servo4.radio_trim);
+    _rc_out[AP_MOTORS_MOT_7]->write(_rc_throttle.radio_min);
 }
 
 // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
@@ -199,11 +199,11 @@ void AP_MotorsSingle::output_armed()
     _servo4.calc_pwm();
 
     // send output to each actuator
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])]->write(_servo1.radio_out);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])]->write(_servo2.radio_out);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3])]->write(_servo3.radio_out);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])]->write(_servo4.radio_out);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_7])]->write(motor_out);
+    _rc_out[AP_MOTORS_MOT_1]->write(_servo1.radio_out);
+    _rc_out[AP_MOTORS_MOT_2]->write(_servo2.radio_out);
+    _rc_out[AP_MOTORS_MOT_3]->write(_servo3.radio_out);
+    _rc_out[AP_MOTORS_MOT_4]->write(_servo4.radio_out);
+    _rc_out[AP_MOTORS_MOT_7]->write(motor_out);
 }
 
 // output_disarmed - sends commands to the motors
@@ -227,23 +227,23 @@ void AP_MotorsSingle::output_test(uint8_t motor_seq, int16_t pwm)
     switch (motor_seq) {
         case 1:
             // flap servo 1
-            _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])]->write(pwm);
+            _rc_out[AP_MOTORS_MOT_1]->write(pwm);
             break;
         case 2:
             // flap servo 2
-            _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])]->write(pwm);
+            _rc_out[AP_MOTORS_MOT_2]->write(pwm);
             break;
         case 3:
             // flap servo 3
-            _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3])]->write(pwm);
+            _rc_out[AP_MOTORS_MOT_3]->write(pwm);
             break;
         case 4:
             // flap servo 4
-            _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])]->write(pwm);
+            _rc_out[AP_MOTORS_MOT_4]->write(pwm);
             break;
         case 5:
             // spin main motor
-            _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_7])]->write(pwm);
+            _rc_out[AP_MOTORS_MOT_7]->write(pwm);
             break;
         default:
             // do nothing

--- a/libraries/AP_Motors/AP_MotorsSingle.h
+++ b/libraries/AP_Motors/AP_MotorsSingle.h
@@ -25,8 +25,9 @@ class AP_MotorsSingle : public AP_Motors {
 public:
 
     /// Constructor
-    AP_MotorsSingle(RC_Channel& rc_roll, RC_Channel& rc_pitch, RC_Channel& rc_throttle, RC_Channel& rc_yaw, RC_Channel& servo1, RC_Channel& servo2, RC_Channel& servo3, RC_Channel& servo4, uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) :
-        AP_Motors(rc_roll, rc_pitch, rc_throttle, rc_yaw, loop_rate, speed_hz),
+    // TODO: possibly convert the servoN params to rc_out[] indexes?
+    AP_MotorsSingle(RC_Channel& rc_roll, RC_Channel& rc_pitch, RC_Channel& rc_throttle, RC_Channel& rc_yaw, RC_Channel& servo1, RC_Channel& servo2, RC_Channel& servo3, RC_Channel& servo4, AP_Actuator_Channel* rc_out[], uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) :
+        AP_Motors(rc_roll, rc_pitch, rc_throttle, rc_yaw, rc_out, loop_rate, speed_hz),
         _servo1(servo1),
         _servo2(servo2),
         _servo3(servo3),

--- a/libraries/AP_Motors/AP_MotorsTri.cpp
+++ b/libraries/AP_Motors/AP_MotorsTri.cpp
@@ -50,18 +50,18 @@ void AP_MotorsTri::set_update_rate( uint16_t speed_hz )
     _speed_hz = speed_hz;
 
     // set update rate for the 3 motors (but not the servo on channel 7)
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])]->set_freq(_speed_hz);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])]->set_freq(_speed_hz);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])]->set_freq(_speed_hz);
+    _rc_out[AP_MOTORS_MOT_1]->set_freq(_speed_hz);
+    _rc_out[AP_MOTORS_MOT_2]->set_freq(_speed_hz);
+    _rc_out[AP_MOTORS_MOT_4]->set_freq(_speed_hz);
 }
 
 // enable - starts allowing signals to be sent to motors
 void AP_MotorsTri::enable()
 {
     // enable output channels
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])]->enable_ch();
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])]->enable_ch();
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])]->enable_ch();
+    _rc_out[AP_MOTORS_MOT_1]->enable_ch();
+    _rc_out[AP_MOTORS_MOT_2]->enable_ch();
+    _rc_out[AP_MOTORS_MOT_4]->enable_ch();
     _rc_out[AP_MOTORS_CH_TRI_YAW]->enable_ch();
 }
 
@@ -72,9 +72,9 @@ void AP_MotorsTri::output_min()
     limit.throttle_lower = true;
 
     // send minimum value to each motor
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])]->write(_rc_throttle.radio_min);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])]->write(_rc_throttle.radio_min);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])]->write(_rc_throttle.radio_min);
+    _rc_out[AP_MOTORS_MOT_1]->write(_rc_throttle.radio_min);
+    _rc_out[AP_MOTORS_MOT_2]->write(_rc_throttle.radio_min);
+    _rc_out[AP_MOTORS_MOT_4]->write(_rc_throttle.radio_min);
     _rc_out[AP_MOTORS_CH_TRI_YAW]->write(_rc_yaw.radio_trim);
 }
 
@@ -83,9 +83,9 @@ void AP_MotorsTri::output_min()
 uint16_t AP_MotorsTri::get_motor_mask()
 {
     // tri copter uses channels 1,2,4 and 7
-    return (1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])) |
-        (1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])) |
-        (1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])) |
+    return (1U << AP_MOTORS_MOT_1) |
+        (1U << AP_MOTORS_MOT_2) |
+        (1U << AP_MOTORS_MOT_4) |
         (1U << AP_MOTORS_CH_TRI_YAW);
 }
 
@@ -183,9 +183,9 @@ void AP_MotorsTri::output_armed()
     }
 
     // send output to each motor
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])]->write(motor_out[AP_MOTORS_MOT_1]);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])]->write(motor_out[AP_MOTORS_MOT_2]);
-    _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])]->write(motor_out[AP_MOTORS_MOT_4]);
+    _rc_out[AP_MOTORS_MOT_1]->write(motor_out[AP_MOTORS_MOT_1]);
+    _rc_out[AP_MOTORS_MOT_2]->write(motor_out[AP_MOTORS_MOT_2]);
+    _rc_out[AP_MOTORS_MOT_4]->write(motor_out[AP_MOTORS_MOT_4]);
 
     // also send out to tail command (we rely on any auto pilot to have updated the rc_yaw->radio_out to the correct value)
     // note we do not save the radio_out to the motor_out array so it may not appear in the ch7out in the status screen of the mission planner
@@ -219,11 +219,11 @@ void AP_MotorsTri::output_test(uint8_t motor_seq, int16_t pwm)
     switch (motor_seq) {
         case 1:
             // front right motor
-            _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])]->write(pwm);
+            _rc_out[AP_MOTORS_MOT_1]->write(pwm);
             break;
         case 2:
             // back motor
-            _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])]->write(pwm);
+            _rc_out[AP_MOTORS_MOT_4]->write(pwm);
             break;
         case 3:
             // back servo
@@ -231,7 +231,7 @@ void AP_MotorsTri::output_test(uint8_t motor_seq, int16_t pwm)
             break;
         case 4:
             // front left motor
-            _rc_out[pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])]->write(pwm);
+            _rc_out[AP_MOTORS_MOT_2]->write(pwm);
             break;
         default:
             // do nothing

--- a/libraries/AP_Motors/AP_MotorsTri.h
+++ b/libraries/AP_Motors/AP_MotorsTri.h
@@ -19,8 +19,8 @@ class AP_MotorsTri : public AP_Motors {
 public:
 
     /// Constructor
-    AP_MotorsTri(RC_Channel& rc_roll, RC_Channel& rc_pitch, RC_Channel& rc_throttle, RC_Channel& rc_yaw, RC_Channel& rc_tail, uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) :
-        AP_Motors(rc_roll, rc_pitch, rc_throttle, rc_yaw, loop_rate, speed_hz),
+    AP_MotorsTri(RC_Channel& rc_roll, RC_Channel& rc_pitch, RC_Channel& rc_throttle, RC_Channel& rc_yaw, RC_Channel& rc_tail, AP_Actuator_Channel* rc_out[], uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) :
+        AP_Motors(rc_roll, rc_pitch, rc_throttle, rc_yaw, rc_out, loop_rate, speed_hz),
         _rc_tail(rc_tail) {
     };
 

--- a/libraries/AP_Motors/AP_MotorsTri.h
+++ b/libraries/AP_Motors/AP_MotorsTri.h
@@ -12,7 +12,7 @@
 #include "AP_Motors.h"
 
 // tail servo uses channel 7
-#define AP_MOTORS_CH_TRI_YAW    CH_7
+#define AP_MOTORS_CH_TRI_YAW    6
 
 /// @class      AP_MotorsTri
 class AP_MotorsTri : public AP_Motors {

--- a/libraries/AP_Motors/AP_MotorsY6.h
+++ b/libraries/AP_Motors/AP_MotorsY6.h
@@ -18,7 +18,7 @@ class AP_MotorsY6 : public AP_MotorsMatrix {
 public:
 
     /// Constructor
-    AP_MotorsY6(RC_Channel& rc_roll, RC_Channel& rc_pitch, RC_Channel& rc_throttle, RC_Channel& rc_yaw, uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) : AP_MotorsMatrix(rc_roll, rc_pitch, rc_throttle, rc_yaw, loop_rate, speed_hz) {
+    AP_MotorsY6(RC_Channel& rc_roll, RC_Channel& rc_pitch, RC_Channel& rc_throttle, RC_Channel& rc_yaw, AP_Actuator_Channel* rc_out[], uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) : AP_MotorsMatrix(rc_roll, rc_pitch, rc_throttle, rc_yaw, rc_out, loop_rate, speed_hz) {
     };
 
     // setup_motors - configures the motors for a Y6

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -22,8 +22,6 @@
 
 #include "AP_Motors_Class.h"
 #include <AP_HAL.h>
-extern const AP_HAL::HAL& hal;
-
 
 // initialise motor map
 #if CONFIG_HAL_BOARD == HAL_BOARD_APM1
@@ -97,11 +95,12 @@ const AP_Param::GroupInfo AP_Motors::var_info[] PROGMEM = {
 };
 
 // Constructor
-AP_Motors::AP_Motors(RC_Channel& rc_roll, RC_Channel& rc_pitch, RC_Channel& rc_throttle, RC_Channel& rc_yaw, uint16_t loop_rate, uint16_t speed_hz) :
+AP_Motors::AP_Motors(RC_Channel& rc_roll, RC_Channel& rc_pitch, RC_Channel& rc_throttle, RC_Channel& rc_yaw, AP_Actuator_Channel* rc_out[], uint16_t loop_rate, uint16_t speed_hz) :
     _rc_roll(rc_roll),
     _rc_pitch(rc_pitch),
     _rc_throttle(rc_throttle),
     _rc_yaw(rc_yaw),
+    _rc_out(rc_out),
     _loop_rate(loop_rate),
     _speed_hz(speed_hz),
     _min_throttle(AP_MOTORS_DEFAULT_MIN_THROTTLE),
@@ -158,7 +157,7 @@ void AP_Motors::throttle_pass_through(int16_t pwm)
         // send the pilot's input directly to each enabled motor
         for (int16_t i=0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
             if (motor_enabled[i]) {
-                hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[i]), pwm);
+                _rc_out[pgm_read_byte(&_motor_to_channel_map[i])]->write(pwm);
             }
         }
     }

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -23,14 +23,6 @@
 #include "AP_Motors_Class.h"
 #include <AP_HAL.h>
 
-// initialise motor map
-#if CONFIG_HAL_BOARD == HAL_BOARD_APM1
-    const uint8_t AP_Motors::_motor_to_channel_map[AP_MOTORS_MAX_NUM_MOTORS] PROGMEM = {APM1_MOTOR_TO_CHANNEL_MAP};
-#else
-    const uint8_t AP_Motors::_motor_to_channel_map[AP_MOTORS_MAX_NUM_MOTORS] PROGMEM = {APM2_MOTOR_TO_CHANNEL_MAP};
-#endif
-
-
 // parameters for the motor class
 const AP_Param::GroupInfo AP_Motors::var_info[] PROGMEM = {
     // 0 was used by TB_RATIO
@@ -157,7 +149,7 @@ void AP_Motors::throttle_pass_through(int16_t pwm)
         // send the pilot's input directly to each enabled motor
         for (int16_t i=0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
             if (motor_enabled[i]) {
-                _rc_out[pgm_read_byte(&_motor_to_channel_map[i])]->write(pwm);
+                _rc_out[i]->write(pwm);
             }
         }
     }

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -11,7 +11,7 @@
 #include <Filter.h>         // filter library
 #include "AP_Actuator_Channel.h"
 
-// offsets for motors in motor_out, motor_enabled and _motor_to_channel_map arrays
+// offsets for motors in motor_out, motor_enabled and _rc_out arrays
 #define AP_MOTORS_MOT_1 0
 #define AP_MOTORS_MOT_2 1
 #define AP_MOTORS_MOT_3 2
@@ -21,18 +21,11 @@
 #define AP_MOTORS_MOT_7 6
 #define AP_MOTORS_MOT_8 7
 
-#define APM1_MOTOR_TO_CHANNEL_MAP CH_1,CH_2,CH_3,CH_4,CH_7,CH_8,CH_10,CH_11
-#define APM2_MOTOR_TO_CHANNEL_MAP CH_1,CH_2,CH_3,CH_4,CH_5,CH_6,CH_7,CH_8
-
 #define AP_MOTORS_MAX_NUM_MOTORS 8
 
 #define AP_MOTORS_DEFAULT_MIN_THROTTLE  130
 #define AP_MOTORS_DEFAULT_MID_THROTTLE  500
 #define AP_MOTORS_DEFAULT_MAX_THROTTLE  1000
-
-// APM board definitions
-#define AP_MOTORS_APM1  1
-#define AP_MOTORS_APM2  2
 
 // frame definitions
 #define AP_MOTORS_PLUS_FRAME        0
@@ -227,9 +220,6 @@ protected:
         uint8_t slow_start          : 1;    // 1 if slow start is active
         uint8_t slow_start_low_end  : 1;    // 1 just after arming so we can ramp up the spin_when_armed value
     } _flags;
-
-    // mapping of motor number (as received from upper APM code) to RC channel output - used to account for differences between APM1 and APM2
-    static const uint8_t _motor_to_channel_map[AP_MOTORS_MAX_NUM_MOTORS] PROGMEM;
 
     // parameters
     AP_Int16            _spin_when_armed;       // used to control whether the motors always spin when armed.  pwm value above radio_min

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -9,8 +9,9 @@
 #include <AP_Notify.h>      // Notify library
 #include <RC_Channel.h>     // RC Channel Library
 #include <Filter.h>         // filter library
+#include "AP_Actuator_Channel.h"
 
-// offsets for motors in motor_out, _motor_filtered and _motor_to_channel_map arrays
+// offsets for motors in motor_out, motor_enabled and _motor_to_channel_map arrays
 #define AP_MOTORS_MOT_1 0
 #define AP_MOTORS_MOT_2 1
 #define AP_MOTORS_MOT_3 2
@@ -86,7 +87,7 @@ class AP_Motors {
 public:
 
     // Constructor
-    AP_Motors(RC_Channel& rc_roll, RC_Channel& rc_pitch, RC_Channel& rc_throttle, RC_Channel& rc_yaw, uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT);
+    AP_Motors(RC_Channel& rc_roll, RC_Channel& rc_pitch, RC_Channel& rc_throttle, RC_Channel& rc_yaw, AP_Actuator_Channel* rc_out[], uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT);
 
     // init
     virtual void        Init() {}
@@ -245,6 +246,7 @@ protected:
     RC_Channel&         _rc_pitch;              // pitch input in from users is held in servo_out
     RC_Channel&         _rc_throttle;           // throttle input in from users is held in servo_out
     RC_Channel&         _rc_yaw;                // yaw input in from users is held in servo_out
+    AP_Actuator_Channel **_rc_out;              // output channels to write to
     uint16_t            _loop_rate;             // rate at which output() function is called (normally 400hz)
     uint16_t            _speed_hz;              // speed in hz to send updates to motors
     int16_t             _min_throttle;          // the minimum throttle to be sent to the motors when they're on (prevents motors stalling while flying)


### PR DESCRIPTION
This puts a thin class between AP_Motors and the HAL so that different busses and protocols can be plugged in for ESC control, including bi-directional ones.  ArduCopter tells the AP_Motors constructor where it wants AP_Motors to output actuator channel updates.  This was briefly discusses on the mailing list.
I also have a simple class for controlling I2C capable ESCs using the SimonK firmware but I'll submit that in a separate step due to doubts expressed on the list and after more testing.
This does not attempt to add reverse-throttle but the class is prototyped with this feature in mind.  The range of values passed to .write() will obviously need to change for that to happen.