### PR TITLE
AP_GPS: Allow switching primary GPS instance with 1 sat difference

### DIFF
--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -331,6 +331,7 @@ public:
     AP_Int8 _min_dgps;
     AP_Int16 _sbp_logmask;
     AP_Int8 _inject_to;
+    uint32_t _last_instance_swap_ms;
 #endif
     AP_Int8 _sbas_mode;
     AP_Int8 _min_elevation;


### PR DESCRIPTION
Treat the case of 5 vs 6 sats differently because the HDOP improvement is significant and you don't get a very good lock at 5 where you do at 6. Instead of just +2 sats for GPS primary selection, if one has 5 and the other has 6 go ahead and switch.