### PR TITLE
bugfix affecting Plane in HIL mode

### DIFF
--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -171,7 +171,7 @@ void Plane::init_ardupilot()
     airspeed.init();
 
     if (g.compass_enabled==true) {
-        if (!compass.init() || !compass.read()) {
+        if (!compass.init() || (!g.hil_mode && !compass.read())) {
             cliSerial->println_P(PSTR("Compass initialisation failed!"));
             g.compass_enabled = false;
         } else {

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -734,6 +734,10 @@ failed:
  */
 bool AP_InertialSensor::accel_calibrated_ok_all() const
 {
+    // calibration is not applicable for HIL mode
+    if (_hil_mode)
+        return true;
+
     // check each accelerometer has offsets saved
     for (uint8_t i=0; i<get_accel_count(); i++) {
         // exactly 0.0 offset is extremely unlikely


### PR DESCRIPTION
Two fixes for HIL mode
1- accelerometers are assumed to be calibrated in HIL mode, hence report as calibrated
2- compass should not be disabled at Plane system startup if no data is presented.

