### PR TITLE
Fabs() to fabsf() cleanup

### DIFF
--- a/ArduCopter/control_acro.pde
+++ b/ArduCopter/control_acro.pde
@@ -127,17 +127,17 @@ static void get_pilot_desired_angle_rates(int16_t roll_in, int16_t pitch_in, int
             rate_bf_level = rate_bf_level*acro_level_mix;
 
             // Calculate rate limit to prevent change of rate through inverted
-            rate_limit = fabs(fabs(rate_bf_request.x)-fabs(rate_bf_level.x));
+            rate_limit = fabsf(fabsf(rate_bf_request.x)-fabsf(rate_bf_level.x));
             rate_bf_request.x += rate_bf_level.x;
             rate_bf_request.x = constrain_float(rate_bf_request.x, -rate_limit, rate_limit);
 
             // Calculate rate limit to prevent change of rate through inverted
-            rate_limit = fabs(fabs(rate_bf_request.y)-fabs(rate_bf_level.y));
+            rate_limit = fabsf(fabs(rate_bf_request.y)-fabsf(rate_bf_level.y));
             rate_bf_request.y += rate_bf_level.y;
             rate_bf_request.y = constrain_float(rate_bf_request.y, -rate_limit, rate_limit);
 
             // Calculate rate limit to prevent change of rate through inverted
-            rate_limit = fabs(fabs(rate_bf_request.z)-fabs(rate_bf_level.z));
+            rate_limit = fabsf(fabsf(rate_bf_request.z)-fabsf(rate_bf_level.z));
             rate_bf_request.z += rate_bf_level.z;
             rate_bf_request.z = constrain_float(rate_bf_request.z, -rate_limit, rate_limit);
         }

--- a/ArduCopter/control_drift.pde
+++ b/ArduCopter/control_drift.pde
@@ -66,7 +66,7 @@ static void drift_run()
     float pitch_vel = vel.y * ahrs.sin_yaw() + vel.x * ahrs.cos_yaw(); // body pitch vel
 
     // gain sceduling for Yaw
-    float pitch_vel2 = min(fabs(pitch_vel), 2000);
+    float pitch_vel2 = min(fabsf(pitch_vel), 2000);
     target_yaw_rate = ((float)target_roll/1.0f) * (1.0f - (pitch_vel2 / 5000.0f)) * g.acro_yaw_p;
 
     roll_vel = constrain_float(roll_vel, -DRIFT_SPEEDLIMIT, DRIFT_SPEEDLIMIT);

--- a/ArduCopter/control_flip.pde
+++ b/ArduCopter/control_flip.pde
@@ -188,14 +188,14 @@ static void flip_run()
 
         if (flip_roll_dir != 0) {
             // we are rolling
-            recovery_angle = fabs(flip_orig_attitude.x - (float)ahrs.roll_sensor);
+            recovery_angle = fabsf(flip_orig_attitude.x - (float)ahrs.roll_sensor);
         } else {
             // we are pitching
-            recovery_angle = fabs(flip_orig_attitude.y - (float)ahrs.pitch_sensor);
+            recovery_angle = fabsf(flip_orig_attitude.y - (float)ahrs.pitch_sensor);
         }
 
         // check for successful recovery
-        if (fabs(recovery_angle) <= FLIP_RECOVERY_ANGLE) {
+        if (fabsf(recovery_angle) <= FLIP_RECOVERY_ANGLE) {
             // restore original flight mode
             if (!set_mode(flip_orig_control_mode)) {
                 // this should never happen but just in case

--- a/ArduCopter/control_poshold.pde
+++ b/ArduCopter/control_poshold.pde
@@ -247,7 +247,7 @@ static void poshold_run()
                 }
 
                 // if velocity is very low reduce braking time to 0.5seconds
-                if ((fabs(vel_right) <= POSHOLD_SPEED_0) && (poshold.brake_timeout_roll > 50*LOOP_RATE_FACTOR)) {
+                if ((fabsf(vel_right) <= POSHOLD_SPEED_0) && (poshold.brake_timeout_roll > 50*LOOP_RATE_FACTOR)) {
                     poshold.brake_timeout_roll = 50*LOOP_RATE_FACTOR;
                 }
 
@@ -341,7 +341,7 @@ static void poshold_run()
                 }
 
                 // if velocity is very low reduce braking time to 0.5seconds
-                if ((fabs(vel_fw) <= POSHOLD_SPEED_0) && (poshold.brake_timeout_pitch > 50*LOOP_RATE_FACTOR)) {
+                if ((fabsf(vel_fw) <= POSHOLD_SPEED_0) && (poshold.brake_timeout_pitch > 50*LOOP_RATE_FACTOR)) {
                     poshold.brake_timeout_pitch = 50*LOOP_RATE_FACTOR;
                 }
 

--- a/ArduCopter/motors.pde
+++ b/ArduCopter/motors.pde
@@ -308,7 +308,7 @@ static bool pre_arm_checks(bool display_failure)
         nav_filter_status filt_status = inertial_nav.get_filter_status();
         bool using_baro_ref = (!filt_status.flags.pred_horiz_pos_rel && filt_status.flags.pred_horiz_pos_abs);
         if (using_baro_ref) {
-            if (fabs(inertial_nav.get_altitude() - baro_alt) > PREARM_MAX_ALT_DISPARITY_CM) {
+            if (fabsf(inertial_nav.get_altitude() - baro_alt) > PREARM_MAX_ALT_DISPARITY_CM) {
                 if (display_failure) {
                     gcs_send_text_P(SEVERITY_HIGH,PSTR("PreArm: Altitude disparity"));
                 }
@@ -674,7 +674,7 @@ static bool arm_checks(bool display_failure, bool arming_from_gcs)
     nav_filter_status filt_status = inertial_nav.get_filter_status();
     bool using_baro_ref = (!filt_status.flags.pred_horiz_pos_rel && filt_status.flags.pred_horiz_pos_abs);
     if (((g.arming_check == ARMING_CHECK_ALL) || (g.arming_check & ARMING_CHECK_BARO)) && using_baro_ref) {
-        if (fabs(inertial_nav.get_altitude() - baro_alt) > PREARM_MAX_ALT_DISPARITY_CM) {
+        if (fabsf(inertial_nav.get_altitude() - baro_alt) > PREARM_MAX_ALT_DISPARITY_CM) {
             if (display_failure) {
                 gcs_send_text_P(SEVERITY_HIGH,PSTR("Arm: Altitude disparity"));
             }

--- a/ArduPlane/commands_logic.pde
+++ b/ArduPlane/commands_logic.pde
@@ -565,7 +565,7 @@ static bool verify_loiter_to_alt()
 
     //has target altitude been reached?
     if (condition_value != 0) {
-        if (fabs(condition_value - current_loc.alt) < 500) {
+        if (labs(condition_value - current_loc.alt) < 500) {
             //Only have to reach the altitude once -- that's why I need
             //this global condition variable.
             //

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
@@ -162,13 +162,13 @@ void AC_AttitudeControl_Heli::rate_bf_to_motor_roll_pitch(float rate_roll_target
     pitch_out = pitch_pd + pitch_i + pitch_ff;
 
     // constrain output and update limit flags
-    if ((float)fabs(roll_out) > AC_ATTITUDE_RATE_RP_CONTROLLER_OUT_MAX) {
+    if (fabsf(roll_out) > AC_ATTITUDE_RATE_RP_CONTROLLER_OUT_MAX) {
         roll_out = constrain_float(roll_out,-AC_ATTITUDE_RATE_RP_CONTROLLER_OUT_MAX,AC_ATTITUDE_RATE_RP_CONTROLLER_OUT_MAX);
         _flags_heli.limit_roll = true;
     }else{
         _flags_heli.limit_roll = false;
     }
-    if ((float)fabs(pitch_out) > AC_ATTITUDE_RATE_RP_CONTROLLER_OUT_MAX) {
+    if (fabsf(pitch_out) > AC_ATTITUDE_RATE_RP_CONTROLLER_OUT_MAX) {
         pitch_out = constrain_float(pitch_out,-AC_ATTITUDE_RATE_RP_CONTROLLER_OUT_MAX,AC_ATTITUDE_RATE_RP_CONTROLLER_OUT_MAX);
         _flags_heli.limit_pitch = true;
     }else{
@@ -298,7 +298,7 @@ float AC_AttitudeControl_Heli::rate_bf_to_motor_yaw(float rate_target_cds)
     yaw_out = pd + i + ff;
 
     // constrain output and update limit flag
-    if ((float)fabs(yaw_out) > AC_ATTITUDE_RATE_YAW_CONTROLLER_OUT_MAX) {
+    if (fabsf(yaw_out) > AC_ATTITUDE_RATE_YAW_CONTROLLER_OUT_MAX) {
         yaw_out = constrain_float(yaw_out,-AC_ATTITUDE_RATE_YAW_CONTROLLER_OUT_MAX,AC_ATTITUDE_RATE_YAW_CONTROLLER_OUT_MAX);
         _flags_heli.limit_yaw = true;
     }else{

--- a/libraries/AC_PID/AC_PID.cpp
+++ b/libraries/AC_PID/AC_PID.cpp
@@ -52,7 +52,7 @@ AC_PID::AC_PID(float initial_p, float initial_i, float initial_d, float initial_
     _kp = initial_p;
     _ki = initial_i;
     _kd = initial_d;
-    _imax = fabs(initial_imax);
+    _imax = fabsf(initial_imax);
     filt_hz(initial_filt_hz);
 
     // reset input filter to first value received
@@ -69,7 +69,7 @@ void AC_PID::set_dt(float dt)
 // filt_hz - set input filter hz
 void AC_PID::filt_hz(float hz)
 {
-    _filt_hz.set(fabs(hz));
+    _filt_hz.set(fabsf(hz));
 
     // sanity check _filt_hz
     _filt_hz = max(_filt_hz, AC_PID_FILT_HZ_MIN);
@@ -171,7 +171,7 @@ void AC_PID::load_gains()
     _ki.load();
     _kd.load();
     _imax.load();
-    _imax = fabs(_imax);
+    _imax = fabsf(_imax);
     _filt_hz.load();
 }
 
@@ -191,7 +191,7 @@ void AC_PID::operator() (float p, float i, float d, float imaxval, float input_f
     _kp = p;
     _ki = i;
     _kd = d;
-    _imax = fabs(imaxval);
+    _imax = fabsf(imaxval);
     _filt_hz = input_filt_hz;
     _dt = dt;
 }

--- a/libraries/AC_PID/AC_PID.h
+++ b/libraries/AC_PID/AC_PID.h
@@ -69,7 +69,7 @@ public:
     void        kP(const float v) { _kp.set(v); }
     void        kI(const float v) { _ki.set(v); }
     void        kD(const float v) { _kd.set(v); }
-    void        imax(const float v) { _imax.set(fabs(v)); }
+    void        imax(const float v) { _imax.set(fabsf(v)); }
     void        filt_hz(const float v);
 
     float       get_integrator() const { return _integrator; }

--- a/libraries/AC_PID/AC_PI_2D.cpp
+++ b/libraries/AC_PID/AC_PI_2D.cpp
@@ -40,7 +40,7 @@ AC_PI_2D::AC_PI_2D(float initial_p, float initial_i, float initial_imax, float i
 
     _kp = initial_p;
     _ki = initial_i;
-    _imax = fabs(initial_imax);
+    _imax = fabsf(initial_imax);
     filt_hz(initial_filt_hz);
 
     // reset input filter to first value received
@@ -58,7 +58,7 @@ void AC_PI_2D::set_dt(float dt)
 // filt_hz - set input filter hz
 void AC_PI_2D::filt_hz(float hz)
 {
-    _filt_hz.set(fabs(hz));
+    _filt_hz.set(fabsf(hz));
 
     // sanity check _filt_hz
     _filt_hz = max(_filt_hz, AC_PI_2D_FILT_HZ_MIN);
@@ -136,7 +136,7 @@ void AC_PI_2D::load_gains()
     _kp.load();
     _ki.load();
     _imax.load();
-    _imax = fabs(_imax);
+    _imax = fabsf(_imax);
     _filt_hz.load();
 
     // calculate the input filter alpha
@@ -157,7 +157,7 @@ void AC_PI_2D::operator() (float p, float i, float imaxval, float input_filt_hz,
 {
     _kp = p;
     _ki = i;
-    _imax = fabs(imaxval);
+    _imax = fabsf(imaxval);
     _filt_hz = input_filt_hz;
     _dt = dt;
     // calculate the input filter alpha

--- a/libraries/AC_PID/AC_PI_2D.h
+++ b/libraries/AC_PID/AC_PI_2D.h
@@ -62,7 +62,7 @@ public:
     // set accessors
     void        kP(const float v) { _kp.set(v); }
     void        kI(const float v) { _ki.set(v); }
-    void        imax(const float v) { _imax.set(fabs(v)); }
+    void        imax(const float v) { _imax.set(fabsf(v)); }
     void        filt_hz(const float v);
 
     Vector2f    get_integrator() const { return _integrator; }

--- a/libraries/AP_HAL/utility/print_vprintf.cpp
+++ b/libraries/AP_HAL/utility/print_vprintf.cpp
@@ -181,7 +181,7 @@ void print_vprintf (AP_HAL::Print *s, unsigned char in_progmem, const char *fmt,
                                 flags |= FL_FLTFIX;
                         } else if (prec > 0)
                                 prec -= 1;
-                        if ((flags & FL_FLTFIX) && fabs(value) > 9999999) {
+                        if ((flags & FL_FLTFIX) && fabsf(value) > 9999999) {
                                 flags = (flags & ~FL_FLTFIX) | FL_FLTEXP;
                         }
 

--- a/libraries/AP_HAL_SITL/sitl_ins.cpp
+++ b/libraries/AP_HAL_SITL/sitl_ins.cpp
@@ -182,7 +182,7 @@ void SITL_State::_update_ins(float roll, 	float pitch, 	float yaw,		// Relative 
     float yAccel2 = yAccel + accel_noise * _rand_float();
     float zAccel2 = zAccel + accel_noise * _rand_float();
 
-    if (fabs(_sitl->accel_fail) > 1.0e-6) {
+    if (fabsf(_sitl->accel_fail) > 1.0e-6f) {
         xAccel1 = _sitl->accel_fail;
         yAccel1 = _sitl->accel_fail;
         zAccel1 = _sitl->accel_fail;

--- a/libraries/AP_Math/examples/location/location.pde
+++ b/libraries/AP_Math/examples/location/location.pde
@@ -254,7 +254,7 @@ static void test_wrap_cd(void)
 
     for (uint8_t i=0; i<sizeof(wrap_PI_tests)/sizeof(wrap_PI_tests[0]); i++) {
         float r = wrap_PI(wrap_PI_tests[i].v);
-        if (fabs(r - wrap_PI_tests[i].wv) > 0.001f) {
+        if (fabsf(r - wrap_PI_tests[i].wv) > 0.001f) {
             hal.console->printf("wrap_PI: v=%f wv=%f r=%f\n",
                                 wrap_PI_tests[i].v,
                                 wrap_PI_tests[i].wv,

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -490,7 +490,7 @@ bool AP_Mission::mavlink_to_mission_cmd(const mavlink_mission_item_t& packet, AP
     case MAV_CMD_NAV_LOITER_TURNS:                      // MAV ID: 18
         copy_location = true;
         num_turns = packet.param1;                      // number of times to circle is held in param1
-        radius_m = fabs(packet.param3);                 // radius in meters is held in high in param3
+        radius_m = fabsf(packet.param3);                // radius in meters is held in high in param3
         cmd.p1 = (((uint16_t)radius_m)<<8) | (uint16_t)num_turns;   // store radius in high byte of p1, num turns in low byte of p1
         cmd.content.location.flags.loiter_ccw = (packet.param3 < 0);
         break;

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -1185,7 +1185,7 @@ void NavEKF::UpdateStrapdownEquationsNED()
     // fast rotations that can cause problems due to gyro scale factor errors.
     float alphaLPF = constrain_float(dtIMUactual, 0.0f, 1.0f);
     yawRateFilt += (state.omega.z - yawRateFilt)*alphaLPF;
-    if (fabs(yawRateFilt) > 1.0f) {
+    if (fabsf(yawRateFilt) > 1.0f) {
         highYawRate = true;
     } else {
         highYawRate = false;


### PR DESCRIPTION
Lots of fabs() that should be fabsf() that needed changing.
- one fabs() call in plane that should have been abs()
- removed some fabs() calls that were then casting to a float, how silly is that!
- in Location there is lots of fabs() for doubles that are correct, those were left alone.