### PR TITLE
Imu3 arming check

### DIFF
--- a/APMrover2/GCS_Mavlink.pde
+++ b/APMrover2/GCS_Mavlink.pde
@@ -1068,7 +1068,9 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
 	// XXX receive a WP from GCS and store in EEPROM
     case MAVLINK_MSG_ID_MISSION_ITEM:
         {
-            handle_mission_item(msg, mission);
+            if (handle_mission_item(msg, mission)) {
+                Log_Write_EntireMission();
+            }
             break;
         }
 

--- a/APMrover2/Log.pde
+++ b/APMrover2/Log.pde
@@ -244,9 +244,21 @@ static void Log_Write_Startup(uint8_t type)
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
 
     // write all commands to the dataflash as well
+    Log_Write_EntireMission();
+}
+
+static void Log_Write_EntireMission()
+{
+    if (mission.num_commands() > 0) {
+        gcs_send_text_P(SEVERITY_LOW, PSTR("New mission"));
+    }
+    else {
+        gcs_send_text_P(SEVERITY_LOW, PSTR("New mission is empty"));
+    }
+
     AP_Mission::Mission_Command cmd;
     for (uint16_t i = 0; i < mission.num_commands(); i++) {
-        if(mission.read_cmd_from_storage(i,cmd)) {
+        if (mission.read_cmd_from_storage(i,cmd)) {
             Log_Write_Cmd(cmd);
         }
     }
@@ -430,6 +442,7 @@ static void start_logging()
 
 // dummy functions
 static void Log_Write_Startup(uint8_t type) {}
+static void Log_Write_EntireMission() {}
 static void Log_Write_Current() {}
 static void Log_Write_Nav_Tuning() {}
 static void Log_Write_Performance() {}

--- a/APMrover2/Log.pde
+++ b/APMrover2/Log.pde
@@ -249,12 +249,7 @@ static void Log_Write_Startup(uint8_t type)
 
 static void Log_Write_EntireMission()
 {
-    if (mission.num_commands() > 0) {
-        gcs_send_text_P(SEVERITY_LOW, PSTR("New mission"));
-    }
-    else {
-        gcs_send_text_P(SEVERITY_LOW, PSTR("New mission is empty"));
-    }
+    gcs_send_text_P(SEVERITY_LOW, PSTR("New mission"));
 
     AP_Mission::Mission_Command cmd;
     for (uint16_t i = 0; i < mission.num_commands(); i++) {

--- a/ArduCopter/GCS_Mavlink.pde
+++ b/ArduCopter/GCS_Mavlink.pde
@@ -956,7 +956,9 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
     // GCS has sent us a command from GCS, store to EEPROM
     case MAVLINK_MSG_ID_MISSION_ITEM:           // MAV ID: 39
     {
-        handle_mission_item(msg, mission);
+        if (handle_mission_item(msg, mission)) {
+            Log_Write_EntireMission();
+        }
         break;
     }
 

--- a/ArduCopter/Log.pde
+++ b/ArduCopter/Log.pde
@@ -464,12 +464,7 @@ static void Log_Write_Startup()
 
 static void Log_Write_EntireMission()
 {
-    if (mission.num_commands() > 0) {
-        gcs_send_text_P(SEVERITY_LOW, PSTR("New mission"));
-    }
-    else {
-        gcs_send_text_P(SEVERITY_LOW, PSTR("New mission is empty"));
-    }
+    gcs_send_text_P(SEVERITY_LOW, PSTR("New mission"));
 
     AP_Mission::Mission_Command cmd;
     for (uint16_t i = 0; i < mission.num_commands(); i++) {

--- a/ArduCopter/Log.pde
+++ b/ArduCopter/Log.pde
@@ -458,6 +458,25 @@ static void Log_Write_Startup()
         LOG_PACKET_HEADER_INIT(LOG_STARTUP_MSG)
     };
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
+
+    Log_Write_EntireMission();
+}
+
+static void Log_Write_EntireMission()
+{
+    if (mission.num_commands() > 0) {
+        gcs_send_text_P(SEVERITY_LOW, PSTR("New mission"));
+    }
+    else {
+        gcs_send_text_P(SEVERITY_LOW, PSTR("New mission is empty"));
+    }
+
+    AP_Mission::Mission_Command cmd;
+    for (uint16_t i = 0; i < mission.num_commands(); i++) {
+        if (mission.read_cmd_from_storage(i,cmd)) {
+            Log_Write_Cmd(cmd);
+        }
+    }
 }
 
 struct PACKED log_Event {
@@ -712,6 +731,7 @@ static void start_logging()
 #else // LOGGING_ENABLED
 
 static void Log_Write_Startup() {}
+static void Log_Write_EntireMission() {}
 #if AUTOTUNE_ENABLED == ENABLED
 static void Log_Write_AutoTune(uint8_t axis, uint8_t tune_step, float rate_target, float rate_min, float rate_max, float new_gain_rp, float new_gain_rd, float new_gain_sp) {}
 static void Log_Write_AutoTuneDetails(float angle_cd, float rate_cds) {}

--- a/ArduCopter/motors.pde
+++ b/ArduCopter/motors.pde
@@ -416,7 +416,16 @@ static bool pre_arm_checks(bool display_failure)
                 // get next accel vector
                 const Vector3f &accel_vec = ins.get_accel(i);
                 Vector3f vec_diff = accel_vec - prime_accel_vec;
-                if (vec_diff.length() > PREARM_MAX_ACCEL_VECTOR_DIFF) {
+                float threshold = PREARM_MAX_ACCEL_VECTOR_DIFF;
+                if (i >= 2) {
+                    /*
+                      for boards with 3 IMUs we only use the first two
+                      in the EKF. Allow for larger accel discrepancy
+                      for IMU3 as it may be running at a different temperature
+                     */
+                    threshold *= 2;
+                }
+                if (vec_diff.length() > threshold) {
                     if (display_failure) {
                         gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: inconsistent Accelerometers"));
                     }

--- a/ArduPlane/GCS_Mavlink.pde
+++ b/ArduPlane/GCS_Mavlink.pde
@@ -1359,7 +1359,9 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
     // GCS has sent us a command from GCS, store to EEPROM
     case MAVLINK_MSG_ID_MISSION_ITEM:
     {
-        handle_mission_item(msg, mission);
+        if (handle_mission_item(msg, mission)) {
+            Log_Write_EntireMission();
+        }
         break;
     }
 

--- a/ArduPlane/Log.pde
+++ b/ArduPlane/Log.pde
@@ -250,12 +250,7 @@ static void Log_Write_Startup(uint8_t type)
 
 static void Log_Write_EntireMission()
 {
-    if (mission.num_commands() > 0) {
-        gcs_send_text_P(SEVERITY_LOW, PSTR("New mission"));
-    }
-    else {
-        gcs_send_text_P(SEVERITY_LOW, PSTR("New mission is empty"));
-    }
+    gcs_send_text_P(SEVERITY_LOW, PSTR("New mission"));
 
     AP_Mission::Mission_Command cmd;
     for (uint16_t i = 0; i < mission.num_commands(); i++) {

--- a/ArduPlane/Log.pde
+++ b/ArduPlane/Log.pde
@@ -245,6 +245,18 @@ static void Log_Write_Startup(uint8_t type)
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
 
     // write all commands to the dataflash as well
+    Log_Write_EntireMission();
+}
+
+static void Log_Write_EntireMission()
+{
+    if (mission.num_commands() > 0) {
+        gcs_send_text_P(SEVERITY_LOW, PSTR("New mission"));
+    }
+    else {
+        gcs_send_text_P(SEVERITY_LOW, PSTR("New mission is empty"));
+    }
+
     AP_Mission::Mission_Command cmd;
     for (uint16_t i = 0; i < mission.num_commands(); i++) {
         if (mission.read_cmd_from_storage(i,cmd)) {
@@ -518,6 +530,7 @@ static void start_logging()
 
 // dummy functions
 static void Log_Write_Startup(uint8_t type) {}
+static void Log_Write_EntireMission() {}
 static void Log_Write_Current() {}
 static void Log_Write_Nav_Tuning() {}
 static void Log_Write_TECS_Tuning() {}

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -57,8 +57,8 @@ AP_Arming::AP_Arming(const AP_AHRS &ahrs_ref, const AP_Baro &baro, Compass &comp
    , _compass(compass)
    , home_is_set(home_set)
    , gcs_send_text_P(gcs_print_func)
-   , last_accel_pass_ms(0)
-   , last_gyro_pass_ms(0)
+   , last_accel_pass_ms{}
+   , last_gyro_pass_ms{}
 {
     AP_Param::setup_object_defaults(this, var_info);
 }
@@ -169,12 +169,21 @@ bool AP_Arming::ins_checks(bool report)
                 // get next accel vector
                 const Vector3f &accel_vec = ins.get_accel(i);
                 Vector3f vec_diff = accel_vec - prime_accel_vec;
-                // allow for up to 0.3 m/s/s difference. Has to pass
+                // allow for up to 0.5 m/s/s difference. Has to pass
                 // in last 10 seconds
-                if (vec_diff.length() <= 0.3f) {
-                    last_accel_pass_ms = hal.scheduler->millis();
+                float threshold = 0.5f;
+                if (i >= 2) {
+                    /*
+                      we allow for a higher threshold for IMU3 as it
+                      runs at a different temperature to IMU1/IMU2,
+                      and is not used for accel data in the EKF
+                     */
+                    threshold *= 3;
                 }
-                if (hal.scheduler->millis() - last_accel_pass_ms > 10000) {
+                if (vec_diff.length() <= threshold) {
+                    last_accel_pass_ms[i] = hal.scheduler->millis();
+                }
+                if (hal.scheduler->millis() - last_accel_pass_ms[i] > 10000) {
                     if (report) {
                         gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: inconsistent Accelerometers"));
                     }
@@ -193,9 +202,9 @@ bool AP_Arming::ins_checks(bool report)
                 // allow for up to 5 degrees/s difference. Pass if its
                 // been OK in last 10 seconds
                 if (vec_diff.length() <= radians(5)) {
-                    last_gyro_pass_ms = hal.scheduler->millis();
+                    last_gyro_pass_ms[i] = hal.scheduler->millis();
                 }
-                if (hal.scheduler->millis() - last_gyro_pass_ms > 10000) {
+                if (hal.scheduler->millis() - last_gyro_pass_ms[i] > 10000) {
                     if (report) {
                         gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: inconsistent gyros"));
                     }

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -77,8 +77,8 @@ private:
     Compass                                         &_compass;
     const enum HomeState                         &home_is_set;
     gcs_send_t_p                              gcs_send_text_P;
-    uint32_t                                  last_accel_pass_ms;
-    uint32_t                                  last_gyro_pass_ms;
+    uint32_t                                  last_accel_pass_ms[INS_MAX_INSTANCES];
+    uint32_t                                  last_gyro_pass_ms[INS_MAX_INSTANCES];
 
     void set_enabled_checks(uint16_t);
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -285,7 +285,7 @@ private:
     void handle_mission_count(AP_Mission &mission, mavlink_message_t *msg);
     void handle_mission_clear_all(AP_Mission &mission, mavlink_message_t *msg);
     void handle_mission_write_partial_list(AP_Mission &mission, mavlink_message_t *msg);
-    void handle_mission_item(mavlink_message_t *msg, AP_Mission &mission);
+    bool handle_mission_item(mavlink_message_t *msg, AP_Mission &mission);
 
     void handle_request_data_stream(mavlink_message_t *msg, bool save);
     void handle_param_request_list(mavlink_message_t *msg);


### PR DESCRIPTION
raise threshold for accel inconsistency check for IMU3

IMU3 rises in temperature a lot more quickly than IMU1/IMU2, which can cause accel inconsistency errors for accel3. 
