### PR TITLE
Plane: properly restart aborted landing

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -936,6 +936,7 @@ private:
     bool verify_command_callback(const AP_Mission::Mission_Command& cmd);
     void print_flight_mode(AP_HAL::BetterStream *port, uint8_t mode);
     void run_cli(AP_HAL::UARTDriver *port);
+    void restart_landing_sequence();
     void log_init();
     uint32_t millis() const;
     uint32_t micros() const;

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -490,6 +490,11 @@ void Plane::exit_mode(enum FlightMode mode)
     if (mode == AUTO) {
         if (mission.state() == AP_Mission::MISSION_RUNNING) {
             mission.stop();
+
+            if (mission.get_current_nav_cmd().id == MAV_CMD_NAV_LAND)
+            {
+                restart_landing_sequence();
+            }
         }
         auto_state.started_flying_in_auto_ms = 0;
     }

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -132,6 +132,7 @@ void AP_Mission::reset()
     _nav_cmd.index         = AP_MISSION_CMD_INDEX_NONE;
     _do_cmd.index          = AP_MISSION_CMD_INDEX_NONE;
     _prev_nav_cmd_index    = AP_MISSION_CMD_INDEX_NONE;
+    _prev_nav_cmd_wp_index = AP_MISSION_CMD_INDEX_NONE;
     init_jump_tracking();
 }
 
@@ -312,6 +313,7 @@ bool AP_Mission::set_current_cmd(uint16_t index)
     // if index is zero then the user wants to completely restart the mission
     if (index == 0 || _flags.state == MISSION_COMPLETE) {
         _prev_nav_cmd_index = AP_MISSION_CMD_INDEX_NONE;
+        _prev_nav_cmd_wp_index = AP_MISSION_CMD_INDEX_NONE;
         // reset the jump tracking to zero
         init_jump_tracking();
         if (index == 0) {
@@ -372,6 +374,10 @@ bool AP_Mission::set_current_cmd(uint16_t index)
         if (is_nav_cmd(cmd)) {
             // save previous nav command index
             _prev_nav_cmd_index = _nav_cmd.index;
+            // save separate previous nav command index if it contains lat,long,alt
+            if (cmd.content.location.lat != 0 && cmd.content.location.lng != 0) {
+                _prev_nav_cmd_wp_index = _nav_cmd.index;
+            }
             // set current navigation command and start it
             _nav_cmd = cmd;
             _flags.nav_cmd_loaded = true;
@@ -1125,6 +1131,10 @@ bool AP_Mission::advance_current_nav_cmd()
         if (is_nav_cmd(cmd)) {
             // save previous nav command index
             _prev_nav_cmd_index = _nav_cmd.index;
+            // save separate previous nav command index if it contains lat,long,alt
+            if (cmd.content.location.lat != 0 && cmd.content.location.lng != 0) {
+                _prev_nav_cmd_wp_index = _nav_cmd.index;
+            }
             // set current navigation command and start it
             _nav_cmd = cmd;
             _flags.nav_cmd_loaded = true;

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -375,7 +375,7 @@ bool AP_Mission::set_current_cmd(uint16_t index)
             // save previous nav command index
             _prev_nav_cmd_index = _nav_cmd.index;
             // save separate previous nav command index if it contains lat,long,alt
-            if (cmd.content.location.lat != 0 && cmd.content.location.lng != 0) {
+            if (!(cmd.content.location.lat == 0 && cmd.content.location.lng == 0)) {
                 _prev_nav_cmd_wp_index = _nav_cmd.index;
             }
             // set current navigation command and start it
@@ -1132,7 +1132,7 @@ bool AP_Mission::advance_current_nav_cmd()
             // save previous nav command index
             _prev_nav_cmd_index = _nav_cmd.index;
             // save separate previous nav command index if it contains lat,long,alt
-            if (cmd.content.location.lat != 0 && cmd.content.location.lng != 0) {
+            if (!(cmd.content.location.lat == 0 && cmd.content.location.lng == 0)) {
                 _prev_nav_cmd_wp_index = _nav_cmd.index;
             }
             // set current navigation command and start it

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -243,6 +243,7 @@ public:
         _cmd_verify_fn(cmd_verify_fn),
         _mission_complete_fn(mission_complete_fn),
         _prev_nav_cmd_index(AP_MISSION_CMD_INDEX_NONE),
+        _prev_nav_cmd_wp_index(AP_MISSION_CMD_INDEX_NONE),
         _last_change_time_ms(0)
     {
         // load parameter defaults
@@ -332,6 +333,11 @@ public:
     ///     if there was no previous nav command it returns AP_MISSION_CMD_INDEX_NONE
     ///     we do not return the entire command to save on RAM
     uint16_t get_prev_nav_cmd_index() const { return _prev_nav_cmd_index; }
+
+    /// get_prev_nav_cmd_with_wp_index - returns the previous "navigation" commands index that contains a waypoint (i.e. position in the mission command list)
+    ///     if there was no previous nav command it returns AP_MISSION_CMD_INDEX_NONE
+    ///     we do not return the entire command to save on RAM
+    uint16_t get_prev_nav_cmd_with_wp_index() const { return _prev_nav_cmd_wp_index; }
 
     /// get_next_nav_cmd - gets next "navigation" command found at or after start_index
     ///     returns true if found, false if not found (i.e. reached end of mission command list)
@@ -454,6 +460,7 @@ private:
     struct Mission_Command  _nav_cmd;   // current "navigation" command.  It's position in the command list is held in _nav_cmd.index
     struct Mission_Command  _do_cmd;    // current "do" command.  It's position in the command list is held in _do_cmd.index
     uint16_t                _prev_nav_cmd_index;    // index of the previous "navigation" command.  Rarely used which is why we don't store the whole command
+    uint16_t                _prev_nav_cmd_wp_index; // index of the previous "navigation" command that contains a waypoint.  Rarely used which is why we don't store the whole command
 
     // jump related variables
     struct jump_tracking_struct {


### PR DESCRIPTION
purpose is explained in issue https://github.com/diydrones/ardupilot/issues/2252

pretty straight forward implementation. When switching away from AUTO during a plane land, decrement mission index so that when we resume AUTO we would start the glide approach from the top waypoint.

All underflow conditions that I can think or are taken care of in set_current_cmd() so they were not needed here.