### PR TITLE
Add PX4Flow sonar

### DIFF
--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_PX4.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_PX4.cpp
@@ -34,6 +34,8 @@
 
 extern const AP_HAL::HAL& hal;
 
+static float last_ground_distance_m = -1;    // value of ground distance read by last sonar sensor in m (<0 = no sensor init)
+
 AP_OpticalFlow_PX4::AP_OpticalFlow_PX4(OpticalFlow &_frontend) : 
 OpticalFlow_backend(_frontend) 
 {}
@@ -57,6 +59,7 @@ void AP_OpticalFlow_PX4::init(void)
 // update - read latest values from sensor and fill in x,y and totals.
 void AP_OpticalFlow_PX4::update(void)
 {
+
     // return immediately if not initialised
     if (_fd == -1) {
         return;
@@ -68,6 +71,7 @@ void AP_OpticalFlow_PX4::update(void)
         struct OpticalFlow::OpticalFlow_state state;
         state.device_id = report.sensor_id;
         state.surface_quality = report.quality;
+        last_ground_distance_m = report.ground_distance_m;
         if (report.integration_timespan > 0) {
             float yawAngleRad = _yawAngleRad();
             float cosYaw = cosf(yawAngleRad);
@@ -89,6 +93,12 @@ void AP_OpticalFlow_PX4::update(void)
 
         _update_frontend(state);
     }
+}
+
+// ground_distance - read ground distance of last sensor data
+float AP_OpticalFlow_PX4_ground_distance(void)
+{
+    return last_ground_distance_m;
 }
 
 #endif // CONFIG_HAL_BOARD == HAL_BOARD_PX4

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_PX4.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_PX4.h
@@ -22,4 +22,7 @@ private:
     uint64_t    _last_timestamp;    // time of last update (used to avoid processing old reports)
 };
 
+// ground_distance
+float AP_OpticalFlow_PX4_ground_distance(void);
+
 #endif

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PX4_Flow.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PX4_Flow.cpp
@@ -1,0 +1,59 @@
+// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ *       AP_RangeFinder_PX4_Flow.cpp - Arduino Library for using sonar on PX4Flow
+ *       Code by krriel (info@krriel.de)
+ */
+
+#include "AP_RangeFinder_PX4_Flow.h"
+#include "AP_OpticalFlow_PX4.h"
+
+/* 
+   The constructor also initialises the rangefinder. Note that this
+   constructor is not called until detect() returns true, so we
+   already know that we should setup the rangefinder
+*/
+AP_RangeFinder_PX4_Flow::AP_RangeFinder_PX4_Flow(RangeFinder &_ranger, uint8_t instance, RangeFinder::RangeFinder_State &_state) :
+    AP_RangeFinder_Backend(_ranger, instance, _state)
+{
+}
+
+/* 
+   return that PX4Flow init is ok, real detect will not work because PX4_Flow will be init after RangeFinder functions
+*/
+bool AP_RangeFinder_PX4_Flow::detect(RangeFinder &_ranger, uint8_t instance)
+{
+    return true;
+}
+
+
+/* 
+   update the state of the sensor
+*/
+void AP_RangeFinder_PX4_Flow::update(void)
+{
+    float dist_m;
+    dist_m = AP_OpticalFlow_PX4_ground_distance();
+    if (dist_m > -0.5) { //PX4Flow init ok
+        if (dist_m < 0.0f) dist_m = 0.0f;
+        state.distance_cm = dist_m * 100.0f;
+        // update range_valid state based on distance measured
+        update_status();
+    } else {
+        set_status(RangeFinder::RangeFinder_NoData);
+    }
+}

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PX4_Flow.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PX4_Flow.h
@@ -1,0 +1,22 @@
+// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+
+#ifndef __AP_RANGEFINDER_PX4_FLOW_H__
+#define __AP_RANGEFINDER_PX4_FLOW_H__
+
+#include "RangeFinder.h"
+#include "RangeFinder_Backend.h"
+
+class AP_RangeFinder_PX4_Flow : public AP_RangeFinder_Backend
+{
+public:
+    // constructor
+    AP_RangeFinder_PX4_Flow(RangeFinder &ranger, uint8_t instance, RangeFinder::RangeFinder_State &_state);
+
+    // static detection function
+    static bool detect(RangeFinder &ranger, uint8_t instance);
+
+    // update state
+    void update(void);
+
+};
+#endif  // __AP_RANGEFINDER_PX4_FLOW_H__

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -20,6 +20,7 @@
 #include "AP_RangeFinder_MaxsonarI2CXL.h"
 #include "AP_RangeFinder_PX4.h"
 #include "AP_RangeFinder_PX4_PWM.h"
+#include "AP_RangeFinder_PX4_Flow.h"
 
 // table of user settable parameters
 const AP_Param::GroupInfo RangeFinder::var_info[] PROGMEM = {
@@ -290,6 +291,13 @@ void RangeFinder::detect_instance(uint8_t instance)
         if (AP_RangeFinder_analog::detect(*this, instance)) {
             state[instance].instance = instance;
             drivers[instance] = new AP_RangeFinder_analog(*this, instance, state[instance]);
+            return;
+        }
+    }
+    if (type == RangeFinder_TYPE_PX4_FLOW) {
+        if (AP_RangeFinder_PX4_Flow::detect(*this, instance)) {
+            state[instance].instance = instance;
+            drivers[instance] = new AP_RangeFinder_PX4_Flow(*this, instance, state[instance]);
             return;
         }
     }

--- a/libraries/AP_RangeFinder/RangeFinder.h
+++ b/libraries/AP_RangeFinder/RangeFinder.h
@@ -44,12 +44,13 @@ public:
 
     // RangeFinder driver types
     enum RangeFinder_Type {
-        RangeFinder_TYPE_NONE   = 0,
-        RangeFinder_TYPE_ANALOG = 1,
-        RangeFinder_TYPE_MBI2C  = 2,
-        RangeFinder_TYPE_PLI2C  = 3,
-        RangeFinder_TYPE_PX4    = 4,
-        RangeFinder_TYPE_PX4_PWM= 5
+        RangeFinder_TYPE_NONE       = 0,
+        RangeFinder_TYPE_ANALOG     = 1,
+        RangeFinder_TYPE_MBI2C      = 2,
+        RangeFinder_TYPE_PLI2C      = 3,
+        RangeFinder_TYPE_PX4        = 4,
+        RangeFinder_TYPE_PX4_PWM    = 5,
+        RangeFinder_TYPE_PX4_FLOW   = 6
     };
 
     enum RangeFinder_Function {


### PR DESCRIPTION
RangeFinder_TYPE_PX4_FLOW = 6 enable sonar function for on-board sonar
of PX4Flow. Nice to have: better link between RangeFinder and
OpticalFlow lib, but it still works.