### PR TITLE
Fixed differential spoilers support, added elevon offset (2015-04-15)

### DIFF
--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -136,6 +136,8 @@ public:
         k_param_hil_mode,
         k_param_land_disarm_delay,
         k_param_glide_slope_threshold,
+        k_param_mixing_offset,
+        k_param_dspoiler_rud_rate,
 
         // 100: Arming parameters
         k_param_arming = 100,
@@ -432,6 +434,8 @@ public:
     AP_Int8 reverse_elevons;
     AP_Int8 reverse_ch1_elevon;
     AP_Int8 reverse_ch2_elevon;
+    AP_Int16 mixing_offset;
+    AP_Int16 dspoiler_rud_rate;
     AP_Int16 num_resets;
     AP_Int32 log_bitmask;
     AP_Int8 reset_switch_chan;

--- a/ArduPlane/Parameters.pde
+++ b/ArduPlane/Parameters.pde
@@ -757,6 +757,22 @@ const AP_Param::Info var_info[] PROGMEM = {
     // @User: User
     GSCALAR(mixing_gain,            "MIXING_GAIN",    0.5f),
 
+    // @Param: MIXING_OFFSET
+    // @DisplayName: Mixing Offset
+    // @Description: The offset for the Vtail and elevon output mixers, as a percentage. This can be used in combination with MIXING_GAIN to configure how the control surfaces respond to input. The response to aileron or elevator input can be increased by setting this parameter to a positive or negative value. A common usage is to enter a positive value to increase the aileron response of the elevons of a flying wing. The default value of zero will leave the aileron-input response equal to the elevator-input response.
+    // @Units: percent
+    // @Range: -1000 1000
+    // @User: User
+    GSCALAR(mixing_offset,          "MIXING_OFFSET",  0),
+
+    // @Param: DSPOILR_RUD_RATE
+    // @DisplayName: Differential spoilers rudder rate
+    // @Description: Sets the amount of deflection that the rudder output will apply to the differential spoilers, as a percentage. The default value of 100 results in full rudder applying full deflection. A value of 0 will result in the differential spoilers exactly following the elevons (no rudder effect).
+    // @Units: percent
+    // @Range: -1000 1000
+    // @User: User
+    GSCALAR(dspoiler_rud_rate,      "DSPOILR_RUD_RATE",  DSPOILR_RUD_RATE_DEFAULT),
+
     // @Param: SYS_NUM_RESETS
     // @DisplayName: Num Resets
     // @Description: Number of APM board resets

--- a/ArduPlane/config.h
+++ b/ArduPlane/config.h
@@ -229,6 +229,10 @@
  # define ELEVON_CH2_REVERSE     DISABLED
 #endif
 
+#ifndef DSPOILR_RUD_RATE_DEFAULT
+ #define DSPOILR_RUD_RATE_DEFAULT 100
+#endif
+
 //////////////////////////////////////////////////////////////////////////////
 // CAMERA TRIGGER AND CONTROL
 //


### PR DESCRIPTION
Update:  I've posted a version of this modification applied to the ArduPlane v3.3.0 release; see below:  https://github.com/diydrones/ardupilot/pull/2137#issuecomment-122608305

This is a resubmit of PR #1736, applied to ArduPlane v3.3.0beta as of 2015-04-15.

Fixes ArduPlane differential spoilers when ELEVON_MIXING=0 and ELEVON_OUTPUT>0 (mixing done in flight controller).  All flight modes are supported.  This functionality is used on flying wings with "split elevons" using two servos on each side.  In v3.2 of ArduPlane, differential spoilers are non-operational (see issue #1032).  This patch fixes them so they operate as described in the ArduPlane docs:  http://plane.ardupilot.com/wiki/differential-spoilers

Added parameter:  DSPOILR_RUD_RATE  "Differential spoilers rudder rate"
Sets the amount of deflection that the rudder output will apply to the differential spoilers, as a percentage. The default value of 100 results in full rudder applying full deflection. A value of 0 will result in the differential spoilers exactly following the elevons (no rudder effect).

Added parameter:  MIXING_OFFSET
The offset for the Vtail and elevon output mixers, as a percentage. This can be used in combination with MIXING_GAIN to configure how the control surfaces respond to input. The response to aileron or elevator input can be increased by setting this parameter to a positive or negative value. A common usage is to enter a positive value to increase the aileron response of the elevons of a flying wing. The default value of zero will leave the aileron-input response equal to the elevator-input response.

Notes:  The new parameter DSPOILR_RUD_RATE allows the rudder effect to be "toned down."  Otherwise it can be too easy to apply too much rudder-spoiler control and stall the wing.  The new parameter MIXING_OFFSET allows the elevon mixing on a wing to be tuned so that the "aileron" effect is greater than the "elevator" effect.  Flying wings are usually pitch-sensitive while being difficult to roll, so this tuning is desirable.

I have successfully tested this patch (on APM2) in a 47" Popwing, in Manual, Stabilized, and GPS-guided flight modes.  I've flown it (on APM2) with the patch applied to the ArduPlane v3.3.0beta1 released as 'ArduPlane-beta' on 2015-02-22.  I've bench tested the patch, applied to ArduPlane v3.3.0beta as of 2015-04-15, on APM2 and Pixhawk.

Source and hex files are also posted here:  http://www.etheli.com/APM/ArduPlane_v3.2.0_etMod

Here is sample set of parameters for testing the new functionality:

DSPOILR_RUD_RATE,75
ELEVON_OUTPUT,2
MIXING_OFFSET,75
RC5_FUNCTION,16
RC5_MAX,1900
RC5_MIN,1100
RC5_REV,1
RC6_FUNCTION,17
RC6_MAX,1900
RC6_MIN,1100
RC6_REV,1

The four servos are plugged into RC1, RC2, RC5 and RC6.  One thing to watch out for is that the RC5_MIN, RC5_MAX, RC6_MIN and RC6_MAX parameters can be modified when a radio calibration is performed.  If this happens, they should be restored to values like the ones above.

--ET