### PR TITLE
AP_Common:

### DIFF
--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -80,10 +80,22 @@
 #define LOWBYTE(i) ((uint8_t)(i))
 #define HIGHBYTE(i) ((uint8_t)(((uint16_t)(i))>>8))
 
-#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
+/*
+ * Returns the number of elements in a array
+ */
+#if __cplusplus < 199711L // < cxx11
+    template <typename T, size_t N>
+    char(&COUNTOF_REQUIRES_ARRAY_ARGUMENT(T(&)[N]))[N];
+    #define ARRAY_SIZE(x) sizeof(COUNTOF_REQUIRES_ARRAY_ARGUMENT(x))
+#else  // >= cxx11
+    template <typename T, size_t N>
+    constexpr size_t ARRAY_SIZE(T const (&)[N]) noexcept
+    {
+        return N;
+    }
+#endif
 
 // @}
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @name	Types

--- a/libraries/AP_HAL_Linux/SPIDriver.cpp
+++ b/libraries/AP_HAL_Linux/SPIDriver.cpp
@@ -51,8 +51,6 @@ LinuxSPIDeviceDriver LinuxSPIDeviceManager::_device[] = {
 LinuxSPIDeviceDriver LinuxSPIDeviceManager::_device[0];
 #endif
 
-#define LINUX_SPI_DEVICE_NUM_DEVICES ARRAY_SIZE(LinuxSPIDeviceManager::_device)
-
 // have a separate semaphore per bus
 LinuxSemaphore LinuxSPIDeviceManager::_semaphore[LINUX_SPI_MAX_BUSES];
 
@@ -128,7 +126,7 @@ void LinuxSPIDeviceDriver::transfer(const uint8_t *data, uint16_t len)
 
 void LinuxSPIDeviceManager::init(void *)
 {
-    for (uint8_t i=0; i<LINUX_SPI_DEVICE_NUM_DEVICES; i++) {
+    for (uint8_t i=0; i<ARRAY_SIZE(LinuxSPIDeviceManager::_device); i++) {
         if (_device[i]._bus >= LINUX_SPI_MAX_BUSES) {
             hal.scheduler->panic("SPIDriver: invalid bus number");
         }
@@ -151,13 +149,13 @@ void LinuxSPIDeviceManager::init(void *)
 void LinuxSPIDeviceManager::cs_assert(enum AP_HAL::SPIDevice type)
 {
     uint16_t bus = 0, i;
-    for (i=0; i<LINUX_SPI_DEVICE_NUM_DEVICES; i++) {
+    for (i=0; i<ARRAY_SIZE(LinuxSPIDeviceManager::_device); i++) {
         if (_device[i]._type == type) {
             bus = _device[i]._bus;
             break;
         }
     }
-    if (i == LINUX_SPI_DEVICE_NUM_DEVICES) {
+    if (i == ARRAY_SIZE(LinuxSPIDeviceManager::_device)) {
         hal.scheduler->panic("Bad device type");
     }
 
@@ -165,7 +163,7 @@ void LinuxSPIDeviceManager::cs_assert(enum AP_HAL::SPIDevice type)
     if(_device[i]._cs_pin == SPI_CS_KERNEL)
         return;
 
-    for (i=0; i<LINUX_SPI_DEVICE_NUM_DEVICES; i++) {
+    for (i=0; i<ARRAY_SIZE(LinuxSPIDeviceManager::_device); i++) {
         if (_device[i]._bus != bus) {
             // not the same bus
             continue;
@@ -177,7 +175,7 @@ void LinuxSPIDeviceManager::cs_assert(enum AP_HAL::SPIDevice type)
             }
         }
     }
-    for (i=0; i<LINUX_SPI_DEVICE_NUM_DEVICES; i++) {
+    for (i=0; i<ARRAY_SIZE(LinuxSPIDeviceManager::_device); i++) {
         if (_device[i]._type == type) {
             _device[i]._cs->write(0);
         }
@@ -187,13 +185,13 @@ void LinuxSPIDeviceManager::cs_assert(enum AP_HAL::SPIDevice type)
 void LinuxSPIDeviceManager::cs_release(enum AP_HAL::SPIDevice type)
 {
     uint16_t bus = 0, i;
-    for (i=0; i<LINUX_SPI_DEVICE_NUM_DEVICES; i++) {
+    for (i=0; i<ARRAY_SIZE(LinuxSPIDeviceManager::_device); i++) {
         if (_device[i]._type == type) {
             bus = _device[i]._bus;
             break;
         }
     }
-    if (i == LINUX_SPI_DEVICE_NUM_DEVICES) {
+    if (i == ARRAY_SIZE(LinuxSPIDeviceManager::_device)) {
         hal.scheduler->panic("Bad device type");
     }
 
@@ -201,7 +199,7 @@ void LinuxSPIDeviceManager::cs_release(enum AP_HAL::SPIDevice type)
     if(_device[i]._cs_pin == SPI_CS_KERNEL)
         return;
 
-    for (i=0; i<LINUX_SPI_DEVICE_NUM_DEVICES; i++) {
+    for (i=0; i<ARRAY_SIZE(LinuxSPIDeviceManager::_device); i++) {
         if (_device[i]._bus != bus) {
             // not the same bus
             continue;
@@ -241,7 +239,7 @@ void LinuxSPIDeviceManager::transaction(LinuxSPIDeviceDriver &driver, const uint
  */
 AP_HAL::SPIDeviceDriver *LinuxSPIDeviceManager::device(enum AP_HAL::SPIDevice dev)
 {
-    for (uint8_t i=0; i<LINUX_SPI_DEVICE_NUM_DEVICES; i++) {
+    for (uint8_t i=0; i<ARRAY_SIZE(LinuxSPIDeviceManager::_device); i++) {
         if (_device[i]._type == dev) {
             return &_device[i];
         }


### PR DESCRIPTION
The good old ARRAY_SIZE macro is dangerous.
Because macros carry no type, the implementation is not robust and bad usage won't be detected at compilation time.
Macros can't be overloaded which would be useful for containers.
There are potential namespace collision issues.

Signed-off-by: Daniel Frenzel <dgdanielf@gmail.com>