### PR TITLE
Plane: fix "logging disabled" build.

### DIFF
--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -781,4 +781,55 @@ void Copter::log_init(void)
     }
 }
 
-#endif // LOGGING_DISABLED
+#else // LOGGING_ENABLED
+
+ #if CLI_ENABLED == ENABLED
+bool Copter::print_log_menu(void) { return true; }
+int8_t Copter::dump_log(uint8_t argc, const Menu::arg *argv) { return 0; }
+int8_t Copter::erase_logs(uint8_t argc, const Menu::arg *argv) { return 0; }
+int8_t Copter::select_logs(uint8_t argc, const Menu::arg *argv) { return 0; }
+int8_t Copter::process_logs(uint8_t argc, const Menu::arg *argv) { return 0; }
+ #endif // CLI_ENABLED == ENABLED
+
+void Copter::do_erase_logs(void) {}
+void Copter::Log_Write_AutoTune(uint8_t axis, uint8_t tune_step, float meas_target, \
+                                float meas_min, float meas_max, float new_gain_rp, \
+                                float new_gain_rd, float new_gain_sp, float new_ddt) {}
+void Copter::Log_Write_AutoTuneDetails(float angle_cd, float rate_cds) {}
+void Copter::Log_Write_Current() {}
+
+void Copter::Log_Write_Nav_Tuning() {}
+void Copter::Log_Write_Control_Tuning() {}
+void Copter::Log_Write_Performance() {}
+void Copter::Log_Write_Attitude(void) {}
+void Copter::Log_Write_Rate() {}
+void Copter::Log_Write_MotBatt() {}
+void Copter::Log_Write_Startup() {}
+void Copter::Log_Write_Event(uint8_t id) {}
+void Copter::Log_Write_Data(uint8_t id, int32_t value) {}
+void Copter::Log_Write_Data(uint8_t id, uint32_t value) {}
+void Copter::Log_Write_Data(uint8_t id, int16_t value) {}
+void Copter::Log_Write_Data(uint8_t id, uint16_t value) {}
+void Copter::Log_Write_Data(uint8_t id, float value) {}
+void Copter::Log_Write_Error(uint8_t sub_system, uint8_t error_code) {}
+void Copter::Log_Write_Baro(void) {}
+void Copter::Log_Write_Parameter_Tuning(uint8_t param, float tuning_val, int16_t control_in, int16_t tune_low, int16_t tune_high) {}
+void Copter::Log_Write_Home_And_Origin() {}
+void Copter::Log_Sensor_Health() {}
+
+ #if FRAME_CONFIG == HELI_FRAME
+void Copter::Log_Write_Heli() {}
+ #endif
+
+ #if CLI_ENABLED == ENABLED
+void Copter::Log_Read(uint16_t log_num, uint16_t start_page, uint16_t end_page) {}
+ #endif // CLI_ENABLED
+
+ #if OPTFLOW == ENABLED
+void Copter::Log_Write_Optflow() {}
+ #endif
+
+void Copter::start_logging() {}
+void Copter::log_init(void) {}
+
+#endif // LOGGING_ENABLED

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -539,10 +539,42 @@ void Plane::log_init(void)
 
 #else // LOGGING_ENABLED
 
-int8_t Plane::process_logs(uint8_t argc, const Menu::arg *argv) 
-{
-    return 0;
-}
+ #if CLI_ENABLED == ENABLED
+bool Plane::print_log_menu(void) { return true; }
+int8_t Plane::dump_log(uint8_t argc, const Menu::arg *argv) { return 0; }
+int8_t Plane::erase_logs(uint8_t argc, const Menu::arg *argv) { return 0; }
+int8_t Plane::select_logs(uint8_t argc, const Menu::arg *argv) { return 0; }
+int8_t Plane::process_logs(uint8_t argc, const Menu::arg *argv) { return 0; }
+ #endif // CLI_ENABLED == ENABLED
 
+void Plane::do_erase_logs(void) {}
+void Plane::Log_Write_Attitude(void) {}
+void Plane::Log_Write_Performance() {}
+void Plane::Log_Write_Startup(uint8_t type) {}
+void Plane::Log_Write_Control_Tuning() {}
+void Plane::Log_Write_TECS_Tuning(void) {}
+void Plane::Log_Write_Nav_Tuning() {}
+void Plane::Log_Write_Status() {}
+void Plane::Log_Write_Sonar() {}
+
+ #if OPTFLOW == ENABLED
+void Plane::Log_Write_Optflow() {}
+ #endif
+
+void Plane::Log_Write_Current() {}
+void Plane::Log_Arm_Disarm() {}
+void Plane::Log_Write_GPS(uint8_t instance) {}
+void Plane::Log_Write_IMU() {}
+void Plane::Log_Write_RC(void) {}
+void Plane::Log_Write_Baro(void) {}
+void Plane::Log_Write_Airspeed(void) {}
+void Plane::Log_Write_Home_And_Origin() {}
+
+ #if CLI_ENABLED == ENABLED
+void Plane::Log_Read(uint16_t log_num, int16_t start_page, int16_t end_page) {}
+ #endif // CLI_ENABLED
+
+void Plane::start_logging() {}
+void Plane::log_init(void) {}
 
 #endif // LOGGING_ENABLED


### PR DESCRIPTION
Re-enables the possibility to build Plane and Copter code without logging support (when LOGGING_ENABLED == DISABLED) by defining empty stubs for logging functions. This is not the most elegant nor optimal solution, but I opted for this to avoid adding even more if/endif clauses all over the source code.