### PR TITLE
Parameter logging

### DIFF
--- a/APMrover2/commands_logic.cpp
+++ b/APMrover2/commands_logic.cpp
@@ -264,15 +264,10 @@ bool Rover::verify_within_distance()
 
 void Rover::do_change_speed(const AP_Mission::Mission_Command& cmd)
 {
-	switch (cmd.p1)
-	{
-		case 0:
-			if (cmd.content.speed.target_ms > 0) {
-				g.speed_cruise.set(cmd.content.speed.target_ms);
-                gcs_send_text_fmt(PSTR("Cruise speed: %.1f m/s"), (double)g.speed_cruise.get());
-            }
-			break;
-	}
+    if (cmd.content.speed.target_ms > 0) {
+        g.speed_cruise.set(cmd.content.speed.target_ms);
+        gcs_send_text_fmt(PSTR("Cruise speed: %.1f m/s"), (double)g.speed_cruise.get());
+    }
 
 	if (cmd.content.speed.throttle_pct > 0 && cmd.content.speed.throttle_pct <= 100) {
 		g.throttle_cruise.set(cmd.content.speed.throttle_pct);

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -210,8 +210,10 @@ void Rover::init_ardupilot()
     }
 #endif
 
-	startup_ground();
+    // Write all current parameters
+    DataFlash.Log_Write_Parameters();
 
+	startup_ground();
 	if (should_log(MASK_LOG_CMD)) {
         Log_Write_Startup(TYPE_GROUNDSTART_MSG);
     }

--- a/ArduCopter/system.pde
+++ b/ArduCopter/system.pde
@@ -252,6 +252,11 @@ static void init_ardupilot()
     heli_init();
 #endif
 
+#if LOGGING_ENABLED == ENABLED
+    // Write all current parameters
+    DataFlash.Log_Write_Parameters();
+#endif
+
     startup_ground(true);
 
 #if LOGGING_ENABLED == ENABLED

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -226,6 +226,9 @@ void Plane::init_ardupilot()
     }
 #endif // CLI_ENABLED
 
+    // Write all current parameters
+    DataFlash.Log_Write_Parameters();
+
     startup_ground();
     if (should_log(MASK_LOG_CMD))
         Log_Write_Startup(TYPE_GROUNDSTART_MSG);

--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -91,6 +91,7 @@ public:
     void Log_Write_Current(const AP_BattMonitor &battery, int16_t throttle);
     void Log_Write_Compass(const Compass &compass);
     void Log_Write_Mode(uint8_t mode);
+    void Log_Write_Parameters(void);
 
     // This structure provides information on the internal member data of a PID for logging purposes
     struct PID_Info {
@@ -124,7 +125,6 @@ protected:
     void Log_Fill_Format(const struct LogStructure *structure, struct log_Format &pkt);
     void Log_Write_Parameter(const AP_Param *ap, const AP_Param::ParamToken &token, 
                              enum ap_var_type type);
-    void Log_Write_Parameters(void);
     virtual uint16_t start_new_log(void) = 0;
 
     const struct LogStructure *_structures;

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -587,8 +587,6 @@ uint16_t DataFlash_Class::StartNewLog(void)
         hal.scheduler->delay(10);
     }
 
-    // and all current parameters
-    Log_Write_Parameters();
     return ret;
 }
 


### PR DESCRIPTION
Moved Log_Write_Parameters to be public so we can call it from the vehicle code at the end of the startup sequence.
We needed to do this because parameters like COMPASS_EXTERNAL are modified by the startup code and if we log the parameters too early we will be recording the wrong value.