### PR TITLE
AP_BoardConfig: add user-defined serial number

### DIFF
--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -78,6 +78,13 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] PROGMEM = {
 #elif CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
 #endif
 
+    // @Param: SERIAL_NUM
+    // @DisplayName: User-defined serial number
+    // @Description: User-defined serial number of this vehicle, it can be any arbitrary number you want and has no effect on the autopilot
+    // @Range: -2147483647 to 2147483648 (any 32bit signed number)
+    // @User: Standard
+    AP_GROUPINFO("SERIAL_NUM", 5, AP_BoardConfig, vehicleSerialNumber, 0),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -21,6 +21,8 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
+    AP_Int32 vehicleSerialNumber;
+
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4
     AP_Int8 _pwm_count;
     AP_Int8 _ser1_rtscts;


### PR DESCRIPTION
new param: BRD_SERIAL_NUM
// @Description: User-defined serial number of this vehicle, it can be any arbitrary number you want and has no effect on the autopilot
// @Range: -2147483647 to 2147483648 (any 32bit signed number)

Pretty straight forward, just an inert value that can be saved to the autopilot that is vehicle agnostic so you can have vehicle number 1,2,3 all easily detectable by the GCS. Is this gets into the Plane beta then it should probably sneak into copter beta so the GCSes can support it with both of the latest vehicle releases.

At a later time I'd like to add support for an arbitrary string instead of an INT32 so you can name your aircraft.