### PR TITLE
Edited min pulse width value for RCOutput

### DIFF
--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -4,6 +4,9 @@
 
 #include "AP_HAL_Namespace.h"
 
+#define RC_OUTPUT_MIN_PULSEWIDTH 400
+#define RC_OUTPUT_MAX_PULSEWIDTH 2100
+
 /* Define the CH_n names, indexed from 1, if we don't have them already */
 #ifndef CH_1
 #define CH_1 0

--- a/libraries/AP_HAL_AVR/RCOutput_APM1.cpp
+++ b/libraries/AP_HAL_AVR/RCOutput_APM1.cpp
@@ -148,8 +148,8 @@ void APM1RCOutput::disable_ch(uint8_t ch) {
 
 /* constrain pwm to be between min and max pulsewidth. */
 static inline uint16_t constrain_period(uint16_t p) {
-    if (p > RC_INPUT_MAX_PULSEWIDTH) return RC_INPUT_MAX_PULSEWIDTH;
-    if (p < RC_INPUT_MIN_PULSEWIDTH) return RC_INPUT_MIN_PULSEWIDTH;
+    if (p > RC_OUTPUT_MAX_PULSEWIDTH) return RC_OUTPUT_MAX_PULSEWIDTH;
+    if (p < RC_OUTPUT_MIN_PULSEWIDTH) return RC_OUTPUT_MIN_PULSEWIDTH;
     return p;
 }
 

--- a/libraries/AP_HAL_AVR/RCOutput_APM2.cpp
+++ b/libraries/AP_HAL_AVR/RCOutput_APM2.cpp
@@ -140,8 +140,8 @@ void APM2RCOutput::disable_ch(uint8_t ch) {
 
 /* constrain pwm to be between min and max pulsewidth. */
 static inline uint16_t constrain_period(uint16_t p) {
-    if (p > RC_INPUT_MAX_PULSEWIDTH) return RC_INPUT_MAX_PULSEWIDTH;
-    if (p < RC_INPUT_MIN_PULSEWIDTH) return RC_INPUT_MIN_PULSEWIDTH;
+    if (p > RC_OUTPUT_MAX_PULSEWIDTH) return RC_OUTPUT_MAX_PULSEWIDTH;
+    if (p < RC_OUTPUT_MIN_PULSEWIDTH) return RC_OUTPUT_MIN_PULSEWIDTH;
     return p;
 }
 


### PR DESCRIPTION
I couldn't get a full range of motion on my servo (only around 110 degrees) when using hal.rcout->write so I poked around and figured out that using a minimum pulse width of 400 let me get complete control (around 180 degrees).