### PR TITLE
Prevent position jump when taking off in loiter using optical flow

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -1005,6 +1005,7 @@ void NavEKF::SelectFlowFusion()
         flowRadXY[0]        = 0.0f;
         flowRadXY[1]        = 0.0f;
         omegaAcrossFlowTime.zero();
+        flowDataValid = true;
     }
     // If the flow measurements have been rejected for too long and we are relying on them, then revert to constant position mode
     if ((flowSensorTimeout || flowFusionTimeout) && PV_AidingMode == AID_RELATIVE) {


### PR DESCRIPTION
Although we were zeroing the flow measurements to constrain the position drift between arming and takeoff, the flow data could still have an invalid status which would casue the EKF to not fuse the zeroed flow measurements, allowing the position to drift and causing a sideways jump when taking off in loiter .

Note, it takes about 2 seconds for the EKF solution to settle after arming, so there is still a possibility of some movement if the copter is armed and jumped into the air immediately.