### PR TITLE
Creation of gittools

### DIFF
--- a/Tools/gittools/SUBSYSTEM_COMMIT_MSG_COMMENTS
+++ b/Tools/gittools/SUBSYSTEM_COMMIT_MSG_COMMENTS
@@ -1,0 +1,5 @@
+# Occurrences of $subsystem will be replaced by the name of the subsystem being
+# committed (when applicable).
+#
+# See: http://dev.ardupilot.com/wiki/submitting-patches-back-to-master/
+#

--- a/Tools/gittools/extensions/git-commit-subsystems
+++ b/Tools/gittools/extensions/git-commit-subsystems
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(dirname $(realpath ${BASH_SOURCE[0]}))
+ROOT=$(dirname $(git -C $SCRIPT_DIR rev-parse --git-dir))
+GITTOOLS_DIR=$(realpath $SCRIPT_DIR/..)
+
+usage() {
+    cat >&$1 <<EOF
+Usage: git commit-subsystems [OPTIONS]
+
+Ardupilot's git extension.
+
+Creates a different commit for each ardupilot's subsystem (vehicles and
+libraries). The items in OPTIONS are passed down to the original git commit
+command. If hooks in Tools/gittools/hooks are installed, the commit message is
+used as a template such that occurrences of \$subsystem are replaced by the
+subsystem being currently committed.
+
+TIP: When using the same message for all subsystems being committed, commit
+options like -F or -m are very useful. Example:
+    git commit-subsystems -m "\$subsystem: refactoring feature X"
+
+NOTE: Using commit message from standard input (value "-" for option -F) isn't
+fully supported yet as it only works when there's only one subsystem staged.
+EOF
+}
+
+args=()
+
+while [[ -n "$1" ]]; do
+    case "$1" in
+    -h|--help)
+        usage 1
+        exit 0
+        ;;
+    *)
+        args+=("$1")
+        ;;
+    esac
+    shift
+done
+
+set -- "${args[@]}"
+
+if ! git diff-files --quiet --exit-code; then
+    echo "You have unstaged changes. Please, commit or stash them before committing subsystems." >&2
+    exit 1
+fi
+
+LIST=$ROOT/.git/COMMIT_SUBSYSTEMS_LIST
+
+echo > $LIST
+
+git diff --name-only --staged | $GITTOOLS_DIR/path-libraries.sh -p > $LIST
+git diff --name-only --staged | $GITTOOLS_DIR/path-nonlibraries.sh -p >> $LIST
+
+echo "Reseting changes in order to add files separately..."
+git reset >/dev/null
+
+# head before commits - for recovery
+RECOVERY_HEAD=$(git log -n 1 --format=%H)
+exit_hook() {
+    [[ $? -eq 0 ]] && return 0
+
+    set +e
+    echo
+    echo "Program interrupted or finished with error(s), reseting head..." >&2
+    git reset $RECOVERY_HEAD >/dev/null
+    echo "Trying to re-add files..." >&2
+    if [[ ! -f $LIST ]]; then
+        echo "File with list of added files not found..." >&2
+    else
+        error=false
+        cat $LIST | while read subsystem path; do
+            if ! git add -- "$path"; then
+                echo "Couldn't add \"$path\"..." >&2
+                error=true
+            fi
+        done
+
+        if $error; then
+            echo "This is embarrassing, couldn't re-add all files. Sorry." >&2
+        else
+            echo "Files re-added." >&2
+        fi
+    fi
+
+    return 1
+}
+
+set -e
+trap "exit 1" SIGINT
+trap exit_hook EXIT
+
+echo "Adding and committing subsystems..."
+exec 3< $LIST
+cur_subsystem=
+while read -u 3 subsystem path; do
+    if [[ $cur_subsystem != $subsystem ]]; then
+        if [[ -n $cur_subsystem ]]; then
+            if ! git commit "$@"; then
+                echo "Couldn't commit subsystem $cur_subsystem, aborting..." >&2
+                exit 1
+            fi
+            echo
+        fi
+        cur_subsystem=$subsystem
+    fi
+    if ! git add -- "$path"; then
+        echo "Couldn't add \"$path\", aborting..." >&2
+        exit 1
+    fi
+done
+# the last one
+if ! git commit "$@"; then
+    echo "Couldn't commit subsystem $cur_subsystem, aborting..." >&2
+    exit 1
+fi
+echo
+
+exec 3<&-

--- a/Tools/gittools/hooks/commit-msg
+++ b/Tools/gittools/hooks/commit-msg
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# commit-mgs hook replaces occurrences of $subsystem with the subsystem being
+# committed (when applicable)
+#
+# See: http://dev.ardupilot.com/wiki/submitting-patches-back-to-master/
+
+export GIT_DIR=$(realpath $GIT_DIR)
+
+LIST=$GIT_DIR/COMMIT_MSG_SUBSYSTEMS
+
+diff_cmd="git diff --name-only --staged"
+$diff_cmd | Tools/gittools/path-nonlibraries.sh > $LIST
+$diff_cmd | Tools/gittools/path-libraries.sh >> $LIST
+
+num_subsystems=$(cat $LIST | wc -l)
+((num_subsystems != 1)) && exit 0
+
+subsystem=$(cat $LIST)
+
+sed -i \
+    -e "s/\(^\|[^\\]\)\$subsystem/\1$subsystem/" \
+    -e 's/\\$subsystem/\$subsystem/' \
+    $1

--- a/Tools/gittools/hooks/post-commit
+++ b/Tools/gittools/hooks/post-commit
@@ -1,0 +1,4 @@
+#!/bin/bash
+export GIT_DIR=$(realpath $GIT_DIR)
+Tools/gittools/verify-version.sh
+exit 0

--- a/Tools/gittools/hooks/pre-commit
+++ b/Tools/gittools/hooks/pre-commit
@@ -8,7 +8,8 @@ num_subsystems=$(
 
 if ((num_subsystems > 1)) && [[ "$ARDUPILOT_SPLIT_CHECK" != "bypass" ]]; then
     cat >&2 <<EOF
-pre-commit: multiples subsystems in commit, please commit them separately...
+pre-commit: multiples subsystems in commit, please either commit them
+separately or use git commit-subsystems...
 
 See: http://dev.ardupilot.com/wiki/submitting-patches-back-to-master/
 

--- a/Tools/gittools/hooks/pre-commit
+++ b/Tools/gittools/hooks/pre-commit
@@ -1,0 +1,23 @@
+#!/bin/bash
+export GIT_DIR=$(realpath $GIT_DIR)
+
+diff_cmd="git diff --name-only --staged"
+num_subsystems=$(
+    { $diff_cmd | Tools/gittools/path-nonlibraries.sh;
+      $diff_cmd | Tools/gittools/path-libraries.sh; } | wc -l)
+
+if ((num_subsystems > 1)) && [[ "$ARDUPILOT_SPLIT_CHECK" != "bypass" ]]; then
+    cat >&2 <<EOF
+pre-commit: multiples subsystems in commit, please commit them separately...
+
+See: http://dev.ardupilot.com/wiki/submitting-patches-back-to-master/
+
+If you really want them committed together, please either use option
+--no-verify or set ARDUPILOT_SPLIT_CHECK=bypass.
+
+Commit aborted.
+EOF
+    exit 1
+fi
+
+exit 0

--- a/Tools/gittools/hooks/prepare-commit-msg
+++ b/Tools/gittools/hooks/prepare-commit-msg
@@ -1,0 +1,11 @@
+#!/bin/bash
+export GIT_DIR=$(realpath $GIT_DIR)
+
+first_comment_line=$(cat $1 | grep -m 1 -n "^#" | grep -o "[0-9]\+")
+((first_comment_line--))
+
+if ((first_comment_line > 0)); then
+    sed -i "${first_comment_line}r$GIT_DIR/SUBSYSTEM_COMMIT_MSG_COMMENTS" $1
+fi
+
+sed -i '1s/^$/$subsystem: BRIEF_DESCRIPTION/' $1

--- a/Tools/gittools/install.sh
+++ b/Tools/gittools/install.sh
@@ -29,3 +29,11 @@ else
         $(git -C $ROOT log -n 1 --format=%H $SCRIPT_DIR)
     echo "Install finished"
 fi
+
+if ! command -v git-commit-subsystems &> /dev/null; then
+    echo
+    cat <<EOF
+Tip: You could add $SCRIPT_DIR/extensions to PATH to easily issue git command
+extensions (git commit-subsystems, for example).
+EOF
+fi

--- a/Tools/gittools/install.sh
+++ b/Tools/gittools/install.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(dirname $(realpath ${BASH_SOURCE[0]}))
+ROOT=$(dirname $(git -C $SCRIPT_DIR rev-parse --git-dir))
+
+errors=0
+
+# link hooks
+echo "Linking git hooks..."
+for f in $SCRIPT_DIR/hooks/*; do
+    ( cd $ROOT/.git/hooks && ln -fs $f ) && continue
+    echo "Error on linking git hook $f" >&2
+    ((errors++))
+done
+
+if ((errors > 0)); then
+    echo "gittools install script has finished with $errors error(s)"
+    exit 1
+else
+    echo "gittools install script has finished successfully!"
+    echo "Updating gitools version information..."
+    git -C $ROOT config gittools.commithash \
+        $(git -C $ROOT log -n 1 --format=%H $SCRIPT_DIR)
+    echo "Install finished"
+fi

--- a/Tools/gittools/install.sh
+++ b/Tools/gittools/install.sh
@@ -5,13 +5,19 @@ ROOT=$(dirname $(git -C $SCRIPT_DIR rev-parse --git-dir))
 
 errors=0
 
-# link hooks
 echo "Linking git hooks..."
 for f in $SCRIPT_DIR/hooks/*; do
     ( cd $ROOT/.git/hooks && ln -fs $f ) && continue
     echo "Error on linking git hook $f" >&2
     ((errors++))
 done
+
+echo "Linking SUBSYSTEM_COMMIT_MSG_COMMENTS..."
+if ! ln -fs $SCRIPT_DIR/SUBSYSTEM_COMMIT_MSG_COMMENTS \
+            $ROOT/.git/SUBSYSTEM_COMMIT_MSG_COMMENTS; then
+    echo "Error on linking SUBSYSTEM_COMMIT_MSG_COMMENTS" >&2
+    ((errors++))
+fi
 
 if ((errors > 0)); then
     echo "gittools install script has finished with $errors error(s)"

--- a/Tools/gittools/path-libraries.sh
+++ b/Tools/gittools/path-libraries.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+usage() {
+    cat >&$1 <<EOF
+Usage: $0 [OPTIONS]
+
+Read a list of files relative to ardupilot's root directory and output the
+libraries they belong to.
+
+Options:
+    --show-paths, -p    Print also file paths after the library name.
+    --help, -h          Show this help message.
+EOF
+}
+
+show_paths=false
+
+while [[ -n $1 ]]; do
+    case "$1" in
+    --show-paths|-p)
+        show_paths=true
+        ;;
+    --help|-h)
+        usage 1
+        exit 0
+        ;;
+    *)
+        usage 2
+        exit 1
+        ;;
+    esac
+
+    shift
+done
+
+if $show_paths; then
+    sedcmd="s,libraries/\([^/]\+\).*,\1\t\0,"
+else
+    sedcmd="s,libraries/\([^/]\+\).*,\1,"
+fi
+
+grep "^libraries/[^\/]\+" | \
+    sed $sedcmd | \
+    sort | \
+    uniq

--- a/Tools/gittools/path-nonlibraries.sh
+++ b/Tools/gittools/path-nonlibraries.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+usage() {
+    cat >&$1 <<EOF
+Usage: $0 [OPTIONS]
+
+Read a list of files relative to ardupilot's root directory and output the
+non-libraries subsystems they belong to.
+
+Options:
+    --show-paths, -p    Print also file paths after the library name.
+    --help, -h          Show this help message.
+EOF
+}
+
+show_paths=false
+
+while [[ -n $1 ]]; do
+    case "$1" in
+    --show-paths|-p)
+        show_paths=true
+        ;;
+    --help|-h)
+        usage 1
+        exit 0
+        ;;
+    *)
+        usage 2
+        exit 1
+        ;;
+    esac
+
+    shift
+done
+
+SCRIPT_DIR=$(dirname $(realpath ${BASH_SOURCE[0]}))
+ROOT=$(dirname $(git -C $SCRIPT_DIR rev-parse --git-dir))
+
+if $show_paths; then
+    sedcmd="s,\([^/]\+\).*,\1\t\0,"
+else
+    sedcmd="s,\([^/]\+\).*,\1,"
+fi
+
+grep -v "^libraries" | \
+    sed $sedcmd | \
+    sort | \
+    uniq | \
+    if $show_paths; then
+        while read d f; do
+            [[ -d "$ROOT/$d" ]] && printf "%s\t%s\n" "$d" "$f"
+        done
+    else
+        while read d; do
+            [[ -d "$ROOT/$d" ]] && echo "$d"
+        done
+    fi

--- a/Tools/gittools/verify-version.sh
+++ b/Tools/gittools/verify-version.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+SCRIPT_DIR=$(dirname $(realpath ${BASH_SOURCE[0]}))
+ROOT=$(dirname $(git -C $SCRIPT_DIR rev-parse --git-dir))
+
+install_version=$(git -C $ROOT config gittools.commithash)
+current_version=$(git -C $ROOT log -n 1 --format=%H $SCRIPT_DIR)
+
+[[ $install_version == $current_version ]] && exit 0
+
+cat >&2 <<EOF
+note: it seems like the installation version of gittools differs from the
+current tree, you can update ardupilot's gittools installation by running
+$SCRIPT_DIR/install.sh
+EOF
+echo
+
+exit 1


### PR DESCRIPTION
Hi guys,

I have been working with some refactoring lately and, with our policy of having separate commits per subsystem, I've come to realize that a tool that creates separate commits automatically would come up handy.

With that said, I'd like to introduce a new tool set in Ardupilot: **gittools** - a set of tools to be used with git in this project. *The developers are not obligated to use it* - ```Tools/gittools/install.sh``` is to be used if they want it in their environment.

Well, in summary, this PR's commits do the following:
- Create git hooks for policy compliance (http://dev.ardupilot.com/wiki/submitting-patches-back-to-master/).
- Add a git command "extension": ```git commit-subsystems``` - splits added changes into commits separated by subsystem (libraries and first level directories other than "libraries").

Again, the changes in this PR don't limit the developer as they have the option to use it or not. But I personally think that might be very useful in some situations.

Best regards, :)
Gustavo Sousa