### PR TITLE
Avoid run-time FPEs due to bad gyro settings if SIM_DRIFT_TIME is 0

### DIFF
--- a/libraries/AP_HAL_AVR_SITL/sitl_ins.cpp
+++ b/libraries/AP_HAL_AVR_SITL/sitl_ins.cpp
@@ -80,7 +80,8 @@ uint16_t SITL_State::_airspeed_sensor(float airspeed)
 
 float SITL_State::_gyro_drift(void)
 {
-	if (_sitl->drift_speed == 0.0) {
+	if (_sitl->drift_speed == 0.0f ||
+	    _sitl->drift_time == 0.0f) {
 		return 0;
 	}
 	double period  = _sitl->drift_time * 2;


### PR DESCRIPTION
_gyro_drift essentially suffers a divide-by-zero if SIM_DRIFT_TIME is 0.  The gyro initialisation routines in AP_InertialSensor do not return once the generated NaN propogates back to them.