### PR TITLE
ArduCopter: log primary compass

### DIFF
--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -425,7 +425,7 @@ struct PACKED log_Compass {
     int16_t  motor_offset_x;
     int16_t  motor_offset_y;
     int16_t  motor_offset_z;
-    uint8_t  primary;
+    uint8_t  health;
 };
 
 struct PACKED log_Mode {
@@ -557,7 +557,7 @@ Format characters in the format string for binary log messages
 	{ LOG_ATTITUDE_MSG, sizeof(log_Attitude),\
       "ATT", "IccccCCCC", "TimeMS,DesRoll,Roll,DesPitch,Pitch,DesYaw,Yaw,ErrRP,ErrYaw" }, \
     { LOG_COMPASS_MSG, sizeof(log_Compass), \
-      "MAG", "IhhhhhhhhhB",    "TimeMS,MagX,MagY,MagZ,OfsX,OfsY,OfsZ,MOfsX,MOfsY,MOfsZ,Prim" }, \
+      "MAG", "IhhhhhhhhhB",    "TimeMS,MagX,MagY,MagZ,OfsX,OfsY,OfsZ,MOfsX,MOfsY,MOfsZ,Health" }, \
     { LOG_MODE_MSG, sizeof(log_Mode), \
       "MODE", "IMB",         "TimeMS,Mode,ModeNum" }
 
@@ -608,9 +608,9 @@ Format characters in the format string for binary log messages
     { LOG_EKF5_MSG, sizeof(log_EKF5), \
       "EKF5","IBhhhcccCC","TimeMS,normInnov,FIX,FIY,AFI,HAGL,offset,RI,meaRng,errHAGL" }, \
     { LOG_COMPASS2_MSG, sizeof(log_Compass), \
-      "MAG2","IhhhhhhhhhB",    "TimeMS,MagX,MagY,MagZ,OfsX,OfsY,OfsZ,MOfsX,MOfsY,MOfsZ,Prim" }, \
+      "MAG2","IhhhhhhhhhB",    "TimeMS,MagX,MagY,MagZ,OfsX,OfsY,OfsZ,MOfsX,MOfsY,MOfsZ,Health" }, \
     { LOG_COMPASS3_MSG, sizeof(log_Compass), \
-      "MAG3","IhhhhhhhhhB",    "TimeMS,MagX,MagY,MagZ,OfsX,OfsY,OfsZ,MOfsX,MOfsY,MOfsZ,Prim" } \
+      "MAG3","IhhhhhhhhhB",    "TimeMS,MagX,MagY,MagZ,OfsX,OfsY,OfsZ,MOfsX,MOfsY,MOfsZ,Health" } \
 
 #if HAL_CPU_CLASS >= HAL_CPU_CLASS_75
 #define LOG_COMMON_STRUCTURES LOG_BASE_STRUCTURES, LOG_EXTRA_STRUCTURES

--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -425,6 +425,7 @@ struct PACKED log_Compass {
     int16_t  motor_offset_x;
     int16_t  motor_offset_y;
     int16_t  motor_offset_z;
+    uint8_t  primary;
 };
 
 struct PACKED log_Mode {
@@ -556,7 +557,7 @@ Format characters in the format string for binary log messages
 	{ LOG_ATTITUDE_MSG, sizeof(log_Attitude),\
       "ATT", "IccccCCCC", "TimeMS,DesRoll,Roll,DesPitch,Pitch,DesYaw,Yaw,ErrRP,ErrYaw" }, \
     { LOG_COMPASS_MSG, sizeof(log_Compass), \
-      "MAG", "Ihhhhhhhhh",    "TimeMS,MagX,MagY,MagZ,OfsX,OfsY,OfsZ,MOfsX,MOfsY,MOfsZ" }, \
+      "MAG", "IhhhhhhhhhB",    "TimeMS,MagX,MagY,MagZ,OfsX,OfsY,OfsZ,MOfsX,MOfsY,MOfsZ,Prim" }, \
     { LOG_MODE_MSG, sizeof(log_Mode), \
       "MODE", "IMB",         "TimeMS,Mode,ModeNum" }
 
@@ -607,9 +608,9 @@ Format characters in the format string for binary log messages
     { LOG_EKF5_MSG, sizeof(log_EKF5), \
       "EKF5","IBhhhcccCC","TimeMS,normInnov,FIX,FIY,AFI,HAGL,offset,RI,meaRng,errHAGL" }, \
     { LOG_COMPASS2_MSG, sizeof(log_Compass), \
-      "MAG2","Ihhhhhhhhh",    "TimeMS,MagX,MagY,MagZ,OfsX,OfsY,OfsZ,MOfsX,MOfsY,MOfsZ" }, \
+      "MAG2","IhhhhhhhhhB",    "TimeMS,MagX,MagY,MagZ,OfsX,OfsY,OfsZ,MOfsX,MOfsY,MOfsZ,Prim" }, \
     { LOG_COMPASS3_MSG, sizeof(log_Compass), \
-      "MAG3","Ihhhhhhhhh",    "TimeMS,MagX,MagY,MagZ,OfsX,OfsY,OfsZ,MOfsX,MOfsY,MOfsZ" } \
+      "MAG3","IhhhhhhhhhB",    "TimeMS,MagX,MagY,MagZ,OfsX,OfsY,OfsZ,MOfsX,MOfsY,MOfsZ,Prim" } \
 
 #if HAL_CPU_CLASS >= HAL_CPU_CLASS_75
 #define LOG_COMMON_STRUCTURES LOG_BASE_STRUCTURES, LOG_EXTRA_STRUCTURES

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -1163,7 +1163,7 @@ void DataFlash_Class::Log_Write_Compass(const Compass &compass)
         motor_offset_x  : (int16_t)mag_motor_offsets.x,
         motor_offset_y  : (int16_t)mag_motor_offsets.y,
         motor_offset_z  : (int16_t)mag_motor_offsets.z,
-        primary         : (uint8_t)compass.get_primary()
+        health          : (uint8_t)compass.healthy(0)
     };
     WriteBlock(&pkt, sizeof(pkt));
     
@@ -1184,7 +1184,7 @@ void DataFlash_Class::Log_Write_Compass(const Compass &compass)
             motor_offset_x  : (int16_t)mag_motor_offsets2.x,
             motor_offset_y  : (int16_t)mag_motor_offsets2.y,
             motor_offset_z  : (int16_t)mag_motor_offsets2.z,
-            primary         : (uint8_t)compass.get_primary()
+            health          : (uint8_t)compass.healthy(1)
         };
         WriteBlock(&pkt2, sizeof(pkt2));
     }
@@ -1206,7 +1206,7 @@ void DataFlash_Class::Log_Write_Compass(const Compass &compass)
             motor_offset_x  : (int16_t)mag_motor_offsets3.x,
             motor_offset_y  : (int16_t)mag_motor_offsets3.y,
             motor_offset_z  : (int16_t)mag_motor_offsets3.z,
-            primary         : (uint8_t)compass.get_primary()
+            health          : (uint8_t)compass.healthy(2)
         };
         WriteBlock(&pkt3, sizeof(pkt3));
     }

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -1162,7 +1162,8 @@ void DataFlash_Class::Log_Write_Compass(const Compass &compass)
         offset_z        : (int16_t)mag_offsets.z,
         motor_offset_x  : (int16_t)mag_motor_offsets.x,
         motor_offset_y  : (int16_t)mag_motor_offsets.y,
-        motor_offset_z  : (int16_t)mag_motor_offsets.z
+        motor_offset_z  : (int16_t)mag_motor_offsets.z,
+        primary         : (uint8_t)compass.get_primary()
     };
     WriteBlock(&pkt, sizeof(pkt));
     
@@ -1182,7 +1183,8 @@ void DataFlash_Class::Log_Write_Compass(const Compass &compass)
             offset_z        : (int16_t)mag_offsets2.z,
             motor_offset_x  : (int16_t)mag_motor_offsets2.x,
             motor_offset_y  : (int16_t)mag_motor_offsets2.y,
-            motor_offset_z  : (int16_t)mag_motor_offsets2.z
+            motor_offset_z  : (int16_t)mag_motor_offsets2.z,
+            primary         : (uint8_t)compass.get_primary()
         };
         WriteBlock(&pkt2, sizeof(pkt2));
     }
@@ -1203,7 +1205,8 @@ void DataFlash_Class::Log_Write_Compass(const Compass &compass)
             offset_z        : (int16_t)mag_offsets3.z,
             motor_offset_x  : (int16_t)mag_motor_offsets3.x,
             motor_offset_y  : (int16_t)mag_motor_offsets3.y,
-            motor_offset_z  : (int16_t)mag_motor_offsets3.z
+            motor_offset_z  : (int16_t)mag_motor_offsets3.z,
+            primary         : (uint8_t)compass.get_primary()
         };
         WriteBlock(&pkt3, sizeof(pkt3));
     }


### PR DESCRIPTION
The compass code (on Pixhawk at least) will fallback to a "healthy"
compass if the primary compass is deemed unhealthy (can't get a reading
for 0.2s on Pixhawk). Unfortunately it's currently not clear when this
is happening and if the compass outputs are significantly different in
flight can lead to unexplained yaw errors as the compass heading used will jump around as
the vehicle switches between compasses. This patch simply logs the
primary compass to the dataflash logs allowing easy diagnosis. The picture attached shows the output
using my faulty compass. I'm pretty sure this functionality would be useful, not only for faulty compasses, but for faulty connections to the compass affected by vibration.
I created this patch because I was having a hard time convincing 3DR that my compass was faulty,
this log output makes it all very clear :)
This patch is very safe as it is only a logging change. I considered logging other metrics of compass health, but just knowing which compass was being used at any time seemed like the most obvious.
![log_primary](https://cloud.githubusercontent.com/assets/2893260/7215740/7be00fa0-e5dc-11e4-977c-ee17941860fe.jpg)
