### PR TITLE
AP_InertialSensor: Change BBBMINI standard orientation

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
@@ -187,7 +187,7 @@ AP_InertialSensor_MPU9250::AP_InertialSensor_MPU9250(AP_InertialSensor &imu) :
     /* no rotation needed */
     _default_rotation(ROTATION_NONE)
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BBBMINI
-    _default_rotation(ROTATION_YAW_270)
+    _default_rotation(ROTATION_NONE)
 #else /* rotate for bbone default (and other boards) */
     _default_rotation(ROTATION_ROLL_180_YAW_90)
 #endif


### PR DESCRIPTION
Because the BBBMINI-PCB https://github.com/mirkix/BBBMINI-PCB is now the default BBBMINI hardware, we change the BBBMINI standard orientation to the orientation of the BBBMINI-PCB IMU.