### PR TITLE
AP_AHRS: avoid FPE when we don't have a compass reading

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -271,6 +271,10 @@ AP_AHRS_DCM::yaw_error_compass(void)
     // get the mag vector in the earth frame
     Vector2f rb = _dcm_matrix.mulXY(mag);
 
+    if (rb.length() < FLT_EPSILON) {
+        return 0.0f;
+    }
+
     rb.normalize();
     if (rb.is_inf()) {
         // not a valid vector


### PR DESCRIPTION
This is an alternative to https://github.com/diydrones/ardupilot/pull/2215

It preserves existing behaviour in terms of return value, and properly uses FLT_EPSILON where the other doesn't.
