### PR TITLE
Build error in: AP_HAL_Linux - I2CDriver 

### DIFF
--- a/libraries/AP_HAL_Linux/I2CDriver.cpp
+++ b/libraries/AP_HAL_Linux/I2CDriver.cpp
@@ -15,6 +15,10 @@
 #include <linux/i2c.h>
 #endif
 
+#ifndef typeof
+    #define typeof __typeof__
+#endif
+
 using namespace Linux;
 
 /*


### PR DESCRIPTION
Fixed build problem: "error: ‘typeof’ was not declared in this scope"

Signed-off-by: dgrat <dgdanielf@gmail.com>