### PR TITLE
GCS_MAVLink in AntennaTracker

### DIFF
--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -165,6 +165,13 @@ void Tracker::send_simstate(mavlink_channel_t chan)
 #endif
 }
 
+void GCS_MAVLINK::handle_guided_request(AP_Mission::Mission_Command&) {
+  
+}
+
+void GCS_MAVLINK::handle_change_alt_request(AP_Mission::Mission_Command&) {
+  
+}
 
 // try to send a message, return false if it won't fit in the serial tx buffer
 bool GCS_MAVLINK::try_send_message(enum ap_message id)


### PR DESCRIPTION
I get I build error, because these two functions are not implemented,
if I build with cmake.
I currently don't know why this is working with the current system.

Signed-off-by: dgrat <dgdanielf@gmail.com>