### PR TITLE
AP_InertialSensor: disable reset on MPU9250

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
@@ -417,11 +417,6 @@ bool AP_InertialSensor_MPU9250::_hardware_init(void)
     // Chip reset
     uint8_t tries;
     for (tries = 0; tries<5; tries++) {
-        // reset device
-        _register_write(MPUREG_PWR_MGMT_1, BIT_PWR_MGMT_1_DEVICE_RESET);
-
-        hal.scheduler->delay(100);
-
         // disable I2C as recommended by the datasheet
         _register_write(MPUREG_USER_CTRL, BIT_USER_CTRL_I2C_IF_DIS);
 


### PR DESCRIPTION
Getting rid of the reset as discussed on gitter earlier today. We need that until we figure out the proper fix for the issue.