### PR TITLE
APM_Control: Remove duplicate include statements

### DIFF
--- a/libraries/APM_Control/AP_PitchController.cpp
+++ b/libraries/APM_Control/AP_PitchController.cpp
@@ -17,9 +17,7 @@
 //	Initial Code by Jon Challinger
 //  Modified by Paul Riseborough
 
-#include <AP_Math.h>
 #include <AP_HAL.h>
-#include <AP_Common.h>
 #include "AP_PitchController.h"
 
 extern const AP_HAL::HAL& hal;

--- a/libraries/APM_Control/AP_RollController.cpp
+++ b/libraries/APM_Control/AP_RollController.cpp
@@ -18,7 +18,6 @@
 //  Modified by Paul Riseborough
 //
 
-#include <AP_Math.h>
 #include <AP_HAL.h>
 #include "AP_RollController.h"
 

--- a/libraries/APM_Control/AP_RollController.h
+++ b/libraries/APM_Control/AP_RollController.h
@@ -9,7 +9,6 @@
 #include <AP_AutoTune.h>
 #include <DataFlash.h>
 #include <AP_Math.h>
-#include <DataFlash.h>
 
 class AP_RollController {
 public:

--- a/libraries/APM_Control/AP_YawController.cpp
+++ b/libraries/APM_Control/AP_YawController.cpp
@@ -18,7 +18,6 @@
 //  Modified by Paul Riseborough to implement a three loop autopilot
 //  topology
 //
-#include <AP_Math.h>
 #include <AP_HAL.h>
 #include "AP_YawController.h"
 


### PR DESCRIPTION
Has no functional difference, simply tidies up the headers.