### PR TITLE
Ardu plane release - External LEDs and Buzzer

### DIFF
--- a/APMrover2/APMrover2.pde
+++ b/APMrover2/APMrover2.pde
@@ -542,8 +542,6 @@ void setup() {
     AP_Notify::flags.pre_arm_gps_check = true;
     AP_Notify::flags.failsafe_battery = false;
 
-    notify.init(false);
-
     battery.init();
 
     rssi_analog_source = hal.analogin->channel(ANALOG_INPUT_NONE);

--- a/APMrover2/system.pde
+++ b/APMrover2/system.pde
@@ -112,6 +112,17 @@ static void init_ardupilot()
 
     BoardConfig.init();
 
+	////////////////////////////////////////////////////////////////////////////////
+	// External LEDs & Buzzer
+	////////////////////////////////////////////////////////////////////////////////
+	bool external_ledbuzz = false;
+
+	if (BoardConfig._ext_ledbuzz.get() == 1) {
+		external_ledbuzz = true;
+	}
+
+	notify.init(external_ledbuzz);
+
     ServoRelayEvents.set_channel_mask(0xFFF0);
 
     set_control_channels();

--- a/ArduPlane/ArduPlane.pde
+++ b/ArduPlane/ArduPlane.pde
@@ -818,8 +818,6 @@ void setup() {
 
     AP_Notify::flags.failsafe_battery = false;
 
-    notify.init(false);
-
     rssi_analog_source = hal.analogin->channel(ANALOG_INPUT_NONE);
 
     init_ardupilot();

--- a/ArduPlane/system.pde
+++ b/ArduPlane/system.pde
@@ -95,6 +95,17 @@ static void init_ardupilot()
 
     BoardConfig.init();
 
+	////////////////////////////////////////////////////////////////////////////////
+	// External LEDs & Buzzer
+	////////////////////////////////////////////////////////////////////////////////
+	bool external_ledbuzz = false;
+
+	if (BoardConfig._ext_ledbuzz.get() == 1) {
+		external_ledbuzz = true;
+	}
+
+	notify.init(external_ledbuzz);
+
     // allow servo set on all channels except first 4
     ServoRelayEvents.set_channel_mask(0xFFF0);
 

--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -40,6 +40,10 @@
 
 #endif
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_APM2
+#define BOARD_EXT_LEDBUZZ_DEFAULT 0
+#endif
+
 extern const AP_HAL::HAL& hal;
 
 // table of user settable parameters
@@ -68,10 +72,19 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] PROGMEM = {
     // @Description: Disabling this option will disable the use of the safety switch on PX4 for arming. Use of the safety switch is highly recommended, so you should leave this option set to 1 except in unusual circumstances.
     // @Values: 0:Disabled,1:Enabled
     AP_GROUPINFO("SAFETYENABLE",   3, AP_BoardConfig, _safety_enable, 1),
+	AP_GROUPEND
 #elif CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
 #endif
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_APM2
+    // @Param: EXT_LEDBUZZ
+    // @DisplayName:  Enable use of external LEDs and buzzer
+    // @Description: Enabling this option will allow the use of the APM’s A4 - A7 pins to add external GPS and Arming LEDs and/or buzzer to your aircraft. A4: MotorLED, A5: Buzzer, A6: GPS LED (will flash with no GPS lock, solid with GPS lock), A7: Arming LED.
+    // @Values: 0:Disabled,1:Enabled
+    AP_GROUPINFO("EXT_LEDBUZZ",   0, AP_BoardConfig, _ext_ledbuzz, BOARD_EXT_LEDBUZZ_DEFAULT),
     AP_GROUPEND
+#endif
+    
 };
 
 void AP_BoardConfig::init()

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -19,6 +19,8 @@ public:
     void init(void);
 
     static const struct AP_Param::GroupInfo var_info[];
+	
+	AP_Int8 _ext_ledbuzz;
 
 private:
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4


### PR DESCRIPTION
Hi, I noticed a pull request from another user from a couple of months ago which added the ability to use external LEDs and buzzer in APM Plane, and APM Rover. There were some concerns with the solution and suggestions made on how best to add this feature. I followed the suggestions and present this as a solution for those of us who want this feature. 

It has been added as a board level parameter as suggested. There is one small issue, the description does not show in mission planner for the newly created parameter "BRD_EXT_LEDBUZZ", other than that everything is working as expected. If you could provide some guidance as to why the descripiton does not show in mission planner (The code appears to be formatted properly) I will make any changes required. 