### PR TITLE
Fix battery monitor Floating Point Exception in SITL.

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
@@ -33,7 +33,12 @@ AP_BattMonitor_Backend::AP_BattMonitor_Backend(AP_BattMonitor &mon, uint8_t inst
 /// capacity_remaining_pct - returns the % battery capacity remaining (0 ~ 100)
 uint8_t AP_BattMonitor_Backend::capacity_remaining_pct() const
 {
-    return (100.0f * (_mon._pack_capacity[_state.instance] - _state.current_total_mah) / _mon._pack_capacity[_state.instance]);
+    float mah_remaining = _mon._pack_capacity[_state.instance] - _state.current_total_mah;
+    if ( _mon._pack_capacity[_state.instance] > 10 ) { // a very very small battery
+        return (100 * (mah_remaining) / _mon._pack_capacity[_state.instance]);
+    } else {
+        return 0;
+    }
 }
 
 /// set capacity for this instance


### PR DESCRIPTION
Hi,

During last couple of days I experienced numerous Floating Points Exceptions whenever I was running SITL (which nonetheless is IMHO a truly superb tool) on Ubuntu 12.04 64-bit. Basically, what was happening was that I was receiving an FPE, shortly after "Ready to Fly" message at initialization. Below goes the backtrace log from gdb:

Program received signal SIGFPE, Arithmetic exception.
warning: (Internal error: pc 0x4ce62f in read in psymtab, but not in symtab.)

warning: (Internal error: pc 0x4ce62f in read in psymtab, but not in symtab.)

0x00000000004ce62f in AP_BattMonitor_Backend::capacity_remaining_pct() const ()
    at /opt/00.FT_src/00.APM/10.Synched/ardupilot/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp:36
36          return (100.0f * (_mon._pack_capacity[_state.instance] - _state.current_total_mah) / _mon._pack_capacity[_state.instance]);
(gdb) bt
#0  0x00000000004ce62f in AP_BattMonitor_Backend::capacity_remaining_pct() const ()
    at /opt/00.FT_src/00.APM/10.Synched/ardupilot/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp:36
#1  0x00000000004cecd7 in AP_BattMonitor::capacity_remaining_pct(unsigned char) const ()
    at /opt/00.FT_src/00.APM/10.Synched/ardupilot/libraries/AP_BattMonitor/AP_BattMonitor.cpp:251
#2  0x000000000040eb62 in AP_BattMonitor::capacity_remaining_pct() const ()
    at /opt/00.FT_src/00.APM/10.Synched/ardupilot/libraries/DataFlash/../AP_BattMonitor/AP_BattMonitor.h:93
#3  0x000000000040f332 in Plane::send_extended_status1(mavlink_channel_t) ()
    at GCS_Mavlink.cpp:251
#4  0x0000000000410486 in GCS_MAVLINK::try_send_message(ap_message) ()
    at GCS_Mavlink.cpp:581
#5  0x000000000044f7c2 in GCS_MAVLINK::send_message(ap_message) ()
    at /opt/00.FT_src/00.APM/10.Synched/ardupilot/libraries/GCS_MAVLink/GCS_Common.cpp:825
#6  0x0000000000410f8e in GCS_MAVLINK::data_stream_send() ()
    at GCS_Mavlink.cpp:950
#7  0x000000000041325d in Plane::gcs_data_stream_send() ()
    at GCS_Mavlink.cpp:1769
#8  0x00000000004070ec in _ZN7FunctorIvJEE14method_wrapperI5PlaneXadL_ZNS2_20gcs

This seems to be related to division by zero, whenever BATT_CAPACITY is set to 0, hence my little sanity check.

Regards,
Przemek