### PR TITLE
SITL: abort sim_vehicle.sh if build fails a second time

### DIFF
--- a/Tools/autotest/sim_vehicle.sh
+++ b/Tools/autotest/sim_vehicle.sh
@@ -292,7 +292,10 @@ fi
 echo "Building $BUILD_TARGET"
 make $BUILD_TARGET -j$NUM_PROCS || {
     make clean
-    make $BUILD_TARGET -j$NUM_PROCS
+    make $BUILD_TARGET -j$NUM_PROCS || {
+	echo >&2 "$0: Build failed"
+	exit 1
+    }
 }
 fi
 popd


### PR DESCRIPTION
Previously a build could fail and we would end up running the old code