### PR TITLE
Plane: fix above_location_current output for users using absolute altitudes.

### DIFF
--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -398,8 +398,8 @@ bool Plane::above_location_current(const Location &loc)
 #endif
 
     float loc_alt_cm = loc.alt;
-    if (!loc.flags.relative_alt) {
-        loc_alt_cm -= home.alt;
+    if (loc.flags.relative_alt) {
+        loc_alt_cm += home.alt;
     }
     return current_loc.alt > loc_alt_cm;
 }


### PR DESCRIPTION
Hi,

I have been flying with this fix for some time now and it seems legit. Fix is based on the fact that current_loc is always absolute and that is exactly where the problem with previous version was. It seems to me that when following a flight plan with absolute altitudes the results of above_location_current were incorrect.