### PR TITLE
Fix bug preventing sending raw gps over chan>0

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -454,20 +454,20 @@ AP_GPS::lock_port(uint8_t instance, bool lock)
 void 
 AP_GPS::send_mavlink_gps_raw(mavlink_channel_t chan)
 {
-    static uint32_t last_send_time_ms;
+    static uint32_t last_send_time_ms[MAVLINK_COMM_3];
     if (status(0) > AP_GPS::NO_GPS) {
         // when we have a GPS then only send new data
-        if (last_send_time_ms == last_message_time_ms(0)) {
+        if (last_send_time_ms[chan-MAVLINK_COMM_0] == last_message_time_ms(0)) {
             return;
         }
-        last_send_time_ms = last_message_time_ms(0);
+        last_send_time_ms[chan-MAVLINK_COMM_0] = last_message_time_ms(0);
     } else {
         // when we don't have a GPS then send at 1Hz
         uint32_t now = hal.scheduler->millis();
-        if (now - last_send_time_ms < 1000) {
+        if (now - last_send_time_ms[chan-MAVLINK_COMM_0] < 1000) {
             return;
         }
-        last_send_time_ms = now;
+        last_send_time_ms[chan-MAVLINK_COMM_0] = now;
     }
     const Location &loc = location(0);
     mavlink_msg_gps_raw_int_send(


### PR DESCRIPTION
Originally a single static variable "last_send_time_ms" in "send_mavlink_gps_raw" would lead to raw gps messages being only sent on channels 0, then, when the function is called for other channels (but the same message) it would be believed that messages are old and won't be sent.
 
This patch changes last_send_time_ms of send_mavlink_gps_raw to an array of the length of the communication channels possible. This way, if an up to date message has been sent on channel 0 it would be sent on other channels as well.
