### PR TITLE
AP_GPS: Fix copy/paste error in ublox (uncovered by coverity)

### DIFF
--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -483,7 +483,7 @@ AP_GPS_UBLOX::_parse_gps(void)
                     _buffer.gnss.configBlock[i].maxTrkCh = _buffer.gnss.numTrkChHw;
                 } else {
                     _buffer.gnss.configBlock[i].resTrkCh = 1;
-                    _buffer.gnss.configBlock[i].resTrkCh = 3;
+                    _buffer.gnss.configBlock[i].maxTrkCh = 3;
                 }
                 _buffer.gnss.configBlock[i].flags = _buffer.gnss.configBlock[i].flags | 0x00000001;
             } else {


### PR DESCRIPTION
A non fatal copy paste error, but it is a valid error. Static analysis is pretty nice for this kind of thing.