### PR TITLE
Copter: add preliminary capability bitmask

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -943,6 +943,7 @@ private:
     void print_flight_mode(AP_HAL::BetterStream *port, uint8_t mode);
     void log_init(void);
     void run_cli(AP_HAL::UARTDriver *port);
+    uint64_t get_capabilities(void);
 
 public:
     void mavlink_delay_cb();

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1416,7 +1416,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
 
         case MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES: {
             if (is_equal(packet.param1,1.0f)) {
-                copter.gcs[chan-MAVLINK_COMM_0].send_autopilot_version();
+                copter.gcs[chan-MAVLINK_COMM_0].send_autopilot_version(copter.get_capabilities());
                 result = MAV_RESULT_ACCEPTED;
             }
             break;
@@ -1714,7 +1714,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
 #endif // AC_RALLY == ENABLED
 
     case MAVLINK_MSG_ID_AUTOPILOT_VERSION_REQUEST:
-        copter.gcs[chan-MAVLINK_COMM_0].send_autopilot_version();
+        copter.gcs[chan-MAVLINK_COMM_0].send_autopilot_version(copter.get_capabilities());
         break;
 
     case MAVLINK_MSG_ID_LED_CONTROL:

--- a/ArduCopter/capabilities.cpp
+++ b/ArduCopter/capabilities.cpp
@@ -1,0 +1,18 @@
+// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+
+#include "Copter.h"
+
+uint64_t Copter::get_capabilities(void)
+{
+    uint64_t capabilities = MAV_PROTOCOL_CAPABILITY_MISSION_FLOAT
+                 | MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT
+                 | MAV_PROTOCOL_CAPABILITY_SET_ATTITUDE_TARGET
+                 | MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_LOCAL_NED
+                 | MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_GLOBAL_INT;
+
+    #if AP_TERRAIN_AVAILABLE
+        capabilities |= MAV_PROTOCOL_CAPABILITY_TERRAIN;
+    #endif
+
+    return capabilities;
+}

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -138,7 +138,7 @@ public:
 #if AP_AHRS_NAVEKF_AVAILABLE
     void send_opticalflow(AP_AHRS_NavEKF &ahrs, const OpticalFlow &optflow);
 #endif
-    void send_autopilot_version(void) const;
+    void send_autopilot_version(uint64_t capabilities = 0) const;
     void send_local_position(const AP_AHRS &ahrs) const;
     void send_vibration(const AP_InertialSensor &ins) const;
     void send_mission_item_reached(uint16_t seq) const;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1245,9 +1245,8 @@ void GCS_MAVLINK::send_opticalflow(AP_AHRS_NavEKF &ahrs, const OpticalFlow &optf
 /*
   send AUTOPILOT_VERSION packet
  */
-void GCS_MAVLINK::send_autopilot_version(void) const
+void GCS_MAVLINK::send_autopilot_version(uint64_t capabilities) const
 {
-    uint16_t capabilities = 0;
     uint32_t flight_sw_version = 0;
     uint32_t middleware_sw_version = 0;
     uint32_t os_sw_version = 0;


### PR DESCRIPTION
@rmackay9 I'll keep going on this tomorrow and actually start adding new things.  I just wanted to check if this is at least the right place to do this.  Unfortunately, I think I have to do this for each vehicle type, because they each define their own `GCS_MAVLINK::send_autopilot_version` in GCS_Common.cpp.