### PR TITLE
sitl ublox hdop addition

### DIFF
--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -49,7 +49,7 @@ AP_GPS_UBLOX::AP_GPS_UBLOX(AP_GPS &_gps, AP_GPS::GPS_State &_state, AP_HAL::UART
     _payload_counter(0),
     _fix_count(0),
     _class(0),
-    noRecievedHdop(true),
+    noReceivedHdop(true),
     _new_position(0),
     _new_speed(0),
     need_rate_update(false),
@@ -580,7 +580,7 @@ AP_GPS_UBLOX::_parse_gps(void)
         break;
     case MSG_DOP:
         Debug("MSG_DOP");
-        noRecievedHdop = false;
+        noReceivedHdop = false;
         state.hdop        = _buffer.dop.hDOP;
 #if UBLOX_FAKE_3DLOCK
         state.hdop = 130;
@@ -606,7 +606,7 @@ AP_GPS_UBLOX::_parse_gps(void)
             next_fix = AP_GPS::NO_FIX;
             state.status = AP_GPS::NO_FIX;
         }
-        if(noRecievedHdop) {
+        if(noReceivedHdop) {
             state.hdop = _buffer.solution.position_DOP;
         }
         state.num_sats    = _buffer.solution.satellites;

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -402,7 +402,7 @@ private:
     uint8_t rate_update_step;
     uint32_t _last_5hz_time;
 
-    bool noRecievedHdop;
+    bool noReceivedHdop;
 
     void 	    _configure_navigation_rate(uint16_t rate_ms);
     void        _configure_message_rate(uint8_t msg_class, uint8_t msg_id, uint8_t rate);

--- a/libraries/AP_HAL_SITL/sitl_gps.cpp
+++ b/libraries/AP_HAL_SITL/sitl_gps.cpp
@@ -211,8 +211,19 @@ void SITL_State::_update_gps_ubx(const struct gps_data *d)
         uint8_t satellites;
         uint32_t res2;
     } sol;
+    struct PACKED ubx_nav_dop {
+        uint32_t time;                                  // GPS msToW
+        uint16_t gDOP;
+        uint16_t pDOP;
+        uint16_t tDOP;
+        uint16_t vDOP;
+        uint16_t hDOP;
+        uint16_t nDOP;
+        uint16_t eDOP;
+    } dop;
     const uint8_t MSG_POSLLH = 0x2;
     const uint8_t MSG_STATUS = 0x3;
+    const uint8_t MSG_DOP = 0x4;
     const uint8_t MSG_VELNED = 0x12;
     const uint8_t MSG_SOL = 0x6;
     uint16_t time_week;
@@ -256,10 +267,20 @@ void SITL_State::_update_gps_ubx(const struct gps_data *d)
     sol.time = time_week_ms;
     sol.week = time_week;
 
+    dop.time = time_week_ms;
+    dop.gDOP = 65535;
+    dop.pDOP = 65535;
+    dop.tDOP = 65535;
+    dop.vDOP = 200;
+    dop.hDOP = 121;
+    dop.nDOP = 65535;
+    dop.eDOP = 65535;
+
     _gps_send_ubx(MSG_POSLLH, (uint8_t*)&pos, sizeof(pos));
     _gps_send_ubx(MSG_STATUS, (uint8_t*)&status, sizeof(status));
     _gps_send_ubx(MSG_VELNED, (uint8_t*)&velned, sizeof(velned));
     _gps_send_ubx(MSG_SOL,    (uint8_t*)&sol, sizeof(sol));
+    _gps_send_ubx(MSG_DOP,    (uint8_t*)&dop, sizeof(dop));
 }
 
 static void swap_uint32(uint32_t *v, uint8_t n)


### PR DESCRIPTION
Adds hdop to the ublox sitl simulation.

Also fixes a spelling error in the ublox driver for hdop fallback