### PR TITLE
build: reduce ~10% in size the binaries for linux builds

### DIFF
--- a/mk/board_native.mk
+++ b/mk/board_native.mk
@@ -14,8 +14,8 @@ WARNFLAGS      +=   -Wwrite-strings -Wformat=2
 WARNFLAGSCXX    =   -Wno-reorder
 DEPFLAGS        =   -MD -MT $@
 
-CXXOPTS         =   -ffunction-sections -fdata-sections -fno-exceptions -fsigned-char
-COPTS           =   -ffunction-sections -fdata-sections -fsigned-char
+CXXOPTS         =   -ffunction-sections -fdata-sections -fno-exceptions -fsigned-char -fno-asynchronous-unwind-tables
+COPTS           =   -ffunction-sections -fdata-sections -fsigned-char -fno-asynchronous-unwind-table
 
 ASOPTS          =   -x assembler-with-cpp 
 


### PR DESCRIPTION
-fasynchronous-unwind-tables is used to add debug information in the
binary that's useful when we use things like backtrace(3), when handling
exceptions and in some other cases we don't use.  It's not possible to
remove this info with tools like strip.  Following are the sizes before
and after the flag for a 64 bit linux build:

ArduCopter $ make -j8 linux >/dev/null 2>&1 && strip ArduCopter.elf
ArduCopter $ ls -lh ArduCopter.elf
-rwxr-xr-x 1 lucas users 748K Jul  2 21:53 ArduCopter.elf
ArduCopter $ size ArduCopter.elf
   text	   data	    bss	    dec	    hex	filename
 759437	   1752	  70264	 831453	  cafdd	ArduCopter.elf

ArduCopter $ make -j8 linux >/dev/null 2>&1 && strip ArduCopter.elf
ArduCopter $ ls -lh ArduCopter.elf
-rwxr-xr-x 1 lucas users 673K Jul  2 21:58 ArduCopter.elf
ArduCopter $ size ArduCopter.elf
   text	   data	    bss	    dec	    hex	filename
 684101	   1752	  70264	 756117	  b8995	ArduCopter.elf