### PR TITLE
Fix vagrant build issues with submodules.

### DIFF
--- a/Tools/vagrant/initvagrant.sh
+++ b/Tools/vagrant/initvagrant.sh
@@ -46,6 +46,9 @@ exportline="export PATH=/opt/$ARM_ROOT/bin:\$PATH"
 if grep -Fxq "$exportline" /home/vagrant/.profile; then echo nothing to do ; else echo $exportline >> /home/vagrant/.profile; fi
 
 echo "source /vagrant/Tools/vagrant/shellinit.sh" >>/home/vagrant/.profile
+# This allows the PX4NuttX build to proceed when the underlying fs is on windows
+# It is only marginally less efficient on Linux
+echo "export PX4_WINTOOL=y" >>/home/vagrant/.profile
 ln -fs /vagrant/Tools/vagrant/screenrc /home/vagrant/.screenrc
 
 # build JSB sim

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,15 +25,19 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       vb.customize ["modifyvm", :id, "--memory", "2048"]
       vb.customize ["modifyvm", :id, "--ioapic", "on"]
       vb.customize ["modifyvm", :id, "--cpus", "2"]
-      # NuttX needs symlinks. If you want to go that route you need this setting, but rsync is easier. 
-#      vb.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/PX4NuttX", "1"]
       # Make some effort to avoid clock skew
       vb.customize ["guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", "5000"]
       vb.customize ["guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-start"]
       vb.customize ["guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-on-restore", "1"]
   end
 
-
+  # The created VM sets PX4_WINTOOL=y to allow builds to proceed using shared folders with using symlinks.
+  # However shared folders are quite slow. If you have rsync installed then this is a faster way of building.
+  # In addition there are problems with px4-clean when using shared folders. Using rsync avoids this.
+  # config.vm.synced_folder ".", "/vagrant", type: "rsync", rsync__auto: true
+  
+  # If you are on windows then you must use a version of git >= 1.8.x to update the submodules
+  # in order to build. Older versions of git use absolute paths for submodules which confuses things.
 
   config.vm.provision :shell, path: "Tools/vagrant/initvagrant.sh"  
 end


### PR DESCRIPTION
Allow px4 firmware to be correctly built under Vagrant.

Please note the following:
1. You must use a version of git 1.8.x or later as version 1.7.x and earlier wrote absolute paths into submodules meaning that they were not portable between host and guest. The px4 toolchain on windows (14 currently) does not contain a new enough version of git.
2. rsync is no longer required but it's use will make builds faster. By default we use the windows support for PX4NuttX which copies files rather than using symlinks. rsync is included in the px4 toolchain on windows.
3. px4-clean does not work unless you are using rsync.