### PR TITLE
Linux UART driver rework

### DIFF
--- a/libraries/AP_HAL/utility/Socket.cpp
+++ b/libraries/AP_HAL/utility/Socket.cpp
@@ -98,7 +98,7 @@ void SocketAPM::set_blocking(bool blocking)
 /*
   send some data
  */
-ssize_t SocketAPM::send(void *buf, size_t size)
+ssize_t SocketAPM::send(const void *buf, size_t size)
 {
     return ::send(fd, buf, size, 0);
 }
@@ -106,7 +106,7 @@ ssize_t SocketAPM::send(void *buf, size_t size)
 /*
   send some data
  */
-ssize_t SocketAPM::sendto(void *buf, size_t size, const char *address, uint16_t port)
+ssize_t SocketAPM::sendto(const void *buf, size_t size, const char *address, uint16_t port)
 {
     struct sockaddr_in sockaddr;
     make_sockaddr(address, port, sockaddr);

--- a/libraries/AP_HAL/utility/Socket.cpp
+++ b/libraries/AP_HAL/utility/Socket.cpp
@@ -134,4 +134,13 @@ ssize_t SocketAPM::recv(void *buf, size_t size, uint32_t timeout_ms)
     return ::recv(fd, buf, size, 0);
 }
 
+ssize_t SocketAPM::recvfrom(void *buf, size_t size, uint32_t timeout_ms, const char *address, uint16_t port)
+{
+    struct sockaddr_in sockaddr;
+    make_sockaddr(address, port, sockaddr);
+    socklen_t socklen = sizeof(sockaddr);
+
+    return ::recvfrom(fd, buf, size, 0, (struct sockaddr *)&sockaddr, &socklen);
+}
+
 #endif // HAL_OS_SOCKETS

--- a/libraries/AP_HAL/utility/Socket.cpp
+++ b/libraries/AP_HAL/utility/Socket.cpp
@@ -35,6 +35,13 @@ datagram(_datagram)
     setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
 }
 
+SocketAPM::~SocketAPM()
+{
+    if (::close(fd) < 0) {
+        perror("close");
+    }
+}
+
 void SocketAPM::make_sockaddr(const char *address, uint16_t port, struct sockaddr_in &sockaddr)
 {
     memset(&sockaddr, 0, sizeof(sockaddr));

--- a/libraries/AP_HAL/utility/Socket.h
+++ b/libraries/AP_HAL/utility/Socket.h
@@ -34,6 +34,8 @@
 class SocketAPM {
 public:
     SocketAPM(bool _datagram);
+    ~SocketAPM();
+
     bool connect(const char *address, uint16_t port);
     bool bind(const char *address, uint16_t port);
     void reuseaddress();

--- a/libraries/AP_HAL/utility/Socket.h
+++ b/libraries/AP_HAL/utility/Socket.h
@@ -41,6 +41,7 @@ public:
 
     ssize_t send(const void *pkt, size_t size);
     ssize_t sendto(const void *buf, size_t size, const char *address, uint16_t port);
+    ssize_t recvfrom(void *pkt, size_t size, uint32_t timeout_ms, const char *address, uint16_t port);
     ssize_t recv(void *pkt, size_t size, uint32_t timeout_ms);
 
 private:

--- a/libraries/AP_HAL/utility/Socket.h
+++ b/libraries/AP_HAL/utility/Socket.h
@@ -40,8 +40,8 @@ public:
     void set_blocking(bool blocking);
 
     ssize_t send(const void *pkt, size_t size);
-    ssize_t sendto(const void *buf, size_t size, const char *address, uint16_t port);
-    ssize_t recvfrom(void *pkt, size_t size, uint32_t timeout_ms, const char *address, uint16_t port);
+    ssize_t sendto(const void *buf, size_t size, const char *address, uint16_t port, uint32_t timeout = 0);
+    ssize_t recvfrom(void *pkt, size_t size, const char *address, uint16_t port, uint32_t timeout = 0);
     ssize_t recv(void *pkt, size_t size, uint32_t timeout_ms);
 
 private:

--- a/libraries/AP_HAL/utility/Socket.h
+++ b/libraries/AP_HAL/utility/Socket.h
@@ -39,8 +39,8 @@ public:
     void reuseaddress();
     void set_blocking(bool blocking);
 
-    ssize_t send(void *pkt, size_t size);
-    ssize_t sendto(void *buf, size_t size, const char *address, uint16_t port);
+    ssize_t send(const void *pkt, size_t size);
+    ssize_t sendto(const void *buf, size_t size, const char *address, uint16_t port);
     ssize_t recv(void *pkt, size_t size, uint32_t timeout_ms);
 
 private:

--- a/libraries/AP_HAL_Linux/ConsoleDevice.cpp
+++ b/libraries/AP_HAL_Linux/ConsoleDevice.cpp
@@ -1,0 +1,67 @@
+#include <AP_HAL.h>
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
+#include "ConsoleDevice.h"
+
+#include <stdio.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+ConsoleDevice::ConsoleDevice() 
+{
+}
+
+ConsoleDevice::~ConsoleDevice()
+{
+
+}
+
+bool ConsoleDevice::close()
+{
+    if (::close(_rd_fd) < 0) {
+        return false;
+    }
+
+    if (::close(_wr_fd) < 0) {
+        return false;
+    }
+
+    return true;
+}
+
+bool ConsoleDevice::open()
+{
+    _rd_fd = STDIN_FILENO;
+    _wr_fd = STDOUT_FILENO;
+
+    return true;
+}
+
+int ConsoleDevice::read(uint8_t *buf, uint16_t n)
+{
+    return ::read(_rd_fd, buf, n);
+}
+
+int ConsoleDevice::write(const uint8_t *buf, uint16_t n)
+{
+    return ::write(_wr_fd, buf, n);
+}
+
+void ConsoleDevice::set_nonblocking()
+{
+    if (fcntl(_rd_fd, F_SETFL, fcntl(_rd_fd, F_GETFL, 0) | O_NONBLOCK) < 0) {
+        ::fprintf(stderr, "Failed to set Console nonblocking %s\n", strerror(errno));
+    }
+
+    if (fcntl(_wr_fd, F_SETFL, fcntl(_wr_fd, F_GETFL, 0) | O_NONBLOCK) < 0) {
+        ::fprintf(stderr, "Failed to set Console nonblocking %s\n",strerror(errno));
+    }
+
+}
+
+void ConsoleDevice::set_speed(uint32_t baudrate)
+{
+}
+
+#endif

--- a/libraries/AP_HAL_Linux/ConsoleDevice.h
+++ b/libraries/AP_HAL_Linux/ConsoleDevice.h
@@ -1,0 +1,24 @@
+#ifndef __AP_HAL_LINUX_CONSOLEDEVICE_UDP_H__
+#define __AP_HAL_LINUX_CONSOLEDEVICE_UDP_H__
+
+#include "SerialDevice.h"
+#include "../AP_HAL/utility/Socket.h"
+
+class ConsoleDevice: public SerialDevice {
+public:
+    ConsoleDevice();
+    virtual ~ConsoleDevice();
+
+    virtual bool open() override;
+    virtual bool close() override;
+    virtual int write(const uint8_t *buf, uint16_t n) override;
+    virtual int read(uint8_t *buf, uint16_t n) override;
+    virtual void set_nonblocking() override;
+    virtual void set_speed(uint32_t speed) override;
+
+private:
+    int _rd_fd = -1;
+    int _wr_fd = -1;
+};
+
+#endif

--- a/libraries/AP_HAL_Linux/SerialDevice.h
+++ b/libraries/AP_HAL_Linux/SerialDevice.h
@@ -1,0 +1,18 @@
+#ifndef __AP_HAL_LINUX_SERIALDEVICE_H__
+#define __AP_HAL_LINUX_SERIALDEVICE_H__
+
+#include <stdint.h>
+
+class SerialDevice {
+public: 
+    virtual ~SerialDevice() {}
+
+    virtual bool open() = 0;
+    virtual bool close() = 0;
+    virtual int write(const uint8_t *buf, uint16_t n) = 0;
+    virtual int read(uint8_t *buf, uint16_t n) = 0;
+    virtual void set_nonblocking() = 0;
+    virtual void set_speed(uint32_t speed) = 0;
+};
+
+#endif

--- a/libraries/AP_HAL_Linux/TCPClientDevice.cpp
+++ b/libraries/AP_HAL_Linux/TCPClientDevice.cpp
@@ -1,0 +1,65 @@
+#include <AP_HAL.h>
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
+
+#include <stdio.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdlib.h>
+
+#include "TCPClientDevice.h"
+
+TCPClientDevice::TCPClientDevice(const char *ip, uint16_t port):
+    _ip(ip),
+    _port(port)
+{
+}
+
+TCPClientDevice::~TCPClientDevice()
+{
+
+}
+
+int TCPClientDevice::write(const uint8_t *buf, uint16_t n)
+{
+    return listener.send(buf, n);
+}
+
+int TCPClientDevice::read(uint8_t *buf, uint16_t n)
+{
+    return listener.recv(buf, n, 1);
+}
+
+bool TCPClientDevice::open()
+{
+    listener.reuseaddress();
+
+    if (!listener.connect(_ip, _port)) {
+        ::printf("connect failed on %s port %u - %s\n",
+                 _ip,
+                 _port,
+                 strerror(errno));
+        ::exit(1);
+    }
+
+    listener.set_blocking(false);
+
+    return true;
+}
+
+bool TCPClientDevice::close()
+{
+    return true;
+}
+
+void TCPClientDevice::set_nonblocking()
+{
+    listener.set_blocking(false);
+}
+
+void TCPClientDevice::set_speed(uint32_t speed)
+{
+
+}
+
+#endif

--- a/libraries/AP_HAL_Linux/TCPClientDevice.h
+++ b/libraries/AP_HAL_Linux/TCPClientDevice.h
@@ -1,0 +1,24 @@
+#ifndef __AP_HAL_LINUX_TCPCLIENTDEVICE_H__
+#define __AP_HAL_LINUX_TCPCLIENTDEVICE_H__
+
+#include "SerialDevice.h"
+#include "../AP_HAL/utility/Socket.h"
+
+class TCPClientDevice: public SerialDevice {
+public:
+    TCPClientDevice(const char *ip, uint16_t port);
+    virtual ~TCPClientDevice();
+
+    virtual bool open() override;
+    virtual bool close() override;
+    virtual void set_nonblocking() override;
+    virtual void set_speed(uint32_t speed) override;
+    virtual int write(const uint8_t *buf, uint16_t n) override;
+    virtual int read(uint8_t *buf, uint16_t n) override;
+private:
+    SocketAPM listener{false};
+    const char *_ip;
+    uint16_t _port;
+};
+
+#endif

--- a/libraries/AP_HAL_Linux/TCPServerDevice.cpp
+++ b/libraries/AP_HAL_Linux/TCPServerDevice.cpp
@@ -1,0 +1,138 @@
+#include <AP_HAL.h>
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
+
+#include <stdio.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <netdb.h>
+
+#include "TCPServerDevice.h"
+
+TCPServerDevice::TCPServerDevice(const char *ip, uint16_t port):
+    _ip(ip),
+    _port(port)
+{
+}
+
+TCPServerDevice::~TCPServerDevice()
+{
+
+}
+
+int TCPServerDevice::write(const uint8_t *buf, uint16_t n)
+{
+    return ::send(_net_fd, buf, n, 0);
+}
+
+int TCPServerDevice::read(uint8_t *buf, uint16_t n)
+{
+    return ::recv(_net_fd, buf, n, 0);
+}
+
+bool TCPServerDevice::open()
+{
+    int one=1;
+    struct sockaddr_in sockaddr;
+    int ret;
+    int client_fd = -1;
+    uint8_t portNumber = 0; /* connecto to _port + portNumber */
+
+    memset(&sockaddr,0,sizeof(sockaddr));
+
+#ifdef HAVE_SOCK_SIN_LEN
+    sockaddr.sin_len = sizeof(sockaddr);
+#endif
+    sockaddr.sin_port = htons(_port + portNumber);
+    sockaddr.sin_family = AF_INET;
+
+    if (strcmp(_ip, "*") == 0) {
+        /* bind to all interfaces */
+        sockaddr.sin_addr.s_addr = htonl(INADDR_ANY);
+    } else {
+        sockaddr.sin_addr.s_addr = inet_addr(_ip);
+    }
+
+    _listen_fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (_listen_fd == -1) {
+        ::printf("socket failed - %s\n", strerror(errno));
+        exit(1);
+    }
+
+    /* we want to be able to re-use ports quickly */
+    setsockopt(_listen_fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+
+    ret = bind(_listen_fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
+
+    if (ret == -1) {
+        ::printf("bind failed on port %u - %s\n",
+                 (unsigned)ntohs(sockaddr.sin_port),
+                 strerror(errno));
+        exit(1);
+    }
+
+    ret = listen(_listen_fd, 5);
+    if (ret == -1) {
+        ::printf("listen failed - %s\n", strerror(errno));
+        exit(1);
+    }
+
+    ::printf("Serial port %u on TCP port %u\n", portNumber, 
+             _port + portNumber);
+    ::fflush(stdout);
+
+    ::printf("Waiting for connection ....\n");
+    ::fflush(stdout);
+
+    struct sockaddr_storage client_addr;
+    socklen_t addr_size;
+
+    client_fd = accept(_listen_fd, (struct sockaddr *) &client_addr, &addr_size);
+
+    if (client_fd == -1) {
+        ::printf("accept() error - %s", strerror(errno));
+        exit(1);
+    }
+
+    struct sockaddr_in *sa4 = (struct sockaddr_in*) &client_addr;
+    printf("%s connected\n", inet_ntoa(sa4->sin_addr) );
+
+    setsockopt(client_fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+    setsockopt(client_fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+
+    /* always run the file descriptor non-blocking, and deal with                                         |
+    *  blocking IO in the higher level calls */
+    fcntl(client_fd, F_SETFL, fcntl(client_fd, F_GETFL, 0) | O_NONBLOCK);
+
+    _net_fd = client_fd;
+
+    return true;
+}
+
+bool TCPServerDevice::close()
+{
+    if (::close(_listen_fd) < 0) {
+        perror("close");
+        return false;
+    }
+
+    if (::close(_net_fd) < 0) {
+        perror("close");
+        return false;
+    }
+
+    return true;
+}
+
+void TCPServerDevice::set_nonblocking()
+{
+}
+
+void TCPServerDevice::set_speed(uint32_t speed)
+{
+
+}
+
+#endif

--- a/libraries/AP_HAL_Linux/TCPServerDevice.h
+++ b/libraries/AP_HAL_Linux/TCPServerDevice.h
@@ -1,0 +1,25 @@
+#ifndef __AP_HAL_LINUX_TCPSERVERDEVICE_H__
+#define __AP_HAL_LINUX_TCPSERVERDEVICE_H__
+
+#include "SerialDevice.h"
+#include "../AP_HAL/utility/Socket.h"
+
+class TCPServerDevice: public SerialDevice {
+public:
+    TCPServerDevice(const char *ip, uint16_t port);
+    virtual ~TCPServerDevice();
+
+    virtual bool open() override;
+    virtual bool close() override;
+    virtual void set_nonblocking() override;
+    virtual void set_speed(uint32_t speed) override;
+    virtual int write(const uint8_t *buf, uint16_t n) override;
+    virtual int read(uint8_t *buf, uint16_t n) override;
+private:
+    const char *_ip;
+    uint16_t _port;
+    int _net_fd = -1;
+    int _listen_fd = -1;
+};
+
+#endif

--- a/libraries/AP_HAL_Linux/UARTDevice.cpp
+++ b/libraries/AP_HAL_Linux/UARTDevice.cpp
@@ -1,0 +1,111 @@
+#include <AP_HAL.h>
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
+
+#include <termios.h>
+#include <stdio.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <poll.h>
+
+#include "UARTDevice.h"
+
+#include <termios.h>
+#include <stdio.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <poll.h>
+
+UARTDevice::UARTDevice(char *device_path): 
+    _device_path(device_path)
+{
+}
+
+UARTDevice::~UARTDevice()
+{
+
+}
+
+bool UARTDevice::close()
+{
+    if (::close(_fd) < 0) {
+        return false;
+    }
+
+    return true;
+}
+
+bool UARTDevice::open()
+{
+    _fd = ::open(_device_path, O_RDWR | O_CLOEXEC);
+
+    if (_fd < 0) {
+        ::fprintf(stderr, "Failed to open UART device %s - %s\n",
+                  _device_path, strerror(errno));
+        return false;
+    }
+
+    _disable_crlf();
+
+    return true;
+}
+
+int UARTDevice::read(uint8_t *buf, uint16_t n)
+{
+    return ::read(_fd, buf, n);
+}
+
+int UARTDevice::write(const uint8_t *buf, uint16_t n)
+{
+    struct pollfd fds;
+    fds.fd = _fd;
+    fds.events = POLLOUT;
+    fds.revents = 0;
+
+    int ret = 0;
+
+    if (poll(&fds, 1, 0) == 1) {
+        ret = ::write(_fd, buf, n);
+    }
+
+    return ret;
+}
+
+void UARTDevice::set_nonblocking()
+{
+    if (fcntl(_fd, F_SETFL, fcntl(_fd, F_GETFL, 0) | O_NONBLOCK) < 0) {
+        ::fprintf(stderr, "Failed to set UART nonblocking %s - %s\n",
+                  _device_path, strerror(errno));
+    }
+
+}
+
+void UARTDevice::_disable_crlf()
+{
+    struct termios t;
+    memset(&t, 0, sizeof(t));
+
+    tcgetattr(_fd, &t);
+
+    // disable LF -> CR/LF
+    t.c_iflag &= ~(BRKINT | ICRNL | IMAXBEL | IXON | IXOFF);
+    t.c_oflag &= ~(OPOST | ONLCR);
+    t.c_lflag &= ~(ISIG | ICANON | IEXTEN | ECHO | ECHOE | ECHOK | ECHOCTL | ECHOKE);
+    t.c_cc[VMIN] = 0;
+
+    tcsetattr(_fd, TCSANOW, &t);
+}
+
+void UARTDevice::set_speed(uint32_t baudrate)
+{
+    struct termios t;
+    memset(&t, 0, sizeof(t));
+
+    tcgetattr(_fd, &t);
+    cfsetspeed(&t, baudrate);
+    tcsetattr(_fd, TCSANOW, &t);
+}
+
+#endif

--- a/libraries/AP_HAL_Linux/UARTDevice.h
+++ b/libraries/AP_HAL_Linux/UARTDevice.h
@@ -1,0 +1,26 @@
+#ifndef __AP_HAL_LINUX_UARTDEVICE_UDP_H__
+#define __AP_HAL_LINUX_UARTDEVICE_UDP_H__
+
+#include "SerialDevice.h"
+#include "../AP_HAL/utility/Socket.h"
+
+class UARTDevice: public SerialDevice {
+public:
+    UARTDevice(char *device_path);
+    virtual ~UARTDevice();
+
+    virtual bool open() override;
+    virtual bool close() override;
+    virtual int write(const uint8_t *buf, uint16_t n) override;
+    virtual int read(uint8_t *buf, uint16_t n) override;
+    virtual void set_nonblocking() override;
+    virtual void set_speed(uint32_t speed) override;
+
+private:
+    void _disable_crlf();
+
+    int _fd = -1;
+    char *_device_path;
+};
+
+#endif

--- a/libraries/AP_HAL_Linux/UARTDriver.cpp
+++ b/libraries/AP_HAL_Linux/UARTDriver.cpp
@@ -61,8 +61,8 @@ void LinuxUARTDriver::begin(uint32_t b)
 void LinuxUARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS) 
 {
     if (device_path == NULL && _console) {
-        _rd_fd = 0;
-        _wr_fd = 1;
+        _rd_fd = STDIN_FILENO;
+        _wr_fd = STDOUT_FILENO;
         fcntl(_rd_fd, F_SETFL, fcntl(_rd_fd, F_GETFL, 0) | O_NONBLOCK);
         fcntl(_wr_fd, F_SETFL, fcntl(_wr_fd, F_GETFL, 0) | O_NONBLOCK);
     } else if (!_initialised) {
@@ -122,8 +122,8 @@ void LinuxUARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
             // Notify that the option is not valid and select standart input and output
             ::printf("LinuxUARTDriver parsing failed, using default\n");
 
-            _rd_fd = 0;
-            _wr_fd = 1;
+            _rd_fd = STDIN_FILENO;
+            _wr_fd = STDOUT_FILENO;
             fcntl(_rd_fd, F_SETFL, fcntl(_rd_fd, F_GETFL, 0) | O_NONBLOCK);
             fcntl(_wr_fd, F_SETFL, fcntl(_wr_fd, F_GETFL, 0) | O_NONBLOCK);
             break;

--- a/libraries/AP_HAL_Linux/UARTDriver.cpp
+++ b/libraries/AP_HAL_Linux/UARTDriver.cpp
@@ -131,16 +131,6 @@ void LinuxUARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
         }
     }
 
-    // we have enough memory to have a larger transmit buffer for
-    // all ports. This means we don't get delays while waiting to
-    // write GPS config packets
-    if (rxS < 1024) {
-        rxS = 8192;
-    }            
-    if (txS < 8192) {
-        txS = 8192;
-    }
-    
     _initialised = false;
     while (_in_timer) hal.scheduler->delay(1);
 
@@ -156,6 +146,23 @@ void LinuxUARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
         t.c_lflag &= ~(ISIG | ICANON | IEXTEN | ECHO | ECHOE | ECHOK | ECHOCTL | ECHOKE);
         t.c_cc[VMIN] = 0;
         tcsetattr(_rd_fd, TCSANOW, &t);
+    }
+
+    _allocate_buffers(rxS, txS);
+}
+
+void LinuxUARTDriver::_allocate_buffers(uint16_t rxS, uint16_t txS)
+{
+    /* we have enough memory to have a larger transmit buffer for
+     * all ports. This means we don't get delays while waiting to
+     * write GPS config packets
+     */
+
+    if (rxS < 8192) {
+        rxS = 8192;
+    }
+    if (txS < 8192) {
+        txS = 8192;
     }
 
     /*

--- a/libraries/AP_HAL_Linux/UARTDriver.cpp
+++ b/libraries/AP_HAL_Linux/UARTDriver.cpp
@@ -26,6 +26,7 @@
 
 #include "UARTDevice.h"
 #include "UDPDevice.h"
+#include "ConsoleDevice.h"
 
 extern const AP_HAL::HAL& hal;
 
@@ -39,8 +40,8 @@ LinuxUARTDriver::LinuxUARTDriver(bool default_console) :
     _flow_control(FLOW_CONTROL_DISABLE)
 {
     if (default_console) {
-        _rd_fd = 0;
-        _wr_fd = 1;
+        _device = new ConsoleDevice();
+        _device->open();
         _console = true;
     }
 }
@@ -64,10 +65,9 @@ void LinuxUARTDriver::begin(uint32_t b)
 void LinuxUARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS) 
 {
     if (device_path == NULL && _console) {
-        _rd_fd = STDIN_FILENO;
-        _wr_fd = STDOUT_FILENO;
-        fcntl(_rd_fd, F_SETFL, fcntl(_rd_fd, F_GETFL, 0) | O_NONBLOCK);
-        fcntl(_wr_fd, F_SETFL, fcntl(_wr_fd, F_GETFL, 0) | O_NONBLOCK);
+        _device = new ConsoleDevice();
+        _device->open();
+        _device->set_nonblocking();
     } else if (!_initialised) {
         if (device_path == NULL) {
             return;
@@ -114,10 +114,9 @@ void LinuxUARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
             // Notify that the option is not valid and select standart input and output
             ::printf("LinuxUARTDriver parsing failed, using default\n");
 
-            _rd_fd = STDIN_FILENO;
-            _wr_fd = STDOUT_FILENO;
-            fcntl(_rd_fd, F_SETFL, fcntl(_rd_fd, F_GETFL, 0) | O_NONBLOCK);
-            fcntl(_wr_fd, F_SETFL, fcntl(_wr_fd, F_GETFL, 0) | O_NONBLOCK);
+            _device = new ConsoleDevice();
+            _device->open();
+            _device->set_nonblocking();
             break;
         }
         }

--- a/libraries/AP_HAL_Linux/UARTDriver.cpp
+++ b/libraries/AP_HAL_Linux/UARTDriver.cpp
@@ -27,6 +27,7 @@
 #include "UARTDevice.h"
 #include "UDPDevice.h"
 #include "ConsoleDevice.h"
+#include "TCPClientDevice.h"
 
 extern const AP_HAL::HAL& hal;
 
@@ -74,8 +75,9 @@ void LinuxUARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
         switch (_parseDevicePath(device_path)){        
         case DEVICE_TCP:
         {
+            _device = new TCPClientDevice(_ip, _base_port);
+            _device->open();
             _connected = false;
-            ::fprintf(stderr, "Please, use UDP instead\n");
             break;
         }   
 

--- a/libraries/AP_HAL_Linux/UARTDriver.cpp
+++ b/libraries/AP_HAL_Linux/UARTDriver.cpp
@@ -175,6 +175,25 @@ void LinuxUARTDriver::_allocate_buffers(uint16_t rxS, uint16_t txS)
     }
 }
 
+void LinuxUARTDriver::_deallocate_buffers()
+{
+    if (_readbuf) {
+        free(_readbuf);
+        _readbuf = NULL;
+    }
+
+    if (_writebuf) {
+        free(_writebuf);
+        _writebuf = NULL;
+    }
+
+    _readbuf_size = _writebuf_size = 0;
+    _writebuf_head = 0;
+    _writebuf_tail = 0;
+    _readbuf_head = 0;
+    _readbuf_tail = 0;
+}
+
 /*
     Device path accepts the following syntaxes:
         - /dev/ttyO1
@@ -396,19 +415,8 @@ void LinuxUARTDriver::end()
     }
     _rd_fd = -1;
     _wr_fd = -1;
-    if (_readbuf) {
-        free(_readbuf);
-        _readbuf = NULL;
-    }
-    if (_writebuf) {
-        free(_writebuf);
-        _writebuf = NULL;
-    }
-    _readbuf_size = _writebuf_size = 0;
-    _writebuf_head = 0;
-    _writebuf_tail = 0;
-    _readbuf_head = 0;
-    _readbuf_tail = 0;
+
+    _deallocate_buffers();
 }
 
 

--- a/libraries/AP_HAL_Linux/UARTDriver.h
+++ b/libraries/AP_HAL_Linux/UARTDriver.h
@@ -48,6 +48,7 @@ private:
     enum flow_control _flow_control;
 
     void _allocate_buffers(uint16_t rxS, uint16_t txS);
+    void _deallocate_buffers();
     void _tcp_start_connection(bool wait_for_connection);
     void _udp_start_connection(void);
     bool _serial_start_connection(void);

--- a/libraries/AP_HAL_Linux/UARTDriver.h
+++ b/libraries/AP_HAL_Linux/UARTDriver.h
@@ -47,6 +47,7 @@ private:
     void _allocate_buffers(uint16_t rxS, uint16_t txS);
     void _tcp_start_connection(bool wait_for_connection);
     void _udp_start_connection(void);
+    bool _serial_start_connection(void);
 
     enum device_type {
         DEVICE_TCP,

--- a/libraries/AP_HAL_Linux/UARTDriver.h
+++ b/libraries/AP_HAL_Linux/UARTDriver.h
@@ -4,6 +4,8 @@
 
 #include <AP_HAL_Linux.h>
 
+#include "SerialDevice.h"
+
 class Linux::LinuxUARTDriver : public AP_HAL::UARTDriver {
 public:
     LinuxUARTDriver(bool default_console);
@@ -32,6 +34,7 @@ public:
     enum flow_control get_flow_control(void) { return _flow_control; }
 
 private:
+    SerialDevice *_device = nullptr;
     int _rd_fd;
     int _wr_fd;
     bool _nonblocking_writes;

--- a/libraries/AP_HAL_Linux/UARTDriver.h
+++ b/libraries/AP_HAL_Linux/UARTDriver.h
@@ -44,6 +44,7 @@ private:
     bool _packetise; // true if writes should try to be on mavlink boundaries
     enum flow_control _flow_control;
 
+    void _allocate_buffers(uint16_t rxS, uint16_t txS);
     void _tcp_start_connection(bool wait_for_connection);
     void _udp_start_connection(void);
 

--- a/libraries/AP_HAL_Linux/UARTDriver.h
+++ b/libraries/AP_HAL_Linux/UARTDriver.h
@@ -35,8 +35,6 @@ public:
 
 private:
     SerialDevice *_device = nullptr;
-    int _rd_fd;
-    int _wr_fd;
     bool _nonblocking_writes;
     bool _console;
     volatile bool _in_timer;
@@ -49,7 +47,6 @@ private:
 
     void _allocate_buffers(uint16_t rxS, uint16_t txS);
     void _deallocate_buffers();
-    void _tcp_start_connection(bool wait_for_connection);
     void _udp_start_connection(void);
     bool _serial_start_connection(void);
 

--- a/libraries/AP_HAL_Linux/UARTDriver.h
+++ b/libraries/AP_HAL_Linux/UARTDriver.h
@@ -48,6 +48,7 @@ private:
     void _allocate_buffers(uint16_t rxS, uint16_t txS);
     void _deallocate_buffers();
     void _udp_start_connection(void);
+    void _tcp_start_connection(void);
     bool _serial_start_connection(void);
 
     enum device_type {

--- a/libraries/AP_HAL_Linux/UDPDevice.cpp
+++ b/libraries/AP_HAL_Linux/UDPDevice.cpp
@@ -1,0 +1,50 @@
+#include <AP_HAL.h>
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
+
+#include <stdio.h>
+
+#include "UDPDevice.h"
+
+UDPDevice::UDPDevice(const char *ip, uint16_t port):
+    _ip(ip),
+    _port(port)
+{
+}
+
+UDPDevice::~UDPDevice()
+{
+
+}
+
+int UDPDevice::write(const uint8_t *buf, uint16_t n)
+{
+    return socket.sendto(buf, n, _ip, _port, 1);
+}
+
+int UDPDevice::read(uint8_t *buf, uint16_t n)
+{
+    return socket.recvfrom(buf, n, _ip, _port, 1);
+}
+
+bool UDPDevice::open()
+{
+    return true;
+}
+
+bool UDPDevice::close()
+{
+    return true;
+}
+
+void UDPDevice::set_nonblocking()
+{
+    socket.set_blocking(false);
+}
+
+void UDPDevice::set_speed(uint32_t speed)
+{
+
+}
+
+#endif

--- a/libraries/AP_HAL_Linux/UDPDevice.h
+++ b/libraries/AP_HAL_Linux/UDPDevice.h
@@ -1,0 +1,24 @@
+#ifndef __AP_HAL_LINUX_UDPDEVICE_UDP_H__
+#define __AP_HAL_LINUX_UDPDEVICE_UDP_H__
+
+#include "SerialDevice.h"
+#include "../AP_HAL/utility/Socket.h"
+
+class UDPDevice: public SerialDevice {
+public:
+    UDPDevice(const char *ip, uint16_t port);
+    virtual ~UDPDevice();
+
+    virtual bool open() override;
+    virtual bool close() override;
+    virtual void set_nonblocking() override;
+    virtual void set_speed(uint32_t speed) override;
+    virtual int write(const uint8_t *buf, uint16_t n) override;
+    virtual int read(uint8_t *buf, uint16_t n) override;
+private:
+    SocketAPM socket{true};
+    const char *_ip;
+    uint16_t _port;
+};
+
+#endif


### PR DESCRIPTION
As we all know Linux UART driver is not really a UART driver anymore. That's why I've make an effort to reimplement the driver. I encapsulated all mediums like UDP, UART and Console into several classes.

The last commit is questionable. Is there any reason to use TCP over UDP? The latter seems more preferable, doesn't it? 

As a side effect of the refactoring some issues with UDP have been solved i.e the APM doesn't exit if there's no GCS available. 
