### PR TITLE
AP_BoardConfig: add user-defined serial number

### DIFF
--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -78,6 +78,13 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] PROGMEM = {
 #elif CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
 #endif
 
+    // @Param: SERIAL_NUM
+    // @DisplayName: User-defined serial number
+    // @Description: User-defined serial number of this vehicle, it can be any arbitrary number you want and has no effect on the autopilot
+    // @Range: -32767 to 32768 (any 16bit signed number)
+    // @User: Standard
+    AP_GROUPINFO("SERIAL_NUM", 5, AP_BoardConfig, vehicleSerialNumber, 0),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -21,6 +21,8 @@ public:
     static const struct AP_Param::GroupInfo var_info[];
 
 private:
+    AP_Int16 vehicleSerialNumber;
+
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4
     AP_Int8 _pwm_count;
     AP_Int8 _ser1_rtscts;


### PR DESCRIPTION
new param: BRD_SERIAL_NUM
// @Description: User-defined serial number of this vehicle, it can be any arbitrary number you want and has no effect on the autopilot
// @Range: -2147483647 to 2147483648 (any 32bit signed number)

duplicate of https://github.com/diydrones/ardupilot/pull/2207 but that branch is now invalid due to a force-push that has confused github so I can't reopen.

I'd like to revisit this. @rmackay9 had decided that SYSID_THISMAV should work but I have determined that it will not suffice. A simple 0-255 value is not a realistic limitation and has the potential to interfere with any GCS implementations. Even though a unique stm32 cpu serial number is in the log it is hard to match that up with an aircraft for a given flight. This makes that process much easier.