### PR TITLE
Dsmx bind

### DIFF
--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -829,6 +829,11 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
 
             switch(packet.command) {
 
+            case MAV_CMD_START_RX_PAIR:
+                // initiate bind procedure
+                hal.rcin->rc_bind(packet.param1);
+                break;
+
             case MAV_CMD_NAV_RETURN_TO_LAUNCH:
                 rover.set_mode(RTL);
                 result = MAV_RESULT_ACCEPTED;

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1374,7 +1374,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
                     result = MAV_RESULT_FAILED;
                     break;
             }
-            brake;
+            break;
 #endif
 
         case MAV_CMD_DO_MOTOR_TEST:

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1374,6 +1374,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
                     result = MAV_RESULT_FAILED;
                     break;
             }
+        brake;
 #endif
 
         case MAV_CMD_DO_MOTOR_TEST:

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1107,6 +1107,11 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
 
         switch(packet.command) {
 
+        case MAV_CMD_START_RX_PAIR:
+            // initiate bind procedure
+            hal.rcin->rc_bind(packet.param1);
+            break;
+
         case MAV_CMD_NAV_TAKEOFF: {
             // param3 : horizontal navigation by pilot acceptable
             // param4 : yaw angle   (not supported)
@@ -1369,7 +1374,6 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
                     result = MAV_RESULT_FAILED;
                     break;
             }
-            break;
 #endif
 
         case MAV_CMD_DO_MOTOR_TEST:

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1374,7 +1374,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
                     result = MAV_RESULT_FAILED;
                     break;
             }
-        brake;
+            brake;
 #endif
 
         case MAV_CMD_DO_MOTOR_TEST:

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1066,7 +1066,6 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
 
         switch(packet.command) {
 
-
         case MAV_CMD_START_RX_PAIR:
             // initiate bind procedure
             hal.rcin->rc_bind(packet.param1);

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1066,6 +1066,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
 
         switch(packet.command) {
 
+
         case MAV_CMD_START_RX_PAIR:
             // initiate bind procedure
             hal.rcin->rc_bind(packet.param1);

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1066,6 +1066,11 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
 
         switch(packet.command) {
 
+        case MAV_CMD_START_RX_PAIR:
+            // initiate bind procedure
+            hal.rcin->rc_bind(packet.param1);
+            break;
+
         case MAV_CMD_NAV_LOITER_UNLIM:
             plane.set_mode(LOITER);
             result = MAV_RESULT_ACCEPTED;

--- a/libraries/AP_HAL/RCInput.h
+++ b/libraries/AP_HAL/RCInput.h
@@ -52,6 +52,9 @@ public:
     /* clear_overrides: equivelant to setting all overrides to 0 */
     virtual void clear_overrides() = 0;
 
+    /* execute receiver bind */
+    virtual void rc_bind(int dsmMode) = 0;
+
 };
 
 #endif // __AP_HAL_RC_INPUT_H__

--- a/libraries/AP_HAL/RCInput.h
+++ b/libraries/AP_HAL/RCInput.h
@@ -53,7 +53,7 @@ public:
     virtual void clear_overrides() = 0;
 
     /* execute receiver bind */
-    virtual void rc_bind(int dsmMode) = 0;
+    virtual void rc_bind(int dsmMode);
 
 };
 

--- a/libraries/AP_HAL/RCInput.h
+++ b/libraries/AP_HAL/RCInput.h
@@ -53,7 +53,7 @@ public:
     virtual void clear_overrides() = 0;
 
     /* execute receiver bind */
-    virtual void rc_bind(int dsmMode);
+    virtual void rc_bind(int dsmMode) { };
 
 };
 

--- a/libraries/AP_HAL_PX4/RCInput.cpp
+++ b/libraries/AP_HAL_PX4/RCInput.cpp
@@ -2,6 +2,9 @@
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4
 #include "RCInput.h"
+#include <fcntl.h>
+#include <unistd.h>
+#include <drivers/drv_pwm_output.h>
 #include <drivers/drv_hrt.h>
 #include <uORB/uORB.h>
 
@@ -112,6 +115,17 @@ void PX4RCInput::_timer_tick(void)
         // note, we rely on the vehicle code checking new_input() 
         // and a timeout for the last valid input to handle failsafe
 	perf_end(_perf_rcin);
+}
+
+void PX4RCInput::rc_bind(int dsmMode)
+{
+        int fd = open("/dev/px4io", 0);
+        if (fd == -1 || ioctl(fd, DSM_BIND_START, (dsmMode == 0) ? DSM2_BIND_PULSES : ((dsmMode == 1) ? DSMX_BIND_PULSES : DSMX8_BIND_PULSES)) != 0) {
+            hal.console->printf("RCInput: Unable to start DSM bind\n");
+        }
+        if (fd != -1) {
+            close(fd);
+        }   
 }
 
 #endif

--- a/libraries/AP_HAL_PX4/RCInput.h
+++ b/libraries/AP_HAL_PX4/RCInput.h
@@ -21,6 +21,8 @@ public:
 
     void _timer_tick(void);
 
+    void rc_bind(int dsmMode);
+
 private:
     /* override state */
     uint16_t _override[RC_INPUT_MAX_CHANNELS];


### PR DESCRIPTION
According to issue PX4: Add Spektrum Satellite Receiver Binding Support #1076

The bind procedure was added to pane, copter and rover code.
The AP_HAL RCInput driver was changed adding rc_bind(int dsmMode) virtual method for top HAL and real code in PX4 HAL, using /dev/px4io and ioctl to issue DSM_BIND_START command.

The MAV_CMD_START_RX_PAIR command was interpreted in GCS_Mavlink.cpp in plane, copter and rover projects to parse the long command and do binding through HAL.

If such possibility will be added to other platforms, only HAL at RCInput rc_bind method should be added for support.