### PR TITLE
Plane: Add glitch detection to rangefinder via baro comparison

### DIFF
--- a/ArduPlane/ArduPlane.pde
+++ b/ArduPlane/ArduPlane.pde
@@ -276,8 +276,10 @@ static RangeFinder rangefinder;
 static struct {
     bool in_range;
     float correction;
+    float correction_offset;
     uint32_t last_correction_time_ms;
     uint8_t in_range_count;
+    uint32_t last_good_corr_ms;
 } rangefinder_state;
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ArduPlane/Log.pde
+++ b/ArduPlane/Log.pde
@@ -353,6 +353,7 @@ struct PACKED log_Sonar {
     uint8_t throttle;
     uint8_t count;
     float correction;
+    float correction_offset;
 };
 
 // Write a sonar packet
@@ -367,7 +368,8 @@ static void Log_Write_Sonar()
         groundspeed : gps.ground_speed(),
         throttle    : (uint8_t)(100 * channel_throttle->norm_output()),
         count       : rangefinder_state.in_range_count,
-        correction  : rangefinder_state.correction
+        correction  : rangefinder_state.correction,
+        correction_offset  : rangefinder_state.correction_offset
     };
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
 }
@@ -468,7 +470,7 @@ static const struct LogStructure log_structure[] PROGMEM = {
     { LOG_NTUN_MSG, sizeof(log_Nav_Tuning),         
       "NTUN", "ICfccccfI",   "TimeMS,Yaw,WpDist,TargBrg,NavBrg,AltErr,Arspd,Alt,GSpdCM" },
     { LOG_SONAR_MSG, sizeof(log_Sonar),             
-      "SONR", "IffffBBf",   "TimeMS,DistCM,Volt,BaroAlt,GSpd,Thr,Cnt,Corr" },
+      "SONR", "IffffBBff",  "TimeMS,DistCM,Volt,BaroAlt,GSpd,Thr,Cnt,Corr,CorrOff" },
     { LOG_ARM_DISARM_MSG, sizeof(log_Arm_Disarm),
       "ARM", "IHB", "TimeMS,ArmState,ArmChecks" },
     { LOG_ATRP_MSG, sizeof(AP_AutoTune::log_ATRP),

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -116,6 +116,8 @@ public:
         k_param_takeoff_throttle_slewrate,
         k_param_takeoff_throttle_max,
         k_param_rangefinder,
+        k_param_rangefinder_corr_tolerance_cm,
+        k_param_rangefinder_corr_tolerance_ms,
         k_param_terrain,
         k_param_terrain_follow,
         k_param_stab_pitch_down_cd_old, // deprecated
@@ -477,6 +479,8 @@ public:
     AP_Float glide_slope_threshold;
     AP_Int8 fbwa_tdrag_chan;
     AP_Int8 rangefinder_landing;
+    AP_Int16 rangefinder_corr_tolerance_cm;
+    AP_Int32 rangefinder_corr_tolerance_ms;
     AP_Int8 flap_slewrate;
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4
     AP_Int8 override_channel;

--- a/ArduPlane/Parameters.pde
+++ b/ArduPlane/Parameters.pde
@@ -996,6 +996,23 @@ const AP_Param::Info var_info[] PROGMEM = {
     // @User: Standard
     GSCALAR(rangefinder_landing,    "RNGFND_LANDING",   0),
 
+    // @Param: RNGFND_CORR_CM
+    // @DisplayName: Allowable baro height minus rangefinder correction height that is allowed.
+    // @Description: Amount of allowable altitude error correction when compared to the barometer. Set to zero to always accept rangefinder data regardless of what the baro data is. This helps reject rangefinder data when crossing over objects such as trees
+    // @Units: centimeters
+    // @Increment: 10
+    // @User: Advanced
+    GSCALAR(rangefinder_corr_tolerance_cm,    "RNGFND_CORR_CM",   100),
+
+    // @Param: RNGFND_CORR_MS
+    // @DisplayName: Duration to reject rangefinder data when above ERROR_CM height.
+    // @Description: Duration to reject rangefinder data when beyond ERROR_CM height. Once this time has expired then range finder height is accepted as-is.
+    // @Units: milliseconds
+    // @Range: 0 10000
+    // @Increment: 100
+    // @User: Advanced
+    GSCALAR(rangefinder_corr_tolerance_ms,    "RNGFND_CORR_MS",   2000),
+
 #if AP_TERRAIN_AVAILABLE
     // @Group: TERRAIN_
     // @Path: ../libraries/AP_Terrain/AP_Terrain.cpp

--- a/ArduPlane/system.pde
+++ b/ArduPlane/system.pde
@@ -455,6 +455,11 @@ static void exit_mode(enum FlightMode mode)
     if (mode == AUTO) {
         if (mission.state() == AP_Mission::MISSION_RUNNING) {
             mission.stop();
+
+            if (mission.get_current_nav_cmd().id == MAV_CMD_NAV_LAND)
+            {
+                restart_landing_sequence();
+            }
         }
     }
 }


### PR DESCRIPTION
added two new params for temporarily rejecting rangefinder data if it diverges too much from baro for a short time such as flying over trees
RNGFND_CORR_CM, 500    // @Description: Amount of allowable altitude error correction when compared to the barometer. Set to zero to always accept rangefinder data regardless of what the baro data is. This helps reject rangefinder data when crossing over objects such as trees

RNGFND_CORR_MS, 2000:    // @Description: Duration to reject rangefinder data when beyond ERROR_CM height. Once this time has expired then range finder height is accepted as-is. This is typical of baro drift