### PR TITLE
adds logging for CH6 parameter tuning

### DIFF
--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -243,6 +243,7 @@ enum FlipState {
 #define LOG_AUTOTUNEDETAILS_MSG         0x1A
 #define LOG_RATE_MSG                    0x1D
 #define LOG_MOTBATT_MSG                 0x1E
+#define LOG_PARAMTUNE_MSG               0x1F
 
 #define MASK_LOG_ATTITUDE_FAST          (1<<0)
 #define MASK_LOG_ATTITUDE_MED           (1<<1)

--- a/ArduCopter/tuning.pde
+++ b/ArduCopter/tuning.pde
@@ -17,6 +17,8 @@ static void tuning() {
     float tuning_value = (float)g.rc_6.control_in / 1000.0f;
     g.rc_6.set_range(g.radio_tuning_low,g.radio_tuning_high);
 
+    Log_Write_Parameter_Tuning(g.radio_tuning, tuning_value, g.rc_6.control_in, g.radio_tuning_low, g.radio_tuning_high);
+
     switch(g.radio_tuning) {
 
     // Roll, Pitch tuning


### PR DESCRIPTION
Logs CH6 tuning values to a new PTUN log struct, specific to
APM::Copter at this point

Tested, seems to work well.

This is a pre-cursor to some coax upper/lower motor mixing I'm about to submit -- you need to see the tuned parameters logged against current draw to see where the optimal mix is