### PR TITLE
AntennaTracker: continuous rotation (CR) servos

### DIFF
--- a/AntennaTracker/AntennaTracker.pde
+++ b/AntennaTracker/AntennaTracker.pde
@@ -1,6 +1,6 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
 
-#define THISFIRMWARE "AntennaTracker V0.7"
+#define THISFIRMWARE "AntennaTracker V0.7.1"
 /*
    Lead developers: Matthew Ridley and Andrew Tridgell
  

--- a/AntennaTracker/GCS_Mavlink.pde
+++ b/AntennaTracker/GCS_Mavlink.pde
@@ -602,9 +602,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
                 }
                 if (is_equal(packet.param4,1.0f)) {
                     // Cant trim radio
-                }
-#if !defined( __AVR_ATmega1280__ )
-                else if (packet.param5 == 1) {
+                } else if (is_equal(packet.param5,1.0f)) {
                     float trim_roll, trim_pitch;
                     AP_InertialSensor_UserInteract_MAVLink interact(this);
                     if(ins.calibrate_accel(&interact, trim_roll, trim_pitch)) {
@@ -622,7 +620,6 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
                         result = MAV_RESULT_FAILED;
                     }
                 }
-#endif
                 result = MAV_RESULT_ACCEPTED;
                 break;
             }

--- a/AntennaTracker/GCS_Mavlink.pde
+++ b/AntennaTracker/GCS_Mavlink.pde
@@ -602,7 +602,9 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
                 }
                 if (is_equal(packet.param4,1.0f)) {
                     // Cant trim radio
-                } else if (is_equal(packet.param5,1.0f)) {
+                }
+#if !defined( __AVR_ATmega1280__ )
+                else if (packet.param5 == 1) {
                     float trim_roll, trim_pitch;
                     AP_InertialSensor_UserInteract_MAVLink interact(this);
                     if(ins.calibrate_accel(&interact, trim_roll, trim_pitch)) {
@@ -620,6 +622,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
                         result = MAV_RESULT_FAILED;
                     }
                 }
+#endif
                 result = MAV_RESULT_ACCEPTED;
                 break;
             }

--- a/AntennaTracker/Parameters.pde
+++ b/AntennaTracker/Parameters.pde
@@ -109,7 +109,7 @@ const AP_Param::Info var_info[] PROGMEM = {
     // @Param: SERVO_TYPE
     // @DisplayName: Type of servo system being used
     // @Description: This allows selection of position servos or on/off servos
-    // @Values: 0:Position,1:OnOff
+    // @Values: 0:Position,1:OnOff,2:ContinuousRotation
     // @User: Standard
     GSCALAR(servo_type,          "SERVO_TYPE",   SERVO_TYPE_POSITION),
 
@@ -178,7 +178,7 @@ const AP_Param::Info var_info[] PROGMEM = {
 
     // @Param: PITCH_RANGE
     // @DisplayName: Pitch Range
-    // @Description: Pitch axis total range of motion in degrees
+    // @Description: Pitch axis total range of motion in degrees. Used if mechanical limits are present. It also prevents gimbal-lock in some cases.
     // @Units: degrees
     // @Increment: 0.1
     // @Range: 0 180

--- a/AntennaTracker/ReleaseNotes.txt
+++ b/AntennaTracker/ReleaseNotes.txt
@@ -1,5 +1,12 @@
 Antenna Tracker Release Notes:
 ------------------------------------------------------------------
+AntennaTracker 0.7.1 29-May-2015
+Changes from 0.7
+1) Added support for continuous rotation (CR) servos
+2) Added test mode for CR servos
+3) Added initialization routine which is especially needed with CR servos and may be useful in other cases
+4) Added manual control mode dedicated for CR servos (also usable with other servos)
+------------------------------------------------------------------
 AntennaTracker 0.7 17-May-2015
 Changes from 0.5 (skipped 0.6 to avoid confusion after the wrong version number was communicated on diydrones.com)
 1) added support for 4th MAVLink channel

--- a/AntennaTracker/control_auto.pde
+++ b/AntennaTracker/control_auto.pde
@@ -11,15 +11,29 @@
 static void update_auto(void)
 {
     // exit immediately if we do not have a valid vehicle position
-    if (!vehicle.location_valid) {
-        return;
+    if ((enum ServoType)g.servo_type.get() != SERVO_TYPE_CR)
+	{ 
+    	if (!vehicle.location_valid) 
+		{
+        	return;
+		}
     }
 
     float yaw = wrap_180_cd((nav_status.bearing+g.yaw_trim)*100) * 0.01f;
     float pitch = constrain_float(nav_status.pitch+g.pitch_trim, -90, 90);
-
+    
+    // pitch limits (useful if you have mechanical limitations). It also keeps tracker from reaching gimbal-lock when pitch is
+    // close to +90 or -90 degrees
+    if (pitch > g.pitch_range)
+    {
+      pitch = g.pitch_range;
+    }
+    if (pitch < -g.pitch_range)
+    {
+      pitch = -g.pitch_range;
+    }
     // only move servos if target is at least distance_min away
-    if ((g.distance_min <= 0) || (nav_status.distance >= g.distance_min)) {
+    if ((g.distance_min <= 0) || (nav_status.distance >= g.distance_min) || (enum ServoType)g.servo_type.get() == SERVO_TYPE_CR) {
         update_pitch_servo(pitch);
         update_yaw_servo(yaw);
     }

--- a/AntennaTracker/control_manual.pde
+++ b/AntennaTracker/control_manual.pde
@@ -18,3 +18,39 @@ static void update_manual(void)
     channel_yaw.output();
     channel_pitch.output();
 }
+
+/*
+ * update_manual_angle - runs the manual controller in angle mode
+ * called at 50hz while control_mode is 'MANUAL'
+ * 
+ * This function converts RC inputs into nav_pitch and nav_bearing
+ */
+static void update_manual_angle(void)
+{
+    int yaw_in;
+    int pitch_in;
+    
+    pitch_in = constrain_int16(channel_pitch.radio_in, channel_pitch.radio_min, channel_pitch.radio_max);
+    yaw_in = constrain_int16(channel_yaw.radio_in, channel_yaw.radio_min, channel_yaw.radio_max);
+     
+    // rc input to angle conversion
+    nav_status.bearing = (float)(yaw_in - channel_yaw.radio_min)/(float)(channel_yaw.radio_max - channel_yaw.radio_min) * 360.0;
+    nav_status.pitch = ( (float)(pitch_in - channel_pitch.radio_min)/(float)(channel_pitch.radio_max - channel_pitch.radio_min) * 180.0) - 90.0;
+    
+    float yaw = wrap_180_cd((nav_status.bearing+g.yaw_trim)*100) * 0.01f;
+    //float yaw = nav_status.bearing
+    float pitch = constrain_float(nav_status.pitch+g.pitch_trim, -90, 90);
+
+    if (pitch > g.pitch_range)
+    {
+      pitch = g.pitch_range;
+    }
+    if (pitch < -g.pitch_range)
+    {
+      pitch = -g.pitch_range;
+    }
+
+    update_pitch_servo(pitch);
+    update_yaw_servo(yaw);
+    
+}

--- a/AntennaTracker/control_servo_test.pde
+++ b/AntennaTracker/control_servo_test.pde
@@ -5,6 +5,40 @@
  */
 
 /*
+ * update_servo_test - runs the servo test controller
+ *  called at 50hz while control_mode is 'SERVO_TEST' mode
+ *  tracker switches into this mode if it ever receives a do-set-servo command from the GCS
+ */
+static void update_servo_test(void)
+{
+    
+    // CR Servo test routine
+    //
+    // Runs at 50Hz to keep servos pointed at set angles
+    
+    
+    if ( (enum ServoType)g.servo_type.get() == SERVO_TYPE_CR)
+    {
+        
+        float yaw = wrap_180_cd((nav_status.bearing+g.yaw_trim)*100) * 0.01f;
+        update_yaw_servo(yaw);
+        
+        float pitch = constrain_float(nav_status.pitch+g.pitch_trim, -90, 90);
+
+        if (pitch > g.pitch_range)
+        {
+          pitch = g.pitch_range;
+        }
+        if (pitch < -g.pitch_range)
+        {
+          pitch = -g.pitch_range;
+        }
+        update_pitch_servo(pitch);
+      
+    }
+}
+
+/*
  * servo_test_set_servo - sets the yaw or pitch servo pwm directly
  *  servo_num are 1 for yaw, 2 for pitch
  */
@@ -24,17 +58,34 @@ static bool servo_test_set_servo(uint8_t servo_num, uint16_t pwm)
     }
 
     // set yaw servo pwm and send output to servo
-    if (servo_num == CH_YAW) {
+    if (servo_num == CH_YAW && (enum ServoType)g.servo_type.get() != SERVO_TYPE_CR) {
         channel_yaw.radio_out = constrain_int16(pwm, channel_yaw.radio_min, channel_yaw.radio_max);
         channel_yaw.output();
     }
 
     // set pitch servo pwm and send output to servo
-    if (servo_num == CH_PITCH) {
+    if (servo_num == CH_PITCH && (enum ServoType)g.servo_type.get() != SERVO_TYPE_CR) {
         channel_pitch.radio_out = constrain_int16(pwm, channel_pitch.radio_min, channel_pitch.radio_max);
         channel_pitch.output();
     }
-
+    
+    // CR servo test
+    int yaw_in;
+    int pitch_in;
+    
+    pitch_in = constrain_int16(pwm, channel_pitch.radio_min, channel_pitch.radio_max);
+    yaw_in = constrain_int16(pwm, channel_yaw.radio_min, channel_yaw.radio_max);
+    
+    if (servo_num == CH_YAW && (enum ServoType)g.servo_type.get() == SERVO_TYPE_CR)
+    {
+        nav_status.bearing = (float)(yaw_in - channel_yaw.radio_min)/(float)(channel_yaw.radio_max - channel_yaw.radio_min) * 360.0;
+    }
+    
+    if (servo_num == CH_PITCH && (enum ServoType)g.servo_type.get() == SERVO_TYPE_CR)
+    {
+        nav_status.pitch = ( (float)(pitch_in - channel_pitch.radio_min)/(float)(channel_pitch.radio_max - channel_pitch.radio_min) * 180.0) - 90.0;
+    }
+    
     // return success
     return true;
 }

--- a/AntennaTracker/defines.h
+++ b/AntennaTracker/defines.h
@@ -3,10 +3,6 @@
 #ifndef _DEFINES_H
 #define _DEFINES_H
 
-// mark a function as not to be inlined
-#define NOINLINE __attribute__((noinline))
-
-
 // Command/Waypoint/Location Options Bitmask
 //--------------------
 #define MASK_OPTIONS_RELATIVE_ALT       (1<<0)          // 1 = Relative

--- a/AntennaTracker/defines.h
+++ b/AntennaTracker/defines.h
@@ -3,6 +3,10 @@
 #ifndef _DEFINES_H
 #define _DEFINES_H
 
+// mark a function as not to be inlined
+#define NOINLINE __attribute__((noinline))
+
+
 // Command/Waypoint/Location Options Bitmask
 //--------------------
 #define MASK_OPTIONS_RELATIVE_ALT       (1<<0)          // 1 = Relative
@@ -22,7 +26,8 @@ enum ControlMode {
 
 enum ServoType {
     SERVO_TYPE_POSITION=0,
-    SERVO_TYPE_ONOFF=1
+    SERVO_TYPE_ONOFF=1,
+    SERVO_TYPE_CR=2
 };
 
 #endif // _DEFINES_H

--- a/AntennaTracker/tracking.pde
+++ b/AntennaTracker/tracking.pde
@@ -94,6 +94,7 @@ static void update_tracking(void)
 
     case MANUAL:
         update_manual();
+		//update_manual_angle(); // Angle-oriented control rather rhan PWM oriented control
         break;
 
     case SCAN:
@@ -101,8 +102,13 @@ static void update_tracking(void)
         break;
 
     case SERVO_TEST:
+        update_servo_test();
+        break;
     case STOP:
+        disarm_servos();
+        break;
     case INITIALISING:
+        update_initialising();
         break;
     }
 }
@@ -167,5 +173,32 @@ static void update_armed_disarmed()
         AP_Notify::flags.armed = true;
     } else {
         AP_Notify::flags.armed = false;
+    }
+}
+
+int delay_timer=0;  // this needs to be done properly
+
+static void update_initialising(void)
+{
+    // fixed angle for pitch initialising. Zero servo output to prevent erratic movement.
+    nav_status.pitch = 45;
+       
+    channel_yaw.disable_out();
+    channel_pitch.enable_out();
+    
+    float pitch = constrain_float(nav_status.pitch+g.pitch_trim, -90, 90);
+    
+    update_pitch_servo(pitch);
+    
+    float ahrs_pitch = degrees(ahrs.pitch);
+    if (ahrs_pitch < 50 && ahrs_pitch > 40)
+    {
+        if (delay_timer == 0) delay_timer = hal.scheduler->millis();
+        // PITCH INITIALISING complete, switch to auto mode after delay
+        if (g.startup_delay > 0 &&
+            hal.scheduler->millis() - delay_timer < g.startup_delay*1000) {
+            return;
+        }
+        set_mode(AUTO);
     }
 }

--- a/AntennaTracker/tracking.pde
+++ b/AntennaTracker/tracking.pde
@@ -41,8 +41,8 @@ static void update_tracker_position()
  */
 static void update_bearing_and_distance()
 {
-    // exit immediately if we do not have a valid vehicle position
-    if (!vehicle.location_valid) {
+    // exit immediately if we do not have a valid vehicle position or servo_test is in progress
+    if (!vehicle.location_valid || control_mode == SERVO_TEST) {
         return;
     }
 


### PR DESCRIPTION
My tracker is equipped with continuous rotation servos (MAX PWM - rotate CW at full speed, MED PWM - stand still, MIN PWM - rotate CCW at full speed). These servos have no mechanical limitation and are basically a PWM-controlled DC motors. My tracker is also equipped with slip-rings in order to rotate freely as many times as it needs to without tangling the wires. I have been working on CR servo mode for quite some time (since version 0.4 - there is a long discussion on diydrones http://diydrones.com/forum/topics/figuring-out-the-antenna-tracker?id=705844%3ATopic%3A1733725&page=15#comments). I was able to merge my changes with current 0.7 version and named it 0.7.1 (to be verified). There are still some ugly parts of my code but it works well (I have some issues but they are not related to my changes). 

Main modifications include:
1) new servo mode (2:ContinuousRotation)
2) new servo control functions (servo.pde)
3) initialisation function - due to specific construction of my tracker i am able to reach gimbal-lock position which may cause pitch to wind-around +90 and -90 degrees which results in 180 degrees change in yaw. In order to prevent my tracker from erratic behavior I implemented INITIALISING mode which disables both servos, moves the pitch to 45 degrees and then moves the yaw (when pitch is at 45 degrees). It jumps to AUTO mode as soon as pitch reaches +45 degrees. This modification may also be useful for other types of trackers since it generally reduces the amount of movements that take place during bootup.
4) in system.pde changed default mode from AUTO to INITIALISING (see above)
5) some addidional conditions - CR servos must be updated constantly, they have no potentiometer feedback and they need to be constantly monitored with an IMU to keep the tracker working. These modifications only affect CR servo mode, standard modes are working as they were before.
6) update_manual_angle function which converts PWM signal into angular information. This is required for CR servos, since they cannot be operated directly by PWM. This mode will also be useful for classic servos (RC input will apply desired angles rather than PWM value)
7) update_servo_test - as mentioned above, the servos need to be updated constantly. Test mode converts the PWM signal from sliders in MP into angular information. This may also be useful for other types of servos, especially for PID tuning.
8) Addidional minor changes including mode changing etc

This is my first pull request and I probably did something wrong - all comments are very welcome.