### PR TITLE
AP_NavEKF: Improve gyro bias learning rate for plane and rover

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -55,7 +55,7 @@
 #define MAG_NOISE_DEFAULT       0.05f
 #define GYRO_PNOISE_DEFAULT     0.015f
 #define ACC_PNOISE_DEFAULT      0.25f
-#define GBIAS_PNOISE_DEFAULT    1E-06f
+#define GBIAS_PNOISE_DEFAULT    8E-06f
 #define ABIAS_PNOISE_DEFAULT    0.00005f
 #define MAGE_PNOISE_DEFAULT     0.0003f
 #define MAGB_PNOISE_DEFAULT     0.0003f
@@ -79,7 +79,7 @@
 #define MAG_NOISE_DEFAULT       0.05f
 #define GYRO_PNOISE_DEFAULT     0.015f
 #define ACC_PNOISE_DEFAULT      0.5f
-#define GBIAS_PNOISE_DEFAULT    1E-06f
+#define GBIAS_PNOISE_DEFAULT    8E-06f
 #define ABIAS_PNOISE_DEFAULT    0.00005f
 #define MAGE_PNOISE_DEFAULT     0.0003f
 #define MAGB_PNOISE_DEFAULT     0.0003f
@@ -106,7 +106,7 @@ extern const AP_HAL::HAL& hal;
 #define STARTUP_WIND_SPEED 3.0f
 
 // initial imu bias uncertainty (deg/sec)
-#define INIT_GYRO_BIAS_UNCERTAINTY  0.1f
+#define INIT_GYRO_BIAS_UNCERTAINTY  1.0f
 #define INIT_ACCEL_BIAS_UNCERTAINTY 0.3f
 
 // Define tuning parameters


### PR DESCRIPTION
This patch increases initial gyro bias uncertainty and plane and rover specific process noise to improve the rate of gyro bias learning.
This reduces the likelihood of a navigation failure due to rapid temperature changes in the inertial sensors causing rapid changes in zero rate offset.

See attached plot showing EKF yaw angle and gyro bias estimate following a 0.05 rad/sec step change in bias applied to IMU1. The EKF_GBIAS_PNOISE parameter has been tuned to provide the fastest response to bias changes without excessive overshoot.

![yaw_gyro_bias_step_response](https://cloud.githubusercontent.com/assets/3596952/7951034/b760e590-09e5-11e5-8c48-657499edabea.png)

The increase in process noise cannot be applied to Copter due to different numerical stability limits arising from the faster update rate which means it already has a faster response to gyro bias changes.