### PR TITLE
Compiler warnings

### DIFF
--- a/APMrover2/APMrover2.pde
+++ b/APMrover2/APMrover2.pde
@@ -828,7 +828,7 @@ static void update_current_mode(void)
 
         // and throttle gives speed in proportion to cruise speed, up
         // to 50% throttle, then uses nudging above that.
-        float target_speed = channel_throttle->pwm_to_angle() * 0.01 * 2 * g.speed_cruise;
+        float target_speed = channel_throttle->pwm_to_angle() * 0.01f * 2 * g.speed_cruise;
         set_reverse(target_speed < 0);
         if (in_reverse) {
             target_speed = constrain_float(target_speed, -g.speed_cruise, 0);

--- a/APMrover2/GCS_Mavlink.pde
+++ b/APMrover2/GCS_Mavlink.pde
@@ -869,7 +869,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
                 break;
 
             case MAV_CMD_PREFLIGHT_CALIBRATION:
-                if (packet.param1 == 1) {
+                if (AP_Math::is_equal(packet.param1,1.0f)) {
                     ins.init_gyro();
                     if (ins.gyro_calibrated_ok_all()) {
                         ahrs.reset_gyro_drift();
@@ -877,13 +877,13 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
                     } else {
                         result = MAV_RESULT_FAILED;
                     }
-                } else if (packet.param3 == 1) {
+                } else if (AP_Math::is_equal(packet.param3,1.0f)) {
                     init_barometer();
                     result = MAV_RESULT_ACCEPTED;
-                } else if (packet.param4 == 1) {
+                } else if (AP_Math::is_equal(packet.param4,1.0f)) {
                     trim_radio();
                     result = MAV_RESULT_ACCEPTED;
-                } else if (packet.param5 == 1) {
+                } else if (AP_Math::is_equal(packet.param5,1.0f)) {
                     float trim_roll, trim_pitch;
                     AP_InertialSensor_UserInteract_MAVLink interact(this);
                     if (g.skip_gyro_cal) {
@@ -905,12 +905,12 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
                 break;
 
             case MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS:
-                if (packet.param1 == 2) {
+                if (AP_Math::is_equal(packet.param1,2.0f)) {
                     // save first compass's offsets
                     compass.set_and_save_offsets(0, packet.param2, packet.param3, packet.param4);
                     result = MAV_RESULT_ACCEPTED;
                 }
-                if (packet.param1 == 5) {
+                if (AP_Math::is_equal(packet.param1,5.0f)) {
                     // save secondary compass's offsets
                     compass.set_and_save_offsets(1, packet.param2, packet.param3, packet.param4);
                     result = MAV_RESULT_ACCEPTED;
@@ -967,15 +967,15 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
             break;
 
         case MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN:
-            if (packet.param1 == 1 || packet.param1 == 3) {
+            if (AP_Math::is_equal(packet.param1,1.0f) || AP_Math::is_equal(packet.param1,3.0f)) {
                 // when packet.param1 == 3 we reboot to hold in bootloader
-                hal.scheduler->reboot(packet.param1 == 3);
+                hal.scheduler->reboot(AP_Math::is_equal(packet.param1,3.0f));
                 result = MAV_RESULT_ACCEPTED;
             }
             break;
 
         case MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES: {
-            if (packet.param1 == 1) {
+            if (AP_Math::is_equal(packet.param1,1.0f)) {
                 gcs[chan-MAVLINK_COMM_0].send_autopilot_version();
                 result = MAV_RESULT_ACCEPTED;
             }

--- a/APMrover2/GCS_Mavlink.pde
+++ b/APMrover2/GCS_Mavlink.pde
@@ -677,7 +677,7 @@ bool GCS_MAVLINK::stream_trigger(enum streams stream_num)
     // parameter sends
     if ((stream_num != STREAM_PARAMS) && 
         (waypoint_receiving || _queued_parameter != NULL)) {
-        rate *= 0.25;
+        rate *= 0.25f;
     }
 
     if (rate <= 0) {

--- a/APMrover2/Log.pde
+++ b/APMrover2/Log.pde
@@ -337,7 +337,7 @@ struct PACKED log_Sonar {
 static void Log_Write_Sonar()
 {
     uint16_t turn_time = 0;
-    if (obstacle.turn_angle != 0) {
+    if (!AP_Math::is_zero(obstacle.turn_angle)) {
         turn_time = hal.scheduler->millis() - obstacle.detected_time_ms;
     }
     struct log_Sonar pkt = {

--- a/APMrover2/Steering.pde
+++ b/APMrover2/Steering.pde
@@ -40,7 +40,7 @@ static bool auto_check_trigger(void)
         return true;
     }
 
-    if (g.auto_trigger_pin == -1 && g.auto_kickstart == 0.0f) {
+    if (g.auto_trigger_pin == -1 && AP_Math::is_zero(g.auto_kickstart)) {
         // no trigger configured - let's go!
         auto_triggered = true;
         return true;
@@ -52,10 +52,10 @@ static bool auto_check_trigger(void)
         return true;            
     }
 
-    if (g.auto_kickstart != 0.0f) {
+    if (!AP_Math::is_zero(g.auto_kickstart)) {
         float xaccel = ins.get_accel().x;
         if (xaccel >= g.auto_kickstart) {
-            gcs_send_text_fmt(PSTR("Triggered AUTO xaccel=%.1f"), xaccel);
+            gcs_send_text_fmt(PSTR("Triggered AUTO xaccel=%.1f"), (double)xaccel);
             auto_triggered = true;
             return true;            
         }
@@ -97,7 +97,7 @@ static void calc_throttle(float target_speed)
       SPEED_TURN_GAIN percentage.
     */
     float steer_rate = fabsf(lateral_acceleration / (g.turn_max_g*GRAVITY_MSS));
-    steer_rate = constrain_float(steer_rate, 0.0, 1.0);
+    steer_rate = constrain_float(steer_rate, 0.0f, 1.0f);
 
     // use g.speed_turn_gain for a 90 degree turn, and in proportion
     // for other turn angles
@@ -105,11 +105,11 @@ static void calc_throttle(float target_speed)
     float speed_turn_ratio = constrain_float(fabsf(turn_angle / 9000.0f), 0, 1);
     float speed_turn_reduction = (100 - g.speed_turn_gain) * speed_turn_ratio * 0.01f;
 
-    float reduction = 1.0 - steer_rate*speed_turn_reduction;
+    float reduction = 1.0f - steer_rate*speed_turn_reduction;
     
     if (control_mode >= AUTO && wp_distance <= g.speed_turn_dist) {
         // in auto-modes we reduce speed when approaching waypoints
-        float reduction2 = 1.0 - speed_turn_reduction;
+        float reduction2 = 1.0f - speed_turn_reduction;
         if (reduction2 < reduction) {
             reduction = reduction2;
         }
@@ -259,8 +259,8 @@ static void set_servos(void)
         */          
         float steering_scaled = channel_steer->norm_output();
         float throttle_scaled = channel_throttle->norm_output();
-        float motor1 = throttle_scaled + 0.5*steering_scaled;
-        float motor2 = throttle_scaled - 0.5*steering_scaled;
+        float motor1 = throttle_scaled + 0.5f*steering_scaled;
+        float motor2 = throttle_scaled - 0.5f*steering_scaled;
         channel_steer->servo_out = 4500*motor1;
         channel_throttle->servo_out = 100*motor2;
         channel_steer->calc_pwm();

--- a/APMrover2/commands_logic.pde
+++ b/APMrover2/commands_logic.pde
@@ -279,7 +279,7 @@ static void do_change_speed(const AP_Mission::Mission_Command& cmd)
 		case 0:
 			if (cmd.content.speed.target_ms > 0) {
 				g.speed_cruise.set(cmd.content.speed.target_ms);
-                gcs_send_text_fmt(PSTR("Cruise speed: %.1f m/s"), g.speed_cruise.get());
+                gcs_send_text_fmt(PSTR("Cruise speed: %.1f m/s"), (double)g.speed_cruise.get());
             }
 			break;
 	}

--- a/APMrover2/radio.pde
+++ b/APMrover2/radio.pde
@@ -54,7 +54,7 @@ static void read_radio()
 	channel_throttle->servo_out = channel_throttle->control_in;
 
 	if (abs(channel_throttle->servo_out) > 50) {
-        throttle_nudge = (g.throttle_max - g.throttle_cruise) * ((fabsf(channel_throttle->norm_input())-0.5) / 0.5);
+        throttle_nudge = (g.throttle_max - g.throttle_cruise) * ((fabsf(channel_throttle->norm_input())-0.5f) / 0.5f);
 	} else {
 		throttle_nudge = 0;
 	}

--- a/APMrover2/setup.pde
+++ b/APMrover2/setup.pde
@@ -510,7 +510,7 @@ static void report_compass()
 
 	// mag declination
 	cliSerial->printf_P(PSTR("Mag Declination: %4.4f\n"),
-							degrees(compass.get_declination()));
+							(double)degrees(compass.get_declination()));
 
 	Vector3f offsets = compass.get_offsets();
 

--- a/APMrover2/setup.pde
+++ b/APMrover2/setup.pde
@@ -88,7 +88,7 @@ setup_show(uint8_t argc, const Menu::arg *argv)
 				cliSerial->printf_P(PSTR("INT32 %s: %ld\n"), argv[1].str, (long)((AP_Int32 *)param)->get());
 				break;
 			case AP_PARAM_FLOAT:
-				cliSerial->printf_P(PSTR("FLOAT %s: %f\n"), argv[1].str, ((AP_Float *)param)->get());
+				cliSerial->printf_P(PSTR("FLOAT %s: %f\n"), argv[1].str, (double)((AP_Float *)param)->get());
 				break;
 			default:
 				cliSerial->printf_P(PSTR("Unhandled parameter type for %s: %d.\n"), argv[1].str, type);
@@ -516,9 +516,9 @@ static void report_compass()
 
 	// mag offsets
 	cliSerial->printf_P(PSTR("Mag offsets: %4.4f, %4.4f, %4.4f\n"),
-							offsets.x,
-							offsets.y,
-							offsets.z);
+                            (double)offsets.x,
+                            (double)offsets.y,
+                            (double)offsets.z);
 	print_blanks(2);
 }
 
@@ -542,9 +542,9 @@ static void
 print_PID(PID * pid)
 {
 	cliSerial->printf_P(PSTR("P: %4.3f, I:%4.3f, D:%4.3f, IMAX:%ld\n"),
-					pid->kP(),
-					pid->kI(),
-					pid->kD(),
+                    (double)pid->kP(),
+                    (double)pid->kI(),
+                    (double)pid->kD(),
 					(long)pid->imax());
 }
 

--- a/APMrover2/test.pde
+++ b/APMrover2/test.pde
@@ -369,8 +369,8 @@ test_ins(uint8_t argc, const Menu::arg *argv)
                             (int)ahrs.roll_sensor / 100,
                             (int)ahrs.pitch_sensor / 100,
                             (uint16_t)ahrs.yaw_sensor / 100,
-                            gyros.x, gyros.y, gyros.z,
-                            accels.x, accels.y, accels.z);
+                            (double)gyros.x, (double)gyros.y, (double)gyros.z,
+                            (double)accels.x, (double)accels.y, (double)accels.z);
         if(cliSerial->available() > 0){
             return (0);
         }
@@ -430,8 +430,8 @@ test_mag(uint8_t argc, const Menu::arg *argv)
                 const Vector3f mag = compass.get_field();
                 cliSerial->printf_P(PSTR("Heading: %ld, XYZ: %.0f, %.0f, %.0f,\tXYZoff: %6.2f, %6.2f, %6.2f\n"),
                                     (wrap_360_cd(ToDeg(heading) * 100)) /100,
-                                    mag.x, mag.y, mag.z,
-                                    mag_ofs.x, mag_ofs.y, mag_ofs.z);
+                                    (double)mag.x, (double)mag.y, (double)mag.z,
+                                    (double)mag_ofs.x, (double)mag_ofs.y, (double)mag_ofs.z);
             } else {
                 cliSerial->println_P(PSTR("compass not healthy"));
             }
@@ -502,14 +502,14 @@ test_sonar(uint8_t argc, const Menu::arg *argv)
 
         if (now - last_print >= 200) {
             cliSerial->printf_P(PSTR("sonar1 dist=%.1f:%.1fcm volt1=%.2f:%.2f   sonar2 dist=%.1f:%.1fcm volt2=%.2f:%.2f\n"), 
-                                sonar_dist_cm_min, 
-                                sonar_dist_cm_max, 
-                                voltage_min,
-                                voltage_max,
-                                sonar2_dist_cm_min, 
-                                sonar2_dist_cm_max, 
-                                voltage2_min,
-                                voltage2_max);
+                                (double)sonar_dist_cm_min,
+                                (double)sonar_dist_cm_max,
+                                (double)voltage_min,
+                                (double)voltage_max,
+                                (double)sonar2_dist_cm_min,
+                                (double)sonar2_dist_cm_max,
+                                (double)voltage2_min,
+                                (double)voltage2_max);
             voltage_min = voltage_max = 0.0f;
             voltage2_min = voltage2_max = 0.0f;
             sonar_dist_cm_min = sonar_dist_cm_max = 0.0f;

--- a/APMrover2/test.pde
+++ b/APMrover2/test.pde
@@ -480,7 +480,7 @@ test_sonar(uint8_t argc, const Menu::arg *argv)
     
         float dist_cm = sonar.distance_cm(0);
         float voltage = sonar.voltage_mv(0);
-        if (sonar_dist_cm_min == 0.0f) {
+        if (AP_Math::is_zero(sonar_dist_cm_min)) {
             sonar_dist_cm_min = dist_cm;
             voltage_min = voltage;
         }
@@ -491,7 +491,7 @@ test_sonar(uint8_t argc, const Menu::arg *argv)
 
         dist_cm = sonar.distance_cm(1);
         voltage = sonar.voltage_mv(1);
-        if (sonar2_dist_cm_min == 0.0f) {
+        if (AP_Math::is_zero(sonar2_dist_cm_min)) {
             sonar2_dist_cm_min = dist_cm;
             voltage2_min = voltage;
         }

--- a/AntennaTracker/GCS_Mavlink.pde
+++ b/AntennaTracker/GCS_Mavlink.pde
@@ -585,7 +585,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
             
             case MAV_CMD_PREFLIGHT_CALIBRATION:
             {
-                if (packet.param1 == 1) {
+                if (AP_Math::is_equal(packet.param1,1.0f)) {
                     ins.init_gyro();
                     if (ins.gyro_calibrated_ok_all()) {
                         ahrs.reset_gyro_drift();
@@ -594,16 +594,16 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
                         result = MAV_RESULT_FAILED;
                     }
                 } 
-                if (packet.param3 == 1) {
+                if (AP_Math::is_equal(packet.param3,1.0f)) {
                     init_barometer();
                     // zero the altitude difference on next baro update
                     nav_status.need_altitude_calibration = true;
                 }
-                if (packet.param4 == 1) {
+                if (AP_Math::is_equal(packet.param4,1.0f)) {
                     // Cant trim radio
                 }
 #if !defined( __AVR_ATmega1280__ )
-                else if (packet.param5 == 1) {
+                else if (AP_Math::is_equal(packet.param5,1.0f)) {
                     float trim_roll, trim_pitch;
                     AP_InertialSensor_UserInteract_MAVLink interact(this);
                     if(ins.calibrate_accel(&interact, trim_roll, trim_pitch)) {
@@ -618,10 +618,10 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
 
             case MAV_CMD_COMPONENT_ARM_DISARM:
                 if (packet.target_component == MAV_COMP_ID_SYSTEM_CONTROL) {
-                    if (packet.param1 == 1.0f) {
+                    if (AP_Math::is_equal(packet.param1,1.0f)) {
                         arm_servos();
                         result = MAV_RESULT_ACCEPTED;
-                    } else if (packet.param1 == 0.0f)  {
+                    } else if (AP_Math::is_zero(packet.param1))  {
                         disarm_servos();
                         result = MAV_RESULT_ACCEPTED;
                     } else {
@@ -665,16 +665,16 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
 
             case MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN:
             {
-                if (packet.param1 == 1 || packet.param1 == 3) {
+                if (AP_Math::is_equal(packet.param1,1.0f) || AP_Math::is_equal(packet.param1,3.0f)) {
                     // when packet.param1 == 3 we reboot to hold in bootloader
-                    hal.scheduler->reboot(packet.param1 == 3);
+                    hal.scheduler->reboot(AP_Math::is_equal(packet.param1,3.0f));
                     result = MAV_RESULT_ACCEPTED;
                 }
                 break;
             }
 
             case MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES: {
-                if (packet.param1 == 1) {
+                if (AP_Math::is_equal(packet.param1,1.0f)) {
                     gcs[chan-MAVLINK_COMM_0].send_autopilot_version();
                     result = MAV_RESULT_ACCEPTED;
                 }

--- a/AntennaTracker/GCS_Mavlink.pde
+++ b/AntennaTracker/GCS_Mavlink.pde
@@ -375,7 +375,7 @@ bool GCS_MAVLINK::stream_trigger(enum streams stream_num)
 
     // send at a much lower rate during parameter sends
     if (_queued_parameter != NULL) {
-        rate *= 0.25;
+        rate *= 0.25f;
     }
 
     if (rate <= 0) {

--- a/AntennaTracker/control_servo_test.pde
+++ b/AntennaTracker/control_servo_test.pde
@@ -5,16 +5,6 @@
  */
 
 /*
- * update_servo_test - runs the servo test controller
- *  called at 50hz while control_mode is 'SERVO_TEST' mode
- *  tracker switches into this mode if it ever receives a do-set-servo command from the GCS
- */
-static void update_servo_test(void)
-{
-    // do nothing
-}
-
-/*
  * servo_test_set_servo - sets the yaw or pitch servo pwm directly
  *  servo_num are 1 for yaw, 2 for pitch
  */

--- a/AntennaTracker/servos.pde
+++ b/AntennaTracker/servos.pde
@@ -234,7 +234,7 @@ static void update_yaw_position_servo(float yaw)
                           (int)slew_dir, (int)new_slew_dir,
                           (long)angle_err,
                           (long)channel_yaw.servo_out,
-                          degrees(ahrs.get_gyro().z));
+                          (double)degrees(ahrs.get_gyro().z));
     }
 
     slew_dir = new_slew_dir;

--- a/AntennaTracker/servos.pde
+++ b/AntennaTracker/servos.pde
@@ -52,7 +52,7 @@ static void update_pitch_position_servo(float pitch)
     // pitch argument is -90 to 90, where 0 is horizontal
     // servo_out is in 100ths of a degree
     float ahrs_pitch = ahrs.pitch_sensor*0.01f;
-    int32_t angle_err = -(ahrs_pitch - pitch) * 100.0;
+    int32_t angle_err = -(ahrs_pitch - pitch) * 100.0f;
     int32_t pitch_limit_cd = g.pitch_range*100/2;
     // Need to configure your servo so that increasing servo_out causes increase in pitch/elevation (ie pointing higher into the sky,
     // above the horizon. On my antenna tracker this requires the pitch/elevation servo to be reversed

--- a/ArduCopter/Attitude.pde
+++ b/ArduCopter/Attitude.pde
@@ -82,7 +82,7 @@ static float get_look_ahead_yaw()
 static void update_thr_average()
 {
     // ensure throttle_average has been initialised
-    if( throttle_average == 0 ) {
+    if( AP_Math::is_zero(throttle_average) ) {
         throttle_average = g.throttle_mid;
         // update position controller
         pos_control.set_throttle_hover(throttle_average);

--- a/ArduCopter/GCS_Mavlink.pde
+++ b/ArduCopter/GCS_Mavlink.pde
@@ -1114,7 +1114,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
             // param6 : longitude
             // param7 : altitude (absolute)
             result = MAV_RESULT_FAILED; // assume failure
-            if(AP_Math::is_equal(packet.param1,1.0f) || AP_Math::is_zero(packet.param5) && AP_Math::is_zero(packet.param6) && AP_Math::is_zero(packet.param7)) {
+            if(AP_Math::is_equal(packet.param1,1.0f) || (AP_Math::is_zero(packet.param5) && AP_Math::is_zero(packet.param6) && AP_Math::is_zero(packet.param7))) {
                 if (set_home_to_current_location_and_lock()) {
                     result = MAV_RESULT_ACCEPTED;
                 }

--- a/ArduCopter/commands_logic.pde
+++ b/ArduCopter/commands_logic.pde
@@ -684,7 +684,7 @@ static bool verify_circle(const AP_Mission::Mission_Command& cmd)
             Vector3f circle_center = pv_location_to_vector(cmd.content.location);
 
             // set target altitude if not provided
-            if (circle_center.z == 0) {
+            if (AP_Math::is_zero(circle_center.z)) {
                 circle_center.z = curr_pos.z;
             }
 

--- a/ArduCopter/commands_logic.pde
+++ b/ArduCopter/commands_logic.pde
@@ -701,7 +701,7 @@ static bool verify_circle(const AP_Mission::Mission_Command& cmd)
     }
 
     // check if we have completed circling
-    return fabsf(circle_nav.get_angle_total()/(2*M_PI)) >= (float)LOWBYTE(cmd.p1);
+    return fabsf(circle_nav.get_angle_total()/(float)(2*M_PI)) >= LOWBYTE(cmd.p1);
 }
 
 // externs to remove compiler warning

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -156,7 +156,7 @@
 #endif
 
 #ifndef SONAR_GAIN_DEFAULT
- # define SONAR_GAIN_DEFAULT 0.8            // gain for controlling how quickly sonar range adjusts target altitude (lower means slower reaction)
+ # define SONAR_GAIN_DEFAULT 0.8f           // gain for controlling how quickly sonar range adjusts target altitude (lower means slower reaction)
 #endif
 
 #ifndef THR_SURFACE_TRACKING_VELZ_MAX
@@ -287,7 +287,7 @@
 
 // arming check's maximum acceptable vector difference between internal and external compass after vectors are normalized to field length of 1.0
 #ifndef COMPASS_ACCEPTABLE_VECTOR_DIFF
-  #define COMPASS_ACCEPTABLE_VECTOR_DIFF    0.75    // pre arm compass check will fail if internal vs external compass direction differ by more than 45 degrees
+  #define COMPASS_ACCEPTABLE_VECTOR_DIFF    0.75f    // pre arm compass check will fail if internal vs external compass direction differ by more than 45 degrees
  #endif
 
 //////////////////////////////////////////////////////////////////////////////

--- a/ArduCopter/control_auto.pde
+++ b/ArduCopter/control_auto.pde
@@ -171,7 +171,7 @@ static void auto_wp_run()
     if (!failsafe.radio) {
         // get pilot's desired yaw rate
         target_yaw_rate = get_pilot_desired_yaw_rate(g.rc_4.control_in);
-        if (target_yaw_rate != 0) {
+        if (!AP_Math::is_zero(target_yaw_rate)) {
             set_auto_yaw_mode(AUTO_YAW_HOLD);
         }
     }
@@ -227,7 +227,7 @@ static void auto_spline_run()
     if (!failsafe.radio) {
         // get pilot's desired yaw rate
         target_yaw_rate = get_pilot_desired_yaw_rate(g.rc_4.control_in);
-        if (target_yaw_rate != 0) {
+        if (!AP_Math::is_zero(target_yaw_rate)) {
             set_auto_yaw_mode(AUTO_YAW_HOLD);
         }
     }
@@ -550,7 +550,7 @@ static void set_auto_yaw_look_at_heading(float angle_deg, float turn_rate_dps, i
     }
 
     // get turn speed
-    if (turn_rate_dps == 0 ) {
+    if (AP_Math::is_zero(turn_rate_dps)) {
         // default to regular auto slew rate
         yaw_look_at_heading_slew = AUTO_YAW_SLEW_RATE;
     }else{

--- a/ArduCopter/control_autotune.pde
+++ b/ArduCopter/control_autotune.pde
@@ -295,7 +295,7 @@ static void autotune_run()
         pos_control.set_alt_target_to_current_alt();
     }else{
         // check if pilot is overriding the controls
-        if (target_roll != 0 || target_pitch != 0 || target_yaw_rate != 0.0f || target_climb_rate != 0) {
+        if (!AP_Math::is_zero(target_roll) || !AP_Math::is_zero(target_pitch) || !AP_Math::is_zero(target_yaw_rate) || !AP_Math::is_zero(target_climb_rate)) {
             if (!autotune_state.pilot_override) {
                 autotune_state.pilot_override = true;
                 // set gains to their original values
@@ -334,7 +334,7 @@ static void autotune_attitude_control()
 {
     float rotation_rate = 0.0f;        // rotation rate in radians/second
     float lean_angle = 0.0f;
-    const float direction_sign = autotune_state.positive_direction ? 1.0 : -1.0;
+    const float direction_sign = autotune_state.positive_direction ? 1.0f : -1.0f;
 
     // check tuning step
     switch (autotune_state.step) {
@@ -747,7 +747,7 @@ static void autotune_backup_gains_and_initialise()
 
     autotune_desired_yaw = ahrs.yaw_sensor;
 
-    g.autotune_aggressiveness = constrain_float(g.autotune_aggressiveness, 0.05, 0.1);
+    g.autotune_aggressiveness = constrain_float(g.autotune_aggressiveness, 0.05f, 0.1f);
 
     // backup original pids and initialise tuned pid values
     if (autotune_roll_enabled()) {
@@ -789,7 +789,7 @@ static void autotune_load_orig_gains()
     // sanity check the gains
     bool failed = false;
     if (autotune_roll_enabled()) {
-        if ((orig_roll_rp != 0) || (orig_roll_sp != 0)) {
+        if (!AP_Math::is_zero(orig_roll_rp) || !AP_Math::is_zero(orig_roll_sp)) {
             g.pid_rate_roll.kP(orig_roll_rp);
             g.pid_rate_roll.kI(orig_roll_ri);
             g.pid_rate_roll.kD(orig_roll_rd);
@@ -799,7 +799,7 @@ static void autotune_load_orig_gains()
         }
     }
     if (autotune_pitch_enabled()) {
-        if ((orig_pitch_rp != 0) || (orig_pitch_sp != 0)) {
+        if (!AP_Math::is_zero(orig_pitch_rp) || !AP_Math::is_zero(orig_pitch_sp)) {
             g.pid_rate_pitch.kP(orig_pitch_rp);
             g.pid_rate_pitch.kI(orig_pitch_ri);
             g.pid_rate_pitch.kD(orig_pitch_rd);
@@ -809,7 +809,7 @@ static void autotune_load_orig_gains()
         }
     }
     if (autotune_yaw_enabled()) {
-        if ((orig_yaw_rp != 0) || (orig_yaw_sp != 0) || (orig_yaw_rLPF != 0)) {
+        if (!AP_Math::is_zero(orig_yaw_rp) || !AP_Math::is_zero(orig_yaw_sp) || !AP_Math::is_zero(orig_yaw_rLPF)) {
             g.pid_rate_yaw.kP(orig_yaw_rp);
             g.pid_rate_yaw.kI(orig_yaw_ri);
             g.pid_rate_yaw.kD(orig_yaw_rd);
@@ -831,7 +831,7 @@ static void autotune_load_tuned_gains()
     // sanity check the gains
     bool failed = true;
     if (autotune_roll_enabled()) {
-        if (tune_roll_rp != 0) {
+        if (!AP_Math::is_zero(tune_roll_rp)) {
             g.pid_rate_roll.kP(tune_roll_rp);
             g.pid_rate_roll.kI(tune_roll_rp*AUTOTUNE_PI_RATIO_FINAL);
             g.pid_rate_roll.kD(tune_roll_rd);
@@ -840,7 +840,7 @@ static void autotune_load_tuned_gains()
         }
     }
     if (autotune_pitch_enabled()) {
-        if (tune_pitch_rp != 0) {
+        if (!AP_Math::is_zero(tune_pitch_rp)) {
             g.pid_rate_pitch.kP(tune_pitch_rp);
             g.pid_rate_pitch.kI(tune_pitch_rp*AUTOTUNE_PI_RATIO_FINAL);
             g.pid_rate_pitch.kD(tune_pitch_rd);
@@ -849,7 +849,7 @@ static void autotune_load_tuned_gains()
         }
     }
     if (autotune_yaw_enabled()) {
-        if (tune_yaw_rp != 0) {
+        if (!AP_Math::is_zero(tune_yaw_rp)) {
             g.pid_rate_yaw.kP(tune_yaw_rp);
             g.pid_rate_yaw.kI(tune_yaw_rp*AUTOTUNE_YAW_PI_RATIO_FINAL);
             g.pid_rate_yaw.kD(0.0f);
@@ -871,21 +871,21 @@ static void autotune_load_intra_test_gains()
     // we are restarting tuning so reset gains to tuning-start gains (i.e. low I term)
     // sanity check the gains
     bool failed = true;
-    if (autotune_roll_enabled() && (orig_roll_rp != 0)) {
+    if (autotune_roll_enabled() && !AP_Math::is_zero(orig_roll_rp)) {
         g.pid_rate_roll.kP(orig_roll_rp);
         g.pid_rate_roll.kI(orig_roll_rp*AUTOTUNE_PI_RATIO_FOR_TESTING);
         g.pid_rate_roll.kD(orig_roll_rd);
         g.p_stabilize_roll.kP(orig_roll_sp);
         failed = false;
     }
-    if (autotune_pitch_enabled() && (orig_pitch_rp != 0)) {
+    if (autotune_pitch_enabled() && !AP_Math::is_zero(orig_pitch_rp)) {
         g.pid_rate_pitch.kP(orig_pitch_rp);
         g.pid_rate_pitch.kI(orig_pitch_rp*AUTOTUNE_PI_RATIO_FOR_TESTING);
         g.pid_rate_pitch.kD(orig_pitch_rd);
         g.p_stabilize_pitch.kP(orig_pitch_sp);
         failed = false;
     }
-    if (autotune_yaw_enabled() && (orig_yaw_rp != 0)) {
+    if (autotune_yaw_enabled() && !AP_Math::is_zero(orig_yaw_rp)) {
         g.pid_rate_yaw.kP(orig_yaw_rp);
         g.pid_rate_yaw.kI(orig_yaw_rp*AUTOTUNE_PI_RATIO_FOR_TESTING);
         g.pid_rate_yaw.kD(orig_yaw_rd);
@@ -906,7 +906,7 @@ static void autotune_load_twitch_gains()
     bool failed = true;
     switch (autotune_state.axis) {
         case AUTOTUNE_AXIS_ROLL:
-            if (tune_roll_rp != 0) {
+            if (!AP_Math::is_zero(tune_roll_rp)) {
                 g.pid_rate_roll.kP(tune_roll_rp);
                 g.pid_rate_roll.kI(tune_roll_rp*0.01f);
                 g.pid_rate_roll.kD(tune_roll_rd);
@@ -915,7 +915,7 @@ static void autotune_load_twitch_gains()
             }
             break;
         case AUTOTUNE_AXIS_PITCH:
-            if (tune_pitch_rp != 0) {
+            if (!AP_Math::is_zero(tune_pitch_rp)) {
                 g.pid_rate_pitch.kP(tune_pitch_rp);
                 g.pid_rate_pitch.kI(tune_pitch_rp*0.01f);
                 g.pid_rate_pitch.kD(tune_pitch_rd);
@@ -924,7 +924,7 @@ static void autotune_load_twitch_gains()
             }
             break;
         case AUTOTUNE_AXIS_YAW:
-            if (tune_yaw_rp != 0) {
+            if (!AP_Math::is_zero(tune_yaw_rp)) {
                 g.pid_rate_yaw.kP(tune_yaw_rp);
                 g.pid_rate_yaw.kI(tune_yaw_rp*0.01f);
                 g.pid_rate_yaw.kD(0.0f);
@@ -947,7 +947,7 @@ static void autotune_save_tuning_gains()
     // if we successfully completed tuning
     if (autotune_state.mode == AUTOTUNE_MODE_SUCCESS) {
         // sanity check the rate P values
-        if (autotune_roll_enabled() && (tune_roll_rp != 0)) {
+        if (autotune_roll_enabled() && !AP_Math::is_zero(tune_roll_rp)) {
             // rate roll gains
             g.pid_rate_roll.kP(tune_roll_rp);
             g.pid_rate_roll.kI(tune_roll_rp*AUTOTUNE_PI_RATIO_FINAL);
@@ -968,7 +968,7 @@ static void autotune_save_tuning_gains()
             orig_roll_sp = g.p_stabilize_roll.kP();
         }
 
-        if (autotune_pitch_enabled() && (tune_pitch_rp != 0)) {
+        if (autotune_pitch_enabled() && !AP_Math::is_zero(tune_pitch_rp)) {
             // rate pitch gains
             g.pid_rate_pitch.kP(tune_pitch_rp);
             g.pid_rate_pitch.kI(tune_pitch_rp*AUTOTUNE_PI_RATIO_FINAL);
@@ -989,7 +989,7 @@ static void autotune_save_tuning_gains()
             orig_pitch_sp = g.p_stabilize_pitch.kP();
         }
 
-        if (autotune_yaw_enabled() && (tune_yaw_rp != 0)) {
+        if (autotune_yaw_enabled() && !AP_Math::is_zero(tune_yaw_rp)) {
             // rate yaw gains
             g.pid_rate_yaw.kP(tune_yaw_rp);
             g.pid_rate_yaw.kI(tune_yaw_rp*AUTOTUNE_YAW_PI_RATIO_FINAL);

--- a/ArduCopter/control_circle.pde
+++ b/ArduCopter/control_circle.pde
@@ -44,7 +44,7 @@ static void circle_run()
     if (!failsafe.radio) {
         // get pilot's desired yaw rate
         target_yaw_rate = get_pilot_desired_yaw_rate(g.rc_4.control_in);
-        if (target_yaw_rate != 0) {
+        if (!AP_Math::is_zero(target_yaw_rate)) {
             circle_pilot_yaw_override = true;
         }
 

--- a/ArduCopter/control_drift.pde
+++ b/ArduCopter/control_drift.pde
@@ -82,7 +82,7 @@ static void drift_run()
     target_roll = constrain_int16(target_roll, -4500, 4500);
 
     // If we let go of sticks, bring us to a stop
-    if(target_pitch == 0){
+    if(AP_Math::is_zero(target_pitch)){
         // .14/ (.03 * 100) = 4.6 seconds till full breaking
         breaker += .03f;
         breaker = min(breaker, DRIFT_SPEEDGAIN);

--- a/ArduCopter/control_flip.pde
+++ b/ArduCopter/control_flip.pde
@@ -218,7 +218,7 @@ static void flip_run()
     }
 
     // output pilot's throttle without angle boost
-    if (throttle_out == 0.0f) {
+    if (throttle_out == 0) {
         attitude_control.set_throttle_out_unstabilized(0,false,g.throttle_filt);
     } else {
         attitude_control.set_throttle_out(throttle_out, false, g.throttle_filt);

--- a/ArduCopter/control_guided.pde
+++ b/ArduCopter/control_guided.pde
@@ -232,7 +232,7 @@ static void guided_pos_control_run()
     if (!failsafe.radio) {
         // get pilot's desired yaw rate
         target_yaw_rate = get_pilot_desired_yaw_rate(g.rc_4.control_in);
-        if (target_yaw_rate != 0) {
+        if (!AP_Math::is_zero(target_yaw_rate)) {
             set_auto_yaw_mode(AUTO_YAW_HOLD);
         }
     }
@@ -262,7 +262,7 @@ static void guided_vel_control_run()
     if (!failsafe.radio) {
         // get pilot's desired yaw rate
         target_yaw_rate = get_pilot_desired_yaw_rate(g.rc_4.control_in);
-        if (target_yaw_rate != 0) {
+        if (!AP_Math::is_zero(target_yaw_rate)) {
             set_auto_yaw_mode(AUTO_YAW_HOLD);
         }
     }
@@ -301,7 +301,7 @@ static void guided_posvel_control_run()
     if (!failsafe.radio) {
         // get pilot's desired yaw rate
         target_yaw_rate = get_pilot_desired_yaw_rate(g.rc_4.control_in);
-        if (target_yaw_rate != 0) {
+        if (!AP_Math::is_zero(target_yaw_rate)) {
             set_auto_yaw_mode(AUTO_YAW_HOLD);
         }
     }
@@ -389,12 +389,12 @@ static bool guided_limit_check()
     const Vector3f& curr_pos = inertial_nav.get_position();
 
     // check if we have gone below min alt
-    if ((guided_limit.alt_min_cm != 0.0f) && (curr_pos.z < guided_limit.alt_min_cm)) {
+    if (!AP_Math::is_zero(guided_limit.alt_min_cm) && (curr_pos.z < guided_limit.alt_min_cm)) {
         return true;
     }
 
     // check if we have gone above max alt
-    if ((guided_limit.alt_max_cm != 0.0f) && (curr_pos.z > guided_limit.alt_max_cm)) {
+    if (!AP_Math::is_zero(guided_limit.alt_max_cm) && (curr_pos.z > guided_limit.alt_max_cm)) {
         return true;
     }
 

--- a/ArduCopter/control_poshold.pde
+++ b/ArduCopter/control_poshold.pde
@@ -641,8 +641,8 @@ static void poshold_get_wind_comp_lean_angles(int16_t &roll_angle, int16_t &pitc
     poshold.wind_comp_timer = 0;
 
     // convert earth frame desired accelerations to body frame roll and pitch lean angles
-    roll_angle = (float)fast_atan((-poshold.wind_comp_ef.x*ahrs.sin_yaw() + poshold.wind_comp_ef.y*ahrs.cos_yaw())/981)*(18000/M_PI);
-    pitch_angle = (float)fast_atan(-(poshold.wind_comp_ef.x*ahrs.cos_yaw() + poshold.wind_comp_ef.y*ahrs.sin_yaw())/981)*(18000/M_PI);
+    roll_angle = (float)fast_atan((-poshold.wind_comp_ef.x*ahrs.sin_yaw() + poshold.wind_comp_ef.y*ahrs.cos_yaw())/981)*(18000/(float)M_PI);
+    pitch_angle = (float)fast_atan(-(poshold.wind_comp_ef.x*ahrs.cos_yaw() + poshold.wind_comp_ef.y*ahrs.sin_yaw())/981)*(18000/(float)M_PI);
 }
 
 // poshold_roll_controller_to_pilot_override - initialises transition from a controller submode (brake or loiter) to a pilot override on roll axis

--- a/ArduCopter/control_poshold.pde
+++ b/ArduCopter/control_poshold.pde
@@ -228,7 +228,7 @@ static void poshold_run()
                 poshold_update_pilot_lean_angle(poshold.pilot_roll, target_roll);
 
                 // switch to BRAKE mode for next iteration if no pilot input
-                if ((target_roll == 0) && (abs(poshold.pilot_roll) < 2 * g.poshold_brake_rate)) {
+                if (AP_Math::is_zero(target_roll) && (abs(poshold.pilot_roll) < 2 * g.poshold_brake_rate)) {
                     // initialise BRAKE mode
                     poshold.roll_mode = POSHOLD_BRAKE;        // Set brake roll mode
                     poshold.brake_roll = 0;                  // initialise braking angle to zero
@@ -277,7 +277,7 @@ static void poshold_run()
                 poshold.roll = poshold.brake_roll + poshold.wind_comp_roll;
 
                 // check for pilot input
-                if (target_roll != 0) {
+                if (!AP_Math::is_zero(target_roll)) {
                     // init transition to pilot override
                     poshold_roll_controller_to_pilot_override();
                 }
@@ -322,7 +322,7 @@ static void poshold_run()
                 poshold_update_pilot_lean_angle(poshold.pilot_pitch, target_pitch);
 
                 // switch to BRAKE mode for next iteration if no pilot input
-                if ((target_pitch == 0) && (abs(poshold.pilot_pitch) < 2 * g.poshold_brake_rate)) {
+                if (AP_Math::is_zero(target_pitch) && (abs(poshold.pilot_pitch) < 2 * g.poshold_brake_rate)) {
                     // initialise BRAKE mode
                     poshold.pitch_mode = POSHOLD_BRAKE;       // set brake pitch mode
                     poshold.brake_pitch = 0;                 // initialise braking angle to zero
@@ -371,7 +371,7 @@ static void poshold_run()
                 poshold.pitch = poshold.brake_pitch + poshold.wind_comp_pitch;
 
                 // check for pilot input
-                if (target_pitch != 0) {
+                if (!AP_Math::is_zero(target_pitch)) {
                     // init transition to pilot override
                     poshold_pitch_controller_to_pilot_override();
                 }
@@ -453,9 +453,9 @@ static void poshold_run()
                     poshold.pitch = poshold_mix_controls(brake_to_loiter_mix, poshold.brake_pitch + poshold.wind_comp_pitch, wp_nav.get_pitch());
 
                     // check for pilot input
-                    if (target_roll != 0 || target_pitch != 0) {
+                    if (!AP_Math::is_zero(target_roll) || !AP_Math::is_zero(target_pitch)) {
                         // if roll input switch to pilot override for roll
-                        if (target_roll != 0) {
+                        if (!AP_Math::is_zero(target_roll)) {
                             // init transition to pilot override
                             poshold_roll_controller_to_pilot_override();
                             // switch pitch-mode to brake (but ready to go back to loiter anytime)
@@ -463,10 +463,10 @@ static void poshold_run()
                             poshold.pitch_mode = POSHOLD_BRAKE_READY_TO_LOITER;
                         }
                         // if pitch input switch to pilot override for pitch
-                        if (target_pitch != 0) {
+                        if (!AP_Math::is_zero(target_pitch)) {
                             // init transition to pilot override
                             poshold_pitch_controller_to_pilot_override();
-                            if (target_roll == 0) {
+                            if (AP_Math::is_zero(target_roll)) {
                                 // switch roll-mode to brake (but ready to go back to loiter anytime)
                                 // no need to reset poshold.brake_roll here as wind comp has not been updated since last brake_roll computation
                                 poshold.roll_mode = POSHOLD_BRAKE_READY_TO_LOITER;
@@ -487,9 +487,9 @@ static void poshold_run()
                     poshold_update_wind_comp_estimate();
 
                     // check for pilot input
-                    if (target_roll != 0 || target_pitch != 0) {
+                    if (!AP_Math::is_zero(target_roll) || !AP_Math::is_zero(target_pitch)) {
                         // if roll input switch to pilot override for roll
-                        if (target_roll != 0) {
+                        if (!AP_Math::is_zero(target_roll)) {
                             // init transition to pilot override
                             poshold_roll_controller_to_pilot_override();
                             // switch pitch-mode to brake (but ready to go back to loiter anytime)
@@ -498,11 +498,11 @@ static void poshold_run()
                             poshold.brake_pitch = 0;
                         }
                         // if pitch input switch to pilot override for pitch
-                        if (target_pitch != 0) {
+                        if (!AP_Math::is_zero(target_pitch)) {
                             // init transition to pilot override
                             poshold_pitch_controller_to_pilot_override();
                             // if roll not overriden switch roll-mode to brake (but be ready to go back to loiter any time)
-                            if (target_roll == 0) {
+                            if (AP_Math::is_zero(target_roll)) {
                                 poshold.roll_mode = POSHOLD_BRAKE_READY_TO_LOITER;
                                 poshold.brake_roll = 0;
                             }
@@ -613,14 +613,14 @@ static void poshold_update_wind_comp_estimate()
     const Vector3f& accel_target = pos_control.get_accel_target();
 
     // update wind compensation in earth-frame lean angles
-    if (poshold.wind_comp_ef.x == 0) {
+    if (AP_Math::is_zero(poshold.wind_comp_ef.x)) {
         // if wind compensation has not been initialised set it immediately to the pos controller's desired accel in north direction
         poshold.wind_comp_ef.x = accel_target.x;
     } else {
         // low pass filter the position controller's lean angle output
         poshold.wind_comp_ef.x = (1.0f-TC_WIND_COMP)*poshold.wind_comp_ef.x + TC_WIND_COMP*accel_target.x;
     }
-    if (poshold.wind_comp_ef.y == 0) {
+    if (AP_Math::is_zero(poshold.wind_comp_ef.y)) {
         // if wind compensation has not been initialised set it immediately to the pos controller's desired accel in north direction
         poshold.wind_comp_ef.y = accel_target.y;
     } else {

--- a/ArduCopter/control_rtl.pde
+++ b/ArduCopter/control_rtl.pde
@@ -144,7 +144,7 @@ static void rtl_climb_return_run()
     if (!failsafe.radio) {
         // get pilot's desired yaw rate
         target_yaw_rate = get_pilot_desired_yaw_rate(g.rc_4.control_in);
-        if (target_yaw_rate != 0) {
+        if (!AP_Math::is_zero(target_yaw_rate)) {
             set_auto_yaw_mode(AUTO_YAW_HOLD);
         }
     }
@@ -200,7 +200,7 @@ static void rtl_loiterathome_run()
     if (!failsafe.radio) {
         // get pilot's desired yaw rate
         target_yaw_rate = get_pilot_desired_yaw_rate(g.rc_4.control_in);
-        if (target_yaw_rate != 0) {
+        if (!AP_Math::is_zero(target_yaw_rate)) {
             set_auto_yaw_mode(AUTO_YAW_HOLD);
         }
     }
@@ -294,7 +294,7 @@ static void rtl_descent_run()
     attitude_control.angle_ef_roll_pitch_rate_ef_yaw(wp_nav.get_roll(), wp_nav.get_pitch(), target_yaw_rate);
 
     // check if we've reached within 20cm of final altitude
-    rtl_state_complete = fabs(pv_alt_above_origin(g.rtl_alt_final) - inertial_nav.get_altitude()) < 20.0f;
+    rtl_state_complete = fabsf(pv_alt_above_origin(g.rtl_alt_final) - inertial_nav.get_altitude()) < 20.0f;
 }
 
 // rtl_loiterathome_start - initialise controllers to loiter over home

--- a/ArduCopter/motors.pde
+++ b/ArduCopter/motors.pde
@@ -346,7 +346,7 @@ static bool pre_arm_checks(bool display_failure)
 
         // check for unreasonable mag field length
         float mag_field = compass.get_field().length();
-        if (mag_field > COMPASS_MAGFIELD_EXPECTED*1.65 || mag_field < COMPASS_MAGFIELD_EXPECTED*0.35) {
+        if (mag_field > COMPASS_MAGFIELD_EXPECTED*1.65f || mag_field < COMPASS_MAGFIELD_EXPECTED*0.35f) {
             if (display_failure) {
                 gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Check mag field"));
             }

--- a/ArduCopter/position_vector.pde
+++ b/ArduCopter/position_vector.pde
@@ -52,7 +52,7 @@ float pv_alt_above_home(float alt_above_origin_cm)
 // pv_get_bearing_cd - return bearing in centi-degrees between two positions
 float pv_get_bearing_cd(const Vector3f &origin, const Vector3f &destination)
 {
-    float bearing = fast_atan2(destination.y-origin.y, destination.x-origin.x) * DEGX100;
+    float bearing = atan2f(destination.y-origin.y, destination.x-origin.x) * DEGX100;
     if (bearing < 0) {
         bearing += 36000;
     }

--- a/ArduCopter/setup.pde
+++ b/ArduCopter/setup.pde
@@ -431,12 +431,12 @@ print_accel_offsets_and_scaling(void)
     const Vector3f &accel_offsets = ins.get_accel_offsets();
     const Vector3f &accel_scale = ins.get_accel_scale();
     cliSerial->printf_P(PSTR("A_off: %4.2f, %4.2f, %4.2f\nA_scale: %4.2f, %4.2f, %4.2f\n"),
-                    (float)accel_offsets.x,                           // Pitch
-                    (float)accel_offsets.y,                           // Roll
-                    (float)accel_offsets.z,                           // YAW
-                    (float)accel_scale.x,                             // Pitch
-                    (float)accel_scale.y,                             // Roll
-                    (float)accel_scale.z);                            // YAW
+                    (double)accel_offsets.x,                           // Pitch
+                    (double)accel_offsets.y,                           // Roll
+                    (double)accel_offsets.z,                           // YAW
+                    (double)accel_scale.x,                             // Pitch
+                    (double)accel_scale.y,                             // Roll
+                    (double)accel_scale.z);                            // YAW
 }
 
 static void
@@ -444,9 +444,9 @@ print_gyro_offsets(void)
 {
     const Vector3f &gyro_offsets = ins.get_gyro_offsets();
     cliSerial->printf_P(PSTR("G_off: %4.2f, %4.2f, %4.2f\n"),
-                    (float)gyro_offsets.x,
-                    (float)gyro_offsets.y,
-                    (float)gyro_offsets.z);
+                    (double)gyro_offsets.x,
+                    (double)gyro_offsets.y,
+                    (double)gyro_offsets.z);
 }
 
 #endif // CLI_ENABLED
@@ -461,7 +461,7 @@ static void report_compass()
 
     // mag declination
     cliSerial->printf_P(PSTR("Mag Dec: %4.4f\n"),
-                    degrees(compass.get_declination()));
+            (double)degrees(compass.get_declination()));
 
     // mag offsets
     Vector3f offsets;
@@ -470,9 +470,9 @@ static void report_compass()
         // mag offsets
         cliSerial->printf_P(PSTR("Mag%d off: %4.4f, %4.4f, %4.4f\n"),
                         (int)i,
-                        offsets.x,
-                        offsets.y,
-                        offsets.z);
+                        (double)offsets.x,
+                        (double)offsets.y,
+                        (double)offsets.z);
     }
 
     // motor compensation
@@ -491,9 +491,9 @@ static void report_compass()
             motor_compensation = compass.get_motor_compensation(i);
             cliSerial->printf_P(PSTR("\nComMot%d: %4.2f, %4.2f, %4.2f\n"),
                         (int)i,
-                        motor_compensation.x,
-                        motor_compensation.y,
-                        motor_compensation.z);
+                        (double)motor_compensation.x,
+                        (double)motor_compensation.y,
+                        (double)motor_compensation.z);
         }
     }
     print_blanks(1);

--- a/ArduCopter/test.pde
+++ b/ArduCopter/test.pde
@@ -63,9 +63,9 @@ test_baro(uint8_t argc, const Menu::arg *argv)
             cliSerial->println_P(PSTR("not healthy"));
         } else {
             cliSerial->printf_P(PSTR("Alt: %0.2fm, Raw: %f Temperature: %.1f\n"),
-                                baro_alt / 100.0,
-                                barometer.get_pressure(), 
-                                barometer.get_temperature());
+                                (double)(baro_alt / 100.0f),
+                                (double)barometer.get_pressure(),
+                                (double)barometer.get_temperature());
         }
         if(cliSerial->available() > 0) {
             return (0);
@@ -138,12 +138,12 @@ test_compass(uint8_t argc, const Menu::arg *argv)
                     const Vector3f &mag = compass.get_field();
                     cliSerial->printf_P(PSTR("Heading: %ld, XYZ: %.0f, %.0f, %.0f,\tXYZoff: %6.2f, %6.2f, %6.2f\n"),
                                         (wrap_360_cd(ToDeg(heading) * 100)) /100,
-                                        mag.x,
-                                        mag.y,
-                                        mag.z,
-                                        mag_ofs.x,
-                                        mag_ofs.y,
-                                        mag_ofs.z);
+                                        (double)mag.x,
+                                        (double)mag.y,
+                                        (double)mag.z,
+                                        (double)mag_ofs.x,
+                                        (double)mag_ofs.y,
+                                        (double)mag_ofs.z);
                 } else {
                     cliSerial->println_P(PSTR("compass not healthy"));
                 }
@@ -185,9 +185,9 @@ test_ins(uint8_t argc, const Menu::arg *argv)
         float test = accel.length() / GRAVITY_MSS;
 
         cliSerial->printf_P(PSTR("a %7.4f %7.4f %7.4f g %7.4f %7.4f %7.4f t %7.4f \n"),
-            accel.x, accel.y, accel.z,
-            gyro.x, gyro.y, gyro.z,
-            test);
+                (double)accel.x, (double)accel.y, (double)accel.z,
+            (double)gyro.x, (double)gyro.y, (double)gyro.z,
+            (double)test);
 
         delay(40);
         if(cliSerial->available() > 0) {
@@ -209,8 +209,8 @@ test_optflow(uint8_t argc, const Menu::arg *argv)
             optflow.update();
             const Vector2f& flowRate = optflow.flowRate();
             cliSerial->printf_P(PSTR("flowX : %7.4f\t flowY : %7.4f\t flow qual : %d\n"),
-                            flowRate.x,
-                            flowRate.y,
+                            (double)flowRate.x,
+                            (double)flowRate.y,
                             (int)optflow.quality());
 
             if(cliSerial->available() > 0) {

--- a/ArduPlane/ArduPlane.pde
+++ b/ArduPlane/ArduPlane.pde
@@ -152,6 +152,8 @@ static void update_events(void);
 void gcs_send_text_fmt(const prog_char_t *fmt, ...);
 static void print_flight_mode(AP_HAL::BetterStream *port, uint8_t mode);
 static bool arm_motors(AP_Arming::ArmingMethod method);
+static bool create_mixer_file(const char *filename);
+static bool setup_failsafe_mixing(void);
 
 ////////////////////////////////////////////////////////////////////////////////
 // DataFlash

--- a/ArduPlane/Attitude.pde
+++ b/ArduPlane/Attitude.pde
@@ -588,7 +588,7 @@ static bool suppress_throttle(void)
         // we're more than 10m from the home altitude
         throttle_suppressed = false;
         gcs_send_text_fmt(PSTR("Throttle unsuppressed - altitude %.2f"), 
-                          (float)(relative_altitude_abs_cm()*0.01f));
+                          (double)(relative_altitude_abs_cm()*0.01f));
         return false;
     }
 
@@ -600,8 +600,8 @@ static bool suppress_throttle(void)
         if ((!ahrs.airspeed_sensor_enabled()) || airspeed.get_airspeed() >= 5) {
             // we're moving at more than 5 m/s
             gcs_send_text_fmt(PSTR("Throttle unsuppressed - speed %.2f airspeed %.2f"), 
-                              gps.ground_speed(),
-                              airspeed.get_airspeed());
+                              (double)gps.ground_speed(),
+                              (double)airspeed.get_airspeed());
             throttle_suppressed = false;
             return false;        
         }

--- a/ArduPlane/Attitude.pde
+++ b/ArduPlane/Attitude.pde
@@ -286,7 +286,7 @@ static void stabilize_acro(float speed_scaler)
     /*
       check for special roll handling near the pitch poles
      */
-    if (g.acro_locking && roll_rate == 0) {
+    if (g.acro_locking && AP_Math::is_zero(roll_rate)) {
         /*
           we have no roll stick input, so we will enter "roll locked"
           mode, and hold the roll we had when the stick was released
@@ -313,7 +313,7 @@ static void stabilize_acro(float speed_scaler)
         channel_roll->servo_out  = rollController.get_rate_out(roll_rate,  speed_scaler);
     }
 
-    if (g.acro_locking && pitch_rate == 0) {
+    if (g.acro_locking && AP_Math::is_zero(pitch_rate)) {
         /*
           user has zero pitch stick input, so we lock pitch at the
           point they release the stick
@@ -459,7 +459,7 @@ static void calc_nav_yaw_ground(void)
     if (flight_stage == AP_SpdHgtControl::FLIGHT_TAKEOFF) {
         steer_rate = 0;
     }
-    if (steer_rate != 0) {
+    if (!AP_Math::is_zero(steer_rate)) {
         // pilot is giving rudder input
         steer_state.locked_course = false;        
     } else if (!steer_state.locked_course) {

--- a/ArduPlane/GCS_Mavlink.pde
+++ b/ArduPlane/GCS_Mavlink.pde
@@ -1049,7 +1049,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
 
         case MAV_CMD_PREFLIGHT_CALIBRATION:
             in_calibration = true;
-            if (packet.param1 == 1) {
+            if (AP_Math::is_equal(packet.param1,1.0f)) {
                 ins.init_gyro();
                 if (ins.gyro_calibrated_ok_all()) {
                     ahrs.reset_gyro_drift();
@@ -1057,16 +1057,16 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
                 } else {
                     result = MAV_RESULT_FAILED;
                 }
-            } else if (packet.param3 == 1) {
+            } else if (AP_Math::is_equal(packet.param3,1.0f)) {
                 init_barometer();
                 if (airspeed.enabled()) {
                     zero_airspeed(false);
                 }
                 result = MAV_RESULT_ACCEPTED;
-            } else if (packet.param4 == 1) {
+            } else if (AP_Math::is_equal(packet.param4,1.0f)) {
                 trim_radio();
                 result = MAV_RESULT_ACCEPTED;
-            } else if (packet.param5 == 1) {
+            } else if (AP_Math::is_equal(packet.param5,1.0f)) {
                 float trim_roll, trim_pitch;
                 AP_InertialSensor_UserInteract_MAVLink interact(this);
                 if (g.skip_gyro_cal) {
@@ -1089,12 +1089,12 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
             break;
 
         case MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS:
-            if (packet.param1 == 2) {
+            if (AP_Math::is_equal(packet.param1,2.0f)) {
                 // save first compass's offsets
                 compass.set_and_save_offsets(0, packet.param2, packet.param3, packet.param4);
                 result = MAV_RESULT_ACCEPTED;
             }
-            if (packet.param1 == 5) {
+            if (AP_Math::is_equal(packet.param1,5.0f)) {
                 // save secondary compass's offsets
                 compass.set_and_save_offsets(1, packet.param2, packet.param3, packet.param4);
                 result = MAV_RESULT_ACCEPTED;
@@ -1102,14 +1102,14 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
             break;
 
         case MAV_CMD_COMPONENT_ARM_DISARM:
-            if (packet.param1 == 1.0f) {
+            if (AP_Math::is_equal(packet.param1,1.0f)) {
                 // run pre_arm_checks and arm_checks and display failures
                 if (arm_motors(AP_Arming::MAVLINK)) {
                     result = MAV_RESULT_ACCEPTED;
                 } else {
                     result = MAV_RESULT_FAILED;
                 }
-            } else if (packet.param1 == 0.0f)  {
+            } else if (AP_Math::is_zero(packet.param1))  {
                 if (disarm_motors()) {
                     result = MAV_RESULT_ACCEPTED;
                 } else {
@@ -1170,9 +1170,9 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
             break;
 
         case MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN:
-            if (packet.param1 == 1 || packet.param1 == 3) {
+            if (AP_Math::is_equal(packet.param1,1.0f) || AP_Math::is_equal(packet.param1,3.0f)) {
                 // when packet.param1 == 3 we reboot to hold in bootloader
-                hal.scheduler->reboot(packet.param1 == 3);
+                hal.scheduler->reboot(AP_Math::is_equal(packet.param1,3.0f));
                 result = MAV_RESULT_ACCEPTED;
             }
             break;
@@ -1227,7 +1227,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
             break;
 
         case MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES: {
-            if (packet.param1 == 1) {
+            if (AP_Math::is_equal(packet.param1,1.0f)) {
                 gcs[chan-MAVLINK_COMM_0].send_autopilot_version();
                 result = MAV_RESULT_ACCEPTED;
             }
@@ -1239,10 +1239,10 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
             // param6 : longitude
             // param7 : altitude (absolute)
             result = MAV_RESULT_FAILED; // assume failure
-            if (packet.param1 == 1) {
+            if (AP_Math::is_equal(packet.param1,1.0f)) {
                 init_home();
             } else {
-                if (packet.param5 == 0 && packet.param6 == 0 && packet.param7 == 0) {
+                if (AP_Math::is_zero(packet.param5) && AP_Math::is_zero(packet.param6) && AP_Math::is_zero(packet.param7)) {
                     // don't allow the 0,0 position
                     break;
                 }
@@ -1383,7 +1383,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
         } else {
             Vector2l point = get_fence_point_with_index(packet.idx);
             mavlink_msg_fence_point_send_buf(msg, chan, msg->sysid, msg->compid, packet.idx, g.fence_total,
-                                             point.x*1.0e-7, point.y*1.0e-7);
+                                             point.x*1.0e-7f, point.y*1.0e-7f);
         }
         break;
     }

--- a/ArduPlane/commands_logic.pde
+++ b/ArduPlane/commands_logic.pde
@@ -425,8 +425,8 @@ static bool verify_takeoff()
             steer_state.hold_course_cd = wrap_360_cd(degrees(takeoff_course)*100);
             gcs_send_text_fmt(PSTR("Holding course %ld at %.1fm/s (%.1f)"), 
                               steer_state.hold_course_cd,
-                              gps.ground_speed(),
-                              degrees(steer_state.locked_course_err));
+                              (double)gps.ground_speed(),
+                              (double)degrees(steer_state.locked_course_err));
         }
     }
 
@@ -441,7 +441,7 @@ static bool verify_takeoff()
     int32_t relative_alt_cm = adjusted_relative_altitude_cm();
     if (relative_alt_cm > auto_state.takeoff_altitude_rel_cm) {
         gcs_send_text_fmt(PSTR("Takeoff complete at %.2fm"), 
-                          relative_alt_cm*0.01f);
+                          (double)(relative_alt_cm*0.01f));
         steer_state.hold_course_cd = -1;
         auto_state.takeoff_complete = true;
         next_WP_loc = prev_WP_loc = current_loc;

--- a/ArduPlane/events.pde
+++ b/ArduPlane/events.pde
@@ -113,7 +113,7 @@ void low_battery_event(void)
         return;
     }
     gcs_send_text_fmt(PSTR("Low Battery %.2fV Used %.0f mAh"),
-                      battery.voltage(), battery.current_total_mah());
+                      (double)battery.voltage(), (double)battery.current_total_mah());
     set_mode(RTL);
     aparm.throttle_cruise.load();
     failsafe.low_battery = true;

--- a/ArduPlane/landing.pde
+++ b/ArduPlane/landing.pde
@@ -57,10 +57,10 @@ static bool verify_land()
 
         if (!auto_state.land_complete) {
             if (!is_flying() && (hal.scheduler->millis()-auto_state.last_flying_ms) > 3000) {
-                gcs_send_text_fmt(PSTR("Flare crash detected: speed=%.1f"), gps.ground_speed());
+                gcs_send_text_fmt(PSTR("Flare crash detected: speed=%.1f"), (double)gps.ground_speed());
             } else {
                 gcs_send_text_fmt(PSTR("Flare %.1fm sink=%.2f speed=%.1f"), 
-                                  height, auto_state.land_sink_rate, gps.ground_speed());
+                        (double)height, (double)auto_state.land_sink_rate, (double)gps.ground_speed());
             }
         }
         auto_state.land_complete = true;

--- a/ArduPlane/navigation.pde
+++ b/ArduPlane/navigation.pde
@@ -182,7 +182,7 @@ static void update_fbwb_speed_height(void)
     
     change_target_altitude(g.flybywire_climb_rate * elevator_input * delta_us_fast_loop * 0.0001f);
     
-    if (elevator_input == 0.0f && last_elevator_input != 0.0f) {
+    if (AP_Math::is_zero(elevator_input) && !AP_Math::is_zero(last_elevator_input)) {
         // the user has just released the elevator, lock in
         // the current altitude
         set_target_altitude_current();

--- a/ArduPlane/setup.pde
+++ b/ArduPlane/setup.pde
@@ -349,9 +349,9 @@ static void report_compass()
 
     // mag offsets
     cliSerial->printf_P(PSTR("Mag offsets: %4.4f, %4.4f, %4.4f\n"),
-                    offsets.x,
-                    offsets.y,
-                    offsets.z);
+                    (double)offsets.x,
+                    (double)offsets.y,
+                    (double)offsets.z);
     print_blanks(2);
 }
 
@@ -419,12 +419,12 @@ print_accel_offsets_and_scaling(void)
     Vector3f accel_offsets = ins.get_accel_offsets();
     Vector3f accel_scale = ins.get_accel_scale();
     cliSerial->printf_P(PSTR("Accel offsets: %4.2f, %4.2f, %4.2f\tscale: %4.2f, %4.2f, %4.2f\n"),
-                    (float)accel_offsets.x,                           // Pitch
-                    (float)accel_offsets.y,                           // Roll
-                    (float)accel_offsets.z,                           // YAW
-                    (float)accel_scale.x,                             // Pitch
-                    (float)accel_scale.y,                             // Roll
-                    (float)accel_scale.z);                            // YAW
+                    (double)accel_offsets.x,                           // Pitch
+                    (double)accel_offsets.y,                           // Roll
+                    (double)accel_offsets.z,                           // YAW
+                    (double)accel_scale.x,                             // Pitch
+                    (double)accel_scale.y,                             // Roll
+                    (double)accel_scale.z);                            // YAW
 }
 
 static void
@@ -432,9 +432,9 @@ print_gyro_offsets(void)
 {
     Vector3f gyro_offsets = ins.get_gyro_offsets();
     cliSerial->printf_P(PSTR("Gyro offsets: %4.2f, %4.2f, %4.2f\n"),
-                    (float)gyro_offsets.x,
-                    (float)gyro_offsets.y,
-                    (float)gyro_offsets.z);
+                    (double)gyro_offsets.x,
+                    (double)gyro_offsets.y,
+                    (double)gyro_offsets.z);
 }
 
 

--- a/ArduPlane/takeoff.pde
+++ b/ArduPlane/takeoff.pde
@@ -37,7 +37,7 @@ static bool auto_takeoff_check(void)
 
     // Check for launch acceleration or timer started. NOTE: relies on TECS 50Hz processing
     if (!launchTimerStarted &&
-        g.takeoff_throttle_min_accel != 0.0f &&
+        !AP_Math::is_zero(g.takeoff_throttle_min_accel) &&
         SpdHgt_Controller->get_VXdot() < g.takeoff_throttle_min_accel) {
         goto no_launch;
     }
@@ -65,7 +65,7 @@ static bool auto_takeoff_check(void)
     }
 
     // Check ground speed and time delay
-    if (((gps.ground_speed() > g.takeoff_throttle_min_speed || g.takeoff_throttle_min_speed == 0.0f)) &&
+    if (((gps.ground_speed() > g.takeoff_throttle_min_speed || AP_Math::is_zero(g.takeoff_throttle_min_speed))) &&
         ((now - last_tkoff_arm_time) >= wait_time_ms)) {
         gcs_send_text_fmt(PSTR("Triggered AUTO, GPSspd = %.1f"), gps.ground_speed());
         launchTimerStarted = false;

--- a/ArduPlane/takeoff.pde
+++ b/ArduPlane/takeoff.pde
@@ -47,7 +47,7 @@ static bool auto_takeoff_check(void)
         launchTimerStarted = true;
         last_tkoff_arm_time = now;
         gcs_send_text_fmt(PSTR("Armed AUTO, xaccel = %.1f m/s/s, waiting %.1f sec"), 
-                          SpdHgt_Controller->get_VXdot(), wait_time_ms*0.001f);
+                (double)SpdHgt_Controller->get_VXdot(), (double)(wait_time_ms*0.001f));
     }
 
     // Only perform velocity check if not timed out
@@ -67,7 +67,7 @@ static bool auto_takeoff_check(void)
     // Check ground speed and time delay
     if (((gps.ground_speed() > g.takeoff_throttle_min_speed || AP_Math::is_zero(g.takeoff_throttle_min_speed))) &&
         ((now - last_tkoff_arm_time) >= wait_time_ms)) {
-        gcs_send_text_fmt(PSTR("Triggered AUTO, GPSspd = %.1f"), gps.ground_speed());
+        gcs_send_text_fmt(PSTR("Triggered AUTO, GPSspd = %.1f"), (double)gps.ground_speed());
         launchTimerStarted = false;
         last_tkoff_arm_time = 0;
         return true;

--- a/ArduPlane/test.pde
+++ b/ArduPlane/test.pde
@@ -446,8 +446,8 @@ test_ins(uint8_t argc, const Menu::arg *argv)
                             (int)ahrs.roll_sensor / 100,
                             (int)ahrs.pitch_sensor / 100,
                             (uint16_t)ahrs.yaw_sensor / 100,
-                            gyros.x, gyros.y, gyros.z,
-                            accels.x, accels.y, accels.z);
+                            (double)gyros.x, (double)gyros.y, (double)gyros.z,
+                            (double)accels.x, (double)accels.y, (double)accels.z);
         }
         if(cliSerial->available() > 0) {
             return (0);
@@ -510,8 +510,8 @@ test_mag(uint8_t argc, const Menu::arg *argv)
                     const Vector3f &mag = compass.get_field();
                     cliSerial->printf_P(PSTR("Heading: %ld, XYZ: %.0f, %.0f, %.0f,\tXYZoff: %6.2f, %6.2f, %6.2f\n"),
                                         (wrap_360_cd(ToDeg(heading) * 100)) /100,
-                                        mag.x, mag.y, mag.z,
-                                        mag_ofs.x, mag_ofs.y, mag_ofs.z);
+                                        (double)mag.x, (double)mag.y, (double)mag.z,
+                                        (double)mag_ofs.x, (double)mag_ofs.y, (double)mag_ofs.z);
                 } else {
                     cliSerial->println_P(PSTR("compass not healthy"));
                 }
@@ -549,7 +549,7 @@ test_airspeed(uint8_t argc, const Menu::arg *argv)
         while(1) {
             hal.scheduler->delay(20);
             read_airspeed();
-            cliSerial->printf_P(PSTR("%.1f m/s\n"), airspeed.get_airspeed());
+            cliSerial->printf_P(PSTR("%.1f m/s\n"), (double)airspeed.get_airspeed());
 
             if(cliSerial->available() > 0) {
                 return (0);
@@ -575,9 +575,9 @@ test_pressure(uint8_t argc, const Menu::arg *argv)
             cliSerial->println_P(PSTR("not healthy"));
         } else {
             cliSerial->printf_P(PSTR("Alt: %0.2fm, Raw: %f Temperature: %.1f\n"),
-                                barometer.get_altitude(),
-                                barometer.get_pressure(), 
-                                barometer.get_temperature());
+                                (double)barometer.get_altitude(),
+                                (double)barometer.get_pressure(),
+                                (double)barometer.get_temperature());
         }
 
         if(cliSerial->available() > 0) {

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -2,6 +2,7 @@
 
 #include "AC_AttitudeControl.h"
 #include <AP_HAL.h>
+#include <AP_Math.h>
 
 // table of user settable parameters
 const AP_Param::GroupInfo AC_AttitudeControl::var_info[] PROGMEM = {
@@ -433,7 +434,7 @@ void AC_AttitudeControl::frame_conversion_ef_to_bf(const Vector3f& ef_vector, Ve
 bool AC_AttitudeControl::frame_conversion_bf_to_ef(const Vector3f& bf_vector, Vector3f& ef_vector)
 {
     // avoid divide by zero
-    if (_ahrs.cos_pitch() == 0.0f) {
+    if (AP_Math::is_zero(_ahrs.cos_pitch())) {
         return false;
     }
     // convert earth frame angle or rates to body frame
@@ -671,14 +672,14 @@ void AC_AttitudeControl::accel_limiting(bool enable_limits)
 {
     if (enable_limits) {
         // if enabling limits, reload from eeprom or set to defaults
-        if (_accel_roll_max == 0.0f) {
+        if (AP_Math::is_zero(_accel_roll_max)) {
             _accel_roll_max.load();
         }
         // if enabling limits, reload from eeprom or set to defaults
-        if (_accel_pitch_max == 0.0f) {
+        if (AP_Math::is_zero(_accel_pitch_max)) {
             _accel_pitch_max.load();
         }
-        if (_accel_yaw_max == 0.0f) {
+        if (AP_Math::is_zero(_accel_yaw_max)) {
             _accel_yaw_max.load();
         }
     } else {
@@ -741,7 +742,7 @@ float AC_AttitudeControl::get_boosted_throttle(float throttle_in)
 // sqrt_controller - response based on the sqrt of the error instead of the more common linear response
 float AC_AttitudeControl::sqrt_controller(float error, float p, float second_ord_lim)
 {
-    if (second_ord_lim == 0.0f || p == 0.0f) {
+    if (AP_Math::is_zero(second_ord_lim) || AP_Math::is_zero(p)) {
         return error*p;
     }
 

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -142,7 +142,7 @@ uint8_t AC_Fence::check_fence(float curr_alt)
             _alt_max_breach_distance = curr_alt - _alt_max;
 
             // check for a new breach or a breach of the backup fence
-            if ((_breached_fences & AC_FENCE_TYPE_ALT_MAX) == 0 || (_alt_max_backup != 0.0f && curr_alt >= _alt_max_backup)) {
+            if ((_breached_fences & AC_FENCE_TYPE_ALT_MAX) == 0 || (!AP_Math::is_zero(_alt_max_backup) && curr_alt >= _alt_max_backup)) {
 
                 // record that we have breached the upper limit
                 record_breach(AC_FENCE_TYPE_ALT_MAX);
@@ -171,7 +171,7 @@ uint8_t AC_Fence::check_fence(float curr_alt)
             _circle_breach_distance = _home_distance - _circle_radius;
 
             // check for a new breach or a breach of the backup fence
-            if ((_breached_fences & AC_FENCE_TYPE_CIRCLE) == 0 || (_circle_radius_backup != 0.0f && _home_distance >= _circle_radius_backup)) {
+            if ((_breached_fences & AC_FENCE_TYPE_CIRCLE) == 0 || (!AP_Math::is_zero(_circle_radius_backup) && _home_distance >= _circle_radius_backup)) {
 
                 // record that we have breached the circular distance limit
                 record_breach(AC_FENCE_TYPE_CIRCLE);

--- a/libraries/AC_PID/AC_HELI_PID.cpp
+++ b/libraries/AC_PID/AC_HELI_PID.cpp
@@ -56,7 +56,7 @@ float AC_HELI_PID::get_ff(float requested_rate) const
 
 float AC_HELI_PID::get_leaky_i(float leak_rate)
 {
-	if((_ki != 0) && (_dt != 0)){
+	if(!AP_Math::is_zero(_ki) && !AP_Math::is_zero(_dt)){
 		_integrator -= (float)_integrator * leak_rate;
 		_integrator += ((float)_input * _ki) * _dt;
 		if (_integrator < -_imax) {

--- a/libraries/AC_PID/AC_PID.cpp
+++ b/libraries/AC_PID/AC_PID.cpp
@@ -132,7 +132,7 @@ float AC_PID::get_p() const
 
 float AC_PID::get_i()
 {
-    if(!is_zero(_ki) && !is_zero(_dt)) {
+    if(!AP_Math::is_zero(_ki) && !AP_Math::is_zero(_dt)) {
         _integrator += ((float)_input * _ki) * _dt;
         if (_integrator < -_imax) {
             _integrator = -_imax;
@@ -199,7 +199,7 @@ void AC_PID::operator() (float p, float i, float d, float imaxval, float input_f
 // calc_filt_alpha - recalculate the input filter alpha
 float AC_PID::get_filt_alpha() const
 {
-    if (is_zero(_filt_hz)) {
+    if (AP_Math::is_zero(_filt_hz)) {
         return 1.0f;
     }
 

--- a/libraries/AC_PID/AC_PI_2D.cpp
+++ b/libraries/AC_PID/AC_PI_2D.cpp
@@ -95,7 +95,7 @@ Vector2f AC_PI_2D::get_p() const
 
 Vector2f AC_PI_2D::get_i()
 {
-    if(!is_zero(_ki) && !is_zero(_dt)) {
+    if(!AP_Math::is_zero(_ki) && !AP_Math::is_zero(_dt)) {
         _integrator += (_input * _ki) * _dt;
         float integrator_length = _integrator.length();
         if ((integrator_length > _imax) && (integrator_length > 0)) {
@@ -109,7 +109,7 @@ Vector2f AC_PI_2D::get_i()
 // get_i_shrink - get_i but do not allow integrator to grow in length (it may shrink)
 Vector2f AC_PI_2D::get_i_shrink()
 {
-    if (!is_zero(_ki) && !is_zero(_dt)) {
+    if (!AP_Math::is_zero(_ki) && !AP_Math::is_zero(_dt)) {
         float integrator_length_orig = min(_integrator.length(),_imax);
         _integrator += (_input * _ki) * _dt;
         float integrator_length_new = _integrator.length();
@@ -167,7 +167,7 @@ void AC_PI_2D::operator() (float p, float i, float imaxval, float input_filt_hz,
 // calc_filt_alpha - recalculate the input filter alpha
 void AC_PI_2D::calc_filt_alpha()
 {
-    if (is_zero(_filt_hz)) {
+    if (AP_Math::is_zero(_filt_hz)) {
         _filt_alpha = 1.0f;
         return;
     }

--- a/libraries/AC_WPNav/AC_Circle.cpp
+++ b/libraries/AC_WPNav/AC_Circle.cpp
@@ -247,7 +247,7 @@ void AC_Circle::init_start_angle(bool use_heading)
             _angle = wrap_PI(_ahrs.yaw-PI);
         } else {
             // get bearing from circle center to vehicle in radians
-            float bearing_rad = fast_atan2(curr_pos.y-_center.y,curr_pos.x-_center.x);
+            float bearing_rad = atan2f(curr_pos.y-_center.y,curr_pos.x-_center.x);
             _angle = wrap_PI(bearing_rad);
         }
     }

--- a/libraries/AC_WPNav/AC_Circle.cpp
+++ b/libraries/AC_WPNav/AC_Circle.cpp
@@ -1,6 +1,7 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
 #include <AP_HAL.h>
 #include <AC_Circle.h>
+#include <AP_Math.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -124,7 +125,7 @@ void AC_Circle::update()
         _angle_total += angle_change;
 
         // if the circle_radius is zero we are doing panorama so no need to update loiter target
-        if (_radius != 0.0f) {
+        if (!AP_Math::is_zero(_radius)) {
             // calculate target position
             Vector3f target;
             target.x = _center.x + _radius * cosf(-_angle);
@@ -178,7 +179,7 @@ void AC_Circle::get_closest_point_on_circle(Vector3f &result)
     float dist = pythagorous2(vec.x, vec.y);
 
     // if current location is exactly at the center of the circle return edge directly behind vehicle
-    if (dist == 0) {
+    if (AP_Math::is_zero(dist)) {
         result.x = _center.x - _radius * _ahrs.cos_yaw();
         result.y = _center.y - _radius * _ahrs.sin_yaw();
         result.z = _center.z;
@@ -242,7 +243,7 @@ void AC_Circle::init_start_angle(bool use_heading)
     } else {
         // if we are exactly at the center of the circle, init angle to directly behind vehicle (so vehicle will backup but not change heading)
         const Vector3f &curr_pos = _inav.get_position();
-        if (curr_pos.x == _center.x && curr_pos.y == _center.y) {
+        if (AP_Math::is_equal(curr_pos.x,_center.x) && AP_Math::is_equal(curr_pos.y,_center.y)) {
             _angle = wrap_PI(_ahrs.yaw-PI);
         } else {
             // get bearing from circle center to vehicle in radians

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -262,11 +262,11 @@ void AC_WPNav::calc_loiter_desired_velocity(float nav_dt, float ekfGndSpdLimit)
 
     float desired_speed = desired_vel.length();
 
-    if (desired_speed != 0.0f) {
+    if (!AP_Math::is_zero(desired_speed)) {
         Vector2f desired_vel_norm = desired_vel/desired_speed;
         float drag_speed_delta = -_loiter_accel_cmss*nav_dt*desired_speed/gnd_speed_limit_cms;
 
-        if (_pilot_accel_fwd_cms == 0.0f && _pilot_accel_rgt_cms == 0.0f) {
+        if (_pilot_accel_fwd_cms == 0 && _pilot_accel_rgt_cms == 0) {
             drag_speed_delta = min(drag_speed_delta,-_loiter_accel_min_cmss*nav_dt);
         }
 
@@ -411,7 +411,7 @@ void AC_WPNav::set_wp_origin_and_destination(const Vector3f& origin, const Vecto
     _track_length = pos_delta.length(); // get track length
 
     // calculate each axis' percentage of the total distance to the destination
-    if (_track_length == 0.0f) {
+    if (AP_Math::is_zero(_track_length)) {
         // avoid possible divide by zero
         _pos_delta_unit.x = 0;
         _pos_delta_unit.y = 0;
@@ -682,15 +682,15 @@ void AC_WPNav::calculate_wp_leash_length()
     }
 
     // calculate the maximum acceleration, maximum velocity, and leash length in the direction of travel
-    if(pos_delta_unit_z == 0.0f && pos_delta_unit_xy == 0.0f){
+    if(AP_Math::is_zero(pos_delta_unit_z) &&AP_Math::is_zero(pos_delta_unit_xy)){
         _track_accel = 0;
         _track_speed = 0;
         _track_leash_length = WPNAV_LEASH_LENGTH_MIN;
-    }else if(_pos_delta_unit.z == 0.0f){
+    }else if(AP_Math::is_zero(_pos_delta_unit.z)){
         _track_accel = _wp_accel_cms/pos_delta_unit_xy;
         _track_speed = _wp_speed_cms/pos_delta_unit_xy;
         _track_leash_length = _pos_control.get_leash_xy()/pos_delta_unit_xy;
-    }else if(pos_delta_unit_xy == 0.0f){
+    }else if(AP_Math::is_zero(pos_delta_unit_xy)){
         _track_accel = _wp_accel_z_cms/pos_delta_unit_z;
         _track_speed = speed_z/pos_delta_unit_z;
         _track_leash_length = leash_z/pos_delta_unit_z;
@@ -954,7 +954,7 @@ void AC_WPNav::advance_spline_target_along_track(float dt)
 
         // scale the spline_time by the velocity we've calculated vs the velocity that came out of the spline calculator
         float target_vel_length = target_vel.length();
-        if (target_vel_length != 0.0f) {
+        if (!AP_Math::is_zero(target_vel_length)) {
             _spline_time_scale = _spline_vel_scaler/target_vel_length;
         }
 

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -962,7 +962,7 @@ void AC_WPNav::advance_spline_target_along_track(float dt)
         _pos_control.set_pos_target(target_pos);
 
         // update the yaw
-        _yaw = RadiansToCentiDegrees(fast_atan2(target_vel.y,target_vel.x));
+        _yaw = RadiansToCentiDegrees(atan2f(target_vel.y,target_vel.x));
 
         // advance spline time to next step
         _spline_time += _spline_time_scale*dt;
@@ -1001,7 +1001,7 @@ void AC_WPNav::calc_spline_pos_vel(float spline_time, Vector3f& position, Vector
 // To-Do: move this to math library
 float AC_WPNav::get_bearing_cd(const Vector3f &origin, const Vector3f &destination) const
 {
-    float bearing = 9000 + fast_atan2(-(destination.x-origin.x), destination.y-origin.y) * 5729.57795f;
+    float bearing = 9000 + atan2f(-(destination.x-origin.x), destination.y-origin.y) * 5729.57795f;
     if (bearing < 0) {
         bearing += 36000;
     }

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -682,7 +682,7 @@ void AC_WPNav::calculate_wp_leash_length()
     }
 
     // calculate the maximum acceleration, maximum velocity, and leash length in the direction of travel
-    if(AP_Math::is_zero(pos_delta_unit_z) &&AP_Math::is_zero(pos_delta_unit_xy)){
+    if(AP_Math::is_zero(pos_delta_unit_z) && AP_Math::is_zero(pos_delta_unit_xy)){
         _track_accel = 0;
         _track_speed = 0;
         _track_leash_length = WPNAV_LEASH_LENGTH_MIN;

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -278,7 +278,7 @@ AP_AHRS_DCM::yaw_error_compass(void)
     }
 
     // update vector holding earths magnetic field (if required)
-    if( _last_declination != _compass->get_declination() ) {
+    if( !AP_Math::is_equal(_last_declination,_compass->get_declination()) ) {
         _last_declination = _compass->get_declination();
         _mag_earth.x = cosf(_last_declination);
         _mag_earth.y = sinf(_last_declination);
@@ -740,7 +740,7 @@ AP_AHRS_DCM::drift_correction(float deltat)
     // flat, but still allow for yaw correction using the
     // accelerometers at high roll angles as long as we have a GPS
     if (AP_AHRS_DCM::use_compass()) {
-        if (have_gps() && gps_gain == 1.0f) {
+        if (have_gps() && AP_Math::is_equal(gps_gain,1.0f)) {
             error[besti].z *= sinf(fabsf(roll));
         } else {
             error[besti].z = 0;

--- a/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.pde
+++ b/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.pde
@@ -125,7 +125,7 @@ void loop(void)
                         ToDeg(drift.y),
                         ToDeg(drift.z),
                         compass.use_for_yaw() ? ToDeg(heading) : 0.0f,
-                        (1.0e6*counter)/(now-last_print));
+                        (1.0e6f*counter)/(now-last_print));
         last_print = now;
         counter = 0;
     }

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -197,7 +197,7 @@ float AP_Baro::get_altitude_difference(float base_pressure, float pressure) cons
 float AP_Baro::get_EAS2TAS(void)
 {
     float altitude = get_altitude();
-    if ((fabsf(altitude - _last_altitude_EAS2TAS) < 100.0f) && (_EAS2TAS != 0.0f)) {
+    if ((fabsf(altitude - _last_altitude_EAS2TAS) < 100.0f) && !AP_Math::is_zero(_EAS2TAS)) {
         // not enough change to require re-calculating
         return _EAS2TAS;
     }
@@ -318,13 +318,13 @@ void AP_Baro::update(void)
     // last 0.5 seconds
     uint32_t now = hal.scheduler->millis();
     for (uint8_t i=0; i<_num_sensors; i++) {
-        sensors[i].healthy = (now - sensors[i].last_update_ms < 500) && sensors[i].pressure != 0;
+        sensors[i].healthy = (now - sensors[i].last_update_ms < 500) && !AP_Math::is_zero(sensors[i].pressure);
     }
 
     for (uint8_t i=0; i<_num_sensors; i++) {
         if (sensors[i].healthy) {
             // update altitude calculation
-            if (sensors[i].ground_pressure == 0) {
+            if (AP_Math::is_zero(sensors[i].ground_pressure)) {
                 sensors[i].ground_pressure = sensors[i].pressure;
             }
             sensors[i].altitude = get_altitude_difference(sensors[i].ground_pressure, sensors[i].pressure);

--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -235,7 +235,7 @@ void AP_Camera::send_feedback(mavlink_channel_t chan, AP_GPS &gps, const AP_AHRS
 */
 bool AP_Camera::update_location(const struct Location &loc)
 {
-    if (_trigg_dist == 0.0f) {
+    if (AP_Math::is_zero(_trigg_dist)) {
         return false;
     }
     if (_last_location.lat == 0 && _last_location.lng == 0) {

--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -284,7 +284,7 @@ bool AP_Compass_AK8963_MPU9250::read_raw()
         _mag_y = (float) int16_val(rx, 2);
         _mag_z = (float) int16_val(rx, 3);
 
-        if (_mag_x == 0 && _mag_y == 0 && _mag_z == 0) {
+        if (AP_Math::is_zero(_mag_x) && AP_Math::is_zero(_mag_y) && AP_Math::is_zero(_mag_z)) {
             return false;
         }
 

--- a/libraries/AP_Compass/AP_Compass_Backend.cpp
+++ b/libraries/AP_Compass/AP_Compass_Backend.cpp
@@ -60,7 +60,7 @@ void AP_Compass_Backend::apply_corrections(Vector3f &mag, uint8_t i)
       being applied so it can be logged correctly
      */
     mag += offsets;
-    if(_compass._motor_comp_type != AP_COMPASS_MOT_COMP_DISABLED && _compass._thr_or_curr != 0.0f) {
+    if(_compass._motor_comp_type != AP_COMPASS_MOT_COMP_DISABLED && !AP_Math::is_zero(_compass._thr_or_curr)) {
         state.motor_offset = mot * _compass._thr_or_curr;
         mag += state.motor_offset;
     } else {

--- a/libraries/AP_Compass/Compass.cpp
+++ b/libraries/AP_Compass/Compass.cpp
@@ -276,10 +276,10 @@ const AP_Param::GroupInfo Compass::var_info[] PROGMEM = {
 //
 Compass::Compass(void) :
     _last_update_usec(0),
-    _null_init_done(false),
     _backend_count(0),
     _compass_count(0),
     _board_orientation(ROTATION_NONE),
+    _null_init_done(false),
     _thr_or_curr(0.0f),
     _hil_mode(false)
 {

--- a/libraries/AP_Compass/Compass.cpp
+++ b/libraries/AP_Compass/Compass.cpp
@@ -533,7 +533,7 @@ bool Compass::configured(uint8_t i)
     }
 
     // exit immediately if all offsets are zero
-    if (get_offsets(i).length() == 0.0f) {
+    if (AP_Math::is_zero(get_offsets(i).length())) {
         return false;
     }
 
@@ -575,7 +575,7 @@ void Compass::setHIL(float roll, float pitch, float yaw)
     // create a rotation matrix for the given attitude
     R.from_euler(roll, pitch, yaw);
 
-    if (_hil.last_declination != get_declination()) {
+    if (!AP_Math::is_equal(_hil.last_declination,get_declination())) {
         _setup_earth_field();
         _hil.last_declination = get_declination();
     }

--- a/libraries/AP_GPS/AP_GPS_SBP.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBP.cpp
@@ -54,11 +54,11 @@ AP_GPS_SBP::AP_GPS_SBP(AP_GPS &_gps, AP_GPS::GPS_State &_state,
                        AP_HAL::UARTDriver *_port) :
     AP_GPS_Backend(_gps, _state, _port),
 
-    crc_error_counter(0),
+    last_injected_data_ms(0),
+    last_iar_num_hypotheses(0),
     last_full_update_tow(0),
     last_full_update_cpu_ms(0),
-    last_injected_data_ms(0),
-    last_iar_num_hypotheses(0)
+    crc_error_counter(0)
 {
 
     Debug("SBP Driver Initialized");
@@ -522,3 +522,4 @@ AP_GPS_SBP::logging_log_raw_sbp(uint16_t msg_type,
 #endif // SBP_HW_LOGGING
 
 #endif // GPS_RTK_AVAILABLE
+

--- a/libraries/AP_HAL_AVR_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_AVR_SITL/SITL_State.cpp
@@ -607,7 +607,7 @@ Vector3f SITL_State::_rand_vec3f(void)
 	Vector3f v = Vector3f(_rand_float(),
                           _rand_float(),
                           _rand_float());
-	if (v.length() != 0.0f) {
+	if (!AP_Math::is_zero(v.length())) {
 		v.normalize();
 	}
 	return v;

--- a/libraries/AP_HAL_AVR_SITL/sitl_ins.cpp
+++ b/libraries/AP_HAL_AVR_SITL/sitl_ins.cpp
@@ -80,8 +80,8 @@ uint16_t SITL_State::_airspeed_sensor(float airspeed)
 
 float SITL_State::_gyro_drift(void)
 {
-    if (_sitl->drift_speed == 0.0f ||
-        _sitl->drift_time == 0.0f) {
+    if (AP_Math::is_zero(_sitl->drift_speed) ||
+            AP_Math::is_zero(_sitl->drift_time)) {
 		return 0;
 	}
 	double period  = _sitl->drift_time * 2;

--- a/libraries/AP_HAL_PX4/Util.cpp
+++ b/libraries/AP_HAL_PX4/Util.cpp
@@ -93,7 +93,7 @@ enum PX4Util::safety_state PX4Util::safety_switch_state(void)
 void PX4Util::set_system_clock(uint64_t time_utc_usec)
 {
     timespec ts;
-    ts.tv_sec = time_utc_usec/1.0e6;
+    ts.tv_sec = time_utc_usec/1.0e6f;
     ts.tv_nsec = (time_utc_usec % 1000000) * 1000;
     clock_settime(CLOCK_REALTIME, &ts);    
 }

--- a/libraries/AP_HAL_VRBRAIN/Util.cpp
+++ b/libraries/AP_HAL_VRBRAIN/Util.cpp
@@ -93,7 +93,7 @@ enum VRBRAINUtil::safety_state VRBRAINUtil::safety_switch_state(void)
 void VRBRAINUtil::set_system_clock(uint64_t time_utc_usec)
 {
     timespec ts;
-    ts.tv_sec = time_utc_usec/1.0e6;
+    ts.tv_sec = time_utc_usec/1.0e6f;
     ts.tv_nsec = (time_utc_usec % 1000000) * 1000;
     clock_settime(CLOCK_REALTIME, &ts);    
 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -7,6 +7,7 @@
 #include <AP_HAL.h>
 #include <AP_Notify.h>
 #include <AP_Vehicle.h>
+#include <AP_Math.h>
 
 /*
   enable TIMING_DEBUG to track down scheduling issues with the main
@@ -556,11 +557,11 @@ bool AP_InertialSensor::calibrate_accel(AP_InertialSensor_UserInteract* interact
         bool success = _calibrate_accel(samples[k], new_offsets[k], new_scaling[k], saved_orientation);
 
         interact->printf_P(PSTR("Offsets[%u]: %.2f %.2f %.2f\n"),
-                           (unsigned)k,
-                           new_offsets[k].x, new_offsets[k].y, new_offsets[k].z);
+                            (unsigned)k,
+                           (double)new_offsets[k].x, (double)new_offsets[k].y, (double)new_offsets[k].z);
         interact->printf_P(PSTR("Scaling[%u]: %.2f %.2f %.2f\n"),
                            (unsigned)k,
-                           new_scaling[k].x, new_scaling[k].y, new_scaling[k].z);
+                           (double)new_scaling[k].x, (double)new_scaling[k].y, (double)new_scaling[k].z);
         if (success) num_ok++;
     }
 
@@ -798,7 +799,7 @@ AP_InertialSensor::_init_gyro()
     for (uint8_t k=0; k<num_gyros; k++) {
         if (!converged[k]) {
             hal.console->printf_P(PSTR("gyro[%u] did not converge: diff=%f dps\n"),
-                                  (unsigned)k, ToDeg(best_diff[k]));
+                                  (unsigned)k, (double)ToDeg(best_diff[k]));
             _gyro_offset[k] = best_avg[k];
             // flag calibration as failed for this gyro
             _gyro_cal_ok[k] = false;
@@ -859,7 +860,7 @@ bool AP_InertialSensor::_check_sample_range(const Vector3f accel_sample[6], enum
     }
     Vector3f range = max_sample - min_sample;
     interact->printf_P(PSTR("AccelRange: %.1f %.1f %.1f"),
-                       range.x, range.y, range.z);
+            (double)range.x, (double)range.y, (double)range.z);
     bool ok = (range.x >= min_range && 
                range.y >= min_range && 
                range.z >= min_range);
@@ -988,7 +989,7 @@ void AP_InertialSensor::_calibrate_find_delta(float dS[6], float JS[6][6], float
         //eliminate all nonzero entries below JS[i][i]
         for( j=i+1; j<6; j++ ) {
             mu = JS[i][j]/JS[i][i];
-            if( mu != 0.0f ) {
+            if( !is_zero(mu) ) {
                 dS[j] -= mu*dS[i];
                 for( k=j; k<6; k++ ) {
                     JS[k][j] -= mu*JS[k][i];

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -989,7 +989,7 @@ void AP_InertialSensor::_calibrate_find_delta(float dS[6], float JS[6][6], float
         //eliminate all nonzero entries below JS[i][i]
         for( j=i+1; j<6; j++ ) {
             mu = JS[i][j]/JS[i][i];
-            if( !is_zero(mu) ) {
+            if( !AP_Math::is_zero(mu) ) {
                 dS[j] -= mu*dS[i];
                 for( k=j; k<6; k++ ) {
                     JS[k][j] -= mu*JS[k][i];

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -798,7 +798,7 @@ AP_InertialSensor::_init_gyro()
     hal.console->println();
     for (uint8_t k=0; k<num_gyros; k++) {
         if (!converged[k]) {
-            hal.console->printf_P(PSTR("gyro[%u] did not converge: diff=%f dps\n"),
+            hal.console->printf_P("gyro[%u] did not converge: diff=%f dps\n",
                                   (unsigned)k, (double)ToDeg(best_diff[k]));
             _gyro_offset[k] = best_avg[k];
             // flag calibration as failed for this gyro

--- a/libraries/AP_InertialSensor/AP_InertialSensor_L3GD20.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_L3GD20.cpp
@@ -399,10 +399,10 @@ void AP_InertialSensor_L3GD20::_register_write_check(uint8_t reg, uint8_t val)
     _register_write(reg, val);
     readed = _register_read(reg);
     if (readed != val){
-	hal.console->printf_P(PSTR("Values doesn't match; written: %02x; read: %02x "), val, readed);
+	hal.console->printf_P("Values doesn't match; written: %02x; read: %02x ", val, readed);
     }
 #if L3GD20_DEBUG
-    hal.console->printf_P(PSTR("Values written: %02x; readed: %02x "), val, readed);
+    hal.console->printf_P("Values written: %02x; readed: %02x ", val, readed);
 #endif
 }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM303D.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM303D.cpp
@@ -480,10 +480,10 @@ void AP_InertialSensor_LSM303D::_register_write_check(uint8_t reg, uint8_t val)
     _register_write(reg, val);
     readed = _register_read(reg);
     if (readed != val){
-	hal.console->printf_P(PSTR("Values doesn't match; written: %02x; read: %02x "), val, readed);
+	hal.console->printf_P("Values doesn't match; written: %02x; read: %02x ", val, readed);
     }
 #if LSM303D_DEBUG
-    hal.console->printf_P(PSTR("Values written: %02x; readed: %02x "), val, readed);
+    hal.console->printf_P("Values written: %02x; readed: %02x ", val, readed);
 #endif
 }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -450,7 +450,7 @@ void AP_InertialSensor_MPU6000::_register_write_check(uint8_t reg, uint8_t val)
     _register_write(reg, val);
     readed = _register_read(reg);
     if (readed != val){
-	hal.console->printf_P(PSTR("Values doesn't match; written: %02x; read: %02x "), val, readed);
+	hal.console->printf_P("Values doesn't match; written: %02x; read: %02x ", val, readed);
     }
 #if MPU6000_DEBUG
     hal.console->printf_P(PSTR("Values written: %02x; readed: %02x "), val, readed);

--- a/libraries/AP_Math/AP_Math.cpp
+++ b/libraries/AP_Math/AP_Math.cpp
@@ -47,11 +47,11 @@ float fast_atan(float v)
     //      origin source: https://gist.github.com/volkansalma/2972237/raw/
     float fast_atan2(float y, float x)
     {
-        if (x == 0.0f) {
+        if (AP_Math::is_zero(x)) {
             if (y > 0.0f) {
                 return FAST_ATAN2_PIBY2_FLOAT;
             }
-            if (y == 0.0f) {
+            if (AP_Math::is_zero(y)) {
                 return 0.0f;
             }
             return -FAST_ATAN2_PIBY2_FLOAT;

--- a/libraries/AP_Math/AP_Math.cpp
+++ b/libraries/AP_Math/AP_Math.cpp
@@ -39,48 +39,6 @@ float fast_atan(float v)
     return (v*(1.6867629106f + v2*0.4378497304f)/(1.6867633134f + v2));
 }
 
-#if HAL_CPU_CLASS < HAL_CPU_CLASS_75 || CONFIG_HAL_BOARD == HAL_BOARD_AVR_SITL
-    #define FAST_ATAN2_PIBY2_FLOAT  1.5707963f
-    // fast_atan2 - faster version of atan2
-    //      126 us on AVR cpu vs 199 for regular atan2
-    //      absolute error is < 0.005 radians or 0.28 degrees
-    //      origin source: https://gist.github.com/volkansalma/2972237/raw/
-    float fast_atan2(float y, float x)
-    {
-        if (AP_Math::is_zero(x)) {
-            if (y > 0.0f) {
-                return FAST_ATAN2_PIBY2_FLOAT;
-            }
-            if (AP_Math::is_zero(y)) {
-                return 0.0f;
-            }
-            return -FAST_ATAN2_PIBY2_FLOAT;
-        }
-        float atan;
-        float z = y/x;
-        if (fabs( z ) < 1.0f) {
-            atan = z / (1.0f + 0.28f * z * z);
-            if (x < 0.0f) {
-                if (y < 0.0f) {
-                    return atan - PI;
-                }
-                return atan + PI;
-            }
-        } else {
-            atan = FAST_ATAN2_PIBY2_FLOAT - (z / (z * z + 0.28f));
-            if (y < 0.0f) {
-                return atan - PI;
-            }
-        }
-        return atan;
-    }
-#else
-    float fast_atan2(float y, float x)
-    {
-        return atan2f(y,x);
-    }
-#endif
-
 #if ROTATION_COMBINATION_SUPPORT
 // find a rotation that is the combination of two other
 // rotations. This is used to allow us to add an overall board

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -75,11 +75,15 @@
 AP_PARAMDEFV(Matrix3f, Matrix3f, AP_PARAM_MATRIX3F);
 AP_PARAMDEFV(Vector3f, Vector3f, AP_PARAM_VECTOR3F);
 
-// are two floats equal
-inline bool     is_equal(const float fVal1, const float fVal2) { return fabsf(fVal1 - fVal2) < FLT_EPSILON ? true : false; }
+class AP_Math {
 
-// are two floats equal
-inline bool     is_zero(const float fVal1) { return fabsf(fVal1) < FLT_EPSILON ? true : false; }
+public:
+    // are two floats equal
+    static inline bool is_equal(const float fVal1, const float fVal2) { return fabsf(fVal1 - fVal2) < FLT_EPSILON ? true : false; }
+
+    // is a float is zero
+    static inline bool is_zero(const float fVal1) { return fabsf(fVal1) < FLT_EPSILON ? true : false; }
+};
 
 // a varient of asin() that always gives a valid answer.
 float           safe_asin(float v);

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -95,12 +95,6 @@ float           safe_sqrt(float v);
 // a faster varient of atan.  accurate to 6 decimal places for values between -1 ~ 1 but then diverges quickly
 float           fast_atan(float v);
 
-// fast_atan2 - faster version of atan2
-//      126 us on AVR cpu vs 199 for regular atan2
-//      absolute error is < 0.005 radians or 0.28 degrees
-//      origin source: https://gist.github.com/volkansalma/2972237/raw/
-float           fast_atan2(float y, float x);
-
 #if ROTATION_COMBINATION_SUPPORT
 // find a rotation that is the combination of two other
 // rotations. This is used to allow us to add an overall board

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -20,6 +20,7 @@
 #include "polygon.h"
 #include "edc.h"
 #include "float.h"
+#include "AP_Param.h"
 
 #ifndef M_PI_F
  #define M_PI_F 3.141592653589793f

--- a/libraries/AP_Math/examples/eulers/eulers.pde
+++ b/libraries/AP_Math/examples/eulers/eulers.pde
@@ -268,7 +268,7 @@ void test_frame_transforms(void)
 static float rand_num(void)
 {
     float ret = ((unsigned)random()) % 2000000;
-    return (ret - 1.0e6) / 1.0e6;
+    return (ret - 1.0e6f) / 1.0e6f;
 }
 
 void test_matrix_rotate(void)

--- a/libraries/AP_Math/examples/location/location.pde
+++ b/libraries/AP_Math/examples/location/location.pde
@@ -69,8 +69,8 @@ static const struct {
 static struct Location location_from_point(Vector2f pt)
 {
     struct Location loc = {0};
-    loc.lat = pt.x * 1.0e7;
-    loc.lng = pt.y * 1.0e7;
+    loc.lat = pt.x * 1.0e7f;
+    loc.lng = pt.y * 1.0e7f;
     return loc;
 }
 
@@ -130,8 +130,8 @@ static void test_offset(void)
 {
     struct Location loc;
 
-    loc.lat = -35*1.0e7;
-    loc.lng = 149*1.0e7;
+    loc.lat = -35*1.0e7f;
+    loc.lng = 149*1.0e7f;
 
     for (uint8_t i=0; i<ARRAY_LENGTH(test_offsets); i++) {
         test_one_offset(loc,

--- a/libraries/AP_Math/examples/polygon/polygon.pde
+++ b/libraries/AP_Math/examples/polygon/polygon.pde
@@ -89,8 +89,8 @@ void setup(void)
         result = Polygon_outside(test_points[i].point,
                 OBC_boundary, ARRAY_LENGTH(OBC_boundary));
         hal.console->printf_P(PSTR("%10f,%10f  %s  %s\n"),
-                        1.0e-7*test_points[i].point.x,
-                        1.0e-7*test_points[i].point.y,
+                        1.0e-7f*test_points[i].point.x,
+                        1.0e-7f*test_points[i].point.y,
                         result ? "OUTSIDE" : "INSIDE ",
                         result == test_points[i].outside ? "PASS" : "FAIL");
         if (result != test_points[i].outside) {

--- a/libraries/AP_Math/examples/rotations/rotations.pde
+++ b/libraries/AP_Math/examples/rotations/rotations.pde
@@ -81,7 +81,7 @@ static void test_euler(enum Rotation rotation, float roll, float pitch, float ya
 {
     Vector3f v, v1, v2, diff;
     Matrix3f rotmat;
-    const float accuracy = 1.0e-6;
+    const float accuracy = 1.0e-6f;
 
     v.x = 1;
     v.y = 2;

--- a/libraries/AP_Math/location.cpp
+++ b/libraries/AP_Math/location.cpp
@@ -128,7 +128,7 @@ void location_update(struct Location &loc, float bearing, float distance)
  */
 void location_offset(struct Location &loc, float ofs_north, float ofs_east)
 {
-    if (ofs_north != 0 || ofs_east != 0) {
+    if (!AP_Math::is_zero(ofs_north) || !AP_Math::is_zero(ofs_east)) {
         int32_t dlat = ofs_north * LOCATION_SCALING_FACTOR_INV;
         int32_t dlng = (ofs_east * LOCATION_SCALING_FACTOR_INV) / longitude_scale(loc);
         loc.lat += dlat;
@@ -254,7 +254,7 @@ void wgsecef2llh(const Vector3d &ecef, Vector3d &llh) {
   const double p = sqrt(ecef[0]*ecef[0] + ecef[1]*ecef[1]);
 
   /* Compute longitude first, this can be done exactly. */
-  if (p != 0)
+  if (!AP_Math::is_zero(p))
     llh[1] = atan2(ecef[1], ecef[0]);
   else
     llh[1] = 0;

--- a/libraries/AP_Math/quaternion.cpp
+++ b/libraries/AP_Math/quaternion.cpp
@@ -174,7 +174,7 @@ void Quaternion::to_axis_angle(Vector3f &v) {
     v = Vector3f(q2,q3,q4);
     if(l >= 1.0e-12f) {
         v /= l;
-        v *= wrap_PI(2.0f * atan2(l,q1));
+        v *= wrap_PI(2.0f * atan2f(l,q1));
     }
 }
 

--- a/libraries/AP_Math/vector2.cpp
+++ b/libraries/AP_Math/vector2.cpp
@@ -113,13 +113,13 @@ Vector2<T> Vector2<T>::operator -(void) const
 template <typename T>
 bool Vector2<T>::operator ==(const Vector2<T> &v) const
 {
-    return (x==v.x && y==v.y);
+    return (AP_Math::is_equal(x,v.x) && AP_Math::is_equal(y,v.y));
 }
 
 template <typename T>
 bool Vector2<T>::operator !=(const Vector2<T> &v) const
 {
-    return (x!=v.x || y!=v.y);
+    return (!AP_Math::is_equal(x,v.x) || !AP_Math::is_equal(y,v.y));
 }
 
 template <typename T>

--- a/libraries/AP_Math/vector3.cpp
+++ b/libraries/AP_Math/vector3.cpp
@@ -19,7 +19,7 @@
 
 #include "AP_Math.h"
 
-#define HALF_SQRT_2 0.70710678118654757f
+#define HALF_SQRT_2 0.70710678118654757
 
 // rotate a vector by a standard rotation, attempting
 // to use the minimum number of floating point operations

--- a/libraries/AP_Math/vector3.cpp
+++ b/libraries/AP_Math/vector3.cpp
@@ -19,7 +19,7 @@
 
 #include "AP_Math.h"
 
-#define HALF_SQRT_2 0.70710678118654757
+#define HALF_SQRT_2 0.70710678118654757f
 
 // rotate a vector by a standard rotation, attempting
 // to use the minimum number of floating point operations
@@ -32,8 +32,8 @@ void Vector3<T>::rotate(enum Rotation rotation)
     case ROTATION_MAX:
         return;
     case ROTATION_YAW_45: {
-        tmp = HALF_SQRT_2*(x - y);
-        y   = HALF_SQRT_2*(x + y);
+        tmp = HALF_SQRT_2*(float)(x - y);
+        y   = HALF_SQRT_2*(float)(x + y);
         x = tmp;
         return;
     }
@@ -42,8 +42,8 @@ void Vector3<T>::rotate(enum Rotation rotation)
         return;
     }
     case ROTATION_YAW_135: {
-        tmp = -HALF_SQRT_2*(x + y);
-        y   =  HALF_SQRT_2*(x - y);
+        tmp = -HALF_SQRT_2*(float)(x + y);
+        y   =  HALF_SQRT_2*(float)(x - y);
         x = tmp;
         return;
     }
@@ -51,8 +51,8 @@ void Vector3<T>::rotate(enum Rotation rotation)
         x = -x; y = -y;
         return;
     case ROTATION_YAW_225: {
-        tmp = HALF_SQRT_2*(y - x);
-        y   = -HALF_SQRT_2*(x + y);
+        tmp = HALF_SQRT_2*(float)(y - x);
+        y   = -HALF_SQRT_2*(float)(x + y);
         x = tmp;
         return;
     }
@@ -61,8 +61,8 @@ void Vector3<T>::rotate(enum Rotation rotation)
         return;
     }
     case ROTATION_YAW_315: {
-        tmp = HALF_SQRT_2*(x + y);
-        y   = HALF_SQRT_2*(y - x);
+        tmp = HALF_SQRT_2*(float)(x + y);
+        y   = HALF_SQRT_2*(float)(y - x);
         x = tmp;
         return;
     }
@@ -71,8 +71,8 @@ void Vector3<T>::rotate(enum Rotation rotation)
         return;
     }
     case ROTATION_ROLL_180_YAW_45: {
-        tmp = HALF_SQRT_2*(x + y);
-        y   = HALF_SQRT_2*(x - y);
+        tmp = HALF_SQRT_2*(float)(x + y);
+        y   = HALF_SQRT_2*(float)(x - y);
         x = tmp; z = -z;
         return;
     }
@@ -81,8 +81,8 @@ void Vector3<T>::rotate(enum Rotation rotation)
         return;
     }
     case ROTATION_ROLL_180_YAW_135: {
-        tmp = HALF_SQRT_2*(y - x);
-        y   = HALF_SQRT_2*(y + x);
+        tmp = HALF_SQRT_2*(float)(y - x);
+        y   = HALF_SQRT_2*(float)(y + x);
         x = tmp; z = -z;
         return;
     }
@@ -91,8 +91,8 @@ void Vector3<T>::rotate(enum Rotation rotation)
         return;
     }
     case ROTATION_ROLL_180_YAW_225: {
-        tmp = -HALF_SQRT_2*(x + y);
-        y   =  HALF_SQRT_2*(y - x);
+        tmp = -HALF_SQRT_2*(float)(x + y);
+        y   =  HALF_SQRT_2*(float)(y - x);
         x = tmp; z = -z;
         return;
     }
@@ -101,8 +101,8 @@ void Vector3<T>::rotate(enum Rotation rotation)
         return;
     }
     case ROTATION_ROLL_180_YAW_315: {
-        tmp =  HALF_SQRT_2*(x - y);
-        y   = -HALF_SQRT_2*(x + y);
+        tmp =  HALF_SQRT_2*(float)(x - y);
+        y   = -HALF_SQRT_2*(float)(x + y);
         x = tmp; z = -z;
         return;
     }
@@ -112,8 +112,8 @@ void Vector3<T>::rotate(enum Rotation rotation)
     }
     case ROTATION_ROLL_90_YAW_45: {
         tmp = z; z = y; y = -tmp;
-        tmp = HALF_SQRT_2*(x - y);
-        y   = HALF_SQRT_2*(x + y);
+        tmp = HALF_SQRT_2*(float)(x - y);
+        y   = HALF_SQRT_2*(float)(x + y);
         x = tmp;
         return;
     }
@@ -124,8 +124,8 @@ void Vector3<T>::rotate(enum Rotation rotation)
     }
     case ROTATION_ROLL_90_YAW_135: {
         tmp = z; z = y; y = -tmp;
-        tmp = -HALF_SQRT_2*(x + y);
-        y   =  HALF_SQRT_2*(x - y);
+        tmp = -HALF_SQRT_2*(float)(x + y);
+        y   =  HALF_SQRT_2*(float)(x - y);
         x = tmp;
         return;
     }
@@ -135,8 +135,8 @@ void Vector3<T>::rotate(enum Rotation rotation)
     }
     case ROTATION_ROLL_270_YAW_45: {
         tmp = z; z = -y; y = tmp;
-        tmp = HALF_SQRT_2*(x - y);
-        y   = HALF_SQRT_2*(x + y);
+        tmp = HALF_SQRT_2*(float)(x - y);
+        y   = HALF_SQRT_2*(float)(x + y);
         x = tmp;
         return;
     }
@@ -147,8 +147,8 @@ void Vector3<T>::rotate(enum Rotation rotation)
     }
     case ROTATION_ROLL_270_YAW_135: {
         tmp = z; z = -y; y = tmp;
-        tmp = -HALF_SQRT_2*(x + y);
-        y   =  HALF_SQRT_2*(x - y);
+        tmp = -HALF_SQRT_2*(float)(x + y);
+        y   =  HALF_SQRT_2*(float)(x - y);
         x = tmp;
         return;
     }
@@ -339,7 +339,7 @@ bool Vector3<T>::operator !=(const Vector3<T> &v) const
 template <typename T>
 float Vector3<T>::angle(const Vector3<T> &v2) const
 {
-    return acosf(((*this)*v2) / (this->length()*v2.length()));
+    return acosf((*this)*v2) / (float)((this->length()*v2.length()));
 }
 
 // multiplication of transpose by a vector

--- a/libraries/AP_Math/vector3.cpp
+++ b/libraries/AP_Math/vector3.cpp
@@ -327,13 +327,13 @@ Vector3<T> Vector3<T>::operator -(void) const
 template <typename T>
 bool Vector3<T>::operator ==(const Vector3<T> &v) const
 {
-    return (x==v.x && y==v.y && z==v.z);
+    return (AP_Math::is_equal(x,v.x) && AP_Math::is_equal(y,v.y) && AP_Math::is_equal(z,v.z));
 }
 
 template <typename T>
 bool Vector3<T>::operator !=(const Vector3<T> &v) const
 {
-    return (x!=v.x || y!=v.y || z!=v.z);
+    return (!AP_Math::is_equal(x,v.x) || !AP_Math::is_equal(y,v.y) || !AP_Math::is_equal(z,v.z));
 }
 
 template <typename T>

--- a/libraries/AP_Math/vector3.h
+++ b/libraries/AP_Math/vector3.h
@@ -51,7 +51,9 @@
 #define VECTOR3_H
 
 #include <math.h>
+#include <float.h>
 #include <string.h>
+
 
 #if defined(MATH_CHECK_INDEXES) && (MATH_CHECK_INDEXES == 1)
 #include <assert.h>
@@ -154,7 +156,8 @@ public:
     bool is_inf(void) const;
 
     // check if all elements are zero
-    bool is_zero(void) const { return x==0 && y == 0 && z == 0; }
+    bool is_zero(void) const { return (fabsf(x) < FLT_EPSILON) && (fabsf(y) < FLT_EPSILON) && (fabsf(z) < FLT_EPSILON); }
+
 
     // rotate by a standard rotation
     void rotate(enum Rotation rotation);

--- a/libraries/AP_Mount/AP_Gimbal.cpp
+++ b/libraries/AP_Mount/AP_Gimbal.cpp
@@ -8,12 +8,13 @@
 #include <AP_Common.h>
 #include <GCS.h>
 #include <AP_SmallEKF.h>
+#include "AP_Math.h"
 
 void AP_Gimbal::receive_feedback(mavlink_channel_t chan, mavlink_message_t *msg)
 {
     decode_feedback(msg);
     update_state();
-    if (_ekf.getStatus() && !isCopterFlipped() && _gimbalParams.K_gimbalRate!=0.0f){
+    if (_ekf.getStatus() && !isCopterFlipped() && !AP_Math::is_zero(_gimbalParams.K_gimbalRate)){
         send_control(chan);
     }
 

--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -154,13 +154,13 @@ void AP_Mount_Servo::stabilize()
         // lead filter
         const Vector3f &gyro = _frontend._ahrs.get_gyro();
 
-        if (_state._stab_roll && _state._roll_stb_lead != 0.0f && fabsf(_frontend._ahrs.pitch) < M_PI/3.0f) {
+        if (_state._stab_roll && !AP_Math::is_zero(_state._roll_stb_lead) && fabsf(_frontend._ahrs.pitch) < (float)M_PI/3.0f) {
             // Compute rate of change of euler roll angle
             float roll_rate = gyro.x + (_frontend._ahrs.sin_pitch() / _frontend._ahrs.cos_pitch()) * (gyro.y * _frontend._ahrs.sin_roll() + gyro.z * _frontend._ahrs.cos_roll());
             _angle_bf_output_deg.x -= degrees(roll_rate) * _state._roll_stb_lead;
         }
 
-        if (_state._stab_tilt && _state._pitch_stb_lead != 0.0f) {
+        if (_state._stab_tilt && !AP_Math::is_zero(_state._pitch_stb_lead)) {
             // Compute rate of change of euler pitch angle
             float pitch_rate = _frontend._ahrs.cos_pitch() * gyro.y - _frontend._ahrs.sin_roll() * gyro.z;
             _angle_bf_output_deg.y -= degrees(pitch_rate) * _state._pitch_stb_lead;

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -4264,7 +4264,7 @@ void NavEKF::readMagData()
         // check if compass offsets have ben changed and adjust EKF bias states to maintain consistent innovations
         if (_ahrs->get_compass()->healthy(0)) {
             Vector3f nowMagOffsets = _ahrs->get_compass()->get_offsets(0);
-            bool changeDetected = ((nowMagOffsets.x != lastMagOffsets.x) || (nowMagOffsets.y != lastMagOffsets.y) || (nowMagOffsets.z != lastMagOffsets.z));
+            bool changeDetected = (!AP_Math::is_equal(nowMagOffsets.x,lastMagOffsets.x) || !AP_Math::is_equal(nowMagOffsets.y,lastMagOffsets.y) || !AP_Math::is_equal(nowMagOffsets.z,lastMagOffsets.z));
             // Ignore bias changes before final mag field and yaw initialisation, as there may have been a compass calibration
             if (changeDetected && secondMagYawInit) {
                 state.body_magfield.x += (nowMagOffsets.x - lastMagOffsets.x) * 0.001f;

--- a/libraries/AP_NavEKF/AP_SmallEKF.cpp
+++ b/libraries/AP_NavEKF/AP_SmallEKF.cpp
@@ -859,7 +859,7 @@ float SmallEKF::calcMagHeadingInnov()
     if (_main_ekf.healthy()) {
         _main_ekf.getMagNED(earth_magfield);
         _main_ekf.getMagXYZ(body_magfield);
-        declination = atan2(earth_magfield.y,earth_magfield.x);
+        declination = atan2f(earth_magfield.y,earth_magfield.x);
     } else {
         body_magfield.zero();
         earth_magfield.zero();
@@ -873,7 +873,7 @@ float SmallEKF::calcMagHeadingInnov()
     Vector3f magMeasNED = Tmn*(magData - body_magfield);
 
     // calculate the innovation where the predicted measurement is the angle wrt magnetic north of the horizontal component of the measured field
-    float innovation = atan2(magMeasNED.y,magMeasNED.x) - declination;
+    float innovation = atan2f(magMeasNED.y,magMeasNED.x) - declination;
 
     // wrap the innovation so it sits on the range from +-pi
     if (innovation > 3.1415927f) {
@@ -910,7 +910,7 @@ void SmallEKF::getDebug(float &tilt, Vector3f &velocity, Vector3f &euler, Vector
     tilt = TiltCorrection;
     velocity = state.velocity;
     state.quat.to_euler(euler.x, euler.y, euler.z);
-    if (dtIMU < 1.0e-6) {
+    if (dtIMU < 1.0e-6f) {
         gyroBias.zero();
     } else {
         gyroBias = state.delAngBias / dtIMU;
@@ -920,7 +920,7 @@ void SmallEKF::getDebug(float &tilt, Vector3f &velocity, Vector3f &euler, Vector
 // get gyro bias data
 void SmallEKF::getGyroBias(Vector3f &gyroBias) const
 {
-    if (dtIMU < 1.0e-6) {
+    if (dtIMU < 1.0e-6f) {
         gyroBias.zero();
     } else {
         gyroBias = state.delAngBias / dtIMU;

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -1154,7 +1154,7 @@ void AP_Param::convert_old_parameter(const struct ConversionInfo *info)
     AP_Param *ap2;
     ap2 = find_P((const prog_char_t *)&info->new_name[0], &ptype);
     if (ap2 == NULL) {
-        hal.console->printf_P(PSTR("Unknown conversion '%S'\n"), info->new_name);
+        hal.console->printf_P("Unknown conversion '%s'\n", info->new_name);
         return;
     }
 
@@ -1184,7 +1184,7 @@ void AP_Param::convert_old_parameter(const struct ConversionInfo *info)
         }
     } else {
         // can't do vector<->scalar conversion, or different vector types
-        hal.console->printf_P(PSTR("Bad conversion type '%S'\n"), info->new_name);
+        hal.console->printf_P("Bad conversion type '%s'\n", info->new_name);
     }
 }
 #pragma GCC diagnostic pop

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -735,7 +735,7 @@ bool AP_Param::save(bool force_save)
         } else {
             v2 = get_default_value(&info->def_value);
         }
-        if (v1 == v2 && !force_save) {
+        if (AP_Math::is_equal(v1,v2) && !force_save) {
             return true;
         }
         if (phdr.type != AP_PARAM_INT32 &&
@@ -1177,7 +1177,7 @@ void AP_Param::convert_old_parameter(const struct ConversionInfo *info)
     } else if (ptype <= AP_PARAM_FLOAT && header.type <= AP_PARAM_FLOAT) {
         // perform scalar->scalar conversion
         float v = ap->cast_to_float((enum ap_var_type)header.type);
-        if (v != ap2->cast_to_float(ptype)) {
+        if (!AP_Math::is_equal(v,ap2->cast_to_float(ptype))) {
             // the value needs to change
             set_value(ptype, ap2, v);
             ap2->save();

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -1094,7 +1094,7 @@ void AP_Param::show(const AP_Param *ap, const char *s,
         port->printf_P(PSTR("%s: %ld\n"), s, (long)((AP_Int32 *)ap)->get());
         break;
     case AP_PARAM_FLOAT:
-        port->printf_P(PSTR("%s: %f\n"), s, ((AP_Float *)ap)->get());
+        port->printf_P(PSTR("%s: %f\n"), s, (double)((AP_Float *)ap)->get());
         break;
     default:
         break;

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -25,6 +25,8 @@
 #include <stddef.h>
 #include <string.h>
 #include <stdint.h>
+#include <math.h>
+#include "float.h"
 
 #include <AP_Progmem.h>
 #include <../StorageManager/StorageManager.h>
@@ -421,7 +423,7 @@ public:
     /// Combined set and save
     ///
     bool set_and_save(const T &v) {
-        bool force = (_value != v);
+        bool force = fabsf(_value - v) < FLT_EPSILON;
         set(v);
         return save(force);
     }

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -356,8 +356,8 @@ void RangeFinder::update_pre_arm_check(uint8_t instance)
     // Check that the range finder has been exercised through a realistic range of movement
     if (((state[instance].pre_arm_distance_max - state[instance].pre_arm_distance_min) > RANGEFINDER_PREARM_REQUIRED_CHANGE_CM) &&
          (state[instance].pre_arm_distance_max < RANGEFINDER_PREARM_ALT_MAX_CM) &&
-         (state[instance].pre_arm_distance_min < (max(_ground_clearance_cm[instance],min_distance_cm(instance)) + 10)) &&
-         (state[instance].pre_arm_distance_min > (min(_ground_clearance_cm[instance],min_distance_cm(instance)) - 10))) {
+         ((int16_t)state[instance].pre_arm_distance_min < (max(_ground_clearance_cm[instance],min_distance_cm(instance)) + 10)) &&
+         ((int16_t)state[instance].pre_arm_distance_min > (min(_ground_clearance_cm[instance],min_distance_cm(instance)) - 10))) {
         state[instance].pre_arm_check = true;
     }
 }

--- a/libraries/AP_RangeFinder/RangeFinder_Backend.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder_Backend.cpp
@@ -33,9 +33,9 @@ AP_RangeFinder_Backend::AP_RangeFinder_Backend(RangeFinder &_ranger, uint8_t ins
 void AP_RangeFinder_Backend::update_status()
 {
     // check distance
-    if (state.distance_cm > ranger._max_distance_cm[state.instance]) {
+    if ((int16_t)state.distance_cm > ranger._max_distance_cm[state.instance]) {
         set_status(RangeFinder::RangeFinder_OutOfRangeHigh);
-    } else if (state.distance_cm < ranger._min_distance_cm[state.instance]) {
+    } else if ((int16_t)state.distance_cm < ranger._min_distance_cm[state.instance]) {
         set_status(RangeFinder::RangeFinder_OutOfRangeLow);
     } else {
         set_status(RangeFinder::RangeFinder_Good);

--- a/libraries/AP_Scheduler/AP_Scheduler.cpp
+++ b/libraries/AP_Scheduler/AP_Scheduler.cpp
@@ -73,7 +73,7 @@ void AP_Scheduler::run(uint16_t time_available)
             if (dt >= interval_ticks*2) {
                 // we've slipped a whole run of this task!
                 if (_debug > 1) {
-                    hal.console->printf_P(PSTR("Scheduler slip task[%u] (%u/%u/%u)\n"), 
+                    hal.console->printf_P("Scheduler slip task[%u] (%u/%u/%u)\n",
                                           (unsigned)i, 
                                           (unsigned)dt,
                                           (unsigned)interval_ticks,
@@ -100,7 +100,7 @@ void AP_Scheduler::run(uint16_t time_available)
                 if (time_taken > _task_time_allowed) {
                     // the event overran!
                     if (_debug > 2) {
-                        hal.console->printf_P(PSTR("Scheduler overrun task[%u] (%u/%u)\n"), 
+                        hal.console->printf_P("Scheduler overrun task[%u] (%u/%u)\n",
                                               (unsigned)i, 
                                               (unsigned)time_taken,
                                               (unsigned)_task_time_allowed);

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -338,35 +338,35 @@ void DataFlash_Class::_print_log_entry(uint8_t msg_type,
         case 'f': {
             float v;
             memcpy(&v, &pkt[ofs], sizeof(v));
-            port->printf_P(PSTR("%f"), v);
+            port->printf_P(PSTR("%f"), (double)v);
             ofs += sizeof(v);
             break;
         }
         case 'c': {
             int16_t v;
             memcpy(&v, &pkt[ofs], sizeof(v));
-            port->printf_P(PSTR("%.2f"), 0.01f*v);
+            port->printf_P(PSTR("%.2f"), (double)(0.01f*v));
             ofs += sizeof(v);
             break;
         }
         case 'C': {
             uint16_t v;
             memcpy(&v, &pkt[ofs], sizeof(v));
-            port->printf_P(PSTR("%.2f"), 0.01f*v);
+            port->printf_P(PSTR("%.2f"), (double)(0.01f*v));
             ofs += sizeof(v);
             break;
         }
         case 'e': {
             int32_t v;
             memcpy(&v, &pkt[ofs], sizeof(v));
-            port->printf_P(PSTR("%.2f"), 0.01f*v);
+            port->printf_P(PSTR("%.2f"), (double)(0.01f*v));
             ofs += sizeof(v);
             break;
         }
         case 'E': {
             uint32_t v;
             memcpy(&v, &pkt[ofs], sizeof(v));
-            port->printf_P(PSTR("%.2f"), 0.01f*v);
+            port->printf_P(PSTR("%.2f"), (double)(0.01f*v));
             ofs += sizeof(v);
             break;
         }

--- a/libraries/Filter/LowPassFilter2p.cpp
+++ b/libraries/Filter/LowPassFilter2p.cpp
@@ -25,7 +25,7 @@
 
 float DigitalBiquadFilter::apply(float sample, const struct biquad_params &params)
 {
-    if(params.cutoff_freq == 0 || params.sample_freq == 0) {
+    if(AP_Math::is_zero(params.cutoff_freq) || AP_Math::is_zero(params.sample_freq)) {
         return sample;
     }
 

--- a/libraries/Filter/examples/Derivative/Derivative.pde
+++ b/libraries/Filter/examples/Derivative/Derivative.pde
@@ -29,7 +29,7 @@ static float noise(void)
 void loop()
 {
     hal.scheduler->delay(50);
-    float t = hal.scheduler->millis()*1.0e-3;
+    float t = hal.scheduler->millis()*1.0e-3f;
     float s = sinf(t);
     //s += noise();
     uint32_t t1 = hal.scheduler->micros();

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -151,8 +151,8 @@ void SITL::convert_body_frame(double rollDeg, double pitchDeg,
 	thetaDot = ToRad(pitchRate);
 	psiDot = ToRad(yawRate);
 
-	*p = phiDot - psiDot*sinf(theta);
-	*q = cosf(phi)*thetaDot + sinf(phi)*psiDot*cosf(theta);
-	*r = cosf(phi)*psiDot*cosf(theta) - sinf(phi)*thetaDot;    
+	*p = phiDot - psiDot*sin(theta);
+	*q = cos(phi)*thetaDot + sin(phi)*psiDot*cos(theta);
+	*r = cos(phi)*psiDot*cos(theta) - sin(phi)*thetaDot;
 }
 


### PR DESCRIPTION
This brings the total compiler warnings from 1350 down to 800. Most of the commits are implementing AP_Math::is_equal() and AP_Math::is_zero(). I've added static functions in a new AP_Math class so it's obvious where we're calling from. the function "is_zero()" is a popular name.
