### PR TITLE
DataFlash_test:make it works with PX4 FMUv2

### DIFF
--- a/libraries/DataFlash/examples/DataFlash_test/Makefile
+++ b/libraries/DataFlash/examples/DataFlash_test/Makefile
@@ -1,2 +1,2 @@
-BOARD	=	mega
+#BOARD	=	mega
 include ../../../../mk/apm.mk

--- a/libraries/DataFlash/examples/DataFlash_test/make.inc
+++ b/libraries/DataFlash/examples/DataFlash_test/make.inc
@@ -21,6 +21,7 @@ LIBRARIES += AP_Notify
 LIBRARIES += AP_Param
 LIBRARIES += AP_Progmem
 LIBRARIES += AP_Rally
+LIBRARIES += AP_RangeFinder
 LIBRARIES += AP_Scheduler
 LIBRARIES += AP_Terrain
 LIBRARIES += AP_Vehicle


### PR DESCRIPTION
I am new to APM code and still learning the examples of APM. The DataFlash_test app seems outdated and has compiling errors (make px4-v2). I have changed the code and made it work on PX4 FMUv2. I have not tested it on other platforms for I don't have the boards. Hope the developers can review the source and make it workable on other platforms.

PS: For such a case, is it right to open a pull request instead of reporting an issue?