### PR TITLE
AP_GPS: Read actual hDOP value from UBLOX messages.

### DIFF
--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -227,7 +227,7 @@
 
 // prearm GPS hdop check
 #ifndef GPS_HDOP_GOOD_DEFAULT
- # define GPS_HDOP_GOOD_DEFAULT         230     // minimum hdop that represents a good position.  used during pre-arm checks if fence is enabled
+ # define GPS_HDOP_GOOD_DEFAULT         140     // minimum hdop that represents a good position.  used during pre-arm checks if fence is enabled
 #endif
 
 // GCS failsafe

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -109,18 +109,21 @@ AP_GPS_UBLOX::send_next_rate_update(void)
     case 4:
         _configure_message_rate(CLASS_NAV, MSG_VELNED, 1); // 36+8 bytes
         break;
-#if UBLOX_HW_LOGGING
     case 5:
+        _configure_message_rate(CLASS_NAV, MSG_DOP, 1); // 18+8 bytes
+        break;
+#if UBLOX_HW_LOGGING
+    case 6:
         // gather MON_HW at 0.5Hz
         _configure_message_rate(CLASS_MON, MSG_MON_HW, 2); // 64+8 bytes
         break;
-    case 6:
+    case 7:
         // gather MON_HW2 at 0.5Hz
         _configure_message_rate(CLASS_MON, MSG_MON_HW2, 2); // 24+8 bytes
         break;
 #endif
 #if UBLOX_RXM_RAW_LOGGING
-    case 7:
+    case 8:
         _configure_message_rate(CLASS_RXM, MSG_RXM_RAW, gps._raw_data);
         break;
     case 8:
@@ -533,6 +536,13 @@ AP_GPS_UBLOX::_parse_gps(void)
         next_fix = state.status;
 #endif
         break;
+    case MSG_DOP:
+        Debug("MSG_DOP");
+        state.hdop        = _buffer.dop.hDOP;
+#if UBLOX_FAKE_3DLOCK
+        state.hdop = 200;
+#endif
+        break;
     case MSG_SOL:
         Debug("MSG_SOL fix_status=%u fix_type=%u",
               _buffer.solution.fix_status,
@@ -554,7 +564,6 @@ AP_GPS_UBLOX::_parse_gps(void)
             state.status = AP_GPS::NO_FIX;
         }
         state.num_sats    = _buffer.solution.satellites;
-        state.hdop        = _buffer.solution.position_DOP;
         if (next_fix >= AP_GPS::GPS_OK_FIX_2D) {
             state.last_gps_time_ms = hal.scheduler->millis();
             if (state.time_week == _buffer.solution.week &&
@@ -570,7 +579,6 @@ AP_GPS_UBLOX::_parse_gps(void)
 #if UBLOX_FAKE_3DLOCK
         next_fix = state.status;
         state.num_sats = 10;
-        state.hdop = 200;
         state.time_week = 1721;
         state.time_week_ms = hal.scheduler->millis() + 3*60*60*1000 + 37000;
         state.last_gps_time_ms = hal.scheduler->millis();

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -126,12 +126,12 @@ AP_GPS_UBLOX::send_next_rate_update(void)
     case 8:
         _configure_message_rate(CLASS_RXM, MSG_RXM_RAW, gps._raw_data);
         break;
-    case 8:
+    case 9:
         _configure_message_rate(CLASS_RXM, MSG_RXM_RAWX, gps._raw_data);
         break;
 #endif
 #if UBLOX_VERSION_AUTODETECTION 
-    case 9:
+    case 10:
         _request_version();
         break;
 #endif

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -121,6 +121,16 @@ private:
         uint32_t time_to_first_fix;
         uint32_t uptime;                                // milliseconds
     };
+    struct PACKED ubx_nav_dop {
+        uint32_t time;                                  // GPS msToW
+        uint16_t gDOP;
+        uint16_t pDOP;
+        uint16_t tDOP;
+        uint16_t vDOP;
+        uint16_t hDOP;
+        uint16_t nDOP;
+        uint16_t eDOP;
+    };
     struct PACKED ubx_nav_solution {
         uint32_t time;
         int32_t time_nsec;
@@ -252,6 +262,7 @@ private:
     union PACKED {
         ubx_nav_posllh posllh;
         ubx_nav_status status;
+        ubx_nav_dop dop;
         ubx_nav_solution solution;
         ubx_nav_velned velned;
         ubx_cfg_nav_settings nav_settings;
@@ -279,6 +290,7 @@ private:
         MSG_ACK_ACK = 0x01,
         MSG_POSLLH = 0x2,
         MSG_STATUS = 0x3,
+        MSG_DOP = 0x4,
         MSG_SOL = 0x6,
         MSG_VELNED = 0x12,
         MSG_CFG_PRT = 0x00,


### PR DESCRIPTION
Before we were reading the position DOP and calling it hDOP. Since the
other drivers actualy read hDOP it seem best to do the same.
Fixes issue https://github.com/diydrones/ardupilot/issues/462.