### PR TITLE
Log mission changes to dataflash

### DIFF
--- a/APMrover2/GCS_Mavlink.pde
+++ b/APMrover2/GCS_Mavlink.pde
@@ -1068,7 +1068,9 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
 	// XXX receive a WP from GCS and store in EEPROM
     case MAVLINK_MSG_ID_MISSION_ITEM:
         {
-            handle_mission_item(msg, mission);
+            if (handle_mission_item(msg, mission)) {
+                Log_Write_EntireMission();
+            }
             break;
         }
 

--- a/APMrover2/Log.pde
+++ b/APMrover2/Log.pde
@@ -244,9 +244,21 @@ static void Log_Write_Startup(uint8_t type)
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
 
     // write all commands to the dataflash as well
+    Log_Write_EntireMission();
+}
+
+static void Log_Write_EntireMission()
+{
+    if (mission.num_commands() > 0) {
+        gcs_send_text_P(SEVERITY_LOW, PSTR("New mission"));
+    }
+    else {
+        gcs_send_text_P(SEVERITY_LOW, PSTR("New mission is empty"));
+    }
+
     AP_Mission::Mission_Command cmd;
     for (uint16_t i = 0; i < mission.num_commands(); i++) {
-        if(mission.read_cmd_from_storage(i,cmd)) {
+        if (mission.read_cmd_from_storage(i,cmd)) {
             Log_Write_Cmd(cmd);
         }
     }
@@ -430,6 +442,7 @@ static void start_logging()
 
 // dummy functions
 static void Log_Write_Startup(uint8_t type) {}
+static void Log_Write_EntireMission() {}
 static void Log_Write_Current() {}
 static void Log_Write_Nav_Tuning() {}
 static void Log_Write_Performance() {}

--- a/APMrover2/Log.pde
+++ b/APMrover2/Log.pde
@@ -249,12 +249,7 @@ static void Log_Write_Startup(uint8_t type)
 
 static void Log_Write_EntireMission()
 {
-    if (mission.num_commands() > 0) {
-        gcs_send_text_P(SEVERITY_LOW, PSTR("New mission"));
-    }
-    else {
-        gcs_send_text_P(SEVERITY_LOW, PSTR("New mission is empty"));
-    }
+    gcs_send_text_P(SEVERITY_LOW, PSTR("New mission"));
 
     AP_Mission::Mission_Command cmd;
     for (uint16_t i = 0; i < mission.num_commands(); i++) {

--- a/ArduCopter/GCS_Mavlink.pde
+++ b/ArduCopter/GCS_Mavlink.pde
@@ -956,7 +956,9 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
     // GCS has sent us a command from GCS, store to EEPROM
     case MAVLINK_MSG_ID_MISSION_ITEM:           // MAV ID: 39
     {
-        handle_mission_item(msg, mission);
+        if (handle_mission_item(msg, mission)) {
+            Log_Write_EntireMission();
+        }
         break;
     }
 

--- a/ArduCopter/Log.pde
+++ b/ArduCopter/Log.pde
@@ -464,12 +464,7 @@ static void Log_Write_Startup()
 
 static void Log_Write_EntireMission()
 {
-    if (mission.num_commands() > 0) {
-        gcs_send_text_P(SEVERITY_LOW, PSTR("New mission"));
-    }
-    else {
-        gcs_send_text_P(SEVERITY_LOW, PSTR("New mission is empty"));
-    }
+    gcs_send_text_P(SEVERITY_LOW, PSTR("New mission"));
 
     AP_Mission::Mission_Command cmd;
     for (uint16_t i = 0; i < mission.num_commands(); i++) {

--- a/ArduCopter/Log.pde
+++ b/ArduCopter/Log.pde
@@ -458,6 +458,25 @@ static void Log_Write_Startup()
         LOG_PACKET_HEADER_INIT(LOG_STARTUP_MSG)
     };
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
+
+    Log_Write_EntireMission();
+}
+
+static void Log_Write_EntireMission()
+{
+    if (mission.num_commands() > 0) {
+        gcs_send_text_P(SEVERITY_LOW, PSTR("New mission"));
+    }
+    else {
+        gcs_send_text_P(SEVERITY_LOW, PSTR("New mission is empty"));
+    }
+
+    AP_Mission::Mission_Command cmd;
+    for (uint16_t i = 0; i < mission.num_commands(); i++) {
+        if (mission.read_cmd_from_storage(i,cmd)) {
+            Log_Write_Cmd(cmd);
+        }
+    }
 }
 
 struct PACKED log_Event {
@@ -712,6 +731,7 @@ static void start_logging()
 #else // LOGGING_ENABLED
 
 static void Log_Write_Startup() {}
+static void Log_Write_EntireMission() {}
 #if AUTOTUNE_ENABLED == ENABLED
 static void Log_Write_AutoTune(uint8_t axis, uint8_t tune_step, float rate_target, float rate_min, float rate_max, float new_gain_rp, float new_gain_rd, float new_gain_sp) {}
 static void Log_Write_AutoTuneDetails(float angle_cd, float rate_cds) {}

--- a/ArduPlane/GCS_Mavlink.pde
+++ b/ArduPlane/GCS_Mavlink.pde
@@ -1352,7 +1352,9 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
     // GCS has sent us a command from GCS, store to EEPROM
     case MAVLINK_MSG_ID_MISSION_ITEM:
     {
-        handle_mission_item(msg, mission);
+        if (handle_mission_item(msg, mission)) {
+            Log_Write_EntireMission();
+        }
         break;
     }
 

--- a/ArduPlane/Log.pde
+++ b/ArduPlane/Log.pde
@@ -250,12 +250,7 @@ static void Log_Write_Startup(uint8_t type)
 
 static void Log_Write_EntireMission()
 {
-    if (mission.num_commands() > 0) {
-        gcs_send_text_P(SEVERITY_LOW, PSTR("New mission"));
-    }
-    else {
-        gcs_send_text_P(SEVERITY_LOW, PSTR("New mission is empty"));
-    }
+    gcs_send_text_P(SEVERITY_LOW, PSTR("New mission"));
 
     AP_Mission::Mission_Command cmd;
     for (uint16_t i = 0; i < mission.num_commands(); i++) {

--- a/ArduPlane/Log.pde
+++ b/ArduPlane/Log.pde
@@ -245,6 +245,18 @@ static void Log_Write_Startup(uint8_t type)
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
 
     // write all commands to the dataflash as well
+    Log_Write_EntireMission();
+}
+
+static void Log_Write_EntireMission()
+{
+    if (mission.num_commands() > 0) {
+        gcs_send_text_P(SEVERITY_LOW, PSTR("New mission"));
+    }
+    else {
+        gcs_send_text_P(SEVERITY_LOW, PSTR("New mission is empty"));
+    }
+
     AP_Mission::Mission_Command cmd;
     for (uint16_t i = 0; i < mission.num_commands(); i++) {
         if (mission.read_cmd_from_storage(i,cmd)) {
@@ -518,6 +530,7 @@ static void start_logging()
 
 // dummy functions
 static void Log_Write_Startup(uint8_t type) {}
+static void Log_Write_EntireMission() {}
 static void Log_Write_Current() {}
 static void Log_Write_Nav_Tuning() {}
 static void Log_Write_TECS_Tuning() {}

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -285,7 +285,7 @@ private:
     void handle_mission_count(AP_Mission &mission, mavlink_message_t *msg);
     void handle_mission_clear_all(AP_Mission &mission, mavlink_message_t *msg);
     void handle_mission_write_partial_list(AP_Mission &mission, mavlink_message_t *msg);
-    void handle_mission_item(mavlink_message_t *msg, AP_Mission &mission);
+    bool handle_mission_item(mavlink_message_t *msg, AP_Mission &mission);
 
     void handle_request_data_stream(mavlink_message_t *msg, bool save);
     void handle_param_request_list(mavlink_message_t *msg);


### PR DESCRIPTION
When uploading a new mission, and the new mission has completed, write the new mission to dataflash so it can be seen when updates are done after boot.

Rover and Plane both dumped their mission on boot and Copter did not. Now all three work the same and log the mission on boot and on full mission changes.

There is no logging if you change a single item of a mission.