### PR TITLE
DataFlash: CLI log dumping - don't truncate lines that contain doubles

### DIFF
--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -374,6 +374,16 @@ void DataFlash_Backend::_print_log_entry(uint8_t msg_type,
             ofs += sizeof(v);
             break;
         }
+        case 'd': {
+            double v;
+            memcpy(&v, &pkt[ofs], sizeof(v));
+            // note that %f here *really* means a single-precision
+            // float, so we lose precision printing this double out
+            // dtoa_engine needed....
+            port->printf_P(PSTR("%f"), (double)v);
+            ofs += sizeof(v);
+            break;
+        }
         case 'c': {
             int16_t v;
             memcpy(&v, &pkt[ofs], sizeof(v));


### PR DESCRIPTION
We currently print doubles out as if they were floats.  The ftoa_engine isn't something to replicate for doubles lightly!