### PR TITLE
Faster and more accurate alignment of the EKF

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -476,7 +476,7 @@ AP_AHRS_DCM::drift_correction_yaw(void)
         _omega_I_sum.z += error_z * _ki_yaw * yaw_deltat;
     }
 
-    _error_yaw = 0.9f * _error_yaw + 0.1f * fabsf(yaw_error);
+    _error_yaw = 0.8f * _error_yaw + 0.2f * fabsf(yaw_error);
 }
 
 
@@ -736,7 +736,7 @@ AP_AHRS_DCM::drift_correction(float deltat)
         return;
     }
 
-    _error_rp = 0.9f * _error_rp + 0.1f * best_error;
+    _error_rp = 0.8f * _error_rp + 0.2f * best_error;
 
     // base the P gain on the spin rate
     float spin_rate = _omega.length();

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -78,7 +78,7 @@ void AP_AHRS_NavEKF::update(void)
     _dcm_attitude(roll, pitch, yaw);
 
     if (!ekf_started) {
-        // wait 10 seconds
+        // wait 1 second for DCM to output a valid tilt error estimate
         if (start_time_ms == 0) {
             start_time_ms = hal.scheduler->millis();
         }

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -38,7 +38,7 @@ public:
     AP_AHRS_DCM(ins, baro, gps),
         EKF(this, baro),
         ekf_started(false),
-        startup_delay_ms(10000),
+        startup_delay_ms(1000),
         start_time_ms(0)
         {
         }

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -450,8 +450,8 @@ bool NavEKF::healthy(void) const
         // extremely unhealthy.
         return false;
     }
-    // Give the filter 10 seconds to settle before use
-    if ((imuSampleTime_ms - ekfStartTime_ms) < 10000) {
+    // Give the filter a second to settle before use
+    if ((imuSampleTime_ms - ekfStartTime_ms) < 1000 ) {
         return false;
     }
     // barometer innovations must be within limits when on-ground
@@ -534,6 +534,11 @@ bool NavEKF::InitialiseFilterDynamic(void)
 
     // If we are a plane and don't have GPS lock then don't initialise
     if (assume_zero_sideslip() && _ahrs->get_gps().status() < AP_GPS::GPS_OK_FIX_3D) {
+        return false;
+    }
+
+    // If the DCM solution has not converged, then don't initialise
+    if (_ahrs->get_error_rp() > 0.02f) {
         return false;
     }
 
@@ -4742,7 +4747,7 @@ void NavEKF::performArmingChecks()
 {
     // determine vehicle arm status and don't allow filter to arm until it has been running for long enough to stabilise
     prevVehicleArmed = vehicleArmed;
-    vehicleArmed = (getVehicleArmStatus() && (imuSampleTime_ms - ekfStartTime_ms) > 10000);
+    vehicleArmed = (getVehicleArmStatus() && (imuSampleTime_ms - ekfStartTime_ms) > 1000);
 
     // check to see if arm status has changed and reset states if it has
     if (vehicleArmed != prevVehicleArmed) {


### PR DESCRIPTION
This replaces the current fixed 10 second delay from DCM startup to EKF alignment with a check that uses the reported DCM roll/pitch accuracy .

It also fixes a bug in the reported DCM roll/pitch accuracy that causes it to report good accuracy when the solution is inverted.