### PR TITLE
Fixes for OS X compilation of SITL with Clang.

### DIFF
--- a/libraries/AP_HAL_SITL/Scheduler.cpp
+++ b/libraries/AP_HAL_SITL/Scheduler.cpp
@@ -8,6 +8,7 @@
 #include <sys/time.h>
 #include <unistd.h>
 #include <fenv.h>
+#include "fenv_polyfill.h"
 
 using namespace HALSITL;
 

--- a/libraries/AP_HAL_SITL/fenv_polyfill.h
+++ b/libraries/AP_HAL_SITL/fenv_polyfill.h
@@ -1,0 +1,32 @@
+
+#ifndef __FENV_POLYFILL_H__
+#define __FENV_POLYFILL_H__
+
+#if (defined __APPLE__) && (defined(__i386__) || defined(__x86_64__))
+
+#include <fenv.h>
+
+// Public domain polyfill for feenableexcept on OS X
+// http://www-personal.umich.edu/~williams/archive/computation/fe-handling-example.c
+
+inline int
+feenableexcept (unsigned int excepts)
+{
+  static fenv_t fenv;
+  unsigned int new_excepts = excepts & FE_ALL_EXCEPT,
+               old_excepts;  // previous masks
+
+  if ( fegetenv (&fenv) ) return -1;
+  old_excepts = fenv.__control & FE_ALL_EXCEPT;
+
+  // unmask
+  fenv.__control &= ~new_excepts;
+  fenv.__mxcsr   &= ~(new_excepts << 7);
+
+  return ( fesetenv (&fenv) ? -1 : old_excepts );
+}
+
+#endif // APPLE
+
+#endif // __FENV_POLYFILL_H__
+

--- a/libraries/AP_Menu/AP_Menu.cpp
+++ b/libraries/AP_Menu/AP_Menu.cpp
@@ -106,7 +106,7 @@ Menu::_run_command(bool prompt_on_enter)
     // XXX should an empty line by itself back out of the current menu?
     while (argc <= _args_max) {
         _argv[argc].str = strtok_r(NULL, " ", &s);
-        if ('\0' == _argv[argc].str)
+        if ('\0' == _argv[argc].str[0])
             break;
         _argv[argc].i = atol(_argv[argc].str);
         _argv[argc].f = atof(_argv[argc].str);      // calls strtod, > 700B !

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -40,7 +40,7 @@
 #define AP_VAROFFSET(type, element) (((uintptr_t)(&((const type *)1)->element))-1)
 
 // find the type of a variable given the class and element
-#define AP_CLASSTYPE(class, element) (((const class *) 1)->element.vtype)
+#define AP_CLASSTYPE(class, element) ((uint8_t)(((const class *) 1)->element.vtype))
 
 // declare a group var_info line
 #define AP_GROUPINFO(name, idx, class, element, def) { AP_CLASSTYPE(class, element), idx, name, AP_VAROFFSET(class, element), {def_value : def} }


### PR DESCRIPTION
See #2366. This has the following commits:

1. Correct a comparison in AP_Menu to determine a null string by specifying a character index.
2. Adds a polyfill for `feenableexcept` on OS X based off a public domain implementation.
3. Corrects a narrowing warning in C11 by explicitly casting AP_CLASSTYPE to a uint8_t (as it's used).
