### PR TITLE
AP_Notify: don't manually define number of notify devices

### DIFF
--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -26,15 +26,15 @@ struct AP_Notify::notify_events_type AP_Notify::events;
     ToneAlarm_PX4 tonealarm;
 #if OREOLED_ENABLED
     OreoLED_PX4 oreoled;
-    NotifyDevice *AP_Notify::_devices[CONFIG_NOTIFY_DEVICES_COUNT] = {&boardled, &toshibaled, &tonealarm, &oreoled};
+    NotifyDevice *AP_Notify::_devices[] = {&boardled, &toshibaled, &tonealarm, &oreoled};
 #else
-    NotifyDevice *AP_Notify::_devices[CONFIG_NOTIFY_DEVICES_COUNT] = {&boardled, &toshibaled, &tonealarm};
+    NotifyDevice *AP_Notify::_devices[] = {&boardled, &toshibaled, &tonealarm};
 #endif
 #elif CONFIG_HAL_BOARD == HAL_BOARD_APM1 || CONFIG_HAL_BOARD == HAL_BOARD_APM2 
     AP_BoardLED boardled;
     ExternalLED externalled;
     Buzzer buzzer;
-    NotifyDevice *AP_Notify::_devices[CONFIG_NOTIFY_DEVICES_COUNT] = {&boardled, &externalled, &buzzer};
+    NotifyDevice *AP_Notify::_devices[] = {&boardled, &externalled, &buzzer};
 #elif CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
     Buzzer buzzer;
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_VRBRAIN_V45
@@ -44,24 +44,26 @@ struct AP_Notify::notify_events_type AP_Notify::events;
 #endif
     ToshibaLED_I2C toshibaled;
     ExternalLED externalled;
-    NotifyDevice *AP_Notify::_devices[CONFIG_NOTIFY_DEVICES_COUNT] = {&boardled, &toshibaled, &externalled, &buzzer};
+    NotifyDevice *AP_Notify::_devices[] = {&boardled, &toshibaled, &externalled, &buzzer};
 #elif CONFIG_HAL_BOARD == HAL_BOARD_LINUX
     #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO
         AP_BoardLED boardled;
         NavioLED_I2C navioled;
         ToshibaLED_I2C toshibaled;
-        NotifyDevice *AP_Notify::_devices[CONFIG_NOTIFY_DEVICES_COUNT] = {&boardled, &navioled, &toshibaled};
+        NotifyDevice *AP_Notify::_devices[] = {&boardled, &navioled, &toshibaled};
     #else
         AP_BoardLED boardled;
         ToshibaLED_I2C toshibaled;
         ToneAlarm_Linux tonealarm;
-        NotifyDevice *AP_Notify::_devices[CONFIG_NOTIFY_DEVICES_COUNT] = {&boardled, &toshibaled, &tonealarm};
+        NotifyDevice *AP_Notify::_devices[] = {&boardled, &toshibaled, &tonealarm};
     #endif
 #else
     AP_BoardLED boardled;
     ToshibaLED_I2C toshibaled;
-    NotifyDevice *AP_Notify::_devices[CONFIG_NOTIFY_DEVICES_COUNT] = {&boardled, &toshibaled};
+    NotifyDevice *AP_Notify::_devices[] = {&boardled, &toshibaled};
 #endif
+
+#define CONFIG_NOTIFY_DEVICES_COUNT (ARRAY_SIZE(AP_Notify::_devices))
 
 // initialisation
 void AP_Notify::init(bool enable_external_leds)
@@ -72,7 +74,7 @@ void AP_Notify::init(bool enable_external_leds)
 
     AP_Notify::flags.external_leds = enable_external_leds;
 
-    for (int i = 0; i < CONFIG_NOTIFY_DEVICES_COUNT; i++) {
+    for (unsigned int i = 0; i < CONFIG_NOTIFY_DEVICES_COUNT; i++) {
         _devices[i]->init();
     }
 }
@@ -80,7 +82,7 @@ void AP_Notify::init(bool enable_external_leds)
 // main update function, called at 50Hz
 void AP_Notify::update(void)
 {
-    for (int i = 0; i < CONFIG_NOTIFY_DEVICES_COUNT; i++) {
+    for (unsigned int i = 0; i < CONFIG_NOTIFY_DEVICES_COUNT; i++) {
         _devices[i]->update();
     }
 
@@ -91,7 +93,7 @@ void AP_Notify::update(void)
 // handle a LED_CONTROL message
 void AP_Notify::handle_led_control(mavlink_message_t *msg)
 {
-    for (int i = 0; i < CONFIG_NOTIFY_DEVICES_COUNT; i++) {
+    for (unsigned int i = 0; i < CONFIG_NOTIFY_DEVICES_COUNT; i++) {
         _devices[i]->handle_led_control(msg);
     }
 }

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -36,22 +36,6 @@
  # define OREOLED_ENABLED   0   // set to 1 to enable OreoLEDs
 #endif
 
-#if CONFIG_HAL_BOARD == HAL_BOARD_PX4
-    #define CONFIG_NOTIFY_DEVICES_COUNT (3+OREOLED_ENABLED)
-#elif CONFIG_HAL_BOARD == HAL_BOARD_APM1 || CONFIG_HAL_BOARD == HAL_BOARD_APM2 
-    #define CONFIG_NOTIFY_DEVICES_COUNT 3
-#elif CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
-    #define CONFIG_NOTIFY_DEVICES_COUNT 4
-#elif CONFIG_HAL_BOARD == HAL_BOARD_LINUX
-    #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO
-        #define CONFIG_NOTIFY_DEVICES_COUNT 3
-    #else
-        #define CONFIG_NOTIFY_DEVICES_COUNT 3
-    #endif
-#else
-    #define CONFIG_NOTIFY_DEVICES_COUNT 2
-#endif
-
 class AP_Notify
 {
 public:
@@ -105,7 +89,7 @@ public:
     static void handle_led_control(mavlink_message_t* msg);
 
 private:
-    static NotifyDevice* _devices[CONFIG_NOTIFY_DEVICES_COUNT];
+    static NotifyDevice* _devices[];
 };
 
 #endif    // __AP_NOTIFY_H__


### PR DESCRIPTION
Like b211b86 (AP_HAL_Linux: don't manually define number of spi devices)
did for spi.