### PR TITLE
EKF corner case fixes

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -662,6 +662,8 @@ private:
     bool gpsAidingBad;              // true when GPS position measurements have been consistently rejected by the filter
     uint32_t lastGpsAidBadTime_ms;  // time in msec gps aiding was last detected to be bad
     float posDownAtArming;          // flight vehicle vertical position at arming used as a reference point
+    bool highYawRate;               // true when the vehicle is doing rapid yaw rotation where gyro scel factor errors could cause loss of heading reference
+    float yawRateFilt;              // filtered yaw rate used to determine when the vehicle is doing rapid yaw rotation where gyro scel factor errors could cause loss of heading reference
 
     // Used by smoothing of state corrections
     Vector10 gpsIncrStateDelta;    // vector of corrections to attitude, velocity and position to be applied over the period between the current and next GPS measurement


### PR DESCRIPTION
These patches address the following corner cases:

Aggressive flying without GPS causes EKF to lose yaw accuracy. Gaining GPS, then causes velocity errors and activation of the fail-safe.

Continual fast yaw yaw rotations and gyro scale factor errors combine to produce large errors in yaw and yaw rate gyro bias estimation which can cause the EKF error check to fail and activation of the failsafe. This was reported by Marco Robustini during AC3.3 beta testing. The fix has been designed to handle 3% scale factor errors, which covers published scale factor variation for both the MPU6000 and L3GD20 gyros.