### PR TITLE
Rover: Merged a bug fix from Plane.

### DIFF
--- a/APMrover2/control_modes.cpp
+++ b/APMrover2/control_modes.cpp
@@ -50,7 +50,7 @@ uint8_t Rover::readSwitch(void){
 
 void Rover::reset_control_switch()
 {
-	oldSwitchPosition = 0;
+	oldSwitchPosition = 254;
 	read_control_switch();
 }
 


### PR DESCRIPTION
Merged a bug fix where mode would not revert on geo-fence disable.
The mode would not revert if the switch was in position 0.
Geofencing will soon be in Rover and I didn't want to forget this bug
and chase it later so committing it now.  It works fine in Rover now
even though the geofencing code isn't in yet.