### PR TITLE
ArduPlane: RTL Autoland skip HOME

### DIFF
--- a/ArduPlane/ArduPlane.pde
+++ b/ArduPlane/ArduPlane.pde
@@ -1422,11 +1422,20 @@ static void update_navigation()
         break;
             
     case RTL:
-        if (g.rtl_autoland && 
+        if (g.rtl_autoland == 1 &&
             !auto_state.checked_for_autoland &&
             nav_controller->reached_loiter_target() && 
             labs(altitude_error_cm) < 1000) {
             // we've reached the RTL point, see if we have a landing sequence
+            jump_to_landing_sequence();
+
+            // prevent running the expensive jump_to_landing_sequence
+            // on every loop
+            auto_state.checked_for_autoland = true;
+        }
+        else if (g.rtl_autoland == 2 &&
+            !auto_state.checked_for_autoland) {
+            // Go directly to the landing sequence
             jump_to_landing_sequence();
 
             // prevent running the expensive jump_to_landing_sequence

--- a/ArduPlane/Parameters.pde
+++ b/ArduPlane/Parameters.pde
@@ -942,7 +942,7 @@ const AP_Param::Info var_info[] PROGMEM = {
     // @Param: RTL_AUTOLAND
     // @DisplayName: RTL auto land
     // @Description: Automatically begin landing sequence after arriving at RTL location. This requires the addition of a DO_LAND_START mission item, which acts as a marker for the start of a landing sequence. The closest landing sequence will be chosen to the current location. 
-    // @Values: 0:Disable,1:Enable
+    // @Values: 0:Disable,1:Enable - go HOME then land,2:Enable - go directly to landing sequence
     // @User: Standard
     GSCALAR(rtl_autoland,         "RTL_AUTOLAND",   0),
 


### PR DESCRIPTION
With RTL_AUTOLAND=1 we navigate to HOME then to the DO_LAND_START commands. Now with RTL_AUTOLAND=2 we head directly to the DO_LAND_START commands and thus skip changing altitude to ALT_HOLD_RTL and waste time/fuel and head directly to the first land waypoint as if it was the next normal waypoint.