### PR TITLE
AP_HAL_Linux: Fix loading Firmware

### DIFF
--- a/libraries/AP_HAL_Linux/RCOutput_AioPRU.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_AioPRU.cpp
@@ -35,7 +35,7 @@ static void catch_sigbus(int sig)
 }
 void LinuxRCOutput_AioPRU::init(void* machtnicht)
 {
-   uint32_t mem_fd, i;
+   uint32_t mem_fd;
    uint32_t *iram;
    uint32_t *ctrl;
 
@@ -54,9 +54,7 @@ void LinuxRCOutput_AioPRU::init(void* machtnicht)
    hal.scheduler->delay(1);
 
    // Load firmware
-   for(i = 0; i < sizeof(PRUcode); i++) {
-      *(iram + i) = PRUcode[i];
-   }
+   memcpy(iram, PRUcode, sizeof(PRUcode));
 
    // Start PRU 1
    *ctrl = 3;


### PR DESCRIPTION
- Use memcpy to load Firmware
- Fix compiler warning