### PR TITLE
Scheduler_test example compile errors

### DIFF
--- a/libraries/AP_Scheduler/examples/Scheduler_test/Scheduler_test.cpp
+++ b/libraries/AP_Scheduler/examples/Scheduler_test/Scheduler_test.cpp
@@ -112,7 +112,7 @@ void SchedTest::ins_update(void)
  */
 void SchedTest::one_hz_print(void)
 {
-    hal.console->printf("one_hz: t=%lu\n", hal.scheduler->millis());
+    hal.console->printf("one_hz: t=%lu\n", (unsigned long)hal.scheduler->millis());
 }
 
 /*
@@ -120,7 +120,7 @@ void SchedTest::one_hz_print(void)
  */
 void SchedTest::five_second_call(void)
 {
-    hal.console->printf("five_seconds: t=%lu ins_counter=%u\n", hal.scheduler->millis(), ins_counter);
+    hal.console->printf("five_seconds: t=%lu ins_counter=%u\n", (unsigned long)hal.scheduler->millis(), ins_counter);
 }
 
 /*


### PR DESCRIPTION
Function printf except a unsigned long(%lu) type, but the hal.scheduler->millis() return a uint32_t. 