### PR TITLE
Rover: init vehicle capabilities

### DIFF
--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -498,6 +498,7 @@ private:
     void do_set_home(const AP_Mission::Mission_Command& cmd);
     void do_digicam_configure(const AP_Mission::Mission_Command& cmd);
     void do_digicam_control(const AP_Mission::Mission_Command& cmd);
+    void init_capabilities(void);
 
 public:
     bool print_log_menu(void);

--- a/APMrover2/capabilities.cpp
+++ b/APMrover2/capabilities.cpp
@@ -1,0 +1,9 @@
+// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+
+#include "Rover.h"
+
+void Rover::init_capabilities(void)
+{
+    hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_MISSION_FLOAT);
+    hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT);
+}

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -210,6 +210,8 @@ void Rover::init_ardupilot()
     }
 #endif
 
+	init_capabilities();
+
 	startup_ground();
     Log_Write_Startup(TYPE_GROUNDSTART_MSG);
 


### PR DESCRIPTION
Mostly just copied from 6765aedb5b384cb6d99414a64e65d189b7111c3c.

Tested in Sitl where it successfully returns `3`.