### PR TITLE
Navio RCInput deinitialization

### DIFF
--- a/libraries/AP_HAL/RCInput.h
+++ b/libraries/AP_HAL/RCInput.h
@@ -16,6 +16,7 @@ public:
      * in the C++ type system.)
      */
     virtual void init(void* implspecific) = 0;
+    virtual void deinit() {};
 
     /**
      * Return true if there has been new input since the last read()

--- a/libraries/AP_HAL_Linux/RCInput_Navio.cpp
+++ b/libraries/AP_HAL_Linux/RCInput_Navio.cpp
@@ -411,6 +411,11 @@ LinuxRCInput_Navio::~LinuxRCInput_Navio()
     delete con_blocks;
 }
 
+void LinuxRCInput_Navio::deinit()
+{
+    stop_dma_and_exit(0);
+}
+
 //Initializing necessary registers
 void LinuxRCInput_Navio::init_registers()
 {

--- a/libraries/AP_HAL_Linux/RCInput_Navio.h
+++ b/libraries/AP_HAL_Linux/RCInput_Navio.h
@@ -126,6 +126,7 @@ private:
     static void stop_dma_and_exit(int param);
     void set_sigaction();
     void set_physical_addresses(int version);
+    void deinit() override;
 
 };
 

--- a/libraries/AP_HAL_Linux/RCInput_Navio.h
+++ b/libraries/AP_HAL_Linux/RCInput_Navio.h
@@ -123,7 +123,8 @@ private:
     void init_PCM();
     void init_DMA();
     void init_buffer();
-    static void stop_dma_and_exit(int param);
+    static void stop_dma();
+    static void termination_handler(int signum);
     void set_sigaction();
     void set_physical_addresses(int version);
     void deinit() override;

--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -394,6 +394,7 @@ void LinuxScheduler::panic(const prog_char_t *errormsg)
 {
     write(1, errormsg, strlen(errormsg));
     write(1, "\n", 1);
+    hal.rcin->deinit();
     hal.scheduler->delay_microseconds(10000);
     exit(1);
 }


### PR DESCRIPTION
The issue has already come up. There's no deinitialization mechanisms at the moment. As APM is rather software than firmware on Linux, there're some clean-up work that needs to be done. The signal handling framework might also be needed. 

RCInput driver for Navio does need that to stop DMA in case of an error. 