### PR TITLE
Discoverable I2C Linux driver

### DIFF
--- a/libraries/AP_HAL_Linux/I2CDriver.cpp
+++ b/libraries/AP_HAL_Linux/I2CDriver.cpp
@@ -20,9 +20,8 @@ using namespace Linux;
 /*
   constructor
  */
-LinuxI2CDriver::LinuxI2CDriver(AP_HAL::Semaphore* semaphore, const char *device) : 
+LinuxI2CDriver::LinuxI2CDriver(AP_HAL::Semaphore* semaphore, const char *device) :
     _semaphore(semaphore),
-    _fd(-1),
     _device(device)
 {
 }

--- a/libraries/AP_HAL_Linux/I2CDriver.cpp
+++ b/libraries/AP_HAL_Linux/I2CDriver.cpp
@@ -4,16 +4,24 @@
 #if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
 #include "I2CDriver.h"
 
+#include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <dirent.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <limits.h>
 #include <sys/ioctl.h>
 #include <linux/i2c-dev.h>
 #ifndef I2C_SMBUS_BLOCK_MAX
 #include <linux/i2c.h>
 #endif
+
+#include <AP_HAL.h>
+
+extern const AP_HAL::HAL& hal;
 
 using namespace Linux;
 
@@ -21,9 +29,62 @@ using namespace Linux;
   constructor
  */
 LinuxI2CDriver::LinuxI2CDriver(AP_HAL::Semaphore* semaphore, const char *device) :
-    _semaphore(semaphore),
-    _device(device)
+    _semaphore(semaphore)
 {
+    _device = strdup(device);
+}
+
+/* Match a given device by the prefix its devpath, i.e. the path returned by
+ * udevadm info -q path /dev/<i2c-device>'. This constructor can be used when
+ * the number of the I2C bus is not stable across reboots. It matches the
+ * first device with a prefix in @devpaths */
+LinuxI2CDriver::LinuxI2CDriver(AP_HAL::Semaphore* semaphore,
+                               const char * const devpaths[]) :
+    _semaphore(semaphore)
+{
+    const char *dirname = "/sys/class/i2c-dev";
+    struct dirent *de;
+    DIR *d;
+
+    d = opendir(dirname);
+    if (!d)
+        hal.scheduler->panic("Could not get list of I2C buses");
+
+    for (de = readdir(d); de; de = readdir(d)) {
+        const char *p, * const *t;
+        char buf[PATH_MAX], buf2[PATH_MAX];
+
+        if (strcmp(de->d_name, ".") == 0 || strcmp(de->d_name, "..") == 0)
+            continue;
+
+        if (snprintf(buf, sizeof(buf), "%s/%s", dirname, de->d_name) >= PATH_MAX)
+            continue;
+
+        p = realpath(buf, buf2);
+        if (!p || strncmp(p, "/sys", sizeof("/sys") - 1))
+            continue;
+
+        p += sizeof("/sys") - 1;
+
+        for (t = devpaths; t && *t; t++) {
+            if (strncmp(p, *t, strlen(*t)) == 0)
+                break;
+        }
+
+        if (!*t)
+            continue;
+
+        /* Found the device name, use the new path */
+        asprintf(&_device, "/dev/%s", de->d_name);
+        break;
+    }
+
+    closedir(d);
+}
+
+LinuxI2CDriver::~LinuxI2CDriver()
+{
+    free(_device);
 }
 
 /*

--- a/libraries/AP_HAL_Linux/I2CDriver.h
+++ b/libraries/AP_HAL_Linux/I2CDriver.h
@@ -41,11 +41,12 @@ public:
     AP_HAL::Semaphore* get_semaphore() { return _semaphore; }
 
 private:
-    AP_HAL::Semaphore* _semaphore;
     bool set_address(uint8_t addr);
-    int _fd;
+
+    AP_HAL::Semaphore* _semaphore;
+    const char *_device = NULL;
+    int _fd = -1;
     uint8_t _addr;
-    const char *_device;
 };
 
 #endif // __AP_HAL_LINUX_I2CDRIVER_H__

--- a/libraries/AP_HAL_Linux/I2CDriver.h
+++ b/libraries/AP_HAL_Linux/I2CDriver.h
@@ -7,6 +7,8 @@
 class Linux::LinuxI2CDriver : public AP_HAL::I2CDriver {
 public:
     LinuxI2CDriver(AP_HAL::Semaphore* semaphore, const char *device);
+    LinuxI2CDriver(AP_HAL::Semaphore* semaphore, const char * const devpaths[]);
+    ~LinuxI2CDriver();
 
     void begin();
     void end();
@@ -44,7 +46,7 @@ private:
     bool set_address(uint8_t addr);
 
     AP_HAL::Semaphore* _semaphore;
-    const char *_device = NULL;
+    char *_device = NULL;
     int _fd = -1;
     uint8_t _addr;
 };


### PR DESCRIPTION
This improves the discoverability of an I2C bus in Linux.  There's a long explanation of the reasoning on the second patch. The first one is just to remove noise from the second patch.

As far as I know this problem doesn't occur on the currently supported boards, so there's no intended changes for them.