### PR TITLE
Copter: use WPNAV_SPEED for RTL

### DIFF
--- a/ArduCopter/control_rtl.cpp
+++ b/ArduCopter/control_rtl.cpp
@@ -13,6 +13,7 @@
 bool Copter::rtl_init(bool ignore_checks)
 {
     if (position_ok() || ignore_checks) {
+        wp_nav.set_speed_xy(WPNAV_WP_SPEED);
         rtl_climb_start();
         return true;
     }else{


### PR DESCRIPTION
Prevents last speed used in mission being used in case of RTL. A slow
photo-mission could have 1m/s speed, giving an inefficient RTL.