### PR TITLE
sim_vehicle: Made autotest conditional more portable.

### DIFF
--- a/Tools/autotest/sim_vehicle.sh
+++ b/Tools/autotest/sim_vehicle.sh
@@ -282,9 +282,9 @@ if [ -n "$OVERRIDE_BUILD_TARGET" ]; then
 fi
 
 autotest="../Tools/autotest"
-[ -d "$autotest" ] && {
+if [ ! -d "$autotest" ]; then
     autotest=$(dirname $(readlink -e $0))
-}
+fi
 pushd $autotest/../../$VEHICLE || {
     echo "Failed to change to vehicle directory for $VEHICLE"
     usage


### PR DESCRIPTION
For some reason the syntax did not work for me.  I changed the conditional for setting the autotest directory to a standard "if" and it now works on my machine.

The problem appeared to be that autotest did not get set to $(dirname $(readlink -e $0)) when "../Tools/autotest" did not exist.  I'm unsure if this happens on all versions of bash or not.