### PR TITLE
Plane: Simplify landing flare criteria by removing redundant check

### DIFF
--- a/ArduPlane/landing.pde
+++ b/ArduPlane/landing.pde
@@ -53,7 +53,7 @@ static bool verify_land()
     if (height <= g.land_flare_alt ||
         height <= auto_state.land_sink_rate * aparm.land_flare_sec ||
         (!rangefinder_state.in_range && location_passed_point(current_loc, prev_WP_loc, next_WP_loc)) ||
-        (fabsf(auto_state.land_sink_rate) < 0.2f && !is_flying())) {
+        !is_flying()) {
 
         if (!auto_state.land_complete) {
             if (!is_flying() && (hal.scheduler->millis()-auto_state.last_flying_ms) > 3000) {


### PR DESCRIPTION
The flare !is_flying() check does not need a sink_rate check in verify_land() because it is already being done here:
https://github.com/diydrones/ardupilot/blob/master/ArduPlane/ArduPlane.pde#L1582
in determine_is_flying() which sets is_flying() so this is redundant.