### PR TITLE
Log mission to log only

### DIFF
--- a/APMrover2/Log.pde
+++ b/APMrover2/Log.pde
@@ -249,7 +249,7 @@ static void Log_Write_Startup(uint8_t type)
 
 static void Log_Write_EntireMission()
 {
-    gcs_send_text_P(SEVERITY_LOW, PSTR("New mission"));
+    DataFlash.Log_Write_Message_P(PSTR("New mission"));
 
     AP_Mission::Mission_Command cmd;
     for (uint16_t i = 0; i < mission.num_commands(); i++) {

--- a/ArduCopter/Log.pde
+++ b/ArduCopter/Log.pde
@@ -464,7 +464,7 @@ static void Log_Write_Startup()
 
 static void Log_Write_EntireMission()
 {
-    gcs_send_text_P(SEVERITY_LOW, PSTR("New mission"));
+    DataFlash.Log_Write_Message_P(PSTR("New mission"));
 
     AP_Mission::Mission_Command cmd;
     for (uint16_t i = 0; i < mission.num_commands(); i++) {

--- a/ArduPlane/Log.pde
+++ b/ArduPlane/Log.pde
@@ -250,7 +250,7 @@ static void Log_Write_Startup(uint8_t type)
 
 static void Log_Write_EntireMission()
 {
-    gcs_send_text_P(SEVERITY_LOW, PSTR("New mission"));
+    DataFlash.Log_Write_Message_P(PSTR("New mission"));
 
     AP_Mission::Mission_Command cmd;
     for (uint16_t i = 0; i < mission.num_commands(); i++) {


### PR DESCRIPTION
when receiving a new mission, and it dumps it to log, just write the "New Mission" text to the log without spamming the GCS which obviously knows you have a new mission.

A tweak from https://github.com/diydrones/ardupilot/pull/2243