### PR TITLE
Corrects all C11 sitl compilation errors on OS X.

### DIFF
--- a/ArduCopter/control_autotune.cpp
+++ b/ArduCopter/control_autotune.cpp
@@ -628,10 +628,10 @@ void Copter::autotune_attitude_control()
             // move to the next tuning type
             switch (autotune_state.tune_type) {
             case AUTOTUNE_TYPE_RD_UP:
-                autotune_state.tune_type++;
+                autotune_state.tune_type = AutoTuneTuneType(autotune_state.tune_type + 1);
                 break;
             case AUTOTUNE_TYPE_RD_DOWN:
-                autotune_state.tune_type++;
+                autotune_state.tune_type = AutoTuneTuneType(autotune_state.tune_type + 1);
                 switch (autotune_state.axis) {
                 case AUTOTUNE_AXIS_ROLL:
                     tune_roll_rd = max(AUTOTUNE_RD_MIN, tune_roll_rd * AUTOTUNE_RD_BACKOFF);
@@ -648,7 +648,7 @@ void Copter::autotune_attitude_control()
                 }
                 break;
             case AUTOTUNE_TYPE_RP_UP:
-                autotune_state.tune_type++;
+                autotune_state.tune_type = AutoTuneTuneType(autotune_state.tune_type + 1);
                 switch (autotune_state.axis) {
                 case AUTOTUNE_AXIS_ROLL:
                     tune_roll_rp = max(AUTOTUNE_RP_MIN, tune_roll_rp * AUTOTUNE_RP_BACKOFF);
@@ -662,7 +662,7 @@ void Copter::autotune_attitude_control()
                 }
                 break;
             case AUTOTUNE_TYPE_SP_DOWN:
-                autotune_state.tune_type++;
+                autotune_state.tune_type = AutoTuneTuneType(autotune_state.tune_type + 1);
                 break;
             case AUTOTUNE_TYPE_SP_UP:
                 // we've reached the end of a D-up-down PI-up-down tune type cycle

--- a/libraries/AP_HAL_SITL/Scheduler.h
+++ b/libraries/AP_HAL_SITL/Scheduler.h
@@ -6,6 +6,7 @@
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 #include "AP_HAL_SITL_Namespace.h"
 #include <sys/time.h>
+#include <fenv.h>
 
 #define SITL_SCHEDULER_MAX_TIMER_PROCS 4
 
@@ -80,6 +81,31 @@ private:
     bool _initialized;
     uint64_t stopped_clock_usec;
 };
+
+#if (defined __APPLE__) && (defined(__i386__) || defined(__x86_64__))
+
+// Public domain polyfill for feenableexcept on OS X
+// http://www-personal.umich.edu/~williams/archive/computation/fe-handling-example.c
+
+inline int
+feenableexcept (unsigned int excepts)
+{
+  static fenv_t fenv;
+  unsigned int new_excepts = excepts & FE_ALL_EXCEPT,
+               old_excepts;  // previous masks
+
+  if ( fegetenv (&fenv) ) return -1;
+  old_excepts = fenv.__control & FE_ALL_EXCEPT;
+
+  // unmask
+  fenv.__control &= ~new_excepts;
+  fenv.__mxcsr   &= ~(new_excepts << 7);
+
+  return ( fesetenv (&fenv) ? -1 : old_excepts );
+}
+
+#endif
+
 #endif
 #endif // __AP_HAL_SITL_SCHEDULER_H__
 

--- a/libraries/AP_Menu/AP_Menu.cpp
+++ b/libraries/AP_Menu/AP_Menu.cpp
@@ -106,7 +106,7 @@ Menu::_run_command(bool prompt_on_enter)
     // XXX should an empty line by itself back out of the current menu?
     while (argc <= _args_max) {
         _argv[argc].str = strtok_r(NULL, " ", &s);
-        if ('\0' == _argv[argc].str)
+        if ('\0' == _argv[argc].str[0])
             break;
         _argv[argc].i = atol(_argv[argc].str);
         _argv[argc].f = atof(_argv[argc].str);      // calls strtod, > 700B !

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -43,7 +43,7 @@
 #define AP_CLASSTYPE(class, element) (((const class *) 1)->element.vtype)
 
 // declare a group var_info line
-#define AP_GROUPINFO(name, idx, class, element, def) { AP_CLASSTYPE(class, element), idx, name, AP_VAROFFSET(class, element), {def_value : def} }
+#define AP_GROUPINFO(name, idx, class, element, def) { static_cast<uint8_t>(AP_CLASSTYPE(class, element)), idx, name, AP_VAROFFSET(class, element), {def_value : def} }
 
 // declare a nested group entry in a group var_info
 #ifdef AP_NESTED_GROUPS_ENABLED

--- a/libraries/AP_Terrain/AP_Terrain.cpp
+++ b/libraries/AP_Terrain/AP_Terrain.cpp
@@ -362,7 +362,7 @@ void AP_Terrain::log_terrain_data(DataFlash_Class &dataflash)
         status         : (uint8_t)status(),
         lat            : loc.lat,
         lng            : loc.lng,
-        spacing        : grid_spacing,
+        spacing        : static_cast<uint16_t>(grid_spacing),
         terrain_height : terrain_height,
         current_height : current_height,
         pending        : pending,


### PR DESCRIPTION
This corrects several narrowing and enum conversion issues.

In addition, this adds a polyfill for feenableexcept. I believe this would be moved to a better location, but I found no obvious location for OS-specific polyfills.