### PR TITLE
SIM_last_letter: Implemented support for starting locations args

### DIFF
--- a/libraries/SITL/SIM_last_letter.h
+++ b/libraries/SITL/SIM_last_letter.h
@@ -48,7 +48,7 @@ private:
     struct servo_packet {
         uint16_t servos[16];
     };
-    
+
     /*
       reply packet sent from last_letter to ArduPilot
      */
@@ -66,7 +66,7 @@ private:
 
     void recv_fdm(const struct sitl_input &input);
     void send_servos(const struct sitl_input &input);
-    void start_last_letter(void);
+    void start_last_letter(const char *home_str);
 
     uint64_t last_timestamp_us;
     SocketAPM sock;


### PR DESCRIPTION
Added code to SIM_last_letter to pass a home argument to last_letter.

last_letter just implemented a starting location argument in Georacer/last_letter@e48e2df606bed0a9352a8da406bb1379e964114e, so this goes along with that.