### PR TITLE
AP_Math/Location:

### DIFF
--- a/libraries/AP_Math/location.cpp
+++ b/libraries/AP_Math/location.cpp
@@ -33,29 +33,13 @@
 // inverse of LOCATION_SCALING_FACTOR
 #define LOCATION_SCALING_FACTOR_INV 89.83204953368922f
 
+
+// Is only used in ArduCopter (which doesn't support ATMega any more)
 float longitude_scale(const struct Location &loc)
 {
-#if HAL_CPU_CLASS < HAL_CPU_CLASS_150
-    static int32_t last_lat;
-    static float scale = 1.0;
-    // don't optimise on faster CPUs. It causes some minor errors on Replay
-    if (labs(last_lat - loc.lat) < 100000) {
-        // we are within 0.01 degrees (about 1km) of the
-        // same latitude. We can avoid the cos() and return
-        // the same scale factor.
-        return scale;
-    }
-    scale = cosf(loc.lat * 1.0e-7f * DEG_TO_RAD);
-    scale = constrain_float(scale, 0.01f, 1.0f);
-    last_lat = loc.lat;
-    return scale;
-#else
     float scale = cosf(loc.lat * 1.0e-7f * DEG_TO_RAD);
     return constrain_float(scale, 0.01f, 1.0f);
-#endif
 }
-
-
 
 // return distance in meters between two locations
 float get_distance(const struct Location &loc1, const struct Location &loc2)


### PR DESCRIPTION
The function seems to be called only from ArduCopter. 
As it does not support anymore slower boards, one may remove the statics and make the function thread safe.