### PR TITLE
AP_HAL_Linux: BBBMINI uses /dev/i2c-2

### DIFF
--- a/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
+++ b/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
@@ -25,7 +25,11 @@ static LinuxUARTDriver uartCDriver(false);
 static LinuxUARTDriver uartEDriver(false);
 
 static LinuxSemaphore  i2cSemaphore;
+#if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BBBMINI
+static LinuxI2CDriver  i2cDriver(&i2cSemaphore, "/dev/i2c-2");
+#else
 static LinuxI2CDriver  i2cDriver(&i2cSemaphore, "/dev/i2c-1");
+#endif
 static LinuxSPIDeviceManager spiDeviceManager;
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO
 static NavioAnalogIn analogIn;


### PR DESCRIPTION
BBBMINI uses /dev/i2c-2 as I2C-Bus.