### PR TITLE
Rover: Removed superfluous speed-type parameter

### DIFF
--- a/APMrover2/commands_logic.cpp
+++ b/APMrover2/commands_logic.cpp
@@ -264,15 +264,10 @@ bool Rover::verify_within_distance()
 
 void Rover::do_change_speed(const AP_Mission::Mission_Command& cmd)
 {
-	switch (cmd.p1)
-	{
-		case 0:
-			if (cmd.content.speed.target_ms > 0) {
-				g.speed_cruise.set(cmd.content.speed.target_ms);
-                gcs_send_text_fmt(PSTR("Cruise speed: %.1f m/s"), (double)g.speed_cruise.get());
-            }
-			break;
-	}
+    if (cmd.content.speed.target_ms > 0) {
+        g.speed_cruise.set(cmd.content.speed.target_ms);
+        gcs_send_text_fmt(PSTR("Cruise speed: %.1f m/s"), (double)g.speed_cruise.get());
+    }
 
 	if (cmd.content.speed.throttle_pct > 0 && cmd.content.speed.throttle_pct <= 100) {
 		g.throttle_cruise.set(cmd.content.speed.throttle_pct);


### PR DESCRIPTION
Unlike Plane, Rover only understands ground speed so there is no need
to specify the speed type parameter for Rover.