### PR TITLE
Fix bug causing takeoff to fail

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -3760,6 +3760,7 @@ bool NavEKF::getLLH(struct Location &loc) const
         loc.alt = EKF_origin.alt - state.position.z*100;
         loc.flags.relative_alt = 0;
         loc.flags.terrain_alt = 0;
+
         // there are three modes of operation, absolute position (GPS fusion), relative position (optical flow fusion) and constant position (no aiding)
         nav_filter_status status;
         getFilterStatus(status);
@@ -3774,7 +3775,8 @@ bool NavEKF::getLLH(struct Location &loc) const
             if ((_ahrs->get_gps().status() >= AP_GPS::GPS_OK_FIX_2D)) {
                 // we have a GPS position fix to return
                 const struct Location &gpsloc = _ahrs->get_gps().location();
-                loc = gpsloc;
+                loc.lat = gpsloc.lat;
+                loc.lng = gpsloc.lng;
                 return true;
             } else {
                 // if no GPS fix, provide last known position before entering the mode


### PR DESCRIPTION
This  bug causes the EKF to return the GPS altitude whilst the vehicle is pre-armed, rather than the baro altitude added to the GPS height of the origin. This caused problems with the way the altitude was being used by copter to set a home position so that fluctuations in GPs height between setting the EKF origin and arming would cause waypoint missions to fly high or low.