### PR TITLE
RFC: support for timesliced timers

### DIFF
--- a/libraries/AP_Baro/AP_Baro_MS5611.cpp
+++ b/libraries/AP_Baro/AP_Baro_MS5611.cpp
@@ -200,7 +200,8 @@ AP_Baro_MS56XX::AP_Baro_MS56XX(AP_Baro &baro, AP_SerialBus *serial, bool use_tim
     _serial->sem_give();
 
     if (_use_timer) {
-        hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&AP_Baro_MS56XX::_timer, void));
+        /* timer needs to be called every 10ms so set the freq_div to 10 */
+        _timesliced = hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&AP_Baro_MS56XX::_timer, void), 10);
     }
 }
 
@@ -251,19 +252,22 @@ bool AP_Baro_MS56XX::_check_crc(void)
     return (0x000F & crc_read) == (n_rem ^ 0x00);
 }
 
+void AP_Baro_MS56XX::_timer(void)
+{
+    if(_timesliced ||
+       hal.scheduler->micros() - _last_timer >= 10000) {
+        _read_from_device();
+        _last_timer = hal.scheduler->micros();
+    }
+}
 
 /*
   Read the sensor. This is a state machine
   We read one time Temperature (state=1) and then 4 times Pressure (states 2-5)
   temperature does not change so quickly...
 */
-void AP_Baro_MS56XX::_timer(void)
+void AP_Baro_MS56XX::_read_from_device(void)
 {
-    // Throttle read rate to 100hz maximum.
-    if (hal.scheduler->micros() - _last_timer < 10000) {
-        return;
-    }
-
     if (!_serial->sem_take_nonblocking()) {
         return;
     }
@@ -310,7 +314,6 @@ void AP_Baro_MS56XX::_timer(void)
         }
     }
 
-    _last_timer = hal.scheduler->micros();
     _serial->sem_give();
 }
 
@@ -438,6 +441,6 @@ void AP_Baro_MS56XX::accumulate(void)
     if (!_use_timer) {
         // the timer isn't being called as a timer, so we need to call
         // it in accumulate()
-        _timer();
+        _read_from_device();
     }
 }

--- a/libraries/AP_Baro/AP_Baro_MS5611.h
+++ b/libraries/AP_Baro/AP_Baro_MS5611.h
@@ -86,6 +86,7 @@ private:
     bool _check_crc();
 
     void _timer();
+    void _read_from_device();
 
     /* Asynchronous state: */
     volatile bool            _updated;
@@ -94,6 +95,7 @@ private:
     volatile uint32_t        _s_D1, _s_D2;
     uint8_t                  _state;
     uint32_t                 _last_timer;
+    bool                     _timesliced;
 
     bool _use_timer;
 

--- a/libraries/AP_Compass/AP_Compass_AK8963.h
+++ b/libraries/AP_Compass/AP_Compass_AK8963.h
@@ -70,6 +70,7 @@ private:
     bool                _initialized;
     uint32_t            _last_update_timestamp;
     uint32_t            _last_accum_time;
+    bool                _timesliced;
 
     AP_AK8963_SerialBus *_bus;
     AP_HAL::Semaphore *_bus_sem;

--- a/libraries/AP_HAL/Scheduler.h
+++ b/libraries/AP_HAL/Scheduler.h
@@ -38,6 +38,8 @@ public:
 
     // register a high priority timer task
     virtual void     register_timer_process(AP_HAL::MemberProc) = 0;
+    virtual bool     register_timer_process(AP_HAL::MemberProc proc, uint8_t freq_div)
+                     {register_timer_process(proc); return false;}
 
     // register a low priority IO task
     virtual void     register_io_process(AP_HAL::MemberProc) = 0;

--- a/libraries/AP_HAL_Linux/Scheduler.h
+++ b/libraries/AP_HAL_Linux/Scheduler.h
@@ -10,6 +10,7 @@
 #include <pthread.h>
 
 #define LINUX_SCHEDULER_MAX_TIMER_PROCS 10
+#define LINUX_SCHEDULER_MAX_TIMESLICED_PROCS 10
 #define LINUX_SCHEDULER_MAX_IO_PROCS 10
 
 class Linux::LinuxScheduler : public AP_HAL::Scheduler {
@@ -29,6 +30,7 @@ public:
                 uint16_t min_time_ms);
 
     void     register_timer_process(AP_HAL::MemberProc);
+    bool     register_timer_process(AP_HAL::MemberProc, uint8_t);
     void     register_io_process(AP_HAL::MemberProc);
     void     suspend_timer_procs();
     void     resume_timer_procs();
@@ -64,6 +66,17 @@ private:
     AP_HAL::MemberProc _timer_proc[LINUX_SCHEDULER_MAX_TIMER_PROCS];
     uint8_t _num_timer_procs;
     volatile bool _in_timer_proc;
+    uint8_t _timeslices_count;
+
+    class timesliced_proc {
+        public:
+        AP_HAL::MemberProc proc;
+        uint8_t timeslot;
+        uint8_t freq_div;
+    };
+    timesliced_proc _timesliced_proc[LINUX_SCHEDULER_MAX_TIMESLICED_PROCS];
+    uint8_t _num_timesliced_procs;
+    uint8_t _max_freq_div;
 
     AP_HAL::MemberProc _io_proc[LINUX_SCHEDULER_MAX_IO_PROCS];
     uint8_t _num_io_procs;
@@ -87,6 +100,7 @@ private:
     void _run_io(void);
     void _create_realtime_thread(pthread_t *ctx, int rtprio, const char *name,
                                  pthread_startroutine_t start_routine);
+    bool _register_timesliced_proc(AP_HAL::MemberProc, uint8_t);
 
     uint64_t stopped_clock_usec;
 


### PR DESCRIPTION
This pull request is more intended to get comments on this way of dealing with lower freq timers.
I have noticed using lttng that the main issue I had with scheduling (SCHED_DEBUG long loops) were due to the fact that even if Baro and Compass timers are called with a lower frequency, they are called on the same iteration of the main timer loop. This causes some very long timer loops that also block the main loop for a long time.
This is a way of getting lower freq timers not to run on the same loop iteration.
I must add that the problems I have with the duration of the Baro and Compass reads are due to the fact that on the bebop all of the basic sensors are connected with an i2c bus, which is very slow compared to spi.