### PR TITLE
Fixes build issues with the vagrantfile now we use Git submodules

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,9 +33,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       vb.customize ["guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-on-restore", "1"]
   end
 
-  config.vm.synced_folder "../PX4Firmware", "/PX4Firmware"
-  config.vm.synced_folder "../PX4NuttX", "/PX4NuttX", type: "rsync"
-  config.vm.synced_folder "../uavcan", "/uavcan"
+
 
   config.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"  
 end


### PR DESCRIPTION
The new use of [Git Submodules](http://dev.ardupilot.com/wiki/git-submodules/) "breaks" the vagrantfile, which assumes that the submodules will be separately cloned (actually not a break, but you do get build warnings, and this should be changed).

This change modifies the vagrantfile to remove the check on the presence of these cloned folders. It builds fine as far as I can tell - certainly there are no build errors and I can connect to copter.

When this is accepted I can update [Setting up SITL using Vagrant](http://dev.ardupilot.com/wiki/simulation-2/sitl-simulator-software-in-the-loop/setting-up-sitl-using-vagrant/) in line with the new approach.

@andyp1per Can you please sanity check this? 
1. Can I also remove the lines:
```
# NuttX needs symlinks. If you want to go that route you need this setting, but rsync is easier. 
#      vb.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/PX4NuttX", "1"]
```
2. Also, does this mean I know longer need to have rsync dependency?


