### PR TITLE
All: Precise Camera Feedback messages

### DIFF
--- a/APMrover2/APMrover2.pde
+++ b/APMrover2/APMrover2.pde
@@ -360,6 +360,9 @@ static int16_t     throttle_nudge = 0;
 // receiver RSSI
 static uint8_t receiver_rssi;
 
+// this is set to true when camera really has been triggered
+static bool camera_triggered;
+
 // the time when the last HEARTBEAT message arrived from a GCS
 static uint32_t last_heartbeat_ms;
 
@@ -607,6 +610,13 @@ static void mount_update(void)
 #endif
 #if CAMERA == ENABLED
     camera.trigger_pic_cleanup();
+    if(camera_triggered == false && camera._feedback_pin != -1 && check_digital_pin(camera._feedback_pin) == 0){
+      gcs_send_message(MSG_CAMERA_FEEDBACK);
+      if (should_log(MASK_LOG_CAMERA)) {
+          DataFlash.Log_Write_Camera(ahrs, gps, current_loc);
+      }
+      camera_triggered = true;
+    }    
 #endif
 }
 

--- a/APMrover2/commands_logic.pde
+++ b/APMrover2/commands_logic.pde
@@ -330,8 +330,11 @@ static void do_take_picture()
 // log_picture - log picture taken and send feedback to GCS
 static void log_picture()
 {
-    gcs_send_message(MSG_CAMERA_FEEDBACK);
-    if (should_log(MASK_LOG_CAMERA)) {
-        DataFlash.Log_Write_Camera(ahrs, gps, current_loc);
+    if(camera._feedback_pin == -1 ){
+      gcs_send_message(MSG_CAMERA_FEEDBACK);
+      if (should_log(MASK_LOG_CAMERA)) {
+          DataFlash.Log_Write_Camera(ahrs, gps, current_loc);
+      }
     }
+    else camera_triggered = false;
 }

--- a/ArduCopter/ArduCopter.pde
+++ b/ArduCopter/ArduCopter.pde
@@ -381,6 +381,9 @@ static AP_BoardConfig BoardConfig;
 // receiver RSSI
 static uint8_t receiver_rssi;
 
+// this is set to true when camera really has been triggered
+static bool camera_triggered;
+
 ////////////////////////////////////////////////////////////////////////////////
 // Failsafe
 ////////////////////////////////////////////////////////////////////////////////
@@ -937,6 +940,13 @@ static void update_mount()
 
 #if CAMERA == ENABLED
     camera.trigger_pic_cleanup();
+    if(camera_triggered == false && camera._feedback_pin != -1 && check_digital_pin(camera._feedback_pin) == 0){
+      gcs_send_message(MSG_CAMERA_FEEDBACK);
+      if (should_log(MASK_LOG_CAMERA)) {
+          DataFlash.Log_Write_Camera(ahrs, gps, current_loc);
+      }
+      camera_triggered = true;
+    }    
 #endif
 }
 
@@ -1214,4 +1224,3 @@ static void update_altitude()
 }
 
 AP_HAL_MAIN();
-

--- a/ArduCopter/commands_logic.pde
+++ b/ArduCopter/commands_logic.pde
@@ -922,10 +922,13 @@ static void do_take_picture()
 // log_picture - log picture taken and send feedback to GCS
 static void log_picture()
 {
-    gcs_send_message(MSG_CAMERA_FEEDBACK);
-    if (should_log(MASK_LOG_CAMERA)) {
-        DataFlash.Log_Write_Camera(ahrs, gps, current_loc);
+    if(camera._feedback_pin == -1 ){
+      gcs_send_message(MSG_CAMERA_FEEDBACK);
+      if (should_log(MASK_LOG_CAMERA)) {
+          DataFlash.Log_Write_Camera(ahrs, gps, current_loc);
+      }
     }
+    else camera_triggered = false;
 }
 
 // point the camera to a specified angle

--- a/ArduCopter/system.pde
+++ b/ArduCopter/system.pde
@@ -399,6 +399,24 @@ static void frsky_telemetry_send(void)
 #endif
 
 /*
+  check a digitial pin for high,low (1/0)
+ */
+static uint8_t check_digital_pin(uint8_t pin)
+{
+    int8_t dpin = hal.gpio->analogPinToDigitalPin(pin);
+    if (dpin == -1) {
+        return 0;
+    }
+    // ensure we are in input mode
+    hal.gpio->pinMode(dpin, HAL_GPIO_INPUT);
+
+    // enable pullup
+    hal.gpio->write(dpin, 1);
+
+    return hal.gpio->read(dpin);
+}
+
+/*
   should we log a message type now?
  */
 static bool should_log(uint32_t mask)

--- a/ArduPlane/ArduPlane.pde
+++ b/ArduPlane/ArduPlane.pde
@@ -425,6 +425,8 @@ static int16_t throttle_nudge = 0;
 // receiver RSSI
 static uint8_t receiver_rssi;
 
+// this is set to true when camera really has been triggered
+static bool camera_triggered;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Ground speed
@@ -919,6 +921,13 @@ static void update_mount(void)
 
 #if CAMERA == ENABLED
     camera.trigger_pic_cleanup();
+    if(camera_triggered == false && camera._feedback_pin != -1 && check_digital_pin(camera._feedback_pin) == 0){
+      gcs_send_message(MSG_CAMERA_FEEDBACK);
+      if (should_log(MASK_LOG_CAMERA)) {
+          DataFlash.Log_Write_Camera(ahrs, gps, current_loc);
+      }
+      camera_triggered = true;
+    }    
 #endif
 }
 

--- a/ArduPlane/ArduPlane.pde
+++ b/ArduPlane/ArduPlane.pde
@@ -1,6 +1,6 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
 
-#define THISFIRMWARE "ArduPlane V3.3.0beta2"
+#define THISFIRMWARE "ArduPlane V3.3.0"
 /*
    Lead developer: Andrew Tridgell
  

--- a/ArduPlane/commands_logic.pde
+++ b/ArduPlane/commands_logic.pde
@@ -791,10 +791,13 @@ static void do_take_picture()
 // log_picture - log picture taken and send feedback to GCS
 static void log_picture()
 {
-    gcs_send_message(MSG_CAMERA_FEEDBACK);
-    if (should_log(MASK_LOG_CAMERA)) {
-        DataFlash.Log_Write_Camera(ahrs, gps, current_loc);
+    if(camera._feedback_pin == -1 ){
+      gcs_send_message(MSG_CAMERA_FEEDBACK);
+      if (should_log(MASK_LOG_CAMERA)) {
+          DataFlash.Log_Write_Camera(ahrs, gps, current_loc);
+      }
     }
+    else camera_triggered = false;
 }
 
 // start_command_callback - callback function called from ap-mission when it begins a new mission command

--- a/ArduPlane/release-notes.txt
+++ b/ArduPlane/release-notes.txt
@@ -1,8 +1,144 @@
-Release 3.3.0beta2, 30th April 2015
------------------------------------
+Release 3.3.0, 20th May 2015
+----------------------------
 
-Changes in this release:
+The ardupilot development team is proud to announce the release of
+version 3.3.0 of APM:Plane. This is a major release with a lot of
+changes. Please read the release notes carefully!
 
+The last stable release was 3 months ago, and since that time we have
+applied over 1200 changes to the code. It has been a period of very
+rapid development for ArduPilot. Explaining all of the changes that
+have been made would take far too long, so I've chosen some key
+changes to explain in detail, and listed the most important secondary
+changes in a short form. Please ask for details if there is a change
+you see listed that you want some more information on.
+
+Arming Changes
+--------------
+
+This is the first release of APM:Plane where ARMING_CHECK and
+ARMING_REQUIRE both default to enabled. That means when you upgrade if
+you didn't previously have arming enabled you will need to learn about
+arming your plane.
+
+Please see this page for more information on arming:
+
+  http://plane.ardupilot.com/wiki/arming-your-plane/
+
+I know many users will be tempted to disable the arming checks, but
+please don't do that without careful thought. The arming checks are an
+important part of ensuring the aircraft is ready to fly, and a common
+cause of flight problems is to takeoff before ArduPilot is ready.
+
+Re-do Accelerometer Calibration
+-------------------------------
+
+Due to a change in the maximum accelerometer range on the Pixhawk all
+users must re-do their accelerometer calibration for this release. If
+you don't then your plane will fail to arm with a message saying that
+you have not calibrated the accelerometers.
+
+Only 3D accel calibration
+-------------------------
+
+The old "1D" accelerometer calibration method has now been removed, so
+you must use the 3D accelerometer calibration method. The old method
+was removed because a significant number of users had poor flights due
+to scaling and offset errors on their accelerometers when they used
+the 1D method. My apologies for people with very large aircraft who
+find the 3D method difficult.
+
+Note that you can do the accelerometer calibration with the autopilot
+outside the aircraft which can make things easier for large aircraft.
+
+Auto-disarm
+-----------
+
+After an auto-landing the autopilot will now by default disarm after
+LAND_DISARMDELAY seconds (with a default of 20 seconds). This feature
+is to prevent the motor from spinning up unexpectedly on the ground
+after a landing.
+
+HIL_MODE parameter
+------------------
+
+It is now possible to configure your autopilot for hardware in the
+loop simulation without loading a special firmware. Just set the
+parameter HIL_MODE to 1 and this will enable HIL for any
+autopilot. This is designed to make it easier for users to try HIL
+without having to find a HIL firmware.
+
+SITL on Windows
+---------------
+
+The SITL software in the loop simulation system has been completely
+rewritten for this release. A major change is to make it possible to
+run SITL on native windows without needing a Linux virtual
+machine. There should be a release of MissionPlanner for Windows soon
+which will make it easy to launch a SITL instance.
+
+The SITL changes also include new backends, including the CRRCSim
+flight simulator. This gives us a much wider range of aircraft we can
+use for SITL. See http://dev.ardupilot.com/wiki/simulation-2/ for more
+information.
+
+Throttle control on takeoff
+---------------------------
+
+A number of users had problems with pitch control on auto-takeoff, and
+with the aircraft exceeding its target speed during takeoff. The
+auto-takeoff code has now been changed to use the normal TECS throttle
+control which should solve this problem.
+
+Rudder only support
+-------------------
+
+There is a new RUDDER_ONLY parameter for aircraft without ailerons,
+where roll is controlled by the rudder. Please see the documentation
+for more information on flying with a rudder only aircraft:
+
+  http://plane.ardupilot.com/wiki/arduplane-parameters/#rudder_only_aircraft_arduplanerudder_only
+
+APM1/APM2 Support
+-----------------
+
+We have managed to keep support for the APM1 and APM2 in this release,
+but in order to fit it in the limited flash space we had to disable
+some more features when building for those boards. For this release
+the AP_Mount code for controlling camera mounts is disabled on
+APM1/APM2.
+
+At some point soon it will become impractical to keep supporting the
+APM1/APM2 for planes. Please consider moving to a 32 bit autopilot
+soon if you are still using an APM1 or APM2.
+
+New INS code
+------------
+
+There have been a lot of changes to the gyro and accelerometer
+handling for this release. The accelerometer range on the Pixhawk has
+been changed to 16g from 8g to prevent clipping on high vibration
+aircraft, and the sampling rate on the lsm303d has been increased to
+1600Hz. 
+
+An important bug has also been fixed which caused aliasing in the
+sampling process from the accelerometers. That bug could cause 
+attitude errors in high vibration environments.
+
+Numerous Landing Changes
+------------------------
+
+Once again there have been a lot of improvements to the automatic
+landing support. Perhaps most important is the introduction of a
+smooth transition from landing approach to the flare, which reduces
+the tendency to pitch up too much on flare. 
+
+There is also a new parameter TECS_LAND_PMAX which controls the
+maximum pitch during landing. This defaults to 10 degrees, but for
+many aircraft a smaller value may be appropriate. Reduce it to 5
+degrees if you find you still get too much pitch up during the flare.
+
+Other secondary changes in this release include:
 
  - a new SerialManager library which gives much more flexible management of serial port assignment
  - changed the default FS_LONG_TIMEOUT to 5 seconds
@@ -61,7 +197,15 @@ Changes in this release:
  - support CRRCSim FDM backend in SITL
  - new general purpose replay parsing code
  - switched to 16g accel range in Pixhawk
+ - added FENCE_AUTOENABLE=2 for disabling just fence floor
+ - added POS dataflash log message
+ - changed GUIDED behaviour to match copter
+ - added support for a 4th MAVLink channel
+ - support setting AHRS_TRIM in preflight calibration
+ - fixed a PX4 mixer out of range error
 
+Best wishes to all APM:Plane users from the dev team, and happy
+flying!
 
 
 Release 3.2.2, February 10th 2015

--- a/ArduPlane/system.pde
+++ b/ArduPlane/system.pde
@@ -678,6 +678,24 @@ static void servo_write(uint8_t ch, uint16_t pwm)
 }
 
 /*
+  check a digitial pin for high,low (1/0)
+ */
+static uint8_t check_digital_pin(uint8_t pin)
+{
+    int8_t dpin = hal.gpio->analogPinToDigitalPin(pin);
+    if (dpin == -1) {
+        return 0;
+    }
+    // ensure we are in input mode
+    hal.gpio->pinMode(dpin, HAL_GPIO_INPUT);
+
+    // enable pullup
+    hal.gpio->write(dpin, 1);
+
+    return hal.gpio->read(dpin);
+}
+
+/*
   should we log a message type now?
  */
 static bool should_log(uint32_t mask)

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -354,6 +354,9 @@ public:
     // true if the AHRS has completed initialisation
     virtual bool initialised(void) const { return true; };
 
+    // time that the AHRS has been up
+    virtual uint32_t uptime_ms(void) const = 0;
+
 protected:
     AHRS_VehicleClass _vehicle_class;
 

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -967,3 +967,14 @@ bool AP_AHRS_DCM::healthy(void) const
     // consider ourselves healthy if there have been no failures for 5 seconds
     return (_last_failure_ms == 0 || hal.scheduler->millis() - _last_failure_ms > 5000);
 }
+
+/*
+  return amount of time that AHRS has been up
+ */
+uint32_t AP_AHRS_DCM::uptime_ms(void) const
+{
+    if (_last_startup_ms == 0) {
+        return 0;
+    }
+    return hal.scheduler->millis() - _last_startup_ms;
+}

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -110,6 +110,9 @@ public:
     // is the AHRS subsystem healthy?
     bool healthy(void) const;
 
+    // time that the AHRS has been up
+    uint32_t uptime_ms(void) const;
+
 private:
     float _ki;
     float _ki_yaw;

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -173,16 +173,15 @@ void AP_Baro::update_calibration()
 float AP_Baro::get_altitude_difference(float base_pressure, float pressure) const
 {
     float ret;
+    float temp    = get_ground_temperature() + 273.15f;
 #if HAL_CPU_CLASS <= HAL_CPU_CLASS_16
     // on slower CPUs use a less exact, but faster, calculation
     float scaling = base_pressure / pressure;
-    float temp    = get_calibration_temperature() + 273.15f;
     ret = logf(scaling) * temp * 29.271267f;
 #else
     // on faster CPUs use a more exact calculation
     float scaling = pressure / base_pressure;
-    float temp    = get_calibration_temperature() + 273.15f;
-
+    
     // This is an exact calculation that is within +-2.5m of the standard atmosphere tables
     // in the troposphere (up to 11,000 m amsl).
 	ret = 153.8462f * temp * (1.0f - expf(0.190259f * logf(scaling)));

--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -49,6 +49,13 @@ const AP_Param::GroupInfo AP_Camera::var_info[] PROGMEM = {
     // @Range: 0 1000
     AP_GROUPINFO("TRIGG_DIST",  4, AP_Camera, _trigg_dist, 0),
 
+    // @Param: FEEDBACK_PIN
+    // @DisplayName: Camera feedback pin
+    // @Description: pin number to use for save accurate camera feedback messages. If set to -1 then don't use a pin flag for this, otherwise this is a pin number which if held high after a picture trigger order, will save camera messages when camera really takes a picture. An universal camera hot shoe is needed
+    // @Values: -1:Disabled, 0-8:APM FeedbackPin, 50-55:PixHawk FeedbackPin
+    // @User: Standard
+    AP_GROUPINFO("FEEDBACK_PIN",  5, AP_Camera, _feedback_pin, AP_CAMERA_FEEDBACK_DEFAULT_FEEDBACK_PIN),    
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -25,6 +25,8 @@
 #define AP_CAMERA_SERVO_ON_PWM              1300    // default PWM value to move servo to when shutter is activated
 #define AP_CAMERA_SERVO_OFF_PWM             1100    // default PWM value to move servo to when shutter is deactivated
 
+#define AP_CAMERA_FEEDBACK_DEFAULT_FEEDBACK_PIN -1  // default is to not use camera feedback pin
+
 /// @class	Camera
 /// @brief	Object managing a Photo or video camera
 class AP_Camera {
@@ -39,7 +41,10 @@ public:
 		AP_Param::setup_object_defaults(this, var_info);
         _apm_relay = obj_relay;
     }
-
+    
+    // pin number for accurate camera feedback messages
+    AP_Int8         _feedback_pin;      
+    
     // single entry point to take pictures
     //  set send_mavlink_msg to true to send DO_DIGICAM_CONTROL message to all components
     void            trigger_pic(bool send_mavlink_msg);

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -526,8 +526,9 @@ bool NavEKF::InitialiseFilterDynamic(void)
         return false;
     }
 
-    // If the DCM solution has not converged, then don't initialise
-    if (_ahrs->get_error_rp() > 0.05f) {
+    // If the DCM solution has not converged, then don't initialise,
+    // unless at least 30s has passed
+    if (_ahrs->get_error_rp() > 0.05f && _ahrs->uptime_ms() < 30000U) {
         return false;
     }
 


### PR DESCRIPTION
Hello everyone,

I want to achieve the exact time and precise coordinates where the pictures are taken. It not depends on PixHawk, as it sends the order to trigger, but is the camera itself who actually decides when to make the shot. 
Some miliseconds are wasted between Pixhawk triggering and camera shooting. This time is variable and depends on multiple factors: light, focus, shutter,... so the  best solution is to use a synchronized flag or a signal, i.e, the camera flash (best solution that I found).

Well, this is not the best solution and  sure this is the worst code you've ever seen, but... it works! Please give me time to complete here the explanation of how to add the hardware necesary for this and how the code works.

Firstly you need an universal Hot Shoe adapter. Not all Hot Shoes will work. You need one that supports Preflash and Flash Ready emulation. I have tried 5 adapters and just one has worked...

Connecting it to the PixHawk is very easy, as you can see below, but be careful: BE SURE THAT YOUR CAMERA OUTPUTS A MAXIMUM OF 5,7 VOLTS THROUGH HOT SHOE FLASH PINS or you will burn your PixHawk.

![hot-shoe-trigger](https://cloud.githubusercontent.com/assets/3317796/7711490/489918b0-fe6b-11e4-9eff-145605d72d47.jpg)

Secondly, you need to configure CAMERA_FEEDBACK_PIN through Mission Planner.
Then, when the function do_take_picture will be called, for example with "Trigger camera now", the code will generate a flag for wait to the Hot Shoe response.
If the Pixhawk detects an input from the Hot Shoe pin, i.e, camera has been truely triggered, a CAM message will be saved to the Dataflash log.
Finally, code will reset the cicle, waiting for a new do_take_picture.

With all, we have a consistent Log, with the same number of CAM messages and pictures, and the best... precise coordinates and time marks for each picture.

Tested with ArduPlane, ArduCopter (should work with ArduRover) on APM1/APM2 and PixHawk.

Regards,
Dario.