### PR TITLE
AP_AHRS: Fix potential offset error in get_position function

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -227,8 +227,10 @@ public:
     // attitude
     virtual const Matrix3f &get_dcm_matrix(void) const = 0;
 
-    // get our current position estimate. Return true if a position is available,
-    // otherwise false. This call fills in lat, lng and alt
+    // Get our current position estimate in WGS-84 coordinates.
+    // Return true if a position is available, otherwise false.
+    // This call fills in lat, lng and alt
+    // lat, long in degrees * 10^7; alt in meters * 100
     virtual bool get_position(struct Location &loc) const = 0;
 
     // return a wind estimation vector, in m/s


### PR DESCRIPTION
Clarifies the get_position function as returning a WGS-84 location
Changes so that if possible, get_position always returns a WGS-84 position estimate