### PR TITLE
ArduPlane: Disable failsafe actions during final approach or land

### DIFF
--- a/ArduPlane/events.cpp
+++ b/ArduPlane/events.cpp
@@ -115,8 +115,11 @@ void Plane::low_battery_event(void)
     }
     gcs_send_text_fmt(PSTR("Low Battery %.2fV Used %.0f mAh"),
                       (double)battery.voltage(), (double)battery.current_total_mah());
-    set_mode(RTL);
-    aparm.throttle_cruise.load();
+    if (flight_stage != AP_SpdHgtControl::FLIGHT_LAND_FINAL &&
+        flight_stage != AP_SpdHgtControl::FLIGHT_LAND_APPROACH) {
+    	set_mode(RTL);
+    	aparm.throttle_cruise.load();
+    }
     failsafe.low_battery = true;
     AP_Notify::flags.failsafe_battery = true;
 }

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -516,7 +516,8 @@ void Plane::check_short_failsafe()
 {
     // only act on changes
     // -------------------
-    if(failsafe.state == FAILSAFE_NONE) {
+    if(failsafe.state == FAILSAFE_NONE && (flight_stage != AP_SpdHgtControl::FLIGHT_LAND_FINAL &&
+            flight_stage != AP_SpdHgtControl::FLIGHT_LAND_APPROACH)) {
         if(failsafe.ch3_failsafe) {                                              // The condition is checked and the flag ch3_failsafe is set in radio.pde
             failsafe_short_on_event(FAILSAFE_SHORT);
         }

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -483,7 +483,8 @@ void Plane::check_long_failsafe()
     uint32_t tnow = millis();
     // only act on changes
     // -------------------
-    if(failsafe.state != FAILSAFE_LONG && failsafe.state != FAILSAFE_GCS) {
+    if(failsafe.state != FAILSAFE_LONG && failsafe.state != FAILSAFE_GCS && flight_stage != AP_SpdHgtControl::FLIGHT_LAND_FINAL &&
+            flight_stage != AP_SpdHgtControl::FLIGHT_LAND_APPROACH) {
         if (failsafe.state == FAILSAFE_SHORT &&
                    (tnow - failsafe.ch3_timer_ms) > g.long_fs_timeout*1000) {
             failsafe_long_on_event(FAILSAFE_LONG);


### PR DESCRIPTION
If the plane is in final or landing,  a Battery failsafe, GCS_Failsafe, or even radio_FS would easily end in disaster.  
-Commonly used fs_short and fs_long actions are not suitable then.
