### PR TITLE
AK8963 improvements

### DIFF
--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -37,22 +37,10 @@
 #define MPUREG_EXT_SENS_DATA_00     0x49
 #define MPUREG_I2C_SLV0_DO          0x63
 
-#define MPUREG_PWR_MGMT_1                               0x6B
-#       define BIT_PWR_MGMT_1_CLK_INTERNAL              0x00            // clock set to internal 8Mhz oscillator
-#       define BIT_PWR_MGMT_1_CLK_XGYRO                 0x01            // PLL with X axis gyroscope reference
-#       define BIT_PWR_MGMT_1_CLK_YGYRO                 0x02            // PLL with Y axis gyroscope reference
-#       define BIT_PWR_MGMT_1_CLK_ZGYRO                 0x03            // PLL with Z axis gyroscope reference
-#       define BIT_PWR_MGMT_1_CLK_EXT32KHZ              0x04            // PLL with external 32.768kHz reference
-#       define BIT_PWR_MGMT_1_CLK_EXT19MHZ              0x05            // PLL with external 19.2MHz reference
-#       define BIT_PWR_MGMT_1_CLK_STOP                  0x07            // Stops the clock and keeps the timing generator in reset
-#       define BIT_PWR_MGMT_1_TEMP_DIS                  0x08            // disable temperature sensor
-#       define BIT_PWR_MGMT_1_CYCLE                     0x20            // put sensor into cycle mode.  cycles between sleep mode and waking up to take a single sample of data from active sensors at a rate determined by LP_WAKE_CTRL
-#       define BIT_PWR_MGMT_1_SLEEP                     0x40            // put sensor into low power sleep mode
-#       define BIT_PWR_MGMT_1_DEVICE_RESET              0x80            // reset entire device
-
 /* bit definitions for MPUREG_USER_CTRL */
 #define MPUREG_USER_CTRL                                0x6A
-#       define BIT_USER_CTRL_I2C_MST_EN                 0x20            /* Enable MPU to act as the I2C Master to external slave sensors */
+/* Enable MPU to act as the I2C Master to external slave sensors */
+#       define BIT_USER_CTRL_I2C_MST_EN                 0x20
 #       define BIT_USER_CTRL_I2C_IF_DIS                 0x10
 
 /* bit definitions for MPUREG_MST_CTRL */
@@ -76,19 +64,16 @@
 
 /* bit definitions for AK8963 CNTL1 */
 #define AK8963_CNTL1                                    0x0A
-#        define    AK8963_CONTINUOUS_MODE1              0x2
-#        define    AK8963_CONTINUOUS_MODE2              0x6
-#        define    AK8963_SELFTEST_MODE                 0x8
-#        define    AK8963_POWERDOWN_MODE                0x0
-#        define    AK8963_FUSE_MODE                     0xf
+#        define    AK8963_CONTINUOUS_MODE1              0x02
+#        define    AK8963_CONTINUOUS_MODE2              0x06
+#        define    AK8963_SELFTEST_MODE                 0x08
+#        define    AK8963_POWERDOWN_MODE                0x00
+#        define    AK8963_FUSE_MODE                     0x0f
 #        define    AK8963_16BIT_ADC                     0x10
 #        define    AK8963_14BIT_ADC                     0x00
 
 #define AK8963_CNTL2                                    0x0B
 #        define AK8963_RESET                            0x01
-
-#define AK8963_ASTC                                     0x0C
-#        define AK8983_SELFTEST_MAGNETIC_FIELD_ON       0x40
 
 #define AK8963_ASAX                                     0x10
 

--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -50,12 +50,6 @@
 #define AK8963_WIA                                      0x00
 #        define AK8963_Device_ID                        0x48
 
-#define AK8963_INFO                                     0x01
-
-#define AK8963_ST1                                      0x02
-#        define AK8963_DRDY                             0x01
-#        define AK8963_DOR                              0x02
-
 #define AK8963_HXL                                      0x03
 
 /* bit definitions for AK8963 CNTL1 */
@@ -464,7 +458,7 @@ bool AP_AK8963_SerialBus_MPU9250::start_measurements()
      * master: we will get the result directly from MPU9250's registers starting
      * from MPUREG_EXT_SENS_DATA_00 when read_raw() is called */
     _write(MPUREG_I2C_SLV0_ADDR, AK8963_I2C_ADDR | READ_FLAG);
-    _write(MPUREG_I2C_SLV0_REG, AK8963_INFO);
+    _write(MPUREG_I2C_SLV0_REG, AK8963_HXL);
     _write(MPUREG_I2C_SLV0_CTRL, I2C_SLV0_EN | count);
 
     return true;
@@ -494,7 +488,7 @@ void AP_AK8963_SerialBus_I2C::register_read(uint8_t address, uint8_t *value, uin
 
 void AP_AK8963_SerialBus_I2C::read_raw(struct raw_value *rv)
 {
-    _i2c->readRegisters(_addr, AK8963_INFO, sizeof(*rv), (uint8_t *) rv);
+    _i2c->readRegisters(_addr, AK8963_HXL, sizeof(*rv), (uint8_t *) rv);
 }
 
 AP_HAL::Semaphore * AP_AK8963_SerialBus_I2C::get_semaphore()

--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -14,14 +14,6 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/*
- *       AP_Compass_AK8963.cpp 
- *       Code by Georgii Staroselskii. Emlid.com
- *
- *       Sensor is connected to SPI port
- *
- */
-
 #include <AP_Math.h>
 #include <AP_HAL.h>
 

--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -120,7 +120,6 @@ AP_Compass_AK8963::AP_Compass_AK8963(Compass &compass, AP_AK8963_SerialBus *bus)
 {
     _mag_x_accum =_mag_y_accum = _mag_z_accum = 0;
     _accum_count = 0;
-    _magnetometer_adc_resolution = AK8963_16BIT_ADC;
 }
 
 AP_Compass_Backend *AP_Compass_AK8963::detect_mpu9250(Compass &compass)
@@ -294,7 +293,7 @@ bool AP_Compass_AK8963::_check_id()
 }
 
 bool AP_Compass_AK8963::_configure() {
-    _bus->register_write(AK8963_CNTL1, AK8963_CONTINUOUS_MODE2 | _magnetometer_adc_resolution);
+    _bus->register_write(AK8963_CNTL1, AK8963_CONTINUOUS_MODE2 | AK8963_16BIT_ADC);
     return true;
 }
 
@@ -310,7 +309,7 @@ bool AP_Compass_AK8963::_calibrate()
     uint8_t cntl1 = _bus->register_read(AK8963_CNTL1);
 
     /* Enable FUSE-mode in order to be able to read calibration data */
-    _bus->register_write(AK8963_CNTL1, AK8963_FUSE_MODE | _magnetometer_adc_resolution);
+    _bus->register_write(AK8963_CNTL1, AK8963_FUSE_MODE | AK8963_16BIT_ADC);
 
     uint8_t response[3];
     _bus->register_read(AK8963_ASAX, response, 3);

--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -102,8 +102,7 @@ AP_Compass_AK8963::AP_Compass_AK8963(Compass &compass, AP_AK8963_SerialBus *bus)
     _last_accum_time(0),
     _bus(bus)
 {
-    _mag_x_accum =_mag_y_accum = _mag_z_accum = 0;
-    _accum_count = 0;
+    _reset_filter();
 }
 
 AP_Compass_Backend *AP_Compass_AK8963::detect_mpu9250(Compass &compass)
@@ -213,20 +212,37 @@ void AP_Compass_AK8963::read()
         return;
     }
 
-    /* Update */
-    Vector3f field(_mag_x_accum * _magnetometer_ASA[0],
-                   _mag_y_accum * _magnetometer_ASA[1],
-                   _mag_z_accum * _magnetometer_ASA[2]);
+    auto field = _get_filtered_field();
+    _make_factory_sensitivity_adjustment(field);
 
-    field /= _accum_count;
-    _mag_x_accum = _mag_y_accum = _mag_z_accum = 0;
-    _accum_count = 0;
+    _reset_filter();
 
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BEBOP
     field.rotate(ROTATION_YAW_90);
 #endif
 
     publish_field(field, _compass_instance);
+}
+
+Vector3f AP_Compass_AK8963::_get_filtered_field() const
+{
+    Vector3f field(_mag_x_accum, _mag_y_accum, _mag_z_accum);
+    field /= _accum_count;
+
+    return field;
+}
+
+void AP_Compass_AK8963::_reset_filter()
+{
+    _mag_x_accum = _mag_y_accum = _mag_z_accum = 0;
+    _accum_count = 0;
+}
+
+void AP_Compass_AK8963::_make_factory_sensitivity_adjustment(Vector3f& field) const
+{
+    field.x *= _magnetometer_ASA[0];
+    field.y *= _magnetometer_ASA[1];
+    field.z *= _magnetometer_ASA[2];
 }
 
 void AP_Compass_AK8963::_update()

--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -397,25 +397,22 @@ void AP_AK8963_SerialBus_MPU9250::register_read(uint8_t address, uint8_t *value,
 
 void AP_AK8963_SerialBus_MPU9250::_read(uint8_t address, uint8_t *buf, uint32_t count)
 {
-    ASSERT(count < 150);
-    uint8_t tx[150];
-    uint8_t rx[150];
+    ASSERT(count < 32);
 
-    tx[0] = address | READ_FLAG;
-    tx[1] = 0;
+    address |= READ_FLAG;
+    uint8_t tx[32] = { address, };
+    uint8_t rx[32] = { };
+
     _spi->transaction(tx, rx, count + 1);
-
     memcpy(buf, rx + 1, count);
 }
 
 void AP_AK8963_SerialBus_MPU9250::_write(uint8_t address, const uint8_t *buf, uint32_t count)
 {
     ASSERT(count < 2);
-    uint8_t tx[2];
+    uint8_t tx[2] = { address, };
 
-    tx[0] = address;
     memcpy(tx+1, buf, count);
-
     _spi->transaction(tx, NULL, count + 1);
 }
 

--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -41,6 +41,10 @@
 #        define I2C_MST_CLOCK_400KHZ                    0x0D
 #        define I2C_MST_CLOCK_258KHZ                    0x08
 
+#define MPUREG_I2C_SLV4_CTRL                            0x34
+#define MPUREG_I2C_MST_DELAY_CTRL                       0x67
+#        define I2C_SLV0_DLY_EN                         0x01
+
 #define AK8963_I2C_ADDR                                 0x0c
 
 #define AK8963_WIA                                      0x00
@@ -450,6 +454,11 @@ AP_HAL::Semaphore * AP_AK8963_SerialBus_MPU9250::get_semaphore()
 bool AP_AK8963_SerialBus_MPU9250::start_measurements()
 {
     const uint8_t count = sizeof(struct raw_value);
+
+    /* Don't sample AK8963 at MPU9250's sample rate. See MPU9250's datasheet
+     * about registers below and registers 73-96, External Sensor Data */
+    _write(MPUREG_I2C_SLV4_CTRL, 31);
+    _write(MPUREG_I2C_MST_DELAY_CTRL, I2C_SLV0_DLY_EN);
 
     /* Configure the registers from AK8963 that will be read by MPU9250's
      * master: we will get the result directly from MPU9250's registers starting

--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -378,17 +378,18 @@ AP_AK8963_SerialBus_MPU9250::AP_AK8963_SerialBus_MPU9250()
 
 void AP_AK8963_SerialBus_MPU9250::register_write(uint8_t address, uint8_t value)
 {
-    _write(MPUREG_I2C_SLV0_ADDR, AK8963_I2C_ADDR);  /* Set the I2C slave addres of AK8963 and set for register_write. */
-    _write(MPUREG_I2C_SLV0_REG, address); /* I2C slave 0 register address from where to begin data transfer */
-    _write(MPUREG_I2C_SLV0_DO, value); /* Register value to continuous measurement in 16-bit */
-    _write(MPUREG_I2C_SLV0_CTRL, I2C_SLV0_EN | 0x01); /* Enable I2C and set 1 byte */
+    const uint8_t count = 1;
+    _write(MPUREG_I2C_SLV0_ADDR, AK8963_I2C_ADDR);
+    _write(MPUREG_I2C_SLV0_REG, address);
+    _write(MPUREG_I2C_SLV0_DO, value);
+    _write(MPUREG_I2C_SLV0_CTRL, I2C_SLV0_EN | count);
 }
 
 void AP_AK8963_SerialBus_MPU9250::register_read(uint8_t address, uint8_t *value, uint8_t count)
 {
-    _write(MPUREG_I2C_SLV0_ADDR, AK8963_I2C_ADDR | READ_FLAG);  /* Set the I2C slave addres of AK8963 and set for read. */
-    _write(MPUREG_I2C_SLV0_REG, address); /* I2C slave 0 register address from where to begin data transfer */
-    _write(MPUREG_I2C_SLV0_CTRL, I2C_SLV0_EN | count); /* Enable I2C and set @count byte */
+    _write(MPUREG_I2C_SLV0_ADDR, AK8963_I2C_ADDR | READ_FLAG);
+    _write(MPUREG_I2C_SLV0_REG, address);
+    _write(MPUREG_I2C_SLV0_CTRL, I2C_SLV0_EN | count);
 
     hal.scheduler->delay(10);
     _read(MPUREG_EXT_SENS_DATA_00, value, count);
@@ -445,9 +446,12 @@ bool AP_AK8963_SerialBus_MPU9250::start_measurements()
 {
     const uint8_t count = sizeof(struct raw_value);
 
-    _write(MPUREG_I2C_SLV0_ADDR, AK8963_I2C_ADDR | READ_FLAG);  /* Set the I2C slave addres of AK8963 and set for read. */
-    _write(MPUREG_I2C_SLV0_REG, AK8963_INFO); /* I2C slave 0 register address from where to begin data transfer */
-    _write(MPUREG_I2C_SLV0_CTRL, I2C_SLV0_EN | count); /* Enable I2C and set @count byte */
+    /* Configure the registers from AK8963 that will be read by MPU9250's
+     * master: we will get the result directly from MPU9250's registers starting
+     * from MPUREG_EXT_SENS_DATA_00 when read_raw() is called */
+    _write(MPUREG_I2C_SLV0_ADDR, AK8963_I2C_ADDR | READ_FLAG);
+    _write(MPUREG_I2C_SLV0_REG, AK8963_INFO);
+    _write(MPUREG_I2C_SLV0_CTRL, I2C_SLV0_EN | count);
 
     return true;
 }

--- a/libraries/AP_Compass/AP_Compass_AK8963.h
+++ b/libraries/AP_Compass/AP_Compass_AK8963.h
@@ -27,8 +27,8 @@ public:
     }
     virtual void register_write(uint8_t address, uint8_t value) = 0;
     virtual AP_HAL::Semaphore* get_semaphore() = 0;
-    virtual bool start_conversion() = 0;
     virtual bool configure() = 0;
+    virtual bool start_measurements() = 0;
     virtual void read_raw(struct raw_value *rv) = 0;
     virtual uint32_t get_dev_id() = 0;
 };
@@ -55,7 +55,7 @@ private:
     } state_t;
 
     bool _reset();
-    bool _configure();
+    bool _setup_mode();
     bool _check_id();
     bool _calibrate();
 
@@ -91,8 +91,8 @@ public:
     void register_read(uint8_t address, uint8_t *value, uint8_t count);
     void register_write(uint8_t address, uint8_t value);
     AP_HAL::Semaphore* get_semaphore();
-    bool start_conversion();
     bool configure();
+    bool start_measurements();
     void read_raw(struct raw_value *rv);
     uint32_t get_dev_id();
 private:
@@ -112,8 +112,8 @@ public:
     void register_read(uint8_t address, uint8_t *value, uint8_t count);
     void register_write(uint8_t address, uint8_t value);
     AP_HAL::Semaphore* get_semaphore();
-    bool start_conversion(){return true;}
-    bool configure(){return true;}
+    bool configure(){ return true; }
+    bool start_measurements() { return true; }
     void read_raw(struct raw_value *rv);
     uint32_t get_dev_id();
 private:

--- a/libraries/AP_Compass/AP_Compass_AK8963.h
+++ b/libraries/AP_Compass/AP_Compass_AK8963.h
@@ -123,7 +123,7 @@ private:
         _write(address, &value, 1);
     }
     AP_HAL::I2CDriver *_i2c;
-    uint8_t _addr;
     AP_HAL::Semaphore *_i2c_sem;
+    uint8_t _addr;
 };
 #endif

--- a/libraries/AP_Compass/AP_Compass_AK8963.h
+++ b/libraries/AP_Compass/AP_Compass_AK8963.h
@@ -13,8 +13,6 @@ class AP_AK8963_SerialBus
 {
 public:
     struct PACKED raw_value {
-        uint8_t info;
-        uint8_t st1;
         int16_t val[3];
         uint8_t st2;
     };

--- a/libraries/AP_Compass/AP_Compass_AK8963.h
+++ b/libraries/AP_Compass/AP_Compass_AK8963.h
@@ -46,27 +46,16 @@ public:
     void        accumulate(void);
 
 private:
-    typedef enum
-    {
-        STATE_UNKNOWN,
-        STATE_CONVERSION,
-        STATE_SAMPLE,
-        STATE_ERROR
-    } state_t;
-
     bool _reset();
     bool _setup_mode();
     bool _check_id();
     bool _calibrate();
 
     void _update();
-    bool _collect_samples();
     void _dump_registers();
     bool _sem_take_blocking();
     bool _sem_take_nonblocking();
     bool _sem_give();
-
-    state_t             _state;
 
     float               _magnetometer_ASA[3] {0, 0, 0};
     uint8_t             _compass_instance;

--- a/libraries/AP_Compass/AP_Compass_AK8963.h
+++ b/libraries/AP_Compass/AP_Compass_AK8963.h
@@ -77,7 +77,6 @@ private:
     uint32_t            _accum_count;
 
     bool                _initialized;
-    uint8_t             _magnetometer_adc_resolution;
     uint32_t            _last_update_timestamp;
     uint32_t            _last_accum_time;
 

--- a/libraries/AP_Compass/AP_Compass_AK8963.h
+++ b/libraries/AP_Compass/AP_Compass_AK8963.h
@@ -46,6 +46,10 @@ public:
     void        accumulate(void);
 
 private:
+    void _make_factory_sensitivity_adjustment(Vector3f& field) const;
+    Vector3f _get_filtered_field() const;
+    void _reset_filter();
+
     bool _reset();
     bool _setup_mode();
     bool _check_id();

--- a/libraries/AP_Compass/AP_Compass_AK8963.h
+++ b/libraries/AP_Compass/AP_Compass_AK8963.h
@@ -12,6 +12,13 @@
 class AP_AK8963_SerialBus
 {
 public:
+    struct PACKED raw_value {
+        uint8_t info;
+        uint8_t st1;
+        int16_t val[3];
+        uint8_t st2;
+    };
+
     virtual void register_read(uint8_t address, uint8_t *value, uint8_t count) = 0;
     uint8_t register_read(uint8_t address) {
         uint8_t reg;
@@ -22,7 +29,7 @@ public:
     virtual AP_HAL::Semaphore* get_semaphore() = 0;
     virtual bool start_conversion() = 0;
     virtual bool configure() = 0;
-    virtual bool read_raw(float &mag_x, float &mag_y, float &mag_z) = 0;
+    virtual void read_raw(struct raw_value *rv) = 0;
     virtual uint32_t get_dev_id() = 0;
 };
 
@@ -62,9 +69,6 @@ private:
     state_t             _state;
 
     float               _magnetometer_ASA[3] {0, 0, 0};
-    float               _mag_x;
-    float               _mag_y;
-    float               _mag_z;
     uint8_t             _compass_instance;
 
     float               _mag_x_accum;
@@ -90,7 +94,7 @@ public:
     AP_HAL::Semaphore* get_semaphore();
     bool start_conversion();
     bool configure();
-    bool read_raw(float &mag_x, float &mag_y, float &mag_z);
+    void read_raw(struct raw_value *rv);
     uint32_t get_dev_id();
 private:
     void _read(uint8_t address, uint8_t *value, uint32_t count);
@@ -111,7 +115,7 @@ public:
     AP_HAL::Semaphore* get_semaphore();
     bool start_conversion(){return true;}
     bool configure(){return true;}
-    bool read_raw(float &mag_x, float &mag_y, float &mag_z);
+    void read_raw(struct raw_value *rv);
     uint32_t get_dev_id();
 private:
     void _read(uint8_t address, uint8_t *value, uint32_t count);


### PR DESCRIPTION
This is a patch set improving the AK8963. At first I started on it because we were resetting it for each sample we get. After talking to @staroselskii however I realized it was not the case anymore since it was fixed in a patch not long ago. However this still simplifies the driver, removes lots of duplication and fixes some non-fatal bugs.

I'm also using patches from @dgrat and @staroselskii. This supersedes #2538.

It's tested on my minnowboards and on navio. It may impact other linux boards as well. @staroselskii  @jberaud @vmayoral, could you give a look?

@staroselskii as we talked today, if you could attach an oscilloscope to the AUX_SDA pin on MPU9250 to check how frequent it's talking to AK8963 with and without https://github.com/lucasdemarchi/ardupilot/commit/43674a0d6622f05b0d6b392836aebc61446ffac2 it'd be good.