### PR TITLE
Plane: use TECS for autotakeoff

### DIFF
--- a/ArduPlane/ArduPlane.pde
+++ b/ArduPlane/ArduPlane.pde
@@ -1195,9 +1195,8 @@ static void handle_auto_mode(void)
     case MAV_CMD_NAV_TAKEOFF:
         takeoff_calc_roll();
         takeoff_calc_pitch();
-        
-        // max throttle for takeoff
-        channel_throttle->servo_out = takeoff_throttle();
+        calc_throttle();
+
         break;
 
     case MAV_CMD_NAV_LAND:

--- a/ArduPlane/Attitude.pde
+++ b/ArduPlane/Attitude.pde
@@ -805,7 +805,11 @@ static void set_servos(void)
             min_throttle = 0;
         }
         if (control_mode == AUTO && flight_stage == AP_SpdHgtControl::FLIGHT_TAKEOFF) {
-            max_throttle = takeoff_throttle();
+            if(aparm.takeoff_throttle_max != 0) {
+                max_throttle = aparm.takeoff_throttle_max;
+            } else {
+                max_throttle = aparm.throttle_max;
+            }
         }
         channel_throttle->servo_out = constrain_int16(channel_throttle->servo_out, 
                                                       min_throttle,

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -464,7 +464,6 @@ public:
     AP_Float takeoff_tdrag_speed1;
     AP_Float takeoff_rotate_speed;
     AP_Int8 takeoff_throttle_slewrate;
-    AP_Int8 takeoff_throttle_max;
     AP_Int8 level_roll_limit;
     AP_Int8 flapin_channel;
     AP_Int8 flaperon_output;

--- a/ArduPlane/Parameters.pde
+++ b/ArduPlane/Parameters.pde
@@ -453,7 +453,7 @@ const AP_Param::Info var_info[] PROGMEM = {
     // @Range: 0 100
     // @Increment: 1
     // @User: Advanced
-    GSCALAR(takeoff_throttle_max,   "TKOFF_THR_MAX",        0),
+    ASCALAR(takeoff_throttle_max,   "TKOFF_THR_MAX",        0),
 
     // @Param: THR_SLEWRATE
     // @DisplayName: Throttle slew rate

--- a/ArduPlane/takeoff.pde
+++ b/ArduPlane/takeoff.pde
@@ -170,13 +170,3 @@ return_zero:
     return 0;
 }
 
-/*
-  return throttle percentage for takeoff
- */
-static uint8_t takeoff_throttle(void)
-{
-    if (g.takeoff_throttle_max != 0) {
-        return g.takeoff_throttle_max;
-    }
-    return aparm.throttle_max;
-}

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -586,11 +586,7 @@ void AP_TECS::_update_throttle_option(int16_t throttle_nudge)
 		nomThr = (aparm.throttle_cruise + throttle_nudge)* 0.01f;
     }
     
-	if (_flight_stage == AP_TECS::FLIGHT_TAKEOFF)
-	{
-		_throttle_dem = _THRmaxf;
-	}
-	else if (_pitch_dem > 0.0f && _PITCHmaxf > 0.0f)
+	if (_pitch_dem > 0.0f && _PITCHmaxf > 0.0f)
 	{
 		_throttle_dem = nomThr + (_THRmaxf - nomThr) * _pitch_dem / _PITCHmaxf;
 	}
@@ -751,7 +747,6 @@ void AP_TECS::_initialise_states(int32_t ptchMinCO_cd, float hgt_afe)
 	else if (_flight_stage == AP_TECS::FLIGHT_TAKEOFF)
 	{
 		_PITCHminf          = 0.000174533f * ptchMinCO_cd;
-		_THRminf            = _THRmaxf - 0.01f;
 		_hgt_dem_adj_last  = hgt_afe;
 		_hgt_dem_adj       = _hgt_dem_adj_last;
 		_hgt_dem_prev      = _hgt_dem_adj_last;
@@ -789,7 +784,11 @@ void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
 	// Convert inputs
     _hgt_dem = hgt_dem_cm * 0.01f;
 	_EAS_dem = EAS_dem_cm * 0.01f;
-    _THRmaxf  = aparm.throttle_max * 0.01f;
+    if (_flight_stage == AP_TECS::FLIGHT_TAKEOFF && aparm.takeoff_throttle_max != 0) {
+        _THRmaxf  = aparm.takeoff_throttle_max * 0.01f;
+    } else {
+        _THRmaxf  = aparm.throttle_max * 0.01f;
+    }
     _THRminf  = aparm.throttle_min * 0.01f;
 
 	// work out the maximum and minimum pitch

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -32,6 +32,7 @@ public:
         AP_Int8 throttle_max;	
         AP_Int8 throttle_slewrate;
         AP_Int8 throttle_cruise;
+        AP_Int8 takeoff_throttle_max;
         AP_Int16 airspeed_min;
         AP_Int16 airspeed_max;
         AP_Int16 pitch_limit_max_cd;


### PR DESCRIPTION
Allow TECS to control the throttle for takeoff, which allows smoothly using less then max throttle, allowing for the plane to climb at the trim airspeed and macs pitch angle, without building up an excess of either. This creates lower power draw, smoother takeoffs. SITL checks out well, and the effect on takeoffs with our aircraft in flight testing is amazing, there is now almost no dip when transitioning from takeoff to the next waypoint.