### PR TITLE
Hostname resolution for IP based connections on Linux

### DIFF
--- a/libraries/AP_HAL/utility/Socket.cpp
+++ b/libraries/AP_HAL/utility/Socket.cpp
@@ -74,7 +74,6 @@ struct addrinfo *SocketAPM::get_address_info(const char *address, uint16_t port)
 
     ret = getaddrinfo(address, service, &hints, &address_info);
     if (ret < 0) {
-        fprintf(stderr, "getaddrinfo: %s\n", gai_strerror(ret));
         return NULL;
     }
 

--- a/libraries/AP_HAL/utility/Socket.cpp
+++ b/libraries/AP_HAL/utility/Socket.cpp
@@ -52,7 +52,7 @@ SocketAPM::~SocketAPM()
     }
 }
 
-struct addrinfo *SocketAPM::get_address_info(const char *address, uint16_t port)
+struct addrinfo *SocketAPM::get_address_info(const char *hostname, uint16_t port) const
 {
     char service[20] = {0};
     int service_length = sizeof(service);
@@ -72,7 +72,7 @@ struct addrinfo *SocketAPM::get_address_info(const char *address, uint16_t port)
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = datagram? SOCK_DGRAM: SOCK_STREAM;
 
-    ret = getaddrinfo(address, service, &hints, &address_info);
+    ret = getaddrinfo(hostname, service, &hints, &address_info);
     if (ret < 0) {
         return NULL;
     }
@@ -80,7 +80,7 @@ struct addrinfo *SocketAPM::get_address_info(const char *address, uint16_t port)
     return address_info;
 }
 
-struct addrinfo *SocketAPM::select_address(struct addrinfo *address_list)
+struct addrinfo *SocketAPM::select_address(struct addrinfo *address_list) const
 {
     for (struct addrinfo *address = address_list; address != NULL; address = address->ai_next) {
         if (address->ai_family == AF_INET) {
@@ -261,7 +261,7 @@ void SocketAPM::set_broadcast(void)
 /*
   return true if there is pending data for input
  */
-bool SocketAPM::pollin(uint32_t timeout_ms)
+bool SocketAPM::pollin(uint32_t timeout_ms) const
 {
     fd_set fds;
     struct timeval tv;
@@ -282,7 +282,7 @@ bool SocketAPM::pollin(uint32_t timeout_ms)
 /*
   return true if there is room for output data
  */
-bool SocketAPM::pollout(uint32_t timeout_ms)
+bool SocketAPM::pollout(uint32_t timeout_ms) const
 {
     fd_set fds;
     struct timeval tv;
@@ -302,7 +302,7 @@ bool SocketAPM::pollout(uint32_t timeout_ms)
 /* 
    start listening for new tcp connections
  */
-bool SocketAPM::listen(uint16_t backlog)
+bool SocketAPM::listen(uint16_t backlog) const
 {
     return ::listen(fd, (int)backlog) == 0;
 }
@@ -311,7 +311,7 @@ bool SocketAPM::listen(uint16_t backlog)
   accept a new connection. Only valid for TCP connections after
   listen has been used. A new socket is returned
 */
-SocketAPM *SocketAPM::accept(uint32_t timeout_ms)
+SocketAPM *SocketAPM::accept(uint32_t timeout_ms) const
 {
     if (!pollin(timeout_ms)) {
         return NULL;

--- a/libraries/AP_HAL/utility/Socket.h
+++ b/libraries/AP_HAL/utility/Socket.h
@@ -52,17 +52,17 @@ public:
     bool last_recv_address(char *hostname, uint16_t *port);
 
     // return true if there is pending data for input
-    bool pollin(uint32_t timeout_ms);
+    bool pollin(uint32_t timeout_ms) const;
 
     // return true if there is room for output data
-    bool pollout(uint32_t timeout_ms);
+    bool pollout(uint32_t timeout_ms) const;
 
     // start listening for new tcp connections
-    bool listen(uint16_t backlog);
+    bool listen(uint16_t backlog) const;
 
     // accept a new connection. Only valid for TCP connections after
     // listen has been used. A new socket is returned
-    SocketAPM *accept(uint32_t timeout_ms);
+    SocketAPM *accept(uint32_t timeout_ms) const;
 
 private:
     bool datagram;
@@ -70,8 +70,8 @@ private:
 
     int fd = -1;
 
-    struct addrinfo *get_address_info(const char *hostname, uint16_t port);
-    struct addrinfo *select_address(struct addrinfo *address_list);
+    struct addrinfo *get_address_info(const char *hostname, uint16_t port) const;
+    struct addrinfo *select_address(struct addrinfo *address_list) const;
 };
 
 #endif // HAL_OS_SOCKETS

--- a/libraries/AP_HAL/utility/Socket.h
+++ b/libraries/AP_HAL/utility/Socket.h
@@ -30,6 +30,7 @@
 #include <netinet/tcp.h>
 #include <arpa/inet.h>
 #include <sys/select.h>
+#include <netdb.h>
 
 class SocketAPM {
 public:
@@ -37,18 +38,18 @@ public:
     SocketAPM(bool _datagram, int _fd);
     ~SocketAPM();
 
-    bool connect(const char *address, uint16_t port);
-    bool bind(const char *address, uint16_t port);
+    bool connect(const char *hostname, uint16_t port);
+    bool bind(const char *hostname, uint16_t port);
     void reuseaddress();
     void set_blocking(bool blocking);
     void set_broadcast(void);
 
     ssize_t send(const void *pkt, size_t size);
-    ssize_t sendto(const void *buf, size_t size, const char *address, uint16_t port);
+    ssize_t sendto(const void *buf, size_t size, const char *hostname, uint16_t port);
     ssize_t recv(void *pkt, size_t size, uint32_t timeout_ms);
 
     // return the IP address and port of the last received packet
-    void last_recv_address(const char *&ip_addr, uint16_t &port);
+    bool last_recv_address(char *hostname, uint16_t *port);
 
     // return true if there is pending data for input
     bool pollin(uint32_t timeout_ms);
@@ -65,11 +66,12 @@ public:
 
 private:
     bool datagram;
-    struct sockaddr_in in_addr {};
+    struct sockaddr_storage in_addr {};
 
     int fd = -1;
 
-    void make_sockaddr(const char *address, uint16_t port, struct sockaddr_in &sockaddr);
+    struct addrinfo *get_address_info(const char *hostname, uint16_t port);
+    struct addrinfo *select_address(struct addrinfo *address_list);
 };
 
 #endif // HAL_OS_SOCKETS

--- a/libraries/AP_HAL_Linux/UDPDevice.cpp
+++ b/libraries/AP_HAL_Linux/UDPDevice.cpp
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <sys/ioctl.h>
 #include <fcntl.h>
+#include <limits.h>
 
 #include "UDPDevice.h"
 
@@ -34,10 +35,12 @@ ssize_t UDPDevice::read(uint8_t *buf, uint16_t n)
 {
     ssize_t ret = socket.recv(buf, n, 0);
     if (!_connected && ret > 0) {
-        const char *ip;
+        char hostname[HOST_NAME_MAX] = {0};
         uint16_t port;
-        socket.last_recv_address(ip, port);
-        _connected = socket.connect(ip, port);
+
+        if (socket.last_recv_address(hostname, &port)) {
+            _connected = socket.connect(hostname, port);
+        }
     }
     return ret;
 }


### PR DESCRIPTION
The intent is to make it possible to connect by hostname rather than by IP. It'll make our lives way easier. There's a bunch of users who use NoIP services and they desperately need this change.

Now one can launch APM like this:

**sudo ArduCopter.elf -A udp:\<hostname\>:\<port\>**

Along the way I've tried to break dependency on IPv4. This has yielded a couple of changes:
- ```sockaddr_storage``` is used instead of ```sockaddr_in```
- ```getaddrinfo()/getnameinfo()``` is used instead of making ```sockaddr_in``` (IPv4-specific structure) by hand and using ```inet_ntoa()```
- ```last_recv_address()``` slightly changed to take a pointer rather than a reference to pointer (I find it very confusing)
- added ```const``` specifier to a couple of methods

There's a handful of little issues, though:
- This code still works with IPv4 only, though. In order to overcome this limitation we need to change the logic a bit, i.e. call ```socket()``` after ```getaddrinfo()```
- ```select_address()``` method limits the usage to IPv4 for now

There's a serious code duplication issue that should also be eliminated. I'd be delighted if anyone pointed out a way to solve this problem.

