### PR TITLE
Force compasses to use SI units

### DIFF
--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -204,9 +204,11 @@ void AP_Compass_AK8963::read()
 
     hal.scheduler->suspend_timer_procs();
     auto field = _get_filtered_field();
+
     _reset_filter();
     hal.scheduler->resume_timer_procs();
     _make_factory_sensitivity_adjustment(field);
+    _make_adc_sensitivity_adjustment(field);
 
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BEBOP
     field.rotate(ROTATION_YAW_90);
@@ -227,6 +229,13 @@ void AP_Compass_AK8963::_reset_filter()
 {
     _mag_x_accum = _mag_y_accum = _mag_z_accum = 0;
     _accum_count = 0;
+}
+
+void AP_Compass_AK8963::_make_adc_sensitivity_adjustment(Vector3f& field) const
+{
+    static const float ADC_16BIT_RESOLUTION = 0.15f;
+
+    field *= ADC_16BIT_RESOLUTION;
 }
 
 void AP_Compass_AK8963::_make_factory_sensitivity_adjustment(Vector3f& field) const

--- a/libraries/AP_Compass/AP_Compass_AK8963.h
+++ b/libraries/AP_Compass/AP_Compass_AK8963.h
@@ -45,6 +45,7 @@ public:
 
 private:
     void _make_factory_sensitivity_adjustment(Vector3f& field) const;
+    void _make_adc_sensitivity_adjustment(Vector3f& field) const;
     Vector3f _get_filtered_field() const;
     void _reset_filter();
 

--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -197,6 +197,28 @@ bool AP_Compass_HMC5843::re_initialise()
 }
 
 
+bool AP_Compass_HMC5843::_detect_version()
+{
+    _base_config = 0x0;
+
+    if (!write_register(ConfigRegA, SampleAveraging_8<<5 | DataOutputRate_75HZ<<2 | NormalOperation) ||
+        !read_register(ConfigRegA, &_base_config)) {
+        return false;
+    }
+    if ( _base_config == (SampleAveraging_8<<5 | DataOutputRate_75HZ<<2 | NormalOperation)) {
+        /* a 5883L supports the sample averaging config */
+        _product_id = AP_COMPASS_TYPE_HMC5883L;
+        return true;
+    } else if (_base_config == (NormalOperation | DataOutputRate_75HZ<<2)) {
+        _product_id = AP_COMPASS_TYPE_HMC5843;
+        return true;
+    } else {
+        /* not behaving like either supported compass type */
+        return false;
+    }
+
+}
+
 // Public Methods //////////////////////////////////////////////////////////////
 bool
 AP_Compass_HMC5843::init()
@@ -216,17 +238,11 @@ AP_Compass_HMC5843::init()
         hal.scheduler->panic(PSTR("Failed to get HMC5843 semaphore"));
     }
 
-    // determine if we are using 5843 or 5883L
-    _base_config = 0;
-    if (!write_register(ConfigRegA, SampleAveraging_8<<5 | DataOutputRate_75HZ<<2 | NormalOperation) ||
-        !read_register(ConfigRegA, &_base_config)) {
-        _i2c_sem->give();
-        hal.scheduler->resume_timer_procs();
-        return false;
+    if (!_detect_version()) {
+        goto errout;
     }
-    if ( _base_config == (SampleAveraging_8<<5 | DataOutputRate_75HZ<<2 | NormalOperation)) {
-        // a 5883L supports the sample averaging config
-        _product_id = AP_COMPASS_TYPE_HMC5883L;
+
+    if (_product_id == AP_COMPASS_TYPE_HMC5883L) {
         calibration_gain = 0x60;
         /*
           note that the HMC5883 datasheet gives the x and y expected
@@ -236,13 +252,6 @@ AP_Compass_HMC5843::init()
         expected_x = 766;
         expected_yz  = 713;
         gain_multiple = 660.0f / 1090;  // adjustment for runtime vs calibration gain
-    } else if (_base_config == (NormalOperation | DataOutputRate_75HZ<<2)) {
-        _product_id = AP_COMPASS_TYPE_HMC5843;
-    } else {
-        // not behaving like either supported compass type
-        _i2c_sem->give();
-        hal.scheduler->resume_timer_procs();
-        return false;
     }
 
     calibration[0] = 0;
@@ -351,6 +360,12 @@ AP_Compass_HMC5843::init()
     }
 
     return success;
+
+errout:
+
+    _i2c_sem->give();
+    hal.scheduler->resume_timer_procs();
+    return false;
 }
 
 // Read Sensor data

--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -327,16 +327,20 @@ bool AP_Compass_HMC5843::_calibrate(uint8_t calibration_gain,
         // still be changing its state from the application of the
         // strap excitation. After that we accept values in a
         // reasonable range
+#define IS_CALIBRATION_VALUE_VALID(val) (val > 0.7f && val < 1.35f)
+
         if (numAttempts > 2 &&
-            cal[0] > 0.7f && cal[0] < 1.35f &&
-            cal[1] > 0.7f && cal[1] < 1.35f &&
-            cal[2] > 0.7f && cal[2] < 1.35f) {
-            // hal.console->printf_P(PSTR("cal=%.2f %.2f %.2f good\n"), cal[0], cal[1], cal[2]);
+            IS_CALIBRATION_VALUE_VALID(cal[0]) &&
+            IS_CALIBRATION_VALUE_VALID(cal[1]) &&
+            IS_CALIBRATION_VALUE_VALID(cal[2])) {
+            // hal.console->printf_P(PSTR("car=%.2f %.2f %.2f good\n"), cal[0], cal[1], cal[2]);
             good_count++;
             calibration[0] += cal[0];
             calibration[1] += cal[1];
             calibration[2] += cal[2];
         }
+
+#undef IS_CALIBRATION_VALUE_VALID
 
 #if 0
         /* useful for debugging */

--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -422,6 +422,16 @@ void AP_Compass_HMC5843::read()
         field.rotate(ROTATION_YAW_90);
     }
 
+    _convert_to_ut(field);
+
     publish_field(field, _compass_instance);
     _retry_time = 0;
+}
+
+void AP_Compass_HMC5843::_convert_to_ut(Vector3f& field) const
+{
+    /* Convert field from mG to uT.
+     * 1T = 10000G */
+
+    field /= 10;
 }

--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -223,8 +223,6 @@ bool AP_Compass_HMC5843::_detect_version()
 bool
 AP_Compass_HMC5843::init()
 {
-    int numAttempts = 0, good_count = 0;
-    bool success = false;
     uint8_t calibration_gain = 0x20;
     uint16_t expected_x = 715;
     uint16_t expected_yz = 715;
@@ -254,9 +252,45 @@ AP_Compass_HMC5843::init()
         gain_multiple = 660.0f / 1090;  // adjustment for runtime vs calibration gain
     }
 
-    calibration[0] = 0;
-    calibration[1] = 0;
-    calibration[2] = 0;
+    if (!_calibrate(calibration_gain, expected_x, expected_yz, gain_multiple)) {
+        goto errout;
+    }
+
+    // leave test mode
+    if (!re_initialise()) {
+        goto errout;
+    }
+
+    read();
+
+#if 0
+    hal.console->printf_P(PSTR("CalX: %.2f CalY: %.2f CalZ: %.2f\n"), 
+                          calibration[0], calibration[1], calibration[2]);
+#endif
+
+    _compass_instance = register_compass();
+    set_dev_id(_compass_instance, _product_id);
+
+    _initialised = true;
+
+    _i2c_sem->give();
+    hal.scheduler->resume_timer_procs();
+
+    return true;
+errout:
+
+    _i2c_sem->give();
+    hal.scheduler->resume_timer_procs();
+    return false;
+}
+
+bool AP_Compass_HMC5843::_calibrate(uint8_t calibration_gain,
+        uint16_t expected_x,
+        uint16_t expected_yz,
+        float gain_multiple)
+{
+    int numAttempts = 0, good_count = 0;
+    bool success = false;
 
     while ( success == 0 && numAttempts < 25 && good_count < 5)
     {
@@ -334,38 +368,7 @@ AP_Compass_HMC5843::init()
         calibration[2] = 1.0;
     }
 
-    // leave test mode
-    if (!re_initialise()) {
-        _i2c_sem->give();
-        hal.scheduler->resume_timer_procs();
-        return false;
-    }
-
-    _i2c_sem->give();
-    hal.scheduler->resume_timer_procs();
-    _initialised = true;
-
-	// perform an initial read
-	read();
-
-#if 0
-    hal.console->printf_P(PSTR("CalX: %.2f CalY: %.2f CalZ: %.2f\n"), 
-                          calibration[0], calibration[1], calibration[2]);
-#endif
-
-    if (success) {
-        // register the compass instance in the frontend
-        _compass_instance = register_compass();
-        set_dev_id(_compass_instance, _product_id);
-    }
-
     return success;
-
-errout:
-
-    _i2c_sem->give();
-    hal.scheduler->resume_timer_procs();
-    return false;
 }
 
 // Read Sensor data

--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -295,6 +295,8 @@ bool AP_Compass_HMC5843::_calibrate(uint8_t calibration_gain,
     int numAttempts = 0, good_count = 0;
     bool success = false;
 
+    float sum_excited[3] = {0.0f, 0.0f, 0.0f};
+
     while (success == 0 && numAttempts < 25 && good_count < 5)
     {
         numAttempts++;
@@ -345,9 +347,9 @@ bool AP_Compass_HMC5843::_calibrate(uint8_t calibration_gain,
             IS_CALIBRATION_VALUE_VALID(cal[1]) &&
             IS_CALIBRATION_VALUE_VALID(cal[2])) {
 
-            _scaling[0] += cal[0];
-            _scaling[1] += cal[1];
-            _scaling[2] += cal[2];
+            sum_excited[0] += cal[0];
+            sum_excited[1] += cal[1];
+            sum_excited[2] += cal[2];
 
             good_count++;
         /* hal.console->printf_P(PSTR("car=%.2f %.2f %.2f good\n"), cal[0], cal[1], cal[2]); */
@@ -374,9 +376,11 @@ bool AP_Compass_HMC5843::_calibrate(uint8_t calibration_gain,
           doesn't have any impact other than the learned compass
           offsets
          */
-        _scaling[0] = _scaling[0] * gain_multiple / good_count;
-        _scaling[1] = _scaling[1] * gain_multiple / good_count;
-        _scaling[2] = _scaling[2] * gain_multiple / good_count;
+
+        _scaling[0] = sum_excited[0] / good_count * gain_multiple;
+        _scaling[1] = sum_excited[1] / good_count * gain_multiple;
+        _scaling[2] = sum_excited[2] / good_count * gain_multiple;
+
         success = true;
     } else {
         /* best guess */

--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -335,17 +335,22 @@ bool AP_Compass_HMC5843::_calibrate(uint8_t calibration_gain,
          * strap excitation. After that we accept values in a
          * reasonable range */
 
+        if (numAttempts <= 2) {
+            continue;
+        }
+
 #define IS_CALIBRATION_VALUE_VALID(val) (val > 0.7f && val < 1.35f)
 
-        if (numAttempts > 2 &&
-            IS_CALIBRATION_VALUE_VALID(cal[0]) &&
+        if (IS_CALIBRATION_VALUE_VALID(cal[0]) &&
             IS_CALIBRATION_VALUE_VALID(cal[1]) &&
             IS_CALIBRATION_VALUE_VALID(cal[2])) {
-            // hal.console->printf_P(PSTR("car=%.2f %.2f %.2f good\n"), cal[0], cal[1], cal[2]);
-            good_count++;
+
             _scaling[0] += cal[0];
             _scaling[1] += cal[1];
             _scaling[2] += cal[2];
+
+            good_count++;
+        /* hal.console->printf_P(PSTR("car=%.2f %.2f %.2f good\n"), cal[0], cal[1], cal[2]); */
         }
 
 #undef IS_CALIBRATION_VALUE_VALID

--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -268,7 +268,7 @@ AP_Compass_HMC5843::init()
 
 #if 0
     hal.console->printf_P(PSTR("CalX: %.2f CalY: %.2f CalZ: %.2f\n"), 
-                          calibration[0], calibration[1], calibration[2]);
+                          _scaling[0], _scaling[1], _scaling[2]);
 #endif
 
     _compass_instance = register_compass();
@@ -343,9 +343,9 @@ bool AP_Compass_HMC5843::_calibrate(uint8_t calibration_gain,
             IS_CALIBRATION_VALUE_VALID(cal[2])) {
             // hal.console->printf_P(PSTR("car=%.2f %.2f %.2f good\n"), cal[0], cal[1], cal[2]);
             good_count++;
-            calibration[0] += cal[0];
-            calibration[1] += cal[1];
-            calibration[2] += cal[2];
+            _scaling[0] += cal[0];
+            _scaling[1] += cal[1];
+            _scaling[2] += cal[2];
         }
 
 #undef IS_CALIBRATION_VALUE_VALID
@@ -369,15 +369,15 @@ bool AP_Compass_HMC5843::_calibrate(uint8_t calibration_gain,
           doesn't have any impact other than the learned compass
           offsets
          */
-        calibration[0] = calibration[0] * gain_multiple / good_count;
-        calibration[1] = calibration[1] * gain_multiple / good_count;
-        calibration[2] = calibration[2] * gain_multiple / good_count;
+        _scaling[0] = _scaling[0] * gain_multiple / good_count;
+        _scaling[1] = _scaling[1] * gain_multiple / good_count;
+        _scaling[2] = _scaling[2] * gain_multiple / good_count;
         success = true;
     } else {
         /* best guess */
-        calibration[0] = 1.0;
-        calibration[1] = 1.0;
-        calibration[2] = 1.0;
+        _scaling[0] = 1.0;
+        _scaling[1] = 1.0;
+        _scaling[2] = 1.0;
     }
 
     return success;
@@ -415,9 +415,9 @@ void AP_Compass_HMC5843::read()
        }
     }
 
-    Vector3f field(_mag_x_accum * calibration[0],
-                   _mag_y_accum * calibration[1],
-                   _mag_z_accum * calibration[2]);
+    Vector3f field(_mag_x_accum * _scaling[0],
+                   _mag_y_accum * _scaling[1],
+                   _mag_z_accum * _scaling[2]);
     field /= _accum_count;
 
     _accum_count = 0;

--- a/libraries/AP_Compass/AP_Compass_HMC5843.h
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.h
@@ -12,7 +12,7 @@
 class AP_Compass_HMC5843 : public AP_Compass_Backend
 {
 private:
-    float               calibration[3] = {0};
+    float               _scaling[3] = {0};
     bool                _initialised;
     bool                read_raw(void);
     uint8_t             _base_config;

--- a/libraries/AP_Compass/AP_Compass_HMC5843.h
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.h
@@ -12,7 +12,7 @@
 class AP_Compass_HMC5843 : public AP_Compass_Backend
 {
 private:
-    float               calibration[3];
+    float               calibration[3] = {0};
     bool                _initialised;
     bool                read_raw(void);
     uint8_t             _base_config;
@@ -20,6 +20,7 @@ private:
     bool                read_register(uint8_t address, uint8_t *value);
     bool                write_register(uint8_t address, uint8_t value);
 
+    bool                _calibrate(uint8_t calibration_gain, uint16_t expected_x, uint16_t expected_yz, float gain_multiple);
     bool                _detect_version();
 
     uint32_t            _retry_time; // when unhealthy the millis() value to retry at

--- a/libraries/AP_Compass/AP_Compass_HMC5843.h
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.h
@@ -19,6 +19,9 @@ private:
     bool                re_initialise(void);
     bool                read_register(uint8_t address, uint8_t *value);
     bool                write_register(uint8_t address, uint8_t value);
+
+    bool                _detect_version();
+
     uint32_t            _retry_time; // when unhealthy the millis() value to retry at
     AP_HAL::Semaphore*  _i2c_sem;
 

--- a/libraries/AP_Compass/AP_Compass_HMC5843.h
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.h
@@ -20,7 +20,7 @@ private:
     bool                read_register(uint8_t address, uint8_t *value);
     bool                write_register(uint8_t address, uint8_t value);
 
-    bool                _calibrate(uint8_t calibration_gain, uint16_t expected_x, uint16_t expected_yz, float gain_multiple);
+    bool                _calibrate(uint8_t calibration_gain, uint16_t expected_x, uint16_t expected_yz);
     bool                _detect_version();
 
     uint32_t            _retry_time; // when unhealthy the millis() value to retry at

--- a/libraries/AP_Compass/AP_Compass_HMC5843.h
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.h
@@ -22,6 +22,7 @@ private:
 
     bool                _calibrate(uint8_t calibration_gain, uint16_t expected_x, uint16_t expected_yz);
     bool                _detect_version();
+    void                _convert_to_ut(Vector3f& field) const;
 
     uint32_t            _retry_time; // when unhealthy the millis() value to retry at
     AP_HAL::Semaphore*  _i2c_sem;

--- a/libraries/AP_Compass/Compass.cpp
+++ b/libraries/AP_Compass/Compass.cpp
@@ -265,6 +265,76 @@ const AP_Param::GroupInfo Compass::var_info[] PROGMEM = {
     AP_GROUPINFO("EXTERN3",23, Compass, _state[2].external, 0),
 #endif
 
+    // @Param: OFS1UT_X
+    // @DisplayName: Compass offsets (uT) on the X axis
+    // @Description: Offset (uT) to be added to the compass #1 x-axis values to compensate for metal in the frame
+    // @Range: -100 100
+    // @Increment: 1
+
+    // @Param: OFS1UT_Y
+    // @DisplayName: Compass offsets (uT) on the Y axis
+    // @Description: Offset (uT) to be added to the compass #1 y-axis values to compensate for metal in the frame
+    // @Range: -100 100
+    // @Increment: 1
+
+    // @Param: OFS1UT_Z
+    // @DisplayName: Compass offsets (uT) on the Z axis
+    // @Description: Offset (uT) to be added to the compass #1 z-axis values to compensate for metal in the frame
+    // @Range: -100 100
+    // @Increment: 1
+#if COMPASS_MAX_INSTANCES == 1
+    AP_GROUPINFO("OFS1UT", 10, Compass, _state[0].offset_ut, 0),
+#elif COMPASS_MAX_INSTANCES == 2
+    AP_GROUPINFO("OFS1UT", 21, Compass, _state[0].offset_ut, 0),
+#elif COMPASS_MAX_INSTANCES == 3
+    AP_GROUPINFO("OFS1UT", 24, Compass, _state[0].offset_ut, 0),
+#endif
+
+    // @Param: OFS2UT_X
+    // @DisplayName: Compass2 offsets (uT) on the X axis
+    // @Description: Offset (uT) to be added to the compass #2 x-axis values to compensate for metal in the frame
+    // @Range: -100 100
+    // @Increment: 1
+
+    // @Param: OFS2UT_Y
+    // @DisplayName: Compass2 offsets (uT) on the Y axis
+    // @Description: Offset (uT) to be added to the compass #2 y-axis values to compensate for metal in the frame
+    // @Range: -100 100
+    // @Increment: 1
+
+    // @Param: OFS2UT_Z
+    // @DisplayName: Compass2 offsets (uT) on the Z axis
+    // @Description: Offset (uT) to be added to the compass #2 z-axis values to compensate for metal in the frame
+    // @Range: -100 100
+    // @Increment: 1
+#if COMPASS_MAX_INSTANCES == 2
+    AP_GROUPINFO("OFS2UT", 22, Compass, _state[1].offset_ut, 0),
+#elif COMPASS_MAX_INSTANCES == 3
+    AP_GROUPINFO("OFS2UT", 25, Compass, _state[1].offset_ut, 0),
+#endif
+
+#if COMPASS_MAX_INSTANCES == 3
+    // @Param: OFS3UT_X
+    // @DisplayName: Compass3 offsets (uT) on the X axis
+    // @Description: Offset (uT) to be added to the compass #3 x-axis values to compensate for metal in the frame
+    // @Range: -100 100
+    // @Increment: 1
+
+    // @Param: OFS3UT_Y
+    // @DisplayName: Compass3 offsets (uT) on the Y axis
+    // @Description: Offset (uT) to be added to the compass #3 y-axis values to compensate for metal in the frame
+    // @Range: -100 100
+    // @Increment: 1
+
+    // @Param: OFS3UT_Z
+    // @DisplayName: Compass3 offsets (uT) on the Z axis
+    // @Description: Offset (uT) to be added to the compass #3 z-axis values to compensate for metal in the frame
+    // @Range: -100 100
+    // @Increment: 1
+    AP_GROUPINFO("OFS3UT", 26, Compass, _state[2].offset_ut, 0),
+#endif
+
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_Compass/Compass.cpp
+++ b/libraries/AP_Compass/Compass.cpp
@@ -354,7 +354,7 @@ Compass::Compass(void) :
     for (uint8_t i=0; i<COMPASS_MAX_BACKEND; i++) {
         _backends[i] = NULL;
         _state[i].last_update_usec = 0;
-    }    
+    }
 
 #if COMPASS_MAX_INSTANCES > 1
     // default device ids to zero.  init() method will overwrite with the actual device ids
@@ -453,7 +453,7 @@ Compass::read(void)
     for (uint8_t i=0; i< _backend_count; i++) {
         // call read on each of the backend. This call updates field[i]
         _backends[i]->read();
-    }    
+    }
     for (uint8_t i=0; i < COMPASS_MAX_INSTANCES; i++) {
         _state[i].healthy = (hal.scheduler->millis() - _state[i].last_update_ms < 500);
     }
@@ -685,7 +685,7 @@ void Compass::_setup_earth_field(void)
 {
     // assume a earth field strength of 400
     _hil.Bearth(400, 0, 0);
-    
+
     // rotate _Bearth for inclination and declination. -66 degrees
     // is the inclination in Canberra, Australia
     Matrix3f R;

--- a/libraries/AP_Compass/Compass.cpp
+++ b/libraries/AP_Compass/Compass.cpp
@@ -465,7 +465,7 @@ Compass::set_offsets(uint8_t i, const Vector3f &offsets)
 {
     // sanity check compass instance provided
     if (i < COMPASS_MAX_INSTANCES) {
-        _state[i].offset.set(offsets);
+        _state[i].offset_ut.set(offsets);
     }
 }
 
@@ -474,7 +474,7 @@ Compass::set_and_save_offsets(uint8_t i, const Vector3f &offsets)
 {
     // sanity check compass instance provided
     if (i < COMPASS_MAX_INSTANCES) {
-        _state[i].offset.set(offsets);
+        _state[i].offset_ut.set(offsets);
         save_offsets(i);
     }
 }
@@ -482,7 +482,7 @@ Compass::set_and_save_offsets(uint8_t i, const Vector3f &offsets)
 void
 Compass::save_offsets(uint8_t i)
 {
-    _state[i].offset.save();  // save offsets
+    _state[i].offset_ut.save();  // save offsets
 #if COMPASS_MAX_INSTANCES > 1
     _state[i].dev_id.save();  // save device id corresponding to these offsets
 #endif

--- a/libraries/AP_Compass/Compass.h
+++ b/libraries/AP_Compass/Compass.h
@@ -38,10 +38,10 @@
  */
 #if HAL_CPU_CLASS > HAL_CPU_CLASS_16
 #define COMPASS_MAX_INSTANCES 3
-#define COMPASS_MAX_BACKEND   3   
+#define COMPASS_MAX_BACKEND   3
 #else
 #define COMPASS_MAX_INSTANCES 1
-#define COMPASS_MAX_BACKEND   1   
+#define COMPASS_MAX_BACKEND   1
 #endif
 
 class Compass
@@ -61,7 +61,7 @@ public:
 
     /// Read the compass and update the mag_ variables.
     ///
-    bool read();    
+    bool read();
 
     /// use spare CPU cycles to accumulate values from the compass if
     /// possible (this method should also be implemented in the backends)
@@ -269,16 +269,16 @@ private:
     enum Rotation _board_orientation;
 
     // primary instance
-    AP_Int8     _primary;                           
+    AP_Int8     _primary;
 
     // declination in radians
     AP_Float    _declination;
 
     // enable automatic declination code
-    AP_Int8     _auto_declination;                  
+    AP_Int8     _auto_declination;
 
     // first-time-around flag used by offset nulling
-    bool        _null_init_done;                           
+    bool        _null_init_done;
 
     // used by offset correction
     static const uint8_t _mag_history_size = 20;

--- a/libraries/AP_Compass/Compass.h
+++ b/libraries/AP_Compass/Compass.h
@@ -114,7 +114,7 @@ public:
     ///
     /// @returns                    The current compass offsets.
     ///
-    const Vector3f &get_offsets(uint8_t i) const { return _state[i].offset; }
+    const Vector3f &get_offsets(uint8_t i) const { return _state[i].offset_ut; }
     const Vector3f &get_offsets(void) const { return get_offsets(get_primary()); }
 
     /// Sets the initial location used to get declination

--- a/libraries/AP_Compass/Compass.h
+++ b/libraries/AP_Compass/Compass.h
@@ -295,6 +295,7 @@ private:
         bool        healthy;
         AP_Int8     orientation;
         AP_Vector3f offset;
+        AP_Vector3f offset_ut;
 
 #if COMPASS_MAX_INSTANCES > 1
         // device id detected at init.  


### PR DESCRIPTION
A replacement for #2397. This one needs extensive testing. 

The code for HMC was slightly refactored. Nothing fancy, just extracted a couple of methods. If that's not needed, let me know!) . There's a couple of places in the HMC's code that I don't entirely understand. Especially this:
```c++
    _mag_x = -rx;
    _mag_y =  ry;
    _mag_z = -rz;
```
Why do we do such a thing? 

And also this one:
```c++
if (_product_id == AP_COMPASS_TYPE_HMC5883L) {
        field.rotate(ROTATION_YAW_90);
}
```

Is it absolutely necessary to rotate on the low level? Cannot it be done on the higher one? 

Magnetometer offsets also need to be adjusted (I suggest using something like 50 uT. That's the magnetic field vector around the Earth's surface).
I also need some insight on PX4 compass driver. 

Updated (9d9068d is the previous HEAD):
- Improved constness in HMC code

Rebased on master (939126671 is the previous HEAD)