### PR TITLE
Sitl lag fix: Sim time was drifting away from wall clock time.

### DIFF
--- a/libraries/AP_HAL/Scheduler.h
+++ b/libraries/AP_HAL/Scheduler.h
@@ -13,6 +13,7 @@ public:
     Scheduler() {}
     virtual void     init(void* implspecific) = 0;
     virtual void     delay(uint16_t ms) = 0;
+    virtual uint64_t get_start_time_micros64() { return 0; }
     virtual uint32_t millis() = 0;
     virtual uint32_t micros() = 0;
     virtual uint64_t millis64() = 0;

--- a/libraries/AP_HAL_SITL/Scheduler.cpp
+++ b/libraries/AP_HAL_SITL/Scheduler.cpp
@@ -39,6 +39,12 @@ void SITLScheduler::init(void *unused)
     gettimeofday(&_sketch_start_time,NULL);
 }
 
+uint64_t SITLScheduler::get_start_time_micros64() 
+{
+    return (1.0e6 * _sketch_start_time.tv_sec +
+                    _sketch_start_time.tv_usec);
+}
+
 uint64_t SITLScheduler::_micros64()
 {
     struct timeval tp;

--- a/libraries/AP_HAL_SITL/Scheduler.h
+++ b/libraries/AP_HAL_SITL/Scheduler.h
@@ -17,6 +17,7 @@ public:
 
     void     init(void *unused);
     void     delay(uint16_t ms);
+    uint64_t get_start_time_micros64();
     uint32_t millis();
     uint32_t micros();
     uint64_t millis64();

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -30,6 +30,8 @@
 #include <Mmsystem.h>
 #endif
 
+extern const AP_HAL::HAL& hal;
+
 /*
   parent class for all simulator types
  */
@@ -176,7 +178,17 @@ void Aircraft::sync_frame_time(void)
                  (double)rate_hz,
                  (double)scaled_frame_time_us);
 #endif
+        uint64_t first_wall_time_us = hal.scheduler->get_start_time_micros64();
+        uint64_t sim_time = first_wall_time_us + hal.scheduler->micros64();
+        int64_t diff = now - sim_time;
+
+        //Watch diff slowly climb
+        printf("%f = %lf - %lf \n", float(diff)     / 1000000.0f,
+                                    double(now)      / 1000000.0,
+                                    double(sim_time) / 1000000.0);
+
         uint32_t sleep_time = scaled_frame_time_us*frame_counter;
+
         if (sleep_time > min_sleep_time) {
             usleep(sleep_time);
         }

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -164,34 +164,24 @@ void Aircraft::sync_frame_time(void)
     uint64_t now = get_wall_time_us();
     if (frame_counter >= 40 &&
         now > last_wall_time_us) {
-        float rate = frame_counter * 1.0e6f/(now - last_wall_time_us);
-        achieved_rate_hz = (0.99f*achieved_rate_hz) + (0.01f*rate);
-        if (achieved_rate_hz < rate_hz * target_speedup) {
-            scaled_frame_time_us *= 0.999f;
-        } else {
-            scaled_frame_time_us /= 0.999f;
-        }
-#if 0
-        ::printf("achieved_rate_hz=%.3f rate=%.2f rate_hz=%.3f sft=%.1f\n",
-                 (double)achieved_rate_hz, 
-                 (double)rate,
-                 (double)rate_hz,
-                 (double)scaled_frame_time_us);
-#endif
+ 
         uint64_t first_wall_time_us = hal.scheduler->get_start_time_micros64();
         uint64_t sim_time = first_wall_time_us + hal.scheduler->micros64();
-        int64_t diff = now - sim_time;
+        uint64_t scaled_wall_time_us = first_wall_time_us + 
+                      (uint64_t) ((now - first_wall_time_us) * target_speedup);
+        int64_t diff = scaled_wall_time_us - sim_time;
 
-        //Watch diff slowly climb
-        printf("%f = %lf - %lf \n", float(diff)     / 1000000.0f,
-                                    double(now)      / 1000000.0,
-                                    double(sim_time) / 1000000.0);
+#if 0
+        printf("%f = %lf - %lf \n", float(diff)                 / 1000000.0f,
+                                    double(scaled_wall_time_us) / 1000000.0,
+                                    double(sim_time)            / 1000000.0);
+#endif //0
 
-        uint32_t sleep_time = scaled_frame_time_us*frame_counter;
-
-        if (sleep_time > min_sleep_time) {
-            usleep(sleep_time);
+        //slow down a bit if sim_time has gotten ahead of wall_time
+        if (diff < 0) {
+            usleep(100000);
         }
+        
         last_wall_time_us = now;
         frame_counter = 0;
     }


### PR DESCRIPTION
When speedup was at 1 (default when running SITL from sim_vehicle script) we noticed the simulation time would drift slowly away from wall clock time.  This is an issue for us because our simulated payload needs to communicate with SITL and the clock differences were killing us.

The first 3 commits of this PR demonstrate the issue.  To see the wall clock drift, leave the last commit off, buld, run SITL (with speedup = 1.0) and then have the plane takeoff (this last step is important to have the FDM exercising at "full tilt," otherwise the drift occurs more slowly).  Our observations are a drift of about 1.2 seconds after 1 minute, 2.8 seconds after 2 minutes, 3.3 secs after 3 minutes, 5.1 secs after 4 minutes, 5.7 secs after 5 mins, and 7.1 secs after 6 minutes, and the drift slowly continues upward after that.

The fourth commit of this PR is the proposed solution.  We think the problem was the previous solution was simply sleeping the CPU too much.