### PR TITLE
Ublox RAW logging - Fixed msg format string & added reserved1 to log

### DIFF
--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -337,10 +337,11 @@ void AP_GPS_UBLOX::log_rxm_raw(const struct ubx_rxm_raw &raw)
             iTOW       : raw.iTOW,
             week       : raw.week,
             numSV      : raw.numSV,
-            sv         : raw.svinfo[i].sv,
+            reserved1  : raw.reserved1,
             cpMes      : raw.svinfo[i].cpMes,
             prMes      : raw.svinfo[i].prMes,
             doMes      : raw.svinfo[i].doMes,
+            sv         : raw.svinfo[i].sv,
             mesQI      : raw.svinfo[i].mesQI,
             cno        : raw.svinfo[i].cno,
             lli        : raw.svinfo[i].lli

--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -489,10 +489,11 @@ struct PACKED log_GPS_RAW {
     int32_t iTOW;
     int16_t week;
     uint8_t numSV;
-    uint8_t sv;
+    uint8_t reserved1;
     double cpMes;
     double prMes;
     float doMes;
+    uint8_t sv;
     int8_t mesQI;
     int8_t cno;
     uint8_t lli;
@@ -540,6 +541,7 @@ Format characters in the format string for binary log messages
   i   : int32_t
   I   : uint32_t
   f   : float
+  d   : double
   n   : char[4]
   N   : char[16]
   Z   : char[64]
@@ -619,7 +621,7 @@ Format characters in the format string for binary log messages
     { LOG_UBX3_MSG, sizeof(log_Ubx3), \
       "UBX3", "IBfff", "TimeMS,Instance,hAcc,vAcc,sAcc" }, \
     { LOG_GPS_RAW_MSG, sizeof(log_GPS_RAW), \
-      "GRAW", "IIHBBddfBbB", "TimeMS,WkMS,Week,NSats,sv,cpMes,prMes,doMes,mesQI,cno,lli" }, \
+      "GRAW", "IihBBddfBbbB", "TimeMS,WkMS,Week,NSats,res1,cpMes,prMes,doMes,sv,mesQI,cno,lli" }, \
     { LOG_ESC1_MSG, sizeof(log_Esc), \
       "ESC1",  "Icccc", "TimeMS,RPM,Volt,Curr,Temp" }, \
     { LOG_ESC2_MSG, sizeof(log_Esc), \

--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -621,7 +621,7 @@ Format characters in the format string for binary log messages
     { LOG_UBX3_MSG, sizeof(log_Ubx3), \
       "UBX3", "IBfff", "TimeMS,Instance,hAcc,vAcc,sAcc" }, \
     { LOG_GPS_RAW_MSG, sizeof(log_GPS_RAW), \
-      "GRAW", "IihBBddfBbbB", "TimeMS,WkMS,Week,NSats,res1,cpMes,prMes,doMes,sv,mesQI,cno,lli" }, \
+      "GRAW", "IihBBddfBbbB", "TimeMS,WkMS,Week,NumSV,res1,cpMes,prMes,doMes,sv,mesQI,cno,lli" }, \
     { LOG_ESC1_MSG, sizeof(log_Esc), \
       "ESC1",  "Icccc", "TimeMS,RPM,Volt,Curr,Temp" }, \
     { LOG_ESC2_MSG, sizeof(log_Esc), \

--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -621,7 +621,7 @@ Format characters in the format string for binary log messages
     { LOG_UBX3_MSG, sizeof(log_Ubx3), \
       "UBX3", "IBfff", "TimeMS,Instance,hAcc,vAcc,sAcc" }, \
     { LOG_GPS_RAW_MSG, sizeof(log_GPS_RAW), \
-      "GRAW", "IihBBddfBbbB", "TimeMS,WkMS,Week,NumSV,res1,cpMes,prMes,doMes,sv,mesQI,cno,lli" }, \
+      "GRAW", "IihBBddfBbbB", "TimeMS,WkMS,Week,numSV,res1,cpMes,prMes,doMes,sv,mesQI,cno,lli" }, \
     { LOG_ESC1_MSG, sizeof(log_Esc), \
       "ESC1",  "Icccc", "TimeMS,RPM,Volt,Curr,Temp" }, \
     { LOG_ESC2_MSG, sizeof(log_Esc), \


### PR DESCRIPTION
Fixed msg "GRAW" format string, update format class definition and added "reserved1" msg to log. Last is for standarize msg output according to following Ublox documentation and simplify postprocessing with RTKlib.

Including reserved1 is optional, but please, take in care that is crucial to follow Ublox standard strings for allow to use messages with RINEX conversion programs.

![ublox doc](https://cloud.githubusercontent.com/assets/3317796/7629043/b6129b00-fa29-11e4-9845-abf28cc4a9a5.jpg)


Regards from Spain,
Dario.