### PR TITLE
SITL: add missing include 'select'

### DIFF
--- a/libraries/AP_HAL_AVR_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_AVR_SITL/UARTDriver.cpp
@@ -34,6 +34,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <sys/select.h>
 
 #include "UARTDriver.h"
 #include "SITL_State.h"


### PR DESCRIPTION
add extra missing include.
fixs issue on Cygwin x64