### PR TITLE
Df state machines

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -73,8 +73,9 @@ const AP_Scheduler::Task Rover::scheduler_tasks[] PROGMEM = {
     { SCHED_TASK(update_notify),          1,    300 },
     { SCHED_TASK(one_second_loop),       50,   3000 },
 #if FRSKY_TELEM_ENABLED == ENABLED
-    { SCHED_TASK(frsky_telemetry_send),  10,    100 }
+    { SCHED_TASK(frsky_telemetry_send),  10,    100 },
 #endif
+    { SCHED_TASK(dataflash_periodic),     1,   2000 }
 };
 
 /*
@@ -312,6 +313,11 @@ void Rover::one_second_loop(void)
     }
 
     ins.set_raw_logging(should_log(MASK_LOG_IMU_RAW));
+}
+
+void Rover::dataflash_periodic(void)
+{
+    DataFlash.periodic_tasks();
 }
 
 void Rover::update_GPS_50Hz(void)

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -135,7 +135,7 @@ private:
     RC_Channel *channel_throttle;
     RC_Channel *channel_learn;
 
-    DataFlash_Class DataFlash;
+    DataFlash_Class DataFlash{FIRMWARE_STRING};
 
     bool in_log_download;
 
@@ -402,10 +402,11 @@ private:
     void gcs_update(void);
     void gcs_send_text_P(MAV_SEVERITY severity, const prog_char_t *str);
     void gcs_retry_deferred(void);
+
     void do_erase_logs(void);
     void Log_Write_Performance();
     void Log_Write_Steering();
-    void Log_Write_Startup(uint8_t type);
+    bool Log_Write_Startup(uint8_t type);
     void Log_Write_Control_Tuning();
     void Log_Write_Nav_Tuning();
     void Log_Write_Sonar();
@@ -414,9 +415,11 @@ private:
     void Log_Write_RC(void);
     void Log_Write_Baro(void);
     void Log_Write_Home_And_Origin();
+    void Log_Write_Vehicle_Startup_Messages();
     void Log_Read(uint16_t log_num, uint16_t start_page, uint16_t end_page);
     void log_init(void);
     void start_logging() ;
+
     void load_parameters(void);
     void throttle_slew_limit(int16_t last_throttle);
     bool auto_check_trigger(void);
@@ -533,6 +536,8 @@ public:
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
     int8_t test_shell(uint8_t argc, const Menu::arg *argv);
 #endif
+
+    void dataflash_periodic(void);
 };
 
 #define MENU_FUNC(func) FUNCTOR_BIND(&rover, &Rover::func, int8_t, uint8_t, const Menu::arg *)

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -213,7 +213,6 @@ void Rover::init_ardupilot()
 	init_capabilities();
 
 	startup_ground();
-    Log_Write_Startup(TYPE_GROUNDSTART_MSG);
 
     set_mode((enum mode)g.initial_mode.get());
 
@@ -511,11 +510,7 @@ bool Rover::should_log(uint32_t mask)
     }
     bool ret = hal.util->get_soft_armed() || (g.log_bitmask & MASK_LOG_WHEN_DISARMED) != 0;
     if (ret && !DataFlash.logging_started() && !in_log_download) {
-        // we have to set in_mavlink_delay to prevent logging while
-        // writing headers
-        in_mavlink_delay = true;
         start_logging();
-        in_mavlink_delay = false;
     }
     return ret;
 }

--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -129,6 +129,7 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] PROGMEM = {
     { SCHED_TASK(ten_hz_logging_loop),  40,    350 },
     { SCHED_TASK(fifty_hz_logging_loop), 8,    110 },
     { SCHED_TASK(full_rate_logging_loop),1,    100 },
+    { SCHED_TASK(dataflash_periodic),    1,   1000 },
     { SCHED_TASK(perf_update),        4000,     75 },
     { SCHED_TASK(read_receiver_rssi),   40,     75 },
     { SCHED_TASK(rpm_update),           40,    200 },
@@ -420,6 +421,11 @@ void Copter::full_rate_logging_loop()
     if (should_log(MASK_LOG_IMU_FAST) || should_log(MASK_LOG_IMU_RAW)) {
         DataFlash.Log_Write_IMUDT(ins);
     }
+}
+
+void Copter::dataflash_periodic(void)
+{
+    DataFlash.periodic_tasks();
 }
 
 // three_hz_loop - 3.3hz loop

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -1,6 +1,7 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-#ifndef _COPTER_H_
-#define _COPTER_H_
+
+#ifndef _COPTER_H
+#define _COPTER_H
 
 #define THISFIRMWARE "APM:Copter V3.4-dev"
 #define FIRMWARE_VERSION 3,4,0,FIRMWARE_VERSION_TYPE_DEV
@@ -132,7 +133,6 @@ class Copter {
     void loop();
 
 private:
-
     // key aircraft parameters passed to multiple libraries
     AP_Vehicle::MultiCopter aparm;
 
@@ -163,7 +163,7 @@ private:
     RC_Channel *channel_yaw;
 
     // Dataflash
-    DataFlash_Class DataFlash;
+    DataFlash_Class DataFlash{FIRMWARE_STRING};
 
     // the rate we run the main loop at
     const AP_InertialSensor::Sample_rate ins_sample_rate;
@@ -634,6 +634,7 @@ private:
     void Log_Write_Heli(void);
 #endif
     void Log_Write_Precland();
+    void Log_Write_Vehicle_Startup_Messages();
     void Log_Read(uint16_t log_num, uint16_t start_page, uint16_t end_page);
     void start_logging() ;
     void load_parameters(void);
@@ -972,6 +973,7 @@ private:
     void log_init(void);
     void run_cli(AP_HAL::UARTDriver *port);
     void init_capabilities(void);
+    void dataflash_periodic(void);
 
 public:
     void mavlink_delay_cb();

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -438,8 +438,6 @@ bool Copter::should_log(uint32_t mask)
     }
     bool ret = motors.armed() || (g.log_bitmask & MASK_LOG_WHEN_DISARMED) != 0;
     if (ret && !DataFlash.logging_started() && !in_log_download) {
-        // we have to set in_mavlink_delay to prevent logging while
-        // writing headers
         start_logging();
     }
     return ret;

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -75,6 +75,7 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] PROGMEM = {
 #endif
     { SCHED_TASK(terrain_update),         5,    500 },
     { SCHED_TASK(update_is_flying_5Hz),  10,    100 },
+    { SCHED_TASK(dataflash_periodic),     1,   1000 },
 };
 
 void Plane::setup() 
@@ -361,6 +362,11 @@ void Plane::terrain_update(void)
         rangefinder.set_estimated_terrain_height(height);
     }
 #endif
+}
+
+void Plane::dataflash_periodic(void)
+{
+    DataFlash.periodic_tasks();
 }
 
 /*

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1,6 +1,7 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-#ifndef _PLANE_H_
-#define _PLANE_H_
+
+#ifndef _PLANE_H
+#define _PLANE_H
 
 #define THISFIRMWARE "ArduPlane V3.4.0beta1"
 #define FIRMWARE_VERSION 3,4,0,FIRMWARE_VERSION_TYPE_BETA
@@ -163,7 +164,7 @@ private:
     // notification object for LEDs, buzzers etc (parameter set to false disables external leds)
     AP_Notify notify;
 
-    DataFlash_Class DataFlash;
+    DataFlash_Class DataFlash{FIRMWARE_STRING};
 
     // has a log download started?
     bool in_log_download;
@@ -698,10 +699,11 @@ private:
     void gcs_send_text_P(MAV_SEVERITY severity, const prog_char_t *str);
     void gcs_send_airspeed_calibration(const Vector3f &vg);
     void gcs_retry_deferred(void);
+
     void do_erase_logs(void);
     void Log_Write_Attitude(void);
     void Log_Write_Performance();
-    void Log_Write_Startup(uint8_t type);
+    bool Log_Write_Startup(uint8_t type);
     void Log_Write_Control_Tuning();
     void Log_Write_TECS_Tuning(void);
     void Log_Write_Nav_Tuning();
@@ -716,8 +718,10 @@ private:
     void Log_Write_Baro(void);
     void Log_Write_Airspeed(void);
     void Log_Write_Home_And_Origin();
+    void Log_Write_Vehicle_Startup_Messages();
     void Log_Read(uint16_t log_num, int16_t start_page, int16_t end_page);
     void start_logging();
+
     void load_parameters(void);
     void adjust_altitude_target();
     void setup_glide_slope(void);
@@ -943,6 +947,7 @@ private:
     uint32_t millis() const;
     uint32_t micros() const;
     void init_capabilities(void);
+    void dataflash_periodic(void);
 
 public:
     void mavlink_delay_cb();

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -242,7 +242,6 @@ void Plane::init_ardupilot()
     init_capabilities();
 
     startup_ground();
-    Log_Write_Startup(TYPE_GROUNDSTART_MSG);
 
     // choose the nav controller
     set_nav_controller();
@@ -718,6 +717,7 @@ void Plane::servo_write(uint8_t ch, uint16_t pwm)
  */
 bool Plane::should_log(uint32_t mask)
 {
+#if LOGGING_ENABLED == ENABLED
     if (!(mask & g.log_bitmask) || in_mavlink_delay) {
         return false;
     }
@@ -725,13 +725,12 @@ bool Plane::should_log(uint32_t mask)
     if (ret && !DataFlash.logging_started() && !in_log_download) {
         // we have to set in_mavlink_delay to prevent logging while
         // writing headers
-        in_mavlink_delay = true;
-        #if LOGGING_ENABLED == ENABLED
         start_logging();
-        #endif
-        in_mavlink_delay = false;
     }
     return ret;
+#else
+    return false;
+#endif
 }
 
 /*

--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -87,7 +87,7 @@ public:
     AP_InertialNav_NavEKF inertial_nav{ahrs};
     AP_Vehicle::FixedWing aparm;
     AP_Airspeed airspeed{aparm};
-    DataFlash_Class dataflash;
+    DataFlash_Class dataflash{PSTR("Replay v0.1")};
 
 private:
     Parameters g;

--- a/libraries/DataFlash/DFMessageWriter.cpp
+++ b/libraries/DataFlash/DFMessageWriter.cpp
@@ -1,0 +1,203 @@
+#include "DFMessageWriter.h"
+
+#include "DataFlash.h"
+
+extern const AP_HAL::HAL& hal;
+
+/* LogStartup - these are simple state machines which allow us to
+ * trickle out messages to the log files
+ */
+
+void DFMessageWriter::reset()
+{
+    _finished = false;
+}
+
+void DFMessageWriter_DFLogStart::reset()
+{
+    DFMessageWriter::reset();
+
+    _writesysinfo.reset();
+    _writeentiremission.reset();
+
+    stage = ls_blockwriter_stage_init;
+    next_format_to_send = 0;
+    ap = AP_Param::first(&token, &type);
+}
+
+void DFMessageWriter_DFLogStart::process()
+{
+    switch(stage) {
+    case ls_blockwriter_stage_init:
+        stage = ls_blockwriter_stage_formats;
+        // fall through
+
+    case ls_blockwriter_stage_formats:
+        // write log formats so the log is self-describing
+        while (next_format_to_send < _DataFlash._num_types) {
+            if (!_DataFlash.Log_Write_Format(&_DataFlash._structures[next_format_to_send])) {
+                return; // call me again!
+            }
+            // provide hook to avoid corrupting the APM1/APM2
+            // dataflash by writing too fast:
+            _DataFlash.WroteStartupFormat();
+            next_format_to_send++;
+        }
+        stage = ls_blockwriter_stage_parms;
+        // fall through
+
+    case ls_blockwriter_stage_parms:
+        while (ap) {
+            if (!_DataFlash.Log_Write_Parameter(ap, token, type)) {
+                return;
+            }
+            ap = AP_Param::next_scalar(&token, &type);
+            _DataFlash.WroteStartupParam();
+        }
+
+        stage = ls_blockwriter_stage_sysinfo;
+        // fall through
+
+    case ls_blockwriter_stage_sysinfo:
+        _writesysinfo.process();
+        if (!_writesysinfo.finished()) {
+            return;
+        }
+        stage = ls_blockwriter_stage_write_entire_mission;
+        // fall through
+
+    case ls_blockwriter_stage_write_entire_mission:
+        _writeentiremission.process();
+        if (!_writeentiremission.finished()) {
+            return;
+        }
+        stage = ls_blockwriter_stage_vehicle_messages;
+        // fall through
+
+    case ls_blockwriter_stage_vehicle_messages:
+        // we guarantee 200 bytes of space for the vehicle startup
+        // messages.  This allows them to be simple functions rather
+        // than e.g. DFMessageWriter-based state machines
+        if (_DataFlash._vehicle_messages) {
+            if (_DataFlash.bufferspace_available() < 200) {
+                return;
+            }
+            _DataFlash._vehicle_messages();
+        }
+        stage = ls_blockwriter_stage_done;
+        // fall through
+
+    case ls_blockwriter_stage_done:
+        break;
+    }
+
+    _finished = true;
+}
+
+void DFMessageWriter_WriteSysInfo::reset()
+{
+    DFMessageWriter::reset();
+    stage = ws_blockwriter_stage_init;
+}
+
+void DFMessageWriter_DFLogStart::set_mission(const AP_Mission *mission)
+{
+    _writeentiremission.set_mission(mission);
+}
+
+
+void DFMessageWriter_WriteSysInfo::process() {
+    switch(stage) {
+
+    case ws_blockwriter_stage_init:
+        stage = ws_blockwriter_stage_firmware_string;
+        // fall through
+
+    case ws_blockwriter_stage_firmware_string:
+        if (! _DataFlash.Log_Write_Message_P(_firmware_string)) {
+            return; // call me again
+        }
+        stage = ws_blockwriter_stage_git_versions;
+        // fall through
+
+    case ws_blockwriter_stage_git_versions:
+#if defined(PX4_GIT_VERSION) && defined(NUTTX_GIT_VERSION)
+        if (! _DataFlash.Log_Write_Message_P(PSTR("PX4: " PX4_GIT_VERSION " NuttX: " NUTTX_GIT_VERSION))) {
+            return; // call me again
+        }
+#endif
+        stage = ws_blockwriter_stage_system_id;
+        // fall through
+
+    case ws_blockwriter_stage_system_id:
+        char sysid[40];
+        if (hal.util->get_system_id(sysid)) {
+            if (! _DataFlash.Log_Write_Message(sysid)) {
+                return; // call me again
+            }
+        }
+        // fall through
+    }
+
+    _finished = true;  // all done!
+}
+
+// void DataFlash_Class::Log_Write_SysInfo(const prog_char_t *firmware_string)
+// {
+//     DFMessageWriter_WriteSysInfo writer(firmware_string);
+//     writer->process();
+// }
+
+void DFMessageWriter_WriteEntireMission::process() {
+    switch(stage) {
+
+    case em_blockwriter_stage_init:
+        if (_mission == NULL) {
+            stage = em_blockwriter_stage_done;
+            break;
+        } else {
+            stage = em_blockwriter_stage_write_new_mission_message;
+        }
+        // fall through
+
+    case em_blockwriter_stage_write_new_mission_message:
+        if (! _DataFlash.Log_Write_Message_P(PSTR("New mission"))) {
+            return; // call me again
+        }
+        stage = em_blockwriter_stage_write_mission_items;
+        // fall through
+
+    case em_blockwriter_stage_write_mission_items:
+        AP_Mission::Mission_Command cmd;
+        while (_mission_number_to_send < _mission->num_commands()) {
+            // upon failure to write the mission we will re-read from
+            // storage; this could be improved.
+            if (_mission->read_cmd_from_storage(_mission_number_to_send,cmd)) {
+                if (!_DataFlash.Log_Write_Mission_Cmd(*_mission, cmd)) {
+                    return; // call me again
+                }
+            }
+            _mission_number_to_send++;
+        }
+        stage = em_blockwriter_stage_done;
+        // fall through
+
+    case em_blockwriter_stage_done:
+        break;
+    }
+
+    _finished = true;
+}
+
+void DFMessageWriter_WriteEntireMission::reset()
+{
+    DFMessageWriter::reset();
+    stage = em_blockwriter_stage_init;
+    _mission_number_to_send = 0;
+}
+
+
+void DFMessageWriter_WriteEntireMission::set_mission(const AP_Mission *mission)
+{
+    _mission = mission;
+}

--- a/libraries/DataFlash/DFMessageWriter.h
+++ b/libraries/DataFlash/DFMessageWriter.h
@@ -1,0 +1,115 @@
+#ifndef DF_LOGSTARTUP_H
+#define DF_LOGSTARTUP_H
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Mission/AP_Mission.h>
+
+class DataFlash_Class;
+
+class DFMessageWriter {
+public:
+    DFMessageWriter(DataFlash_Class &DataFlash) :
+        _DataFlash(DataFlash) { }
+
+    virtual void reset() = 0;
+    virtual void process() = 0;
+    virtual bool finished() { return _finished; };
+
+protected:
+    bool _finished;
+    DataFlash_Class &_DataFlash;
+};
+
+
+class DFMessageWriter_WriteSysInfo : public DFMessageWriter {
+public:
+    DFMessageWriter_WriteSysInfo(DataFlash_Class &DataFlash,
+                                 const prog_char_t *firmware_string) :
+        DFMessageWriter(DataFlash),
+        _firmware_string(firmware_string)
+        { }
+
+    void reset();
+    void process();
+
+private:
+    enum write_sysinfo_blockwriter_stage {
+        ws_blockwriter_stage_init,
+        ws_blockwriter_stage_firmware_string,
+        ws_blockwriter_stage_git_versions,
+        ws_blockwriter_stage_system_id
+    };
+    write_sysinfo_blockwriter_stage stage;
+
+    const prog_char_t *_firmware_string;
+};
+
+class DFMessageWriter_WriteEntireMission : public DFMessageWriter {
+public:
+    DFMessageWriter_WriteEntireMission(DataFlash_Class &DataFlash) :
+        DFMessageWriter(DataFlash),
+        _mission_number_to_send(0),
+        stage(em_blockwriter_stage_init),
+        _mission(NULL)
+        { }
+    void reset();
+    void process();
+
+    void set_mission(const AP_Mission *mission);
+
+private:
+    enum entire_mission_blockwriter_stage {
+        em_blockwriter_stage_init,
+        em_blockwriter_stage_write_new_mission_message,
+        em_blockwriter_stage_write_mission_items,
+        em_blockwriter_stage_done
+    };
+
+    const AP_Mission *_mission;
+    uint16_t _mission_number_to_send;
+    entire_mission_blockwriter_stage stage;
+};
+
+class DFMessageWriter_DFLogStart : public DFMessageWriter {
+public:
+    DFMessageWriter_DFLogStart(DataFlash_Class &DataFlash,
+                               const prog_char_t *firmware_string) :
+        DFMessageWriter{DataFlash},
+        _writesysinfo(DataFlash, firmware_string),
+        _writeentiremission(DataFlash)
+        {
+        }
+
+    void reset();
+    void process();
+
+    void set_mission(const AP_Mission *mission);
+
+private:
+
+    enum log_start_blockwriter_stage {
+        ls_blockwriter_stage_init,
+        ls_blockwriter_stage_formats,
+        ls_blockwriter_stage_parms,
+        ls_blockwriter_stage_sysinfo,
+        ls_blockwriter_stage_write_entire_mission,
+        ls_blockwriter_stage_vehicle_messages,
+        ls_blockwriter_stage_done,
+    };
+
+    log_start_blockwriter_stage stage;
+
+    uint16_t next_format_to_send;
+    AP_Param::ParamToken token;
+    AP_Param *ap;
+    enum ap_var_type type;
+    uint16_t num_format_types;
+    const struct LogStructure *_structures;
+
+
+    DFMessageWriter_WriteSysInfo _writesysinfo;
+    DFMessageWriter_WriteEntireMission _writeentiremission;
+};
+
+#endif
+

--- a/libraries/DataFlash/DataFlash.cpp
+++ b/libraries/DataFlash/DataFlash.cpp
@@ -1,9 +1,29 @@
 #include "DataFlash.h"
 
-// start functions pass straight through to backend:
-void DataFlash_Class::WriteBlock(const void *pBuffer, uint16_t size) {
-    backend->WriteBlock(pBuffer, size);
+#include "DataFlash_Backend.h"
+
+void DataFlash_Class::setVehicle_Startup_Log_Writer(vehicle_startup_message_Log_Writer writer)
+{
+    _vehicle_messages = writer;
 }
+
+void DataFlash_Class::set_mission(const AP_Mission *mission) {
+    _startup_messagewriter.set_mission(mission);
+}
+
+// start functions pass straight through to backend:
+bool DataFlash_Class::WriteBlock(const void *pBuffer, uint16_t size) {
+    return backend->WriteBlock(pBuffer, size);
+}
+
+bool DataFlash_Class::WriteCriticalBlock(const void *pBuffer, uint16_t size) {
+    return backend->WriteCriticalBlock(pBuffer, size);
+}
+
+bool DataFlash_Class::WritePrioritisedBlock(const void *pBuffer, uint16_t size, bool is_critical) {
+    return backend->WritePrioritisedBlock(pBuffer, size, is_critical);
+}
+
 uint16_t DataFlash_Class::start_new_log() {
     return backend->start_new_log();
 }
@@ -19,6 +39,10 @@ bool DataFlash_Class::CardInserted(void) {
 // remove me in favour of calling "DoTimeConsumingPreparations" all the time?
 bool DataFlash_Class::NeedErase(void) {
     return backend->NeedErase();
+}
+
+uint16_t DataFlash_Class::bufferspace_available(void) {
+    return backend->bufferspace_available();
 }
 
 uint16_t DataFlash_Class::find_last_log(void) {
@@ -64,6 +88,18 @@ bool DataFlash_Class::logging_started(void) {
 
 void DataFlash_Class::EnableWrites(bool enable) {
     backend->EnableWrites(enable);
+}
+
+void DataFlash_Class::periodic_tasks() {
+    backend->periodic_tasks();
+}
+
+void DataFlash_Class::WroteStartupFormat() {
+    backend->WroteStartupFormat();
+}
+
+void DataFlash_Class::WroteStartupParam() {
+    backend->WroteStartupParam();
 }
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL || CONFIG_HAL_BOARD == HAL_BOARD_LINUX

--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -19,19 +19,29 @@
 #include <AP_BattMonitor/AP_BattMonitor.h>
 #include <AP_RPM/AP_RPM.h>
 #include <stdint.h>
-#include "DataFlash_Backend.h"
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4
 #include <uORB/topics/esc_status.h>
 #endif
 
+#include "DFMessageWriter.h"
 
 class DataFlash_Backend;
+class DFMessageWriter;
 
 class DataFlash_Class
 {
+    friend class DFMessageWriter_DFLogStart; // for access to _num_types etc
+
 public:
     FUNCTOR_TYPEDEF(print_mode_fn, void, AP_HAL::BetterStream*, uint8_t);
+    FUNCTOR_TYPEDEF(vehicle_startup_message_Log_Writer, void);
+    DataFlash_Class(const prog_char_t *firmware_string) :
+        _startup_messagewriter(DFMessageWriter_DFLogStart(*this,firmware_string)),
+        _vehicle_messages(NULL)
+        { }
+
+    void set_mission(const AP_Mission *mission);
 
     // initialisation
     void Init(const struct LogStructure *structure, uint8_t num_types);
@@ -42,7 +52,9 @@ public:
     void EraseAll();
 
     /* Write a block of data at current offset */
-    void WriteBlock(const void *pBuffer, uint16_t size);
+    bool WriteBlock(const void *pBuffer, uint16_t size);
+    /* Write an *important* block of data at current offset */
+    bool WriteCriticalBlock(const void *pBuffer, uint16_t size);
 
     // high level interface
     uint16_t find_last_log(void);
@@ -60,13 +72,16 @@ public:
     void ListAvailableLogs(AP_HAL::BetterStream *port);
 #endif // DATAFLASH_NO_CLI
 
-    /* logging methods common to all vehicles */
+    uint16_t bufferspace_available();
+
+    void setVehicle_Startup_Log_Writer(vehicle_startup_message_Log_Writer writer);
+
     uint16_t StartNewLog(void);
     void AddLogFormats(const struct LogStructure *structures, uint8_t num_types);
     void EnableWrites(bool enable);
     void Log_Write_SysInfo(const prog_char_t *firmware_string);
-    void Log_Write_Format(const struct LogStructure *structure);
-    void Log_Write_Parameter(const char *name, float value);
+    bool Log_Write_Format(const struct LogStructure *structure);
+    bool Log_Write_Parameter(const char *name, float value);
     void Log_Write_GPS(const AP_GPS &gps, uint8_t instance, int32_t relative_alt);
     void Log_Write_IMU(const AP_InertialSensor &ins);
     void Log_Write_IMUDT(const AP_InertialSensor &ins);
@@ -80,21 +95,21 @@ public:
 #if AP_AHRS_NAVEKF_AVAILABLE
     void Log_Write_EKF(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled);
 #endif
-    void Log_Write_MavCmd(uint16_t cmd_total, const mavlink_mission_item_t& mav_cmd);
+    bool Log_Write_MavCmd(uint16_t cmd_total, const mavlink_mission_item_t& mav_cmd);
     void Log_Write_Radio(const mavlink_radio_t &packet);
-    void Log_Write_Message(const char *message);
-    void Log_Write_Message_P(const prog_char_t *message);
+    bool Log_Write_Message(const char *message);
+    bool Log_Write_Message_P(const prog_char_t *message);
     void Log_Write_Camera(const AP_AHRS &ahrs, const AP_GPS &gps, const Location &current_loc);
     void Log_Write_ESC(void);
     void Log_Write_Airspeed(AP_Airspeed &airspeed);
     void Log_Write_Attitude(AP_AHRS &ahrs, const Vector3f &targets);
     void Log_Write_Current(const AP_BattMonitor &battery, int16_t throttle);
     void Log_Write_Compass(const Compass &compass);
-    void Log_Write_Mode(uint8_t mode);
+    bool Log_Write_Mode(uint8_t mode);
     void Log_Write_Parameters(void);
 
     void Log_Write_EntireMission(const AP_Mission &mission);
-    void Log_Write_Mission_Cmd(const AP_Mission &mission,
+    bool Log_Write_Mission_Cmd(const AP_Mission &mission,
                                const AP_Mission::Mission_Command &cmd);
     void Log_Write_Origin(uint8_t origin_type, const Location &loc);
     void Log_Write_RPM(const AP_RPM &rpm_sensor);
@@ -118,14 +133,31 @@ public:
     void flush(void);
 #endif
 
+    void periodic_tasks(); // may want to split this into GCS/non-GCS duties
+
+    // this is out here for the trickle-startup-messages logging.
+    // Think before calling.
+    bool Log_Write_Parameter(const AP_Param *ap, const AP_Param::ParamToken &token, 
+                             enum ap_var_type type);
+
+    DFMessageWriter_DFLogStart _startup_messagewriter;
+    vehicle_startup_message_Log_Writer _vehicle_messages;
+
 protected:
     void Log_Fill_Format(const struct LogStructure *structure, struct log_Format &pkt);
-    void Log_Write_Parameter(const AP_Param *ap, const AP_Param::ParamToken &token, 
-                             enum ap_var_type type);
     uint16_t start_new_log(void);
+
+    void WroteStartupFormat();
+    void WroteStartupParam();
 
     const struct LogStructure *_structures;
     uint8_t _num_types;
+
+    /* Write a block with specified importance */
+    /* might be useful if you have a boolean indicating a message is
+     * important... */
+    bool WritePrioritisedBlock(const void *pBuffer, uint16_t size,
+                               bool is_critical);
 
 private:
     DataFlash_Backend *backend;
@@ -847,8 +879,5 @@ enum LogOriginType {
 
 // message types 200 to 210 reversed for GPS driver use
 // message types 211 to 220 reversed for autotune use
-
-#include "DataFlash_Block.h"
-#include "DataFlash_File.h"
 
 #endif

--- a/libraries/DataFlash/DataFlash_APM1.cpp
+++ b/libraries/DataFlash/DataFlash_APM1.cpp
@@ -401,3 +401,18 @@ void DataFlash_APM1::ChipErase()
     _spi_sem->give();
     
 }
+
+// Writing too quickly to DF on APM1/APM2 corrupts the flash.  This
+// could be done at a lower level to more generally restrict bandwidth
+void DataFlash_APM1::WroteStartupFormat()
+{
+    if (! hal.util->get_soft_armed()) {
+        hal.scheduler->delay(10);
+    }
+}
+void DataFlash_APM1::WroteStartupParam()
+{
+    if (! hal.util->get_soft_armed()) {
+        hal.scheduler->delay(2);
+    }
+}

--- a/libraries/DataFlash/DataFlash_APM1.h
+++ b/libraries/DataFlash/DataFlash_APM1.h
@@ -49,6 +49,9 @@ public:
     void        Init(const struct LogStructure *structure, uint8_t num_types);
     void        ReadManufacturerID();
     bool        CardInserted();
+
+    void WroteStartupFormat();
+    void WroteStartupParam();
 };
 
 #endif

--- a/libraries/DataFlash/DataFlash_APM2.cpp
+++ b/libraries/DataFlash/DataFlash_APM2.cpp
@@ -407,3 +407,18 @@ void DataFlash_APM2::ChipErase()
     // release SPI bus for use by other sensors
     _spi_sem->give();
 }
+
+// Writing too quickly to DF on APM1/APM2 corrupts the flash.  This
+// could be done at a lower level to more generally restrict bandwidth
+void DataFlash_APM2::WroteStartupFormat()
+{
+    if (! hal.util->get_soft_armed()) {
+        hal.scheduler->delay(10);
+    }
+}
+void DataFlash_APM2::WroteStartupParam()
+{
+    if (! hal.util->get_soft_armed()) {
+        hal.scheduler->delay(2);
+    }
+}

--- a/libraries/DataFlash/DataFlash_APM2.h
+++ b/libraries/DataFlash/DataFlash_APM2.h
@@ -50,6 +50,9 @@ public:
     void        Init(const struct LogStructure *structure, uint8_t num_types);
     void        ReadManufacturerID();
     bool        CardInserted();
+
+    void WroteStartupFormat();
+    void WroteStartupParam();
 };
 
 #endif

--- a/libraries/DataFlash/DataFlash_Backend.cpp
+++ b/libraries/DataFlash/DataFlash_Backend.cpp
@@ -1,0 +1,81 @@
+#include "DataFlash_Backend.h"
+
+#include "DFMessageWriter.h"
+
+extern const AP_HAL::HAL& hal;
+
+void DataFlash_Backend::periodic_10Hz(const uint32_t now)
+{
+}
+void DataFlash_Backend::periodic_1Hz(const uint32_t now)
+{
+}
+void DataFlash_Backend::periodic_fullrate(const uint32_t now)
+{
+}
+
+void DataFlash_Backend::periodic_tasks()
+{
+    uint32_t now = hal.scheduler->millis();
+    if (now - _last_periodic_1Hz > 1000) {
+        periodic_1Hz(now);
+        _last_periodic_1Hz = now;
+    }
+    if (now - _last_periodic_10Hz > 100) {
+        periodic_10Hz(now);
+        _last_periodic_10Hz = now;
+    }
+    periodic_fullrate(now);
+}
+
+
+void DataFlash_Backend::internal_error() {
+    _internal_errors++;
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    abort();
+#endif
+}
+
+// this method can be overridden to do extra things with your buffer.
+// for example, in DataFlash_MAVLink we may push messages into the UART.
+void DataFlash_Backend::push_log_blocks() {
+    WriteMoreStartupMessages();
+}
+
+// returns true if all startup messages have been written (and thus it
+// is OK for other messages to go to the log)
+bool DataFlash_Backend::WriteBlockCheckStartupMessages()
+{
+    if (_front._startup_messagewriter.finished()) {
+        return true;
+    }
+
+    if (_writing_startup_messages) {
+        // we have been called by a messagewriter, so writing is OK
+        return true;
+    }
+
+    // we're not writing startup messages, so this must be some random
+    // caller hoping to write blocks out.  Push out log blocks - we
+    // might end up clearing the buffer.....
+    push_log_blocks();
+    if (_front._startup_messagewriter.finished()) {
+        return true;
+    }
+
+    // sorry!  currently busy writing out startup messages...
+    return false;
+}
+
+// source more messages from the startup message writer:
+void DataFlash_Backend::WriteMoreStartupMessages()
+{
+
+    if (_front._startup_messagewriter.finished()) {
+        return;
+    }
+
+    _writing_startup_messages = true;
+    _front._startup_messagewriter.process();
+    _writing_startup_messages = false;
+}

--- a/libraries/DataFlash/DataFlash_Block.h
+++ b/libraries/DataFlash/DataFlash_Block.h
@@ -26,7 +26,7 @@ public:
     void EraseAll();
 
     /* Write a block of data at current offset */
-    void WriteBlock(const void *pBuffer, uint16_t size);
+    bool WritePrioritisedBlock(const void *pBuffer, uint16_t size, bool is_critical);
 
     // high level interface
     uint16_t find_last_log(void);
@@ -45,6 +45,8 @@ public:
     void ShowDeviceInfo(AP_HAL::BetterStream *port);
     void ListAvailableLogs(AP_HAL::BetterStream *port);
 #endif
+
+    uint16_t bufferspace_available();
 
 private:
     struct PageHeader {

--- a/libraries/DataFlash/DataFlash_File.h
+++ b/libraries/DataFlash/DataFlash_File.h
@@ -36,7 +36,8 @@ public:
     void EraseAll();
 
     /* Write a block of data at current offset */
-    void WriteBlock(const void *pBuffer, uint16_t size);
+    bool WritePrioritisedBlock(const void *pBuffer, uint16_t size, bool is_critical);
+    uint16_t bufferspace_available();
 
     // high level interface
     uint16_t find_last_log(void);
@@ -57,7 +58,8 @@ public:
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL || CONFIG_HAL_BOARD == HAL_BOARD_LINUX
     void flush(void);
 #endif
-
+    void periodic_fullrate(const uint32_t now);
+    
 private:
     int _write_fd;
     int _read_fd;
@@ -90,6 +92,11 @@ private:
     void stop_logging(void);
 
     void _io_timer(void);
+
+    uint16_t critical_message_reserved_space() const {
+        // possibly make this a proportional to buffer size?
+        return 1024;
+    };
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4 || CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
     // performance counters

--- a/libraries/DataFlash/DataFlash_SITL.cpp
+++ b/libraries/DataFlash/DataFlash_SITL.cpp
@@ -3,6 +3,8 @@
   hacked up DataFlash library for Desktop support
 */
 
+#include "DataFlash_SITL.h"
+
 #include <AP_HAL/AP_HAL.h>
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
@@ -14,7 +16,6 @@
 #include <fcntl.h>
 #include <stdint.h>
 #include <assert.h>
-#include "DataFlash.h"
 
 #pragma GCC diagnostic ignored "-Wunused-result"
 
@@ -160,5 +161,3 @@ void DataFlash_SITL::ChipErase()
 
 
 #endif
-
-

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -1011,7 +1011,7 @@ bool DataFlash_Class::Log_Write_Message(const char *message)
         msg  : {}
     };
     strncpy(pkt.msg, message, sizeof(pkt.msg));
-    return WriteBlock(&pkt, sizeof(pkt));
+    return WriteCriticalBlock(&pkt, sizeof(pkt));
 }
 
 // Write a text message to the log
@@ -1023,7 +1023,7 @@ bool DataFlash_Class::Log_Write_Message_P(const prog_char_t *message)
         msg  : {}
     };
     strncpy_P(pkt.msg, message, sizeof(pkt.msg));
-    return WriteBlock(&pkt, sizeof(pkt));
+    return WriteCriticalBlock(&pkt, sizeof(pkt));
 }
 
 // Write a POWR packet
@@ -1401,7 +1401,7 @@ bool DataFlash_Class::Log_Write_Mode(uint8_t mode)
         mode     : mode,
         mode_num : mode
     };
-    return WriteBlock(&pkt, sizeof(pkt));
+    return WriteCriticalBlock(&pkt, sizeof(pkt));
 }
 
 // Write ESC status messages


### PR DESCRIPTION
These patches do two things:
 - allow the log startup messages (PARM, FMT, some messages) to be fed to the DF system gradually, rather than the DF system blurting them all out "instantly".
 - reserve space for "critical" messages.  If we have less than 1k of bufferspace remaining we drop non-critical messages.


Needs testing on APM 1 or 2, which I don't have one of.  I'm not sure I've gotten the progmem stuff correct.

If APM2 works, this can be folded into 5 commits.
