### PR TITLE
SITL: param SITL_ARSP_FAIL should be a float instead of INT8

### DIFF
--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -62,7 +62,7 @@ public:
     AP_Float accel2_noise; // in m/s/s
     AP_Vector3f accel_bias; // in m/s/s
     AP_Float aspd_noise;  // in m/s
-    AP_Int8 aspd_fail;    // pitot tube failure
+    AP_Float aspd_fail;   // pitot tube failure
 
     AP_Float mag_noise;   // in mag units (earth field is 818)
     AP_Float mag_error;   // in degrees


### PR DESCRIPTION
this param was meant to represent an airspeed which is a float. This works with an INT8 but the intent was to have a floating point accurate airspeed