### PR TITLE
Copter: IMU full-rate logging LOG_BITMASK flag

### DIFF
--- a/ArduCopter/ArduCopter.pde
+++ b/ArduCopter/ArduCopter.pde
@@ -753,6 +753,7 @@ static const AP_Scheduler::Task scheduler_tasks[] PROGMEM = {
     { update_mount,          8,     45 },
     { ten_hz_logging_loop,  40,     30 },
     { fifty_hz_logging_loop, 8,     22 },
+    { full_rate_logging_loop, 1,     22 },
     { perf_update,        4000,     20 },
     { read_receiver_rssi,   40,      5 },
 #if FRSKY_TELEM_ENABLED == ENABLED
@@ -1076,6 +1077,15 @@ static void fifty_hz_logging_loop()
         DataFlash.Log_Write_IMU(ins);
     }
 #endif
+}
+
+// full_rate_logging_loop
+// should be run at the MAIN_LOOP_RATE
+static void full_rate_logging_loop()
+{
+    if (should_log(MASK_LOG_FULL_IMU)) {
+        DataFlash.Log_Write_IMU(ins);
+    }
 }
 
 // three_hz_loop - 3.3hz loop

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -261,6 +261,7 @@ enum FlipState {
 #define MASK_LOG_CAMERA                 (1<<15)
 #define MASK_LOG_WHEN_DISARMED          (1UL<<16)
 #define MASK_LOG_MOTBATT                (1UL<<17)
+#define MASK_LOG_FULL_IMU               (1UL<<18)
 #define MASK_LOG_ANY                    0xFFFF
 
 // DATA - event logging


### PR DESCRIPTION
Tridge thought this might be useful for using Replay to diagnose the EKF problem.  The existing IMU logging code logs at 1/8 the main loop rate - this patch adds an additional flag to log at the full rate.
