### PR TITLE
All: Precise Camera Feedback messages

### DIFF
--- a/APMrover2/Log.cpp
+++ b/APMrover2/Log.cpp
@@ -48,6 +48,10 @@ bool Rover::print_log_menu(void)
 		PLOG(COMPASS);
 		PLOG(CAMERA);
 		PLOG(STEERING);
+                PLOG(RC);
+                PLOG(WHEN_DISARMED);
+                PLOG(IMU_RAW);
+                PLOG(TRIGGER);
 		#undef PLOG
 	}
 
@@ -98,7 +102,7 @@ int8_t Rover::erase_logs(uint8_t argc, const Menu::arg *argv)
 
 int8_t Rover::select_logs(uint8_t argc, const Menu::arg *argv)
 {
-	uint16_t	bits;
+	uint32_t	bits;
 
 	if (argc != 2) {
 		cliSerial->printf_P(PSTR("missing log type\n"));
@@ -114,7 +118,7 @@ int8_t Rover::select_logs(uint8_t argc, const Menu::arg *argv)
 	// bits accordingly.
 	//
 	if (!strcasecmp_P(argv[1].str, PSTR("all"))) {
-		bits = ~0;
+		bits = 0xFFFFFFFFUL;
 	} else {
 		#define TARG(_s)	if (!strcasecmp_P(argv[1].str, PSTR(#_s))) bits |= MASK_LOG_ ## _s
 		TARG(ATTITUDE_FAST);
@@ -131,6 +135,10 @@ int8_t Rover::select_logs(uint8_t argc, const Menu::arg *argv)
 		TARG(COMPASS);
 		TARG(CAMERA);
 		TARG(STEERING);
+                TARG(RC);
+                TARG(WHEN_DISARMED);
+                TARG(IMU_RAW);
+                TARG(TRIGGER);
 		#undef TARG
 	}
 
@@ -460,4 +468,3 @@ void Rover::start_logging() {}
 void Rover::Log_Write_RC(void) {}
 
 #endif // LOGGING_ENABLED
-

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -371,6 +371,7 @@ private:
     // private member functions
     void ahrs_update();
     void mount_update(void);
+    void update_trigger(void);    
     void update_alt();
     void gcs_failsafe_check(void);
     void compass_accumulate(void);

--- a/APMrover2/commands_logic.cpp
+++ b/APMrover2/commands_logic.cpp
@@ -314,8 +314,16 @@ void Rover::do_take_picture()
 // log_picture - log picture taken and send feedback to GCS
 void Rover::log_picture()
 {
-    gcs_send_message(MSG_CAMERA_FEEDBACK);
-    if (should_log(MASK_LOG_CAMERA)) {
-        DataFlash.Log_Write_Camera(ahrs, gps, current_loc);
+    if (camera._feedback_pin == -1 ){
+      gcs_send_message(MSG_CAMERA_FEEDBACK);
+      if (should_log(MASK_LOG_CAMERA)) {
+          DataFlash.Log_Write_Camera(ahrs, gps, current_loc);
+      }
+    }
+    else {
+      camera._camera_triggered = 0;
+      if (should_log(MASK_LOG_TRIGGER)) {
+          DataFlash.Log_Write_Trigger(ahrs, gps, current_loc);
+      }      
     }
 }

--- a/APMrover2/config.h
+++ b/APMrover2/config.h
@@ -299,7 +299,8 @@
     MASK_LOG_COMPASS | \
     MASK_LOG_CURRENT | \
     MASK_LOG_STEERING | \
-    MASK_LOG_CAMERA
+    MASK_LOG_CAMERA | \
+    MASK_LOG_TRIGGER
 #else
 // other systems have plenty of space for full logs
 #define DEFAULT_LOG_BITMASK   0xffff

--- a/APMrover2/defines.h
+++ b/APMrover2/defines.h
@@ -88,8 +88,9 @@ enum mode {
 #define MASK_LOG_CAMERA   		(1<<12)
 #define MASK_LOG_STEERING  		(1<<13)
 #define MASK_LOG_RC     		(1<<14)
-#define MASK_LOG_WHEN_DISARMED  (1UL<<16)
-#define MASK_LOG_IMU_RAW        (1UL<<19)
+#define MASK_LOG_WHEN_DISARMED          (1UL<<16)
+#define MASK_LOG_IMU_RAW                (1UL<<19)
+#define MASK_LOG_TRIGGER                (1UL<<20)
 
 // Waypoint Modes
 // ----------------

--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -124,16 +124,17 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] PROGMEM = {
     { SCHED_TASK(gcs_send_deferred),     8,    550 },   // 22
     { SCHED_TASK(gcs_data_stream_send),  8,    550 },   // 23
     { SCHED_TASK(update_mount),          8,     75 },   // 24
-    { SCHED_TASK(ten_hz_logging_loop),  40,    350 },   // 25
-    { SCHED_TASK(fifty_hz_logging_loop), 8,    110 },   // 26
-    { SCHED_TASK(full_rate_logging_loop),1,    100 },   // 27
-    { SCHED_TASK(perf_update),        4000,     75 },   // 28
-    { SCHED_TASK(read_receiver_rssi),   40,     75 },   // 29
+    { SCHED_TASK(update_trigger),        8,     75 },   // 25
+    { SCHED_TASK(ten_hz_logging_loop),  40,    350 },   // 26
+    { SCHED_TASK(fifty_hz_logging_loop), 8,    110 },   // 27
+    { SCHED_TASK(full_rate_logging_loop),1,    100 },   // 28
+    { SCHED_TASK(perf_update),        4000,     75 },   // 29
+    { SCHED_TASK(read_receiver_rssi),   40,     75 },   // 30
 #if FRSKY_TELEM_ENABLED == ENABLED
-    { SCHED_TASK(frsky_telemetry_send), 80,     75 },   // 30
+    { SCHED_TASK(frsky_telemetry_send), 80,     75 },   // 31
 #endif
 #if EPM_ENABLED == ENABLED
-    { SCHED_TASK(epm_update),           40,     75 },   // 31
+    { SCHED_TASK(epm_update),           40,     75 },   // 32
 #endif
 #ifdef USERHOOK_FASTLOOP
     { SCHED_TASK(userhook_FastLoop),     4,     75 },
@@ -306,15 +307,25 @@ void Copter::throttle_loop()
 
 // update_mount - update camera mount position
 // should be run at 50hz
-void Copter::update_mount()
+void Copter::update_mount(void)
 {
 #if MOUNT == ENABLED
-    // update camera mount's position
     camera_mount.update();
 #endif
+}
 
+// update camera trigger
+void Copter::update_trigger(void)
+{
 #if CAMERA == ENABLED
     camera.trigger_pic_cleanup();
+    if(camera._camera_triggered == 0 && camera._feedback_pin != -1 && check_digital_pin(camera._feedback_pin) == 0){
+      gcs_send_message(MSG_CAMERA_FEEDBACK);
+      if (should_log(MASK_LOG_CAMERA)) {
+          DataFlash.Log_Write_Camera(ahrs, gps, current_loc);
+      }
+      camera._camera_triggered = 1;
+    }    
 #endif
 }
 
@@ -621,4 +632,3 @@ void loop(void)
 }
 
 AP_HAL_MAIN();
-

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -520,6 +520,7 @@ private:
     void rc_loop();
     void throttle_loop();
     void update_mount();
+    void update_trigger(void);
     void update_batt_compass(void);
     void ten_hz_logging_loop();
     void fifty_hz_logging_loop();
@@ -882,6 +883,7 @@ private:
     bool optflow_position_ok();
     void update_auto_armed();
     void check_usb_mux(void);
+    uint8_t check_digital_pin(uint8_t pin);
     void frsky_telemetry_send(void);
     bool should_log(uint32_t mask);
     bool current_mode_has_user_takeoff(bool must_navigate);

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -30,21 +30,33 @@ bool Copter::print_log_menu(void)
     if (0 == g.log_bitmask) {
         cliSerial->printf_P(PSTR("none"));
     }else{
-        if (g.log_bitmask & MASK_LOG_ATTITUDE_FAST) cliSerial->printf_P(PSTR(" ATTITUDE_FAST"));
-        if (g.log_bitmask & MASK_LOG_ATTITUDE_MED) cliSerial->printf_P(PSTR(" ATTITUDE_MED"));
-        if (g.log_bitmask & MASK_LOG_GPS) cliSerial->printf_P(PSTR(" GPS"));
-        if (g.log_bitmask & MASK_LOG_PM) cliSerial->printf_P(PSTR(" PM"));
-        if (g.log_bitmask & MASK_LOG_CTUN) cliSerial->printf_P(PSTR(" CTUN"));
-        if (g.log_bitmask & MASK_LOG_NTUN) cliSerial->printf_P(PSTR(" NTUN"));
-        if (g.log_bitmask & MASK_LOG_RCIN) cliSerial->printf_P(PSTR(" RCIN"));
-        if (g.log_bitmask & MASK_LOG_IMU) cliSerial->printf_P(PSTR(" IMU"));
-        if (g.log_bitmask & MASK_LOG_CMD) cliSerial->printf_P(PSTR(" CMD"));
-        if (g.log_bitmask & MASK_LOG_CURRENT) cliSerial->printf_P(PSTR(" CURRENT"));
-        if (g.log_bitmask & MASK_LOG_RCOUT) cliSerial->printf_P(PSTR(" RCOUT"));
-        if (g.log_bitmask & MASK_LOG_OPTFLOW) cliSerial->printf_P(PSTR(" OPTFLOW"));
-        if (g.log_bitmask & MASK_LOG_COMPASS) cliSerial->printf_P(PSTR(" COMPASS"));
-        if (g.log_bitmask & MASK_LOG_CAMERA) cliSerial->printf_P(PSTR(" CAMERA"));
-        if (g.log_bitmask & MASK_LOG_PID) cliSerial->printf_P(PSTR(" PID"));
+        // Macro to make the following code a bit easier on the eye.
+        // Pass it the capitalised name of the log option, as defined
+        // in defines.h but without the LOG_ prefix.  It will check for
+        // the bit being set and print the name of the log option to suit.
+ #define PLOG(_s) if (g.log_bitmask & MASK_LOG_ ## _s) cliSerial->printf_P(PSTR(" %S"), PSTR(# _s))
+        PLOG(ATTITUDE_FAST);
+        PLOG(ATTITUDE_MED);
+        PLOG(GPS);
+        PLOG(PM);
+        PLOG(CTUN);
+        PLOG(NTUN);
+        PLOG(RCIN);
+        PLOG(IMU);
+        PLOG(CMD);
+        PLOG(CURRENT);
+        PLOG(RCOUT);
+        PLOG(OPTFLOW);
+        PLOG(PID);
+        PLOG(COMPASS);
+        PLOG(INAV);
+        PLOG(CAMERA);
+        PLOG(WHEN_DISARMED);
+        PLOG(MOTBATT);
+        PLOG(IMU_FAST);
+        PLOG(IMU_RAW);        
+        PLOG(TRIGGER);        
+ #undef PLOG        
     }
 
     cliSerial->println();
@@ -94,7 +106,7 @@ int8_t Copter::erase_logs(uint8_t argc, const Menu::arg *argv)
 
 int8_t Copter::select_logs(uint8_t argc, const Menu::arg *argv)
 {
-    uint16_t bits;
+    uint32_t bits;
 
     if (argc != 2) {
         cliSerial->printf_P(PSTR("missing log type\n"));
@@ -110,7 +122,7 @@ int8_t Copter::select_logs(uint8_t argc, const Menu::arg *argv)
     // bits accordingly.
     //
     if (!strcasecmp_P(argv[1].str, PSTR("all"))) {
-        bits = ~0;
+        bits = 0xFFFFFFFFUL;
     } else {
  #define TARG(_s)        if (!strcasecmp_P(argv[1].str, PSTR(# _s))) bits |= MASK_LOG_ ## _s
         TARG(ATTITUDE_FAST);
@@ -125,9 +137,15 @@ int8_t Copter::select_logs(uint8_t argc, const Menu::arg *argv)
         TARG(CURRENT);
         TARG(RCOUT);
         TARG(OPTFLOW);
-        TARG(COMPASS);
-        TARG(CAMERA);
         TARG(PID);
+        TARG(COMPASS);
+        TARG(INAV);
+        TARG(CAMERA);
+        TARG(WHEN_DISARMED);
+        TARG(MOTBATT);
+        TARG(IMU_FAST);
+        TARG(IMU_RAW);        
+        TARG(TRIGGER);        
  #undef TARG
     }
 

--- a/ArduCopter/commands_logic.cpp
+++ b/ArduCopter/commands_logic.cpp
@@ -883,9 +883,17 @@ void Copter::do_take_picture()
 // log_picture - log picture taken and send feedback to GCS
 void Copter::log_picture()
 {
-    gcs_send_message(MSG_CAMERA_FEEDBACK);
-    if (should_log(MASK_LOG_CAMERA)) {
-        DataFlash.Log_Write_Camera(ahrs, gps, current_loc);
+    if (camera._feedback_pin == -1 ){
+      gcs_send_message(MSG_CAMERA_FEEDBACK);
+      if (should_log(MASK_LOG_CAMERA)) {
+          DataFlash.Log_Write_Camera(ahrs, gps, current_loc);
+      }
+    }
+    else {
+      camera._camera_triggered = 0;
+      if (should_log(MASK_LOG_TRIGGER)) {
+          DataFlash.Log_Write_Trigger(ahrs, gps, current_loc);
+      }      
     }
 }
 

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -260,6 +260,7 @@ enum FlipState {
 #define MASK_LOG_MOTBATT                (1UL<<17)
 #define MASK_LOG_IMU_FAST               (1UL<<18)
 #define MASK_LOG_IMU_RAW                (1UL<<19)
+#define MASK_LOG_TRIGGER                (1UL<<20)
 #define MASK_LOG_ANY                    0xFFFF
 
 // DATA - event logging

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -400,6 +400,24 @@ void Copter::frsky_telemetry_send(void)
 #endif
 
 /*
+  check a digitial pin for high,low (1/0)
+ */
+uint8_t Copter::check_digital_pin(uint8_t pin)
+{
+    int8_t dpin = hal.gpio->analogPinToDigitalPin(pin);
+    if (dpin == -1) {
+        return 0;
+    }
+    // ensure we are in input mode
+    hal.gpio->pinMode(dpin, HAL_GPIO_INPUT);
+
+    // enable pullup
+    hal.gpio->write(dpin, 1);
+
+    return hal.gpio->read(dpin);
+}
+
+/*
   should we log a message type now?
  */
 bool Copter::should_log(uint32_t mask)

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -49,6 +49,7 @@ bool Plane::print_log_menu(void)
         PLOG(CAMERA);
         PLOG(RC);
         PLOG(SONAR);
+        PLOG(TRIGGER);        
  #undef PLOG
     }
 
@@ -132,6 +133,7 @@ int8_t Plane::select_logs(uint8_t argc, const Menu::arg *argv)
         TARG(CAMERA);
         TARG(RC);
         TARG(SONAR);
+        TARG(TRIGGER);        
  #undef TARG
     }
 

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -803,6 +803,7 @@ private:
     void update_notify();
     void resetPerfData(void);
     void check_usb_mux(void);
+    uint8_t check_digital_pin(uint8_t pin);    
     void print_comma(void);
     void servo_write(uint8_t ch, uint16_t pwm);
     bool should_log(uint32_t mask);
@@ -829,6 +830,7 @@ private:
     void one_second_loop(void);
     void airspeed_ratio_update(void);
     void update_mount(void);
+    void update_trigger(void);    
     void log_perf_info(void);
     void compass_save(void);
     void update_logging1(void);

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -773,9 +773,17 @@ void Plane::do_take_picture()
 // log_picture - log picture taken and send feedback to GCS
 void Plane::log_picture()
 {
-    gcs_send_message(MSG_CAMERA_FEEDBACK);
-    if (should_log(MASK_LOG_CAMERA)) {
-        DataFlash.Log_Write_Camera(ahrs, gps, current_loc);
+    if (camera._feedback_pin == -1 ){
+      gcs_send_message(MSG_CAMERA_FEEDBACK);
+      if (should_log(MASK_LOG_CAMERA)) {
+          DataFlash.Log_Write_Camera(ahrs, gps, current_loc);
+      }
+    }
+    else {
+      camera._camera_triggered = 0;
+      if (should_log(MASK_LOG_TRIGGER)) {
+          DataFlash.Log_Write_Trigger(ahrs, gps, current_loc);
+      }      
     }
 }
 

--- a/ArduPlane/config.h
+++ b/ArduPlane/config.h
@@ -356,15 +356,16 @@
     MASK_LOG_ATTITUDE_MED | \
     MASK_LOG_GPS | \
     MASK_LOG_PM | \
+    MASK_LOG_CTUN | \    
     MASK_LOG_NTUN | \
-    MASK_LOG_CTUN | \
     MASK_LOG_MODE | \
     MASK_LOG_CMD | \
-    MASK_LOG_COMPASS | \
     MASK_LOG_CURRENT | \
+    MASK_LOG_COMPASS | \    
     MASK_LOG_TECS | \
     MASK_LOG_CAMERA | \
-    MASK_LOG_RC
+    MASK_LOG_RC | \
+    MASK_LOG_TRIGGER
 #else
 // other systems have plenty of space for full logs
 #define DEFAULT_LOG_BITMASK   0xffff

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -135,6 +135,7 @@ enum log_messages {
 #define MASK_LOG_ARM_DISARM             (1<<15)
 #define MASK_LOG_WHEN_DISARMED          (1UL<<16)
 #define MASK_LOG_IMU_RAW                (1UL<<19)
+#define MASK_LOG_TRIGGER                (1UL<<20)
 
 // Waypoint Modes
 // ----------------

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -682,6 +682,24 @@ void Plane::servo_write(uint8_t ch, uint16_t pwm)
 }
 
 /*
+  check a digitial pin for high,low (1/0)
+ */
+uint8_t Plane::check_digital_pin(uint8_t pin)
+{
+    int8_t dpin = hal.gpio->analogPinToDigitalPin(pin);
+    if (dpin == -1) {
+        return 0;
+    }
+    // ensure we are in input mode
+    hal.gpio->pinMode(dpin, HAL_GPIO_INPUT);
+
+    // enable pullup
+    hal.gpio->write(dpin, 1);
+
+    return hal.gpio->read(dpin);
+}
+
+/*
   should we log a message type now?
  */
 bool Plane::should_log(uint32_t mask)

--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -49,6 +49,13 @@ const AP_Param::GroupInfo AP_Camera::var_info[] PROGMEM = {
     // @Range: 0 1000
     AP_GROUPINFO("TRIGG_DIST",  4, AP_Camera, _trigg_dist, 0),
 
+    // @Param: FEEDBACK_PIN
+    // @DisplayName: Camera feedback pin
+    // @Description: pin number to use for save accurate camera feedback messages. If set to -1 then don't use a pin flag for this, otherwise this is a pin number which if held high after a picture trigger order, will save camera messages when camera really takes a picture. An universal camera hot shoe is needed
+    // @Values: -1:Disabled, 0-8:APM FeedbackPin, 50-55:PixHawk FeedbackPin
+    // @User: Standard
+    AP_GROUPINFO("FEEDBACK_PIN",  5, AP_Camera, _feedback_pin, AP_CAMERA_FEEDBACK_DEFAULT_FEEDBACK_PIN),    
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -25,6 +25,8 @@
 #define AP_CAMERA_SERVO_ON_PWM              1300    // default PWM value to move servo to when shutter is activated
 #define AP_CAMERA_SERVO_OFF_PWM             1100    // default PWM value to move servo to when shutter is deactivated
 
+#define AP_CAMERA_FEEDBACK_DEFAULT_FEEDBACK_PIN -1  // default is to not use camera feedback pin
+
 /// @class	Camera
 /// @brief	Object managing a Photo or video camera
 class AP_Camera {
@@ -40,6 +42,12 @@ public:
         _apm_relay = obj_relay;
     }
 
+    // pin number for accurate camera feedback messages
+    AP_Int8         _feedback_pin;
+    
+    // this is set to 1 when camera really has been triggered    
+    AP_Int8         _camera_triggered;
+    
     // single entry point to take pictures
     //  set send_mavlink_msg to true to send DO_DIGICAM_CONTROL message to all components
     void            trigger_pic(bool send_mavlink_msg);

--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -81,6 +81,7 @@ public:
     void Log_Write_Message(const char *message);
     void Log_Write_Message_P(const prog_char_t *message);
     void Log_Write_Camera(const AP_AHRS &ahrs, const AP_GPS &gps, const Location &current_loc);
+    void Log_Write_Trigger(const AP_AHRS &ahrs, const AP_GPS &gps, const Location &current_loc);    
     void Log_Write_ESC(void);
     void Log_Write_Airspeed(AP_Airspeed &airspeed);
     void Log_Write_Attitude(AP_AHRS &ahrs, const Vector3f &targets);
@@ -419,6 +420,20 @@ struct PACKED log_Camera {
     uint16_t yaw;
 };
 
+struct PACKED log_Trigger {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;    
+    uint32_t gps_time;
+    uint16_t gps_week;
+    int32_t  latitude;
+    int32_t  longitude;
+    int32_t  altitude;
+    int32_t  altitude_rel;
+    int16_t  roll;
+    int16_t  pitch;
+    uint16_t yaw;
+};
+
 struct PACKED log_Attitude {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -625,13 +640,15 @@ Format characters in the format string for binary log messages
       "ARSP",  "Qffcff",   "TimeUS,Airspeed,DiffPress,Temp,RawPress,Offset" }, \
     { LOG_CURRENT_MSG, sizeof(log_Current), \
       "CURR", "QhhhHfh","TimeUS,Throttle,Volt,Curr,Vcc,CurrTot,Volt2" },\
-	{ LOG_ATTITUDE_MSG, sizeof(log_Attitude),\
+    { LOG_ATTITUDE_MSG, sizeof(log_Attitude),\
       "ATT", "QccccCCCC", "TimeUS,DesRoll,Roll,DesPitch,Pitch,DesYaw,Yaw,ErrRP,ErrYaw" }, \
     { LOG_COMPASS_MSG, sizeof(log_Compass), \
       "MAG", "QhhhhhhhhhB",    "TimeUS,MagX,MagY,MagZ,OfsX,OfsY,OfsZ,MOfsX,MOfsY,MOfsZ,Health" }, \
     { LOG_MODE_MSG, sizeof(log_Mode), \
-      "MODE", "QMB",         "TimeUS,Mode,ModeNum" }
-
+      "MODE", "QMB",         "TimeUS,Mode,ModeNum" }, \
+    { LOG_TRIGGER_MSG, sizeof(log_Trigger), \
+      "TRIG", "QIHLLeeccC","TimeUS,GPSTime,GPSWeek,Lat,Lng,Alt,RelAlt,Roll,Pitch,Yaw" }
+      
 // messages for more advanced boards
 #define LOG_EXTRA_STRUCTURES \
     { LOG_GPS2_MSG, sizeof(log_GPS2), \
@@ -707,7 +724,7 @@ Format characters in the format string for binary log messages
     { LOG_PIDA_MSG, sizeof(log_PID), \
       "PIDA", "Qffffff",  "TimeUS,Des,P,I,D,FF,AFF" }, \
     { LOG_BAR2_MSG, sizeof(log_BARO), \
-      "BAR2",  "Qffcf", "TimeUS,Alt,Press,Temp,CRt" }
+      "BAR2",  "Qffcf", "TimeUS,Alt,Press,Temp,CRt" }      
 
 #if HAL_CPU_CLASS >= HAL_CPU_CLASS_75
 #define LOG_COMMON_STRUCTURES LOG_BASE_STRUCTURES, LOG_EXTRA_STRUCTURES
@@ -718,28 +735,28 @@ Format characters in the format string for binary log messages
 // message types 0 to 100 reversed for vehicle specific use
 
 // message types for common messages
-#define LOG_FORMAT_MSG	  128
+#define LOG_FORMAT_MSG    128
 #define LOG_PARAMETER_MSG 129
-#define LOG_GPS_MSG		  130
-#define LOG_IMU_MSG		  131
-#define LOG_MESSAGE_MSG	  132
+#define LOG_GPS_MSG       130
+#define LOG_IMU_MSG       131
+#define LOG_MESSAGE_MSG   132
 #define LOG_RCIN_MSG      133
 #define LOG_RCOUT_MSG     134
-#define LOG_IMU2_MSG	  135
-#define LOG_BARO_MSG	  136
-#define LOG_POWR_MSG	  137
-#define LOG_AHR2_MSG	  138
+#define LOG_IMU2_MSG      135
+#define LOG_BARO_MSG      136
+#define LOG_POWR_MSG      137
+#define LOG_AHR2_MSG      138
 #define LOG_SIMSTATE_MSG  139
 #define LOG_EKF1_MSG      140
 #define LOG_EKF2_MSG      141
 #define LOG_EKF3_MSG      142
 #define LOG_EKF4_MSG      143
-#define LOG_GPS2_MSG	  144
+#define LOG_GPS2_MSG      144
 #define LOG_CMD_MSG       145
-#define LOG_RADIO_MSG	  146
+#define LOG_RADIO_MSG     146
 #define LOG_ATRP_MSG      147
 #define LOG_CAMERA_MSG    148
-#define LOG_IMU3_MSG	  149
+#define LOG_IMU3_MSG      149
 #define LOG_TERRAIN_MSG   150
 #define LOG_UBX1_MSG      151
 #define LOG_UBX2_MSG      152
@@ -753,7 +770,7 @@ Format characters in the format string for binary log messages
 #define LOG_ESC7_MSG      160
 #define LOG_ESC8_MSG      161
 #define LOG_EKF5_MSG      162
-#define LOG_BAR2_MSG	  163
+#define LOG_BAR2_MSG      163
 #define LOG_ARSP_MSG      164
 #define LOG_ATTITUDE_MSG  165
 #define LOG_CURRENT_MSG   166
@@ -773,6 +790,7 @@ Format characters in the format string for binary log messages
 #define LOG_PIDP_MSG      180
 #define LOG_PIDY_MSG      181
 #define LOG_PIDA_MSG      182
+#define LOG_TRIGGER_MSG   183
 
 // message types 200 to 210 reversed for GPS driver use
 // message types 211 to 220 reversed for autotune use

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -1155,6 +1155,34 @@ void DataFlash_Class::Log_Write_Camera(const AP_AHRS &ahrs, const AP_GPS &gps, c
     WriteBlock(&pkt, sizeof(pkt));
 }
 
+// Write a Trigger packet
+void DataFlash_Class::Log_Write_Trigger(const AP_AHRS &ahrs, const AP_GPS &gps, const Location &current_loc)
+{
+    int32_t altitude, altitude_rel;
+    if (current_loc.flags.relative_alt) {
+        altitude = current_loc.alt+ahrs.get_home().alt;
+        altitude_rel = current_loc.alt;
+    } else {
+        altitude = current_loc.alt;
+        altitude_rel = current_loc.alt - ahrs.get_home().alt;
+    }
+
+    struct log_Trigger pkt = {
+        LOG_PACKET_HEADER_INIT(LOG_TRIGGER_MSG),
+        time_us     : hal.scheduler->micros64(),        
+        gps_time    : gps.time_week_ms(),
+        gps_week    : gps.time_week(),
+        latitude    : current_loc.lat,
+        longitude   : current_loc.lng,
+        altitude    : altitude,
+        altitude_rel: altitude_rel,
+        roll        : (int16_t)ahrs.roll_sensor,
+        pitch       : (int16_t)ahrs.pitch_sensor,
+        yaw         : (uint16_t)ahrs.yaw_sensor
+    };
+    WriteBlock(&pkt, sizeof(pkt));
+}
+
 // Write an attitude packet
 void DataFlash_Class::Log_Write_Attitude(AP_AHRS &ahrs, const Vector3f &targets)
 {


### PR DESCRIPTION
Hello everyone,

Well, I think this is the ultimate for make affordable this thing...

I want to achieve the exact time and precise coordinates where the pictures are taken. It not depends on PixHawk, as it sends the order to trigger, but is the camera itself who actually decides when to make the shot. 
Some miliseconds are wasted between Pixhawk triggering and camera shooting. This time is variable and depends on multiple factors: light, focus, shutter,... so the best solution is to use a synchronized flag or a signal, i.e, the camera flash (best solution that I found).

Well, this is not the best solution and sure this is the worst code you've ever seen, but... it works!

Please give me time to complete here the explanation of how to add the hardware necesary for this and how the code works.

Here you are:

Firstly you need an universal Hot Shoe adapter. Not all Hot Shoes will work. You need one that supports Preflash and Flash Ready emulation. I have tried 5 adapters and just one has worked...
Connecting it to the PixHawk is very easy, as you can see below, but be careful: BE SURE THAT YOUR CAMERA OUTPUTS A MAXIMUM OF 5,7 VOLTS THROUGH HOT SHOE FLASH PINS or you will burn your PixHawk.
 
![hot-shoe-trigger](https://cloud.githubusercontent.com/assets/3317796/8025183/89a9db6a-0d4c-11e5-8763-142d49c5e577.jpg)

Secondly, you need to configure CAMERA_FEEDBACK_PIN through Mission Planner.
Then, when the function do_take_picture will be called, for example with "Trigger camera now", the code will generate a flag for wait to the Hot Shoe response.
If the Pixhawk detects an input from the Hot Shoe pin, i.e, camera has been truely triggered, a CAM message will be saved to the Dataflash log.

Finally, code will reset the cicle, waiting for a new do_take_picture.
With all, we have a consistent Log, with the same number of CAM messages and pictures, and the best... precise coordinates and time marks for each picture.

I have included an option for log a "TRIGGER" message that corresponds with the "normal" CAM messages. So now we have two signals or logs for the trigger process: when you require to the camera to shot a picture, the "TRIGGER" (TRIG) message is generated, and then, when the camera really takes the picture, the "CAMERA_FEEDBACK" (CAM) message will be saved.

This is highly useful for compare the time and conditions we have between we order the trigger with the autopilot board and when camera really takes the picture.

![sin titulo](https://cloud.githubusercontent.com/assets/3317796/8025304/6f5cf0a8-0d51-11e5-8e10-a711694b6a91.jpg)


For configure the "TRIGGER" message, you need to enable it trough CLI, i.e, Enable CLI in the full parameter list and reset the board. Go to Mission Planner/Terminal and connect with the controller. Then activate (enable) the TRIGGER msg typing "ENABLE TRIGGER" inside logs menu (for Rover #2381 has to be merged).

Tested with ArduPlane, ArduCopter and APMrover2 on APM1/APM2 and PixHawk.
Fully compatible with Sony NEX series and Olympus E-PMx series (both with universal hot shoe adapters).

I can provide log files to confirm the operation of this pull request if necessary.

Regards,
Dario.
