### PR TITLE
Add option to use GPS height for navigation

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -456,6 +456,9 @@ private:
     // align the NE earth magnetic field states with the published declination
     void alignMagStateDeclination();
 
+    // calculate filtered offset between baro height measurement and EKF height estimate
+    void calcFiltBaroOffset();
+
     // EKF Mavlink Tuneable Parameters
     AP_Float _gpsHorizVelNoise;     // GPS horizontal velocity measurement noise : m/s
     AP_Float _gpsVertVelNoise;      // GPS vertical velocity measurement noise : m/s


### PR DESCRIPTION
Use of GPs alt is selected by setting the EKF_ALT_SOURCE parameter to 2
Reverts to Baro if GPS times out.
Calculates and offset to be applied to Baro height to prevent height jumps when reverting, either due to to loss of GPS or changing the  parameter.
Baro height is used prior to setting the GPS origin