### PR TITLE
Showstopper in AP_Compass:

### DIFF
--- a/libraries/AP_Compass/Compass.cpp
+++ b/libraries/AP_Compass/Compass.cpp
@@ -366,7 +366,7 @@ Compass::_detect_backends(void)
 
     if (_backend_count == 0 ||
         _compass_count == 0) {
-        hal.scheduler->panic(PSTR("No Compass backends available"));
+        hal.scheduler->warning(PSTR("No Compass backends available") );
     }
 }
 

--- a/libraries/AP_HAL/Scheduler.h
+++ b/libraries/AP_HAL/Scheduler.h
@@ -55,6 +55,8 @@ public:
     virtual void     system_initialized() = 0;
 
     virtual void     panic(const prog_char_t *errormsg) = 0;
+    virtual void     warning(const prog_char_t *errormsg) = 0;
+    
     virtual void     reboot(bool hold_in_bootloader) = 0;
 
     /**

--- a/libraries/AP_HAL_AVR/Scheduler.cpp
+++ b/libraries/AP_HAL_AVR/Scheduler.cpp
@@ -225,6 +225,12 @@ void AVRScheduler::system_initialized() {
     _initialized = true;
 }
 
+void AVRScheduler::warning(const prog_char_t* errormsg) {
+    /* Print the error message on both ports */
+    hal.uartA->println_P(errormsg);
+    hal.uartC->println_P(errormsg);
+}
+
 void AVRScheduler::panic(const prog_char_t* errormsg) {
     /* Suspend timer processes. We still want the timer event to go off
      * to run the _failsafe code, however. */

--- a/libraries/AP_HAL_AVR/Scheduler.h
+++ b/libraries/AP_HAL_AVR/Scheduler.h
@@ -46,6 +46,7 @@ public:
     void     system_initialized();
 
     void     panic(const prog_char_t *errormsg);
+    void     warning(const prog_char_t *errormsg);
     void     reboot(bool hold_in_bootloader);
 
     void     set_timer_speed(uint16_t timer_hz);

--- a/libraries/AP_HAL_Empty/Scheduler.cpp
+++ b/libraries/AP_HAL_Empty/Scheduler.cpp
@@ -74,6 +74,10 @@ void EmptyScheduler::panic(const prog_char_t *errormsg) {
     for(;;);
 }
 
+void EmptyScheduler::warning(const prog_char_t *errormsg) {
+    hal.console->println_P(errormsg);
+}
+
 void EmptyScheduler::reboot(bool hold_in_bootloader) {
     for(;;);
 }

--- a/libraries/AP_HAL_Empty/Scheduler.h
+++ b/libraries/AP_HAL_Empty/Scheduler.h
@@ -33,6 +33,7 @@ public:
     void     system_initialized();
 
     void     panic(const prog_char_t *errormsg);
+    void     warning(const prog_char_t *errormsg);
     void     reboot(bool hold_in_bootloader);
 
 };

--- a/libraries/AP_HAL_FLYMAPLE/Scheduler.cpp
+++ b/libraries/AP_HAL_FLYMAPLE/Scheduler.cpp
@@ -237,6 +237,10 @@ void FLYMAPLEScheduler::panic(const prog_char_t *errormsg) {
     for(;;);
 }
 
+void FLYMAPLEScheduler::warning(const prog_char_t *errormsg) {
+    hal.console->println_P(errormsg);
+}
+
 void FLYMAPLEScheduler::reboot(bool hold_in_bootloader) {
     hal.uartA->println_P(PSTR("GOING DOWN FOR A REBOOT\r\n"));
     hal.scheduler->delay(100);

--- a/libraries/AP_HAL_FLYMAPLE/Scheduler.h
+++ b/libraries/AP_HAL_FLYMAPLE/Scheduler.h
@@ -54,6 +54,7 @@ public:
     void     system_initialized();
 
     void     panic(const prog_char_t *errormsg);
+    void     warning(const prog_char_t *errormsg);
     void     reboot(bool hold_in_bootloader);
 
 private:

--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -386,6 +386,12 @@ void LinuxScheduler::panic(const prog_char_t *errormsg)
     exit(1);
 }
 
+void LinuxScheduler::warning(const prog_char_t *errormsg) 
+{
+    write(1, errormsg, strlen(errormsg));
+    write(1, "\n", 1);
+}
+
 bool LinuxScheduler::in_timerprocess() 
 {
     return _in_timer_proc;

--- a/libraries/AP_HAL_Linux/Scheduler.h
+++ b/libraries/AP_HAL_Linux/Scheduler.h
@@ -44,6 +44,7 @@ public:
     void     system_initialized();
 
     void     panic(const prog_char_t *errormsg);
+    void     warning(const prog_char_t *errormsg);
     void     reboot(bool hold_in_bootloader);
 
     void     stop_clock(uint64_t time_usec);

--- a/libraries/AP_HAL_PX4/Scheduler.cpp
+++ b/libraries/AP_HAL_PX4/Scheduler.cpp
@@ -383,6 +383,12 @@ void PX4Scheduler::panic(const prog_char_t *errormsg)
     exit(1);
 }
 
+void PX4Scheduler::warning(const prog_char_t *errormsg) 
+{
+    write(1, errormsg, strlen(errormsg));
+    write(1, "\n", 1);
+}
+
 bool PX4Scheduler::in_timerprocess() 
 {
     return getpid() != _main_task_pid;

--- a/libraries/AP_HAL_PX4/Scheduler.h
+++ b/libraries/AP_HAL_PX4/Scheduler.h
@@ -60,6 +60,7 @@ public:
     void     resume_timer_procs();
     void     reboot(bool hold_in_bootloader);
     void     panic(const prog_char_t *errormsg);
+    void     warning(const prog_char_t *errormsg);
 
     bool     in_timerprocess();
     bool     system_initializing();

--- a/libraries/AP_HAL_SITL/Scheduler.cpp
+++ b/libraries/AP_HAL_SITL/Scheduler.cpp
@@ -263,6 +263,10 @@ void SITLScheduler::panic(const prog_char_t *errormsg) {
     for(;;);
 }
 
+void SITLScheduler::warning(const prog_char_t *errormsg) {
+    hal.console->println_P(errormsg);
+}
+
 /*
   set simulation timestamp
  */

--- a/libraries/AP_HAL_SITL/Scheduler.h
+++ b/libraries/AP_HAL_SITL/Scheduler.h
@@ -38,6 +38,7 @@ public:
 
     void     reboot(bool hold_in_bootloader);
     void     panic(const prog_char_t *errormsg);
+    void     warning(const prog_char_t *errormsg);
 
     bool     interrupts_are_blocked(void) {
         return _nested_atomic_ctr != 0;

--- a/libraries/AP_HAL_VRBRAIN/Scheduler.cpp
+++ b/libraries/AP_HAL_VRBRAIN/Scheduler.cpp
@@ -334,6 +334,12 @@ void VRBRAINScheduler::panic(const prog_char_t *errormsg)
     exit(1);
 }
 
+void VRBRAINScheduler::warning(const prog_char_t *errormsg)
+{
+    write(1, errormsg, strlen(errormsg));
+    write(1, "\n", 1);
+}
+
 bool VRBRAINScheduler::in_timerprocess()
 {
     return getpid() != _main_task_pid;

--- a/libraries/AP_HAL_VRBRAIN/Scheduler.h
+++ b/libraries/AP_HAL_VRBRAIN/Scheduler.h
@@ -40,6 +40,7 @@ public:
     void     resume_timer_procs();
     void     reboot(bool hold_in_bootloader);
     void     panic(const prog_char_t *errormsg);
+    void     warning(const prog_char_t *errormsg);
 
     bool     in_timerprocess();
     bool     system_initializing();


### PR DESCRIPTION
If I call the init() function on a board without connected compass,
the system will halt/exit or whatever.
This is absolutely unnecessary for an init function,
as the init() function is designated to return a bool if sucessful.
Instead the function never reaches it's end
and hangs in an endless loop for AVR and exits if linux.

I added a function called "warning()" to the scheduler. 
Currently I just added output of the problem. 
However it would be smart to extent it for logging.
In case of linux systems the possibilities could go further.

I would suggest to overthink the usage of panic in the lib in general.
There are several exceptions which will lead to a vehicle crash. 

Signed-off-by: dgrat <dgdanielf@gmail.com>