### PR TITLE
Rover: Implemented loitering at a waypoint if Param1 is non-zero

### DIFF
--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -358,6 +358,12 @@ private:
     static const AP_Param::Info var_info[];
     static const LogStructure log_structure[];
 
+    // Loiter control
+    uint16_t loiter_time_max; // How long we should loiter at the nav_waypoint (time in seconds)
+    uint32_t loiter_time;     // How long have we been loitering - The start time in millis
+
+    float distance_past_wp; // record the distance we have gone past the wp
+
 private:
     // private member functions
     void ahrs_update();

--- a/APMrover2/Steering.cpp
+++ b/APMrover2/Steering.cpp
@@ -85,8 +85,10 @@ bool Rover::use_pivot_steering(void)
   calculate the throtte for auto-throttle modes
  */
 void Rover::calc_throttle(float target_speed)
-{  
-    if (!auto_check_trigger()) {
+{
+    // If not autostarting OR we are loitering at a waypoint
+    // then set the throttle to minimum
+    if (!auto_check_trigger() || loiter_time > 0) {
         channel_throttle->servo_out = g.throttle_min.get();
         return;
     }
@@ -196,6 +198,12 @@ void Rover::calc_lateral_acceleration()
  */
 void Rover::calc_nav_steer()
 {
+    // check to see if the rover is loitering
+    if (loiter_time > 0) {
+        channel_steer->servo_out = 0;
+        return;
+    }
+
     // add in obstacle avoidance
     lateral_acceleration += (obstacle.turn_angle/45.0f) * g.turn_max_g;
 


### PR DESCRIPTION
Rover now honours the Param1 setting of a time in seconds for a
NAV_WAYPOINT and the Rover will loiter at that waypoint for that
period of time.
Note that as soon as the Rover reaches that waypoint the loiter timer
will start.  If you enter a different mode during this time (HOLD for
instance) the timer doesn't stop.  If you then switch back to AUTO
mode and the timer has expired the Rover will immediately move to the
next mission item.
If your Rover reaches the waypoint and then due to its speed it rolls
(floats) past the waypoint even though the motor isn't running
ArduPilot currently will report this.  If you THEN change mode (HOLD
for instance) the loiter timer doesn't stop and then change back to
AUTO the rover will move and take you back to that waypoint but still
not reset the loiter timer.  If you reach that waypoint and the timer
has expired the Rover will immediately move onto the next waypoint.