### PR TITLE
Discoverable I2C Linux driver v2

### DIFF
--- a/libraries/AP_HAL_Linux/I2CDriver.cpp
+++ b/libraries/AP_HAL_Linux/I2CDriver.cpp
@@ -1,8 +1,8 @@
-
 #include <AP_HAL.h>
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
 #include "I2CDriver.h"
+#include "Util.h"
 
 #include <errno.h>
 #include <sys/types.h>
@@ -30,6 +30,9 @@ LinuxI2CDriver::LinuxI2CDriver(AP_HAL::Semaphore* semaphore, const char *device)
     _semaphore(semaphore)
 {
     _device = strdup(device);
+
+    if (!((LinuxUtil*)hal.util)->is_chardev_node(_device))
+        hal.scheduler->panic("I2C device is not a chardev node");
 }
 
 /* Match a given device by the prefix its devpath, i.e. the path returned by
@@ -78,6 +81,9 @@ LinuxI2CDriver::LinuxI2CDriver(AP_HAL::Semaphore* semaphore,
     }
 
     closedir(d);
+
+    if (!((LinuxUtil*)hal.util)->is_chardev_node(_device))
+        hal.scheduler->panic("I2C device is not a chardev node");
 }
 
 LinuxI2CDriver::~LinuxI2CDriver()

--- a/libraries/AP_HAL_Linux/I2CDriver.cpp
+++ b/libraries/AP_HAL_Linux/I2CDriver.cpp
@@ -20,9 +20,8 @@ using namespace Linux;
 /*
   constructor
  */
-LinuxI2CDriver::LinuxI2CDriver(AP_HAL::Semaphore* semaphore, const char *device) : 
+LinuxI2CDriver::LinuxI2CDriver(AP_HAL::Semaphore* semaphore, const char *device) :
     _semaphore(semaphore),
-    _fd(-1),
     _device(device)
 {
 }

--- a/libraries/AP_HAL_Linux/I2CDriver.h
+++ b/libraries/AP_HAL_Linux/I2CDriver.h
@@ -41,11 +41,12 @@ public:
     AP_HAL::Semaphore* get_semaphore() { return _semaphore; }
 
 private:
-    AP_HAL::Semaphore* _semaphore;
     bool set_address(uint8_t addr);
-    int _fd;
+
+    AP_HAL::Semaphore* _semaphore;
+    const char *_device = NULL;
+    int _fd = -1;
     uint8_t _addr;
-    const char *_device;
 };
 
 #endif // __AP_HAL_LINUX_I2CDRIVER_H__

--- a/libraries/AP_HAL_Linux/I2CDriver.h
+++ b/libraries/AP_HAL_Linux/I2CDriver.h
@@ -7,6 +7,8 @@
 class Linux::LinuxI2CDriver : public AP_HAL::I2CDriver {
 public:
     LinuxI2CDriver(AP_HAL::Semaphore* semaphore, const char *device);
+    LinuxI2CDriver(AP_HAL::Semaphore* semaphore, const char * const devpaths[]);
+    ~LinuxI2CDriver();
 
     void begin();
     void end();
@@ -44,7 +46,7 @@ private:
     bool set_address(uint8_t addr);
 
     AP_HAL::Semaphore* _semaphore;
-    const char *_device = NULL;
+    char *_device = NULL;
     int _fd = -1;
     uint8_t _addr;
 };

--- a/libraries/AP_HAL_Linux/Util.cpp
+++ b/libraries/AP_HAL_Linux/Util.cpp
@@ -2,6 +2,7 @@
 #if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
 #include <stdio.h>
 #include <stdarg.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <errno.h>
@@ -60,6 +61,16 @@ void LinuxUtil::set_system_clock(uint64_t time_utc_usec)
     ts.tv_nsec = (time_utc_usec % 1000000) * 1000;
     clock_settime(CLOCK_REALTIME, &ts);    
 #endif    
+}
+
+bool LinuxUtil::is_chardev_node(const char *path)
+{
+    struct stat st;
+
+    if (!path || lstat(path, &st) < 0)
+        return false;
+
+    return S_ISCHR(st.st_mode);
 }
 
 #endif // CONFIG_HAL_BOARD == HAL_BOARD_LINUX

--- a/libraries/AP_HAL_Linux/Util.h
+++ b/libraries/AP_HAL_Linux/Util.h
@@ -31,6 +31,8 @@ public:
      */
     void set_system_clock(uint64_t time_utc_usec);
 
+    bool is_chardev_node(const char *path);
+
 private:
 	static Linux::ToneAlarm _toneAlarm;
     int saved_argc;


### PR DESCRIPTION
Second version of #2454

This improves the discoverability of an I2C bus in Linux. There's a long explanation of the reasoning on the second patch. The first one is just to remove noise from the second patch.

As far as I know this problem doesn't occur on the currently supported boards, so there's no intended changes for them.

Changes from v1:
- Include commits to make sure the device is a char dev for both constructors