### PR TITLE
SITL: implement hardware airspeed failures

### DIFF
--- a/libraries/AP_HAL_SITL/sitl_ins.cpp
+++ b/libraries/AP_HAL_SITL/sitl_ins.cpp
@@ -210,7 +210,8 @@ void SITL_State::_update_ins(float roll, 	float pitch, 	float yaw,		// Relative 
 
 
     sonar_pin_value    = _ground_sonar();
-    airspeed_pin_value = _airspeed_sensor(airspeed + (_sitl->aspd_noise * _rand_float()));
+    float airspeed_simulated = (fabsf(_sitl->aspd_fail) > 1.0e-6f) ? _sitl->aspd_fail : airspeed;
+    airspeed_pin_value = _airspeed_sensor(airspeed_simulated + (_sitl->aspd_noise * _rand_float()));
 }
 
 #endif

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -70,6 +70,7 @@ const AP_Param::GroupInfo SITL::var_info[] PROGMEM = {
     AP_GROUPINFO("WIND_DELAY",    40, SITL,  wind_delay, 0),
     AP_GROUPINFO("MAG_OFS",       41, SITL,  mag_ofs, 0),
     AP_GROUPINFO("ACC2_RND",      42, SITL,  accel2_noise, 0),
+    AP_GROUPINFO("ARSP_FAIL",     43, SITL,  aspd_fail, 0),
     AP_GROUPEND
 };
 

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -62,6 +62,8 @@ public:
     AP_Float accel2_noise; // in m/s/s
     AP_Vector3f accel_bias; // in m/s/s
     AP_Float aspd_noise;  // in m/s
+    AP_Int8 aspd_fail;    // pitot tube failure
+
     AP_Float mag_noise;   // in mag units (earth field is 818)
     AP_Float mag_error;   // in degrees
     AP_Vector3f mag_mot;  // in mag units per amp


### PR DESCRIPTION
Allow SITL testing of pitot tube hardware failures. SIM_ARSP_FAIL (float) sets the m/s value you want the airspeed to report. Use zero (0) to use the normally generated airspeed, otherwise it is set statically (plus the noise) at the value you set which will simulate a clogged tube