### PR TITLE
Correct param3 (empty) to param1 (Minimum pitch ) for MAV_CMD_NAV_TAK…

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1138,7 +1138,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
             break;
 
         case MAV_CMD_NAV_TAKEOFF: {
-            // param3 : horizontal navigation by pilot acceptable
+            // param1 : horizontal navigation by pilot acceptable
             // param4 : yaw angle   (not supported)
             // param5 : latitude    (not supported)
             // param6 : longitude   (not supported)
@@ -1146,7 +1146,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
 
             float takeoff_alt = packet.param7 * 100;      // Convert m to cm
 
-            if(copter.do_user_takeoff(takeoff_alt, is_zero(packet.param3))) {
+            if(copter.do_user_takeoff(takeoff_alt, is_zero(packet.param1))) {
                 result = MAV_RESULT_ACCEPTED;
             } else {
                 result = MAV_RESULT_FAILED;


### PR DESCRIPTION
…EOFF according to MAVLink definition.
Closing https://github.com/diydrones/ardupilot/issues/2314