### PR TITLE
AP_InertialSensor: don't check drdy register without pin

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -250,7 +250,8 @@ void AP_MPU6000_BusDriver_SPI::read_burst(uint8_t *samples,
     for (i=0; i<14; i++) {
         if (rx.d[i] != 0) break;
     }
-    if ((rx.int_status&~0x6) != (_drdy_pin==NULL?0:BIT_RAW_RDY_INT) || i == 14) {
+    if ((_drdy_pin != NULL && (rx.int_status&~0x6) != BIT_RAW_RDY_INT)
+        || i == 14) {
         // likely a bad bus transaction
         if (++_error_count > 4) {
             set_bus_speed(AP_HAL::SPIDeviceDriver::SPI_SPEED_LOW);


### PR DESCRIPTION
In MPU6000 if we are not using a data_ready pin we should not check the
DATA_RDY_INT bit in Interrupt Status register. That's because we read
that register in _data_ready() function in order to decide if data is
ready and that register is automatically cleared when we do so.

Reading the register again and checking if it's set to 0 is racy because
more data could already have been generated and the bit asserted again.
Setting the bus speed to low speed just make things worse because
there's no way back to high speed and the cause is not a bad transfer
but rather a check we cannot reliably do.

This can be noticed by printing an error message when we enter the
condition. We don't add that message here because that could spam the
console.