### PR TITLE
Navio/AP_InertialSensor: Fixes a build problem with Navio/Linux builds, as ..

### DIFF
--- a/libraries/AP_InertialSensor/LSM9DS0/AP_InertialSensor_LSM9DS0.cpp
+++ b/libraries/AP_InertialSensor/LSM9DS0/AP_InertialSensor_LSM9DS0.cpp
@@ -20,7 +20,11 @@
 */
 
 #include <AP_HAL.h>
+
 #if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
+
+#if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_PXF || CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_ERLE || CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BBBMINI
+
 #include "AP_InertialSensor_LSM9DS0.h"
 #include "../AP_HAL_Linux/GPIO.h"
 
@@ -812,5 +816,7 @@ void AP_InertialSensor_LSM9DS0::_dump_registers(void)
 
 }
 #endif
+
+#endif // CONFIG_HAL_BOARD_SUBTYPE
 
 #endif // CONFIG_HAL_BOARD


### PR DESCRIPTION
.. this driver relies on a header definition for BBB boards, which gets not included if the NAVIO macro is set. Please check the header files for more info.

Signed-off-by: dgrat <dgdanielf@gmail.com>