### PR TITLE
"Centralized" acceleration vibration and clipping calculation

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -303,6 +303,7 @@ AP_InertialSensor::AP_InertialSensor() :
 #endif
 
         _accel_max_abs_offsets[i] = 3.5f;
+        _accel_sample_rates[i] = 0;
     }
     memset(_delta_velocity_valid,0,sizeof(_delta_velocity_valid));
     memset(_delta_angle_valid,0,sizeof(_delta_angle_valid));

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -299,6 +299,9 @@ private:
     // accelerometer max absolute offsets to be used for calibration
     float _accel_max_abs_offsets[INS_MAX_INSTANCES];
 
+    // accelerometer sample rate in units of Hz
+    uint32_t _accel_sample_rates[INS_MAX_INSTANCES];
+
     // temperatures for an instance if available
     float _temperature[INS_MAX_INSTANCES];
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -84,6 +84,12 @@ void AP_InertialSensor_Backend::_set_accel_max_abs_offset(uint8_t instance,
     _imu._accel_max_abs_offsets[instance] = max_offset;
 }
 
+void AP_InertialSensor_Backend::_set_accel_sample_rate(uint8_t instance,
+                                                       uint32_t rate)
+{
+    _imu._accel_sample_rates[instance] = rate;
+}
+
 // set accelerometer error_count
 void AP_InertialSensor_Backend::_set_accel_error_count(uint8_t instance, uint32_t error_count)
 {

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -65,9 +65,6 @@ void AP_InertialSensor_Backend::_publish_delta_velocity(uint8_t instance, const 
     _imu._delta_velocity_valid[instance] = true;
 }
 
-/*
-  rotate accel vector, scale and add the accel offset
- */
 void AP_InertialSensor_Backend::_publish_accel(uint8_t instance, const Vector3f &accel, bool rotate_and_correct)
 {
     _imu._accel[instance] = accel;
@@ -76,6 +73,13 @@ void AP_InertialSensor_Backend::_publish_accel(uint8_t instance, const Vector3f 
     if (rotate_and_correct) {
         _rotate_and_correct_accel(instance, _imu._accel[instance]);
     }
+
+#if INS_VIBRATION_CHECK
+    if (_imu._accel_sample_rates[instance] > 0) {
+        float dt = 1.0f / _imu._accel_sample_rates[instance];
+        _imu.calc_vibration_and_clipping(instance, accel, dt);
+    }
+#endif
 }
 
 void AP_InertialSensor_Backend::_set_accel_max_abs_offset(uint8_t instance,

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -76,6 +76,12 @@ protected:
     // set accelerometer max absolute offset for calibration
     void _set_accel_max_abs_offset(uint8_t instance, float offset);
 
+    // set accelerometer sample rate
+    void _set_accel_sample_rate(uint8_t instance, uint32_t rate);
+    uint32_t _accel_sample_rate(uint8_t instance) const {
+        return _imu._accel_sample_rates[instance];
+    }
+
     // publish a temperature value
     void _publish_temperature(uint8_t instance, float temperature);
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
@@ -315,6 +315,8 @@ bool AP_InertialSensor_MPU9250::_init_sensor(void)
     // start the timer process to read samples
     hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&AP_InertialSensor_MPU9250::_poll_data, void));
 
+    _set_accel_sample_rate(_accel_instance, DEFAULT_SAMPLE_RATE);
+
 #if MPU9250_DEBUG
     _dump_registers(_spi);
 #endif

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
@@ -159,6 +159,9 @@ extern const AP_HAL::HAL& hal;
 #define BITS_DLPF_CFG_2100HZ_NOLPF              0x07
 #define BITS_DLPF_CFG_MASK                              0x07
 
+#define DEFAULT_SMPLRT_DIV MPUREG_SMPLRT_1000HZ
+#define DEFAULT_SAMPLE_RATE (1000 / (DEFAULT_SMPLRT_DIV + 1))
+
 /*
  *  PS-MPU-9250A-00.pdf, page 8, lists LSB sensitivity of
  *  gyro as 16.4 LSB/DPS at scale factor of +/- 2000dps (FS_SEL==3)
@@ -178,8 +181,8 @@ AP_InertialSensor_MPU9250::AP_InertialSensor_MPU9250(AP_InertialSensor &imu) :
     _last_accel_filter_hz(-1),
     _last_gyro_filter_hz(-1),
     _shared_data_idx(0),
-    _accel_filter(1000, 15),
-    _gyro_filter(1000, 15),
+    _accel_filter(DEFAULT_SAMPLE_RATE, 15),
+    _gyro_filter(DEFAULT_SAMPLE_RATE, 15),
     _have_sample_available(false),
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_PXF
     _default_rotation(ROTATION_ROLL_180_YAW_270)
@@ -451,7 +454,7 @@ inline void AP_InertialSensor_MPU9250::_register_write(uint8_t reg, uint8_t val)
  */
 void AP_InertialSensor_MPU9250::_set_accel_filter(uint8_t filter_hz)
 {
-    _accel_filter.set_cutoff_frequency(1000, filter_hz);
+    _accel_filter.set_cutoff_frequency(DEFAULT_SAMPLE_RATE, filter_hz);
 }
 
 /*
@@ -459,7 +462,7 @@ void AP_InertialSensor_MPU9250::_set_accel_filter(uint8_t filter_hz)
  */
 void AP_InertialSensor_MPU9250::_set_gyro_filter(uint8_t filter_hz)
 {
-    _gyro_filter.set_cutoff_frequency(1000, filter_hz);
+    _gyro_filter.set_cutoff_frequency(DEFAULT_SAMPLE_RATE, filter_hz);
 }
 
 
@@ -488,7 +491,7 @@ bool AP_InertialSensor_MPU9250::_hardware_init(void)
 
     // set sample rate to 1kHz, and use the 2 pole filter to give the
     // desired rate
-    _register_write(MPUREG_SMPLRT_DIV, MPUREG_SMPLRT_1000HZ);
+    _register_write(MPUREG_SMPLRT_DIV, DEFAULT_SMPLRT_DIV);
     _register_write(MPUREG_GYRO_CONFIG, BITS_GYRO_FS_2000DPS);  // Gyro scale 2000º/s
 
     // RM-MPU-9250A-00.pdf, pg. 15, select accel full scale 16g

--- a/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
@@ -164,6 +164,7 @@ bool AP_InertialSensor_PX4::_init_sensor(void)
         if (samplerate < 100 || samplerate > 10000) {
             hal.scheduler->panic("Invalid accel sample rate");
         }
+        _set_accel_sample_rate(_accel_instance[i], (uint32_t) samplerate);
         _accel_sample_time[i] = 1.0f / samplerate;
     }
 
@@ -188,7 +189,7 @@ bool AP_InertialSensor_PX4::_init_sensor(void)
 void AP_InertialSensor_PX4::_set_accel_filter_frequency(uint8_t filter_hz)
 {
     for (uint8_t i=0; i<_num_accel_instances; i++) {
-        float samplerate = 1.0f / _accel_sample_time[i];
+        float samplerate = _accel_sample_rate(_accel_instance[i]);
         _accel_filter[i].set_cutoff_frequency(samplerate, filter_hz);
     }
 }
@@ -279,9 +280,6 @@ void AP_InertialSensor_PX4::_new_accel_sample(uint8_t i, accel_report &accel_rep
 
     // publish a temperature (for logging purposed only)
     _publish_temperature(frontend_instance, accel_report.temperature);
-
-    // check noise
-    _imu.calc_vibration_and_clipping(frontend_instance, accel, dt);
 
 #ifdef AP_INERTIALSENSOR_PX4_DEBUG
     _accel_dt_max[i] = max(_accel_dt_max[i],dt);


### PR DESCRIPTION
Hi, this PR:
- makes it possible to make acceleration vibration and clipping be called from a common place;
- makes AP_InertialSensor_PX4 consistent with the new change;
- makes AP_InertialSensor_MPU9250 publish the accelerometer sample rate to enable vibration and clipping calculation.

I think this approach is better than making each backend class call for vibration and clipping calculation by itself.