### PR TITLE
send do-digicam-control and do-digicam-configure to components

### DIFF
--- a/APMrover2/GCS_Mavlink.pde
+++ b/APMrover2/GCS_Mavlink.pde
@@ -1154,6 +1154,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
     case MAVLINK_MSG_ID_DIGICAM_CONTROL:
     {
         camera.control_msg(msg);
+        log_picture();
         break;
     }
 #endif // CAMERA == ENABLED

--- a/APMrover2/GCS_Mavlink.pde
+++ b/APMrover2/GCS_Mavlink.pde
@@ -1147,7 +1147,6 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
 #if CAMERA == ENABLED
     case MAVLINK_MSG_ID_DIGICAM_CONFIGURE:
     {
-        camera.configure_msg(msg);
         break;
     }
 

--- a/APMrover2/commands_logic.pde
+++ b/APMrover2/commands_logic.pde
@@ -7,6 +7,10 @@ static void do_within_distance(const AP_Mission::Mission_Command& cmd);
 static void do_change_speed(const AP_Mission::Mission_Command& cmd);
 static void do_set_home(const AP_Mission::Mission_Command& cmd);
 static bool verify_nav_wp(const AP_Mission::Mission_Command& cmd);
+#if CAMERA == ENABLED
+static void do_digicam_configure(const AP_Mission::Mission_Command& cmd);
+static void do_digicam_control(const AP_Mission::Mission_Command& cmd);
+#endif
 
 /********************************************************************************/
 // Command Event Handlers
@@ -79,10 +83,11 @@ start_command(const AP_Mission::Mission_Command& cmd)
             break;
 
         case MAV_CMD_DO_DIGICAM_CONFIGURE:                  // Mission command to configure an on-board camera controller system. |Modes: P, TV, AV, M, Etc| Shutter speed: Divisor number for one second| Aperture: F stop number| ISO number e.g. 80, 100, 200, Etc| Exposure type enumerator| Command Identity| Main engine cut-off time before camera trigger in seconds/10 (0 means no cut-off)|
+            do_digicam_configure(cmd);
             break;
 
         case MAV_CMD_DO_DIGICAM_CONTROL:                    // Mission command to control an on-board camera controller system. |Session control e.g. show/hide lens| Zoom's absolute position| Zooming step value to offset zoom from the current position| Focus Locking, Unlocking or Re-locking| Shooting Command| Command Identity| Empty|
-            do_take_picture();
+            do_digicam_control(cmd);
             break;
 
         case MAV_CMD_DO_SET_CAM_TRIGG_DIST:
@@ -295,14 +300,37 @@ static void do_set_home(const AP_Mission::Mission_Command& cmd)
 	}
 }
 
+// do_digicam_configure Send Digicam Configure message with the camera library
+static void do_digicam_configure(const AP_Mission::Mission_Command& cmd)
+{
+#if CAMERA == ENABLED
+    camera.configure_cmd(cmd);
+#endif
+}
+
+// do_digicam_control Send Digicam Control message with the camera library
+static void do_digicam_control(const AP_Mission::Mission_Command& cmd)
+{
+#if CAMERA == ENABLED
+    camera.control_cmd(cmd);
+    log_picture();
+#endif
+}
+
 // do_take_picture - take a picture with the camera library
 static void do_take_picture()
 {
 #if CAMERA == ENABLED
-    camera.trigger_pic();
+    camera.trigger_pic(true);
+    log_picture();
+#endif
+}
+
+// log_picture - log picture taken and send feedback to GCS
+static void log_picture()
+{
     gcs_send_message(MSG_CAMERA_FEEDBACK);
     if (should_log(MASK_LOG_CAMERA)) {
         DataFlash.Log_Write_Camera(ahrs, gps, current_loc);
     }
-#endif
 }

--- a/ArduCopter/GCS_Mavlink.pde
+++ b/ArduCopter/GCS_Mavlink.pde
@@ -1517,7 +1517,8 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
         break;
 
     case MAVLINK_MSG_ID_DIGICAM_CONTROL:
-        do_take_picture();
+        camera.control_msg(msg);
+        log_picture();
         break;
 #endif // CAMERA == ENABLED
 

--- a/ArduPlane/GCS_Mavlink.pde
+++ b/ArduPlane/GCS_Mavlink.pde
@@ -1544,7 +1544,8 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
 
     case MAVLINK_MSG_ID_DIGICAM_CONTROL:
     {
-        do_take_picture();
+        camera.control_msg(msg);
+        log_picture();
         break;
     }
 #endif // CAMERA == ENABLED

--- a/ArduPlane/commands_logic.pde
+++ b/ArduPlane/commands_logic.pde
@@ -14,6 +14,10 @@ static void do_change_speed(const AP_Mission::Mission_Command& cmd);
 static void do_set_home(const AP_Mission::Mission_Command& cmd);
 static void do_continue_and_change_alt(const AP_Mission::Mission_Command& cmd);
 static bool verify_nav_wp(const AP_Mission::Mission_Command& cmd);
+#if CAMERA == ENABLED
+static void do_digicam_configure(const AP_Mission::Mission_Command& cmd);
+static void do_digicam_control(const AP_Mission::Mission_Command& cmd);
+#endif
 
 
 /********************************************************************************/
@@ -152,10 +156,12 @@ start_command(const AP_Mission::Mission_Command& cmd)
         break;
 
     case MAV_CMD_DO_DIGICAM_CONFIGURE:                  // Mission command to configure an on-board camera controller system. |Modes: P, TV, AV, M, Etc| Shutter speed: Divisor number for one second| Aperture: F stop number| ISO number e.g. 80, 100, 200, Etc| Exposure type enumerator| Command Identity| Main engine cut-off time before camera trigger in seconds/10 (0 means no cut-off)|
+        do_digicam_configure(cmd);
         break;
 
     case MAV_CMD_DO_DIGICAM_CONTROL:                    // Mission command to control an on-board camera controller system. |Session control e.g. show/hide lens| Zoom's absolute position| Zooming step value to offset zoom from the current position| Focus Locking, Unlocking or Re-locking| Shooting Command| Command Identity| Empty|
-        do_take_picture();
+        // do_digicam_control Send Digicam Control message with the camera library
+        do_digicam_control(cmd);
         break;
 
     case MAV_CMD_DO_SET_CAM_TRIGG_DIST:
@@ -650,16 +656,39 @@ static void do_set_home(const AP_Mission::Mission_Command& cmd)
     }
 }
 
+// do_digicam_configure Send Digicam Configure message with the camera library
+static void do_digicam_configure(const AP_Mission::Mission_Command& cmd)
+{
+#if CAMERA == ENABLED
+    camera.configure_cmd(cmd);
+#endif
+}
+
+// do_digicam_control Send Digicam Control message with the camera library
+static void do_digicam_control(const AP_Mission::Mission_Command& cmd)
+{
+#if CAMERA == ENABLED
+    camera.control_cmd(cmd);
+    log_picture();
+#endif
+}
+
 // do_take_picture - take a picture with the camera library
 static void do_take_picture()
 {
 #if CAMERA == ENABLED
-    camera.trigger_pic();
+    camera.trigger_pic(true);
+    log_picture();
+#endif
+}
+
+// log_picture - log picture taken and send feedback to GCS
+static void log_picture()
+{
     gcs_send_message(MSG_CAMERA_FEEDBACK);
     if (should_log(MASK_LOG_CAMERA)) {
         DataFlash.Log_Write_Camera(ahrs, gps, current_loc);
     }
-#endif
 }
 
 // start_command_callback - callback function called from ap-mission when it begins a new mission command

--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -200,6 +200,9 @@ void AP_Camera::configure_cmd(const AP_Mission::Mission_Command& cmd)
 
 void AP_Camera::control_cmd(const AP_Mission::Mission_Command& cmd)
 {
+    // take picture
+    trigger_pic(false);
+
     mavlink_message_t msg;
     mavlink_command_long_t mav_cmd_long = {};
 

--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -74,8 +74,9 @@ AP_Camera::relay_pic()
 }
 
 /// single entry point to take pictures
+///  set send_mavlink_msg to true to send DO_DIGICAM_CONTROL message to all components
 void
-AP_Camera::trigger_pic()
+AP_Camera::trigger_pic(bool send_mavlink_msg)
 {
     _image_index++;
     switch (_trigger_type)
@@ -86,6 +87,20 @@ AP_Camera::trigger_pic()
     case AP_CAMERA_TRIGGER_TYPE_RELAY:
         relay_pic();                    // basic relay activation
         break;
+    }
+
+    if (send_mavlink_msg) {
+        // create command long mavlink message
+        mavlink_command_long_t cmd_msg;
+        memset(&cmd_msg, 0, sizeof(cmd_msg));
+        cmd_msg.command = MAV_CMD_DO_DIGICAM_CONTROL;
+
+        // create message
+        mavlink_message_t msg;
+        mavlink_msg_command_long_encode(0, 0, &msg, &cmd_msg);
+
+        // forward to all components
+        GCS_MAVLINK::send_to_components(&msg);
     }
 }
 
@@ -150,7 +165,7 @@ AP_Camera::control_msg(mavlink_message_t* msg)
      */
     if (packet.shot)
     {
-        trigger_pic();
+        trigger_pic(false);
     }
 }
 

--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -123,27 +123,6 @@ AP_Camera::trigger_pic_cleanup()
     }
 }
 
-/// decode MavLink that configures camera
-void
-AP_Camera::configure_msg(mavlink_message_t* msg)
-{
-    __mavlink_digicam_configure_t packet;
-    mavlink_msg_digicam_configure_decode(msg, &packet);
-    // This values may or not be used by APM
-    // They are bypassed as "echo" to a external specialized board
-    /*
-     *  packet.aperture
-     *  packet.command_id
-     *  packet.engine_cut_off
-     *  packet.exposure_type
-     *  packet.extra_param
-     *  packet.extra_value
-     *  packet.iso
-     *  packet.mode
-     *  packet.shutter_speed
-     */
-}
-
 /// decode MavLink that controls camera
 void
 AP_Camera::control_msg(mavlink_message_t* msg)

--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -169,6 +169,35 @@ AP_Camera::control_msg(mavlink_message_t* msg)
     }
 }
 
+// Mission command processing
+void AP_Camera::configure_cmd(AP_Mission::Mission_Command& cmd)
+{
+    mavlink_mission_item_t mav_cmd = {};
+
+    // convert command to mavlink message
+    if (AP_Mission::mission_cmd_to_mavlink(cmd, mav_cmd)) {
+        // convert mission item to mavlink message
+        // convert mission item to mavlink message
+        mavlink_message_t msg;
+        mavlink_msg_mission_item_encode(0, 0, &msg, &mav_cmd);
+        // send to all components
+        GCS_MAVLINK::send_to_components(&msg);
+    }
+}
+
+void AP_Camera::control_cmd(AP_Mission::Mission_Command& cmd)
+{
+    mavlink_mission_item_t mav_cmd = {};
+
+    // convert command to mavlink mission item
+    if (AP_Mission::mission_cmd_to_mavlink(cmd, mav_cmd)) {
+        // convert mission item to mavlink message
+        mavlink_message_t msg;
+        mavlink_msg_mission_item_encode(0, 0, &msg, &mav_cmd);
+        // send to all components
+        GCS_MAVLINK::send_to_components(&msg);
+    }
+}
 
 /*
   Send camera feedback to the GCS

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -13,6 +13,7 @@
 #include <AP_Relay.h>
 #include <AP_GPS.h>
 #include <AP_AHRS.h>
+#include <AP_Mission.h>
 
 #define AP_CAMERA_TRIGGER_TYPE_SERVO                0
 #define AP_CAMERA_TRIGGER_TYPE_RELAY                1
@@ -51,6 +52,10 @@ public:
     void            configure_msg(mavlink_message_t* msg);
     void            control_msg(mavlink_message_t* msg);
     void            send_feedback(mavlink_channel_t chan, AP_GPS &gps, const AP_AHRS &ahrs, const Location &current_loc);
+
+    // Mission command processing
+    void            configure_cmd(AP_Mission::Mission_Command& cmd);
+    void            control_cmd(AP_Mission::Mission_Command& cmd);
 
     // set camera trigger distance in a mission
     void            set_trigger_distance(uint32_t distance_m) { _trigg_dist.set(distance_m); }

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -49,7 +49,6 @@ public:
     void            trigger_pic_cleanup();
 
     // MAVLink methods
-    void            configure_msg(mavlink_message_t* msg);
     void            control_msg(mavlink_message_t* msg);
     void            send_feedback(mavlink_channel_t chan, AP_GPS &gps, const AP_AHRS &ahrs, const Location &current_loc);
 

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -54,8 +54,8 @@ public:
     void            send_feedback(mavlink_channel_t chan, AP_GPS &gps, const AP_AHRS &ahrs, const Location &current_loc);
 
     // Mission command processing
-    void            configure_cmd(AP_Mission::Mission_Command& cmd);
-    void            control_cmd(AP_Mission::Mission_Command& cmd);
+    void            configure_cmd(const AP_Mission::Mission_Command& cmd);
+    void            control_cmd(const AP_Mission::Mission_Command& cmd);
 
     // set camera trigger distance in a mission
     void            set_trigger_distance(uint32_t distance_m) { _trigg_dist.set(distance_m); }

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -9,6 +9,7 @@
 #include <AP_Param.h>
 #include <AP_Common.h>
 #include <GCS_MAVLink.h>
+#include <GCS.h>
 #include <AP_Relay.h>
 #include <AP_GPS.h>
 #include <AP_AHRS.h>
@@ -39,7 +40,8 @@ public:
     }
 
     // single entry point to take pictures
-    void            trigger_pic();
+    //  set send_mavlink_msg to true to send DO_DIGICAM_CONTROL message to all components
+    void            trigger_pic(bool send_mavlink_msg);
 
     // de-activate the trigger after some delay, but without using a delay() function
     // should be called at 50hz from main program

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -603,8 +603,23 @@ bool AP_Mission::mavlink_to_mission_cmd(const mavlink_mission_item_t& packet, AP
         cmd.p1 = packet.param1;                         // 0 = no roi, 1 = next waypoint, 2 = waypoint number, 3 = fixed location, 4 = given target (not supported)
         break;
 
+    case MAV_CMD_DO_DIGICAM_CONFIGURE:                  // MAV ID: 202
+        cmd.content.digicam_configure.shooting_mode = packet.param1;
+        cmd.content.digicam_configure.shutter_speed = packet.param2;
+        cmd.content.digicam_configure.aperture = packet.param3;
+        cmd.content.digicam_configure.ISO = packet.param4;
+        cmd.content.digicam_configure.exposure_type = packet.x;
+        cmd.content.digicam_configure.cmd_id = packet.y;
+        cmd.content.digicam_configure.engine_cutoff_time = packet.z;
+        break;
+
     case MAV_CMD_DO_DIGICAM_CONTROL:                    // MAV ID: 203
-        // command takes no parameters
+        cmd.content.digicam_control.session = packet.param1;
+        cmd.content.digicam_control.zoom_pos = packet.param2;
+        cmd.content.digicam_control.zoom_step = packet.param3;
+        cmd.content.digicam_control.focus_lock = packet.param4;
+        cmd.content.digicam_control.shooting_cmd = packet.x;
+        cmd.content.digicam_control.cmd_id = packet.y;
         break;
 
     case MAV_CMD_DO_MOUNT_CONTROL:                      // MAV ID: 205
@@ -881,8 +896,23 @@ bool AP_Mission::mission_cmd_to_mavlink(const AP_Mission::Mission_Command& cmd, 
         packet.param1 = cmd.p1;                         // 0 = no roi, 1 = next waypoint, 2 = waypoint number, 3 = fixed location, 4 = given target (not supported)
         break;
 
+    case MAV_CMD_DO_DIGICAM_CONFIGURE:                  // MAV ID: 202
+        packet.param1 = cmd.content.digicam_configure.shooting_mode;
+        packet.param2 = cmd.content.digicam_configure.shutter_speed;
+        packet.param3 = cmd.content.digicam_configure.aperture;
+        packet.param4 = cmd.content.digicam_configure.ISO;
+        packet.x = cmd.content.digicam_configure.exposure_type;
+        packet.y = cmd.content.digicam_configure.cmd_id;
+        packet.z = cmd.content.digicam_configure.engine_cutoff_time;
+        break;
+
     case MAV_CMD_DO_DIGICAM_CONTROL:                    // MAV ID: 203
-        // these commands takes no parameters
+        packet.param1 = cmd.content.digicam_control.session;
+        packet.param2 = cmd.content.digicam_control.zoom_pos;
+        packet.param3 = cmd.content.digicam_control.zoom_step;
+        packet.param4 = cmd.content.digicam_control.focus_lock;
+        packet.x = cmd.content.digicam_control.shooting_cmd;
+        packet.y = cmd.content.digicam_control.cmd_id;
         break;
 
     case MAV_CMD_DO_MOUNT_CONTROL:                      // MAV ID: 205

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -113,6 +113,27 @@ public:
         float yaw;              // yaw angle (relative to vehicle heading) in degrees
     };
 
+    // digicam control command structure
+    struct PACKED Digicam_Configure {
+        uint8_t shooting_mode;  // ProgramAuto = 1, AV = 2, TV = 3, Man=4, IntelligentAuto=5, SuperiorAuto=6
+        uint16_t shutter_speed;
+        uint8_t aperture;       // F stop number * 10
+        uint16_t ISO;           // 80, 100, 200, etc
+        uint8_t exposure_type;
+        uint8_t cmd_id;
+        float engine_cutoff_time;   // seconds
+    };
+
+    // digicam control command structure
+    struct PACKED Digicam_Control {
+        uint8_t session;        // 1 = on, 0 = off
+        uint8_t zoom_pos;
+        uint8_t zoom_step;
+        uint8_t focus_lock;
+        uint8_t shooting_cmd;
+        uint8_t cmd_id;
+    };
+
     // set cam trigger distance command structure
     struct PACKED Cam_Trigg_Distance {
         float meters;           // distance
@@ -162,6 +183,12 @@ public:
 
         // mount control
         Mount_Control mount_control;
+
+        // camera configure
+        Digicam_Configure digicam_configure;
+
+        // camera control
+        Digicam_Control digicam_control;
 
         // cam trigg distance
         Cam_Trigg_Distance cam_trigg_dist;

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -149,6 +149,12 @@ public:
     */
     static void send_statustext_all(const prog_char_t *msg);
 
+    /*
+      send a MAVLink message to all components with this vehicle's system id
+      This is a no-op if no routes to components have been learned
+    */
+    static void send_to_components(const mavlink_message_t* msg) { routing.send_to_components(msg); }
+
 private:
     void        handleMessage(mavlink_message_t * msg);
 

--- a/libraries/GCS_MAVLink/MAVLink_routing.h
+++ b/libraries/GCS_MAVLink/MAVLink_routing.h
@@ -35,6 +35,12 @@ public:
     */
     bool check_and_forward(mavlink_channel_t in_channel, const mavlink_message_t* msg);
 
+    /*
+      send a MAVLink message to all components with this vehicle's system id
+      This is a no-op if no routes to components have been learned
+    */
+    void send_to_components(const mavlink_message_t* msg);
+
 private:
     // a simple linear routing table. We don't expect to have a lot of
     // routes, so a scalable structure isn't worthwhile yet.


### PR DESCRIPTION
These patches will send do-digicam-control and do-digicam-configure messages to the vehicle's components. This allows a MAVProxy enabled camera controller to be activated during mission either manually by the pilot using the ch7/ch8 switches (copter only) or as part of a mission.

The situation in which the GCS sends the message is already handled by the existing mavlink routing/forwarding code.

This is a combination of commits by Randy and Jaime Machuca
