### PR TITLE
Compass learning: field learning

### DIFF
--- a/libraries/AP_Compass/Compass_learn.cpp
+++ b/libraries/AP_Compass/Compass_learn.cpp
@@ -1,5 +1,6 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
 #include "Compass.h"
+#include <AP_Math.h>
 
 // don't allow any axis of the offset to go above 2000
 #define COMPASS_OFS_LIMIT 2000
@@ -47,7 +48,9 @@ Compass::learn_offsets(void)
             for (uint8_t i=0; i<_mag_history_size; i++) {
                 // fill the history buffer with the current mag vector,
                 // with the offset removed
-                _state[k].mag_history[i] = Vector3i((field.x+0.5f) - ofs.x, (field.y+0.5f) - ofs.y, (field.z+0.5f) - ofs.z);
+                _state[k].mag_history[i] = Vector3i(round_half(field.x) - ofs.x, 
+                                                    round_half(field.y) - ofs.y, 
+                                                    round_half(field.z) - ofs.z);
             }
             _state[k].mag_history_index = 0;
         }
@@ -92,9 +95,9 @@ Compass::learn_offsets(void)
         }
 
         // put the vector in the history
-        _state[k].mag_history[_state[k].mag_history_index] = Vector3i((field.x+0.5f) - ofs.x, 
-                                                                      (field.y+0.5f) - ofs.y, 
-                                                                      (field.z+0.5f) - ofs.z);
+        _state[k].mag_history[_state[k].mag_history_index] = Vector3i(round_half(field.x) - ofs.x, 
+                                                                      round_half(field.y) - ofs.y, 
+                                                                      round_half(field.z) - ofs.z);
         _state[k].mag_history_index = (_state[k].mag_history_index + 1) % _mag_history_size;
 
         // equation 6 of Bills paper

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -82,6 +82,14 @@ static inline bool is_equal(const float fVal1, const float fVal2) { return fabsf
 // is a float is zero
 static inline bool is_zero(const float fVal1) { return fabsf(fVal1) < FLT_EPSILON ? true : false; }
 
+// Round a float up, bias: 0.5
+// fVal ~ 0: 0
+// fVal > 0: round up positive values
+// fVal < 0: round up for negative values
+static inline double round_half(const double fVal) {
+  return is_zero(fVal) ? 0 : fVal < 0 ? floor(fVal - 0.5) : floor(fVal + 0.5);
+}
+
 // a varient of asin() that always gives a valid answer.
 float           safe_asin(float v);
 
@@ -96,7 +104,7 @@ enum Rotation           rotation_combination(enum Rotation r1, enum Rotation r2,
 #endif
 
 // longitude_scale - returns the scaler to compensate for shrinking longitude as you move north or south from the equator
-// Note: this does not include the scaling to convert longitude/latitude points to meters or centimeters
+// Note: this does not include the scaling to convert longitude/latitude points to meters or centimetres
 float                   longitude_scale(const struct Location &loc);
 
 // return distance in meters between two locations


### PR DESCRIPTION
I think, if the magnetic field vector can contain negative numbers, 
the following parts can be replaced.
Otherwise, the learning function may drift slowly towards positive values. 
The speed would depend on the sample rate and the orientation. 
If it cannot contain negative values, the following implementation would be still more general. 