### PR TITLE
AutoTest: Add ability to run SITL in screen on AC3.2.1

### DIFF
--- a/Tools/autotest/run_in_terminal_window.sh
+++ b/Tools/autotest/run_in_terminal_window.sh
@@ -13,8 +13,14 @@ elif [ -x /usr/bin/konsole ]; then
   /usr/bin/konsole --hold -e $*
 elif [ -x /usr/bin/gnome-terminal ]; then
   /usr/bin/gnome-terminal -e "$*"
+elif [ -n "$STY" ]; then
+  # We are running inside of screen, try to start it there
+  /usr/bin/screen -X screen -t $name $*
 else
-  echo "ERROR: Please install xterm"
-  exit 1
+  filename="/tmp/$name.log"
+  echo "Window access not found, logging to $filename"
+  cmd="$1"
+  shift
+  ( run_cmd.sh $cmd $* &>$filename < /dev/null ) &
 fi
 exit 0


### PR DESCRIPTION
This is a minor update to the AC3.2.1 branch to allow easy running of SITL in 'screen' when used on a headless linux machine.