### PR TITLE
.gitignore update for jsbsim changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,8 @@
 /Tools/ArdupilotMegaPlanner/wix/obj
 /Tools/autotest/ch7_mission.txt
 /Tools/autotest/aircraft/Rascal/reset.xml
+/Tools/autotest/jsbsim_fgout_0.xml
+/Tools/autotest/jsbsim_start_0.xml
 /Tools/autotest/jsb_sim/fgout.xml
 /Tools/autotest/jsb_sim/rascal_test.xml
 ArduCopter/Debug/


### PR DESCRIPTION
- It seems jsbsim has changed the filenames and the location of _fgout.xml and rascal_test.
- I'm not sure if this is a mistake or new behavior but either way these files are generated and don't need to be tracked.