### PR TITLE
Plane: Smoother alt_offset

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -809,6 +809,11 @@ void Plane::update_alt()
     geofence_check(true);
 
     update_flight_stage();
+
+    // if there has been an update to the baro, it must be Low-Passed to reduce step-input glitches in EKF
+    if (g.alt_offset != plane.alt_offset_filtered) {
+        plane.alt_offset_filtered = (0.95f*plane.alt_offset_filtered + 0.05f*g.alt_offset) + 0.5f; // add 0.5f for rounding
+    }
 }
 
 /*

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -646,6 +646,9 @@ private:
     // time that rudder arming has been running
     uint32_t rudder_arm_timer;
 
+    // alt_offset smoothed to inhibit step inputs from the differential baro
+    int16_t alt_offset_filtered = 0;
+
     void demo_servos(uint8_t i);
     void adjust_nav_pitch_throttle(void);
     void update_load_factor(void);

--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -223,7 +223,7 @@ int32_t Plane::relative_target_altitude_cm(void)
     }
 #endif
     int32_t relative_alt = target_altitude.amsl_cm - home.alt;
-    relative_alt += int32_t(g.alt_offset)*100;
+    relative_alt += int32_t(plane.alt_offset_filtered)*100;
     relative_alt += rangefinder_correction() * 100;
     return relative_alt;
 }
@@ -424,7 +424,7 @@ void Plane::setup_terrain_target_alt(Location &loc)
  */
 int32_t Plane::adjusted_altitude_cm(void)
 {
-    return current_loc.alt - (g.alt_offset*100);
+    return current_loc.alt - (plane.alt_offset_filtered*100);
 }
 
 /*


### PR DESCRIPTION
- To reduce large step inputs tripping up the EKF, writes to g.alt_offset should be smoothed
- TODO: change the units from INT16 in meters to float or INT32 in cm.
- TODO: move this whole thing into baro library GND_ALT_OFFSET and remove ALT_OFFSET from Plane. I am not doing this now for legacy reasons.

https://github.com/diydrones/ardupilot/issues/2508