### PR TITLE
Allows last_letter to start at the location specified by the SITL arguments

### DIFF
--- a/libraries/SITL/SIM_last_letter.cpp
+++ b/libraries/SITL/SIM_last_letter.cpp
@@ -60,11 +60,17 @@ void last_letter::start_last_letter(void)
             close(i);
         }
 
-        int ret = execlp("roslaunch", 
-                         "roslaunch", 
+        char argHome[50];
+        sprintf(argHome,"home:=[%f,%f,%f]",home.lat*1.0e-7,home.lng*1.0e-7,(double)home.alt);
+
+        int ret = execlp("roslaunch",
+                         "roslaunch",
                          "last_letter",
                          "launcher.launch",
                          "ArduPlane:=true",
+                         "simRate:=500",
+                         "deltaT:=0.002",
+                         argHome,
                          NULL);
         if (ret != 0) {
             perror("roslaunch");

--- a/libraries/SITL/SIM_last_letter.cpp
+++ b/libraries/SITL/SIM_last_letter.cpp
@@ -61,7 +61,7 @@ void last_letter::start_last_letter(void)
         }
 
         char argHome[50];
-        sprintf(argHome,"home:=[%f,%f,%f]",home.lat*1.0e-7,home.lng*1.0e-7,(double)home.alt);
+        sprintf(argHome,"home:=[%f,%f,%f]",home.lat*1.0e-7,home.lng*1.0e-7,(double)home.alt*1.0e-2);
 
         int ret = execlp("roslaunch",
                          "roslaunch",


### PR DESCRIPTION
SITL can now use the `home` argument to set the simulation starting position.