### PR TITLE
HMC5883 on MPU6000's auxiliary bus (and more)

### DIFF
--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -79,10 +79,6 @@
 #endif
 #endif
 
-#if !defined(HAL_COMPASS_AK8963_I2C_ADDR)
-#define HAL_COMPASS_AK8963_I2C_ADDR 0xC
-#endif
-
 extern const AP_HAL::HAL& hal;
 
 AP_Compass_AK8963::AP_Compass_AK8963(Compass &compass, AP_AK8963_SerialBus *bus) :
@@ -112,11 +108,13 @@ AP_Compass_Backend *AP_Compass_AK8963::detect_mpu9250(Compass &compass)
     return sensor;
 }
 
-AP_Compass_Backend *AP_Compass_AK8963::detect_i2c1(Compass &compass)
+
+AP_Compass_Backend *AP_Compass_AK8963::detect_i2c(Compass &compass,
+                                                  AP_HAL::I2CDriver *i2c,
+                                                  uint8_t addr)
 {
-    AP_Compass_AK8963 *sensor = new AP_Compass_AK8963(compass,
-                                                  new AP_AK8963_SerialBus_I2C(
-                                                  hal.i2c1, HAL_COMPASS_AK8963_I2C_ADDR));
+    AP_Compass_AK8963 *sensor =
+        new AP_Compass_AK8963(compass, new AP_AK8963_SerialBus_I2C(i2c, addr));
 
     if (sensor == nullptr) {
         return nullptr;

--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -93,13 +93,30 @@ AP_Compass_AK8963::AP_Compass_AK8963(Compass &compass, AP_AK8963_SerialBus *bus)
 
 AP_Compass_Backend *AP_Compass_AK8963::detect_mpu9250(Compass &compass)
 {
-    AP_Compass_AK8963 *sensor = new AP_Compass_AK8963(compass,
-                                                  new AP_AK8963_SerialBus_MPU9250());
+    AP_AK8963_SerialBus *bus = new AP_AK8963_SerialBus_MPU9250();
+    if (!bus)
+        return nullptr;
+    return _detect(compass, bus);
+}
 
+AP_Compass_Backend *AP_Compass_AK8963::detect_i2c(Compass &compass,
+                                                  AP_HAL::I2CDriver *i2c,
+                                                  uint8_t addr)
+{
+    AP_AK8963_SerialBus *bus = new AP_AK8963_SerialBus_I2C(i2c, addr);
+    if (!bus)
+        return nullptr;
+    return _detect(compass, bus);
+}
+
+AP_Compass_Backend *AP_Compass_AK8963::_detect(Compass &compass,
+                                               AP_AK8963_SerialBus *bus)
+{
+    AP_Compass_AK8963 *sensor = new AP_Compass_AK8963(compass, bus);
     if (sensor == nullptr) {
+        delete bus;
         return nullptr;
     }
-
     if (!sensor->init()) {
         delete sensor;
         return nullptr;
@@ -108,24 +125,9 @@ AP_Compass_Backend *AP_Compass_AK8963::detect_mpu9250(Compass &compass)
     return sensor;
 }
 
-
-AP_Compass_Backend *AP_Compass_AK8963::detect_i2c(Compass &compass,
-                                                  AP_HAL::I2CDriver *i2c,
-                                                  uint8_t addr)
+AP_Compass_AK8963::~AP_Compass_AK8963()
 {
-    AP_Compass_AK8963 *sensor =
-        new AP_Compass_AK8963(compass, new AP_AK8963_SerialBus_I2C(i2c, addr));
-
-    if (sensor == nullptr) {
-        return nullptr;
-    }
-
-    if (!sensor->init()) {
-        delete sensor;
-        return nullptr;
-    }
-
-    return sensor;
+    delete _bus;
 }
 
 /* stub to satisfy Compass API*/

--- a/libraries/AP_Compass/AP_Compass_AK8963.h
+++ b/libraries/AP_Compass/AP_Compass_AK8963.h
@@ -17,6 +17,7 @@ public:
         uint8_t st2;
     };
 
+    virtual ~AP_AK8963_SerialBus() { }
     virtual void register_read(uint8_t address, uint8_t *value, uint8_t count) = 0;
     uint8_t register_read(uint8_t address) {
         uint8_t reg;
@@ -34,18 +35,21 @@ public:
 class AP_Compass_AK8963 : public AP_Compass_Backend
 {
 public:
-    AP_Compass_AK8963(Compass &compass, AP_AK8963_SerialBus *bus);
-
     static AP_Compass_Backend *detect_mpu9250(Compass &compass);
     static AP_Compass_Backend *detect_i2c(Compass &compass,
                                           AP_HAL::I2CDriver *i2c,
                                           uint8_t addr);
+
+    AP_Compass_AK8963(Compass &compass, AP_AK8963_SerialBus *bus);
+    ~AP_Compass_AK8963();
 
     bool        init(void);
     void        read(void);
     void        accumulate(void);
 
 private:
+    static AP_Compass_Backend *_detect(Compass &compass, AP_AK8963_SerialBus *bus);
+
     void _make_factory_sensitivity_adjustment(Vector3f& field) const;
     Vector3f _get_filtered_field() const;
     void _reset_filter();
@@ -73,7 +77,7 @@ private:
     uint32_t            _last_update_timestamp;
     uint32_t            _last_accum_time;
 
-    AP_AK8963_SerialBus *_bus;
+    AP_AK8963_SerialBus *_bus = nullptr;
     AP_HAL::Semaphore *_bus_sem;
 };
 

--- a/libraries/AP_Compass/AP_Compass_AK8963.h
+++ b/libraries/AP_Compass/AP_Compass_AK8963.h
@@ -37,7 +37,9 @@ public:
     AP_Compass_AK8963(Compass &compass, AP_AK8963_SerialBus *bus);
 
     static AP_Compass_Backend *detect_mpu9250(Compass &compass);
-    static AP_Compass_Backend *detect_i2c1(Compass &compass);
+    static AP_Compass_Backend *detect_i2c(Compass &compass,
+                                          AP_HAL::I2CDriver *i2c,
+                                          uint8_t addr);
 
     bool        init(void);
     void        read(void);

--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -269,7 +269,7 @@ AP_Compass_HMC5843::init()
 
 #if 0
     hal.console->printf_P(PSTR("CalX: %.2f CalY: %.2f CalZ: %.2f\n"),
-                          calibration[0], calibration[1], calibration[2]);
+                          _scaling[0], _scaling[1], _scaling[2]);
 #endif
 
     _compass_instance = register_compass();
@@ -336,9 +336,9 @@ bool AP_Compass_HMC5843::_calibrate(uint8_t calibration_gain,
             IS_CALIBRATION_VALUE_VALID(cal[2])) {
             // hal.console->printf_P(PSTR("car=%.2f %.2f %.2f good\n"), cal[0], cal[1], cal[2]);
             good_count++;
-            calibration[0] += cal[0];
-            calibration[1] += cal[1];
-            calibration[2] += cal[2];
+            _scaling[0] += cal[0];
+            _scaling[1] += cal[1];
+            _scaling[2] += cal[2];
         }
 
 #undef IS_CALIBRATION_VALUE_VALID
@@ -362,15 +362,15 @@ bool AP_Compass_HMC5843::_calibrate(uint8_t calibration_gain,
           doesn't have any impact other than the learned compass
           offsets
          */
-        calibration[0] = calibration[0] * gain_multiple / good_count;
-        calibration[1] = calibration[1] * gain_multiple / good_count;
-        calibration[2] = calibration[2] * gain_multiple / good_count;
+        _scaling[0] = _scaling[0] * gain_multiple / good_count;
+        _scaling[1] = _scaling[1] * gain_multiple / good_count;
+        _scaling[2] = _scaling[2] * gain_multiple / good_count;
         success = true;
     } else {
         /* best guess */
-        calibration[0] = 1.0;
-        calibration[1] = 1.0;
-        calibration[2] = 1.0;
+        _scaling[0] = 1.0;
+        _scaling[1] = 1.0;
+        _scaling[2] = 1.0;
     }
 
     return success;
@@ -404,9 +404,9 @@ void AP_Compass_HMC5843::read()
        }
     }
 
-    Vector3f field(_mag_x_accum * calibration[0],
-                   _mag_y_accum * calibration[1],
-                   _mag_z_accum * calibration[2]);
+    Vector3f field(_mag_x_accum * _scaling[0],
+                   _mag_y_accum * _scaling[1],
+                   _mag_z_accum * _scaling[2]);
     field /= _accum_count;
 
     _accum_count = 0;

--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -150,37 +150,37 @@ void AP_Compass_HMC5843::accumulate(void)
         // have the right orientation!)
         return;
     }
-   uint32_t tnow = hal.scheduler->micros();
-   if (_accum_count != 0 && (tnow - _last_accum_time) < 13333) {
-	  // the compass gets new data at 75Hz
-	  return;
-   }
+    uint32_t tnow = hal.scheduler->micros();
+    if (_accum_count != 0 && (tnow - _last_accum_time) < 13333) {
+        // the compass gets new data at 75Hz
+        return;
+    }
 
-   if (!_i2c_sem->take(1)) {
-       // the bus is busy - try again later
-       return;
-   }
-   bool result = read_raw();
-   _i2c_sem->give();
+    if (!_i2c_sem->take(1)) {
+        // the bus is busy - try again later
+        return;
+    }
+    bool result = read_raw();
+    _i2c_sem->give();
 
-   if (result) {
-	  // the _mag_N values are in the range -2048 to 2047, so we can
-	  // accumulate up to 15 of them in an int16_t. Let's make it 14
-	  // for ease of calculation. We expect to do reads at 10Hz, and
-	  // we get new data at most 75Hz, so we don't expect to
-	  // accumulate more than 8 before a read
-	  _mag_x_accum += _mag_x;
-	  _mag_y_accum += _mag_y;
-	  _mag_z_accum += _mag_z;
-	  _accum_count++;
-	  if (_accum_count == 14) {
-		 _mag_x_accum /= 2;
-		 _mag_y_accum /= 2;
-		 _mag_z_accum /= 2;
-		 _accum_count = 7;
-	  }
-	  _last_accum_time = tnow;
-   }
+    if (result) {
+        // the _mag_N values are in the range -2048 to 2047, so we can
+        // accumulate up to 15 of them in an int16_t. Let's make it 14
+        // for ease of calculation. We expect to do reads at 10Hz, and
+        // we get new data at most 75Hz, so we don't expect to
+        // accumulate more than 8 before a read
+        _mag_x_accum += _mag_x;
+        _mag_y_accum += _mag_y;
+        _mag_z_accum += _mag_z;
+        _accum_count++;
+        if (_accum_count == 14) {
+            _mag_x_accum /= 2;
+            _mag_y_accum /= 2;
+            _mag_z_accum /= 2;
+            _accum_count = 7;
+        }
+        _last_accum_time = tnow;
+    }
 }
 
 
@@ -291,14 +291,14 @@ bool AP_Compass_HMC5843::_calibrate(uint8_t calibration_gain,
     int numAttempts = 0, good_count = 0;
     bool success = false;
 
-    while ( success == 0 && numAttempts < 25 && good_count < 5)
+    while (success == 0 && numAttempts < 25 && good_count < 5)
     {
-        // record number of attempts at initialisation
         numAttempts++;
 
         // force positiveBias (compass should return 715 for all channels)
         if (!write_register(ConfigRegA, PositiveBiasConfig))
-            continue;      // compass not responding on the bus
+            continue;   // compass not responding on the bus
+
         hal.scheduler->delay(50);
 
         // set gains
@@ -316,6 +316,7 @@ bool AP_Compass_HMC5843::_calibrate(uint8_t calibration_gain,
         float cal[3];
 
         // hal.console->printf_P(PSTR("mag %d %d %d\n"), _mag_x, _mag_y, _mag_z);
+
         cal[0] = fabsf(expected_x / (float)_mag_x);
         cal[1] = fabsf(expected_yz / (float)_mag_y);
         cal[2] = fabsf(expected_yz / (float)_mag_z);
@@ -326,6 +327,7 @@ bool AP_Compass_HMC5843::_calibrate(uint8_t calibration_gain,
         // still be changing its state from the application of the
         // strap excitation. After that we accept values in a
         // reasonable range
+
 #define IS_CALIBRATION_VALUE_VALID(val) (val > 0.7f && val < 1.35f)
 
         if (numAttempts > 2 &&
@@ -389,26 +391,26 @@ void AP_Compass_HMC5843::read()
         }
         if (!re_initialise()) {
             _retry_time = hal.scheduler->millis() + 1000;
-			hal.i2c->setHighSpeed(false);
+            hal.i2c->setHighSpeed(false);
             return;
         }
     }
 
-	if (_accum_count == 0) {
-	   accumulate();
+    if (_accum_count == 0) {
+       accumulate();
        if (_retry_time != 0) {
-		  hal.i2c->setHighSpeed(false);
-		  return;
-	   }
-	}
+          hal.i2c->setHighSpeed(false);
+          return;
+       }
+    }
 
     Vector3f field(_mag_x_accum * calibration[0],
                    _mag_y_accum * calibration[1],
                    _mag_z_accum * calibration[2]);
     field /= _accum_count;
 
-	_accum_count = 0;
-	_mag_x_accum = _mag_y_accum = _mag_z_accum = 0;
+    _accum_count = 0;
+    _mag_x_accum = _mag_y_accum = _mag_z_accum = 0;
 
     // rotate to the desired orientation
     if (_product_id == AP_COMPASS_TYPE_HMC5883L) {

--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -326,16 +326,20 @@ bool AP_Compass_HMC5843::_calibrate(uint8_t calibration_gain,
         // still be changing its state from the application of the
         // strap excitation. After that we accept values in a
         // reasonable range
+#define IS_CALIBRATION_VALUE_VALID(val) (val > 0.7f && val < 1.35f)
+
         if (numAttempts > 2 &&
-            cal[0] > 0.7f && cal[0] < 1.35f &&
-            cal[1] > 0.7f && cal[1] < 1.35f &&
-            cal[2] > 0.7f && cal[2] < 1.35f) {
-            // hal.console->printf_P(PSTR("cal=%.2f %.2f %.2f good\n"), cal[0], cal[1], cal[2]);
+            IS_CALIBRATION_VALUE_VALID(cal[0]) &&
+            IS_CALIBRATION_VALUE_VALID(cal[1]) &&
+            IS_CALIBRATION_VALUE_VALID(cal[2])) {
+            // hal.console->printf_P(PSTR("car=%.2f %.2f %.2f good\n"), cal[0], cal[1], cal[2]);
             good_count++;
             calibration[0] += cal[0];
             calibration[1] += cal[1];
             calibration[2] += cal[2];
         }
+
+#undef IS_CALIBRATION_VALUE_VALID
 
 #if 0
         /* useful for debugging */

--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -260,6 +260,11 @@ AP_Compass_HMC5843::init()
         goto errout;
     }
 
+    _initialised = true;
+    _i2c_sem->give();
+    hal.scheduler->resume_timer_procs();
+
+    // perform an initial read
     read();
 
 #if 0
@@ -270,14 +275,9 @@ AP_Compass_HMC5843::init()
     _compass_instance = register_compass();
     set_dev_id(_compass_instance, _product_id);
 
-    _initialised = true;
-
-    _i2c_sem->give();
-    hal.scheduler->resume_timer_procs();
-
     return true;
-errout:
 
+errout:
     _i2c_sem->give();
     hal.scheduler->resume_timer_procs();
     return false;

--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -128,22 +128,22 @@ bool AP_Compass_HMC5843::write_register(uint8_t address, uint8_t value)
 // Read Sensor data
 bool AP_Compass_HMC5843::read_raw()
 {
-    uint8_t buff[6];
+    struct AP_HMC5843_SerialBus::raw_value rv;
 
-    if (_bus->register_read(0x03, buff, 6) != 0) {
+    if (_bus->register_read(0x03, (uint8_t*)&rv, sizeof(rv)) != 0) {
         _bus->set_high_speed(false);
         _retry_time = hal.scheduler->millis() + 1000;
         return false;
     }
 
     int16_t rx, ry, rz;
-    rx = (((int16_t)buff[0]) << 8) | buff[1];
+    rx = (((int16_t)rv.val[0]) << 8) | rv.val[1];
     if (_product_id == AP_COMPASS_TYPE_HMC5883L) {
-        rz = (((int16_t)buff[2]) << 8) | buff[3];
-        ry = (((int16_t)buff[4]) << 8) | buff[5];
+        rz = (((int16_t)rv.val[2]) << 8) | rv.val[3];
+        ry = (((int16_t)rv.val[4]) << 8) | rv.val[5];
     } else {
-        ry = (((int16_t)buff[2]) << 8) | buff[3];
-        rz = (((int16_t)buff[4]) << 8) | buff[5];
+        ry = (((int16_t)rv.val[2]) << 8) | rv.val[3];
+        rz = (((int16_t)rv.val[4]) << 8) | rv.val[5];
     }
     if (rx == -4096 || ry == -4096 || rz == -4096) {
         // no valid data available

--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -328,14 +328,18 @@ bool AP_Compass_HMC5843::_calibrate(uint8_t calibration_gain,
         // strap excitation. After that we accept values in a
         // reasonable range
 
+        if (numAttempts <= 2) {
+            continue;
+        }
+
 #define IS_CALIBRATION_VALUE_VALID(val) (val > 0.7f && val < 1.35f)
 
-        if (numAttempts > 2 &&
-            IS_CALIBRATION_VALUE_VALID(cal[0]) &&
+        if (IS_CALIBRATION_VALUE_VALID(cal[0]) &&
             IS_CALIBRATION_VALUE_VALID(cal[1]) &&
             IS_CALIBRATION_VALUE_VALID(cal[2])) {
             // hal.console->printf_P(PSTR("car=%.2f %.2f %.2f good\n"), cal[0], cal[1], cal[2]);
             good_count++;
+
             _scaling[0] += cal[0];
             _scaling[1] += cal[1];
             _scaling[2] += cal[2];

--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -244,10 +244,9 @@ AP_Compass_HMC5843::init()
     uint16_t expected_yz = 715;
     float gain_multiple = 1.0;
 
-    hal.scheduler->suspend_timer_procs();
-    hal.scheduler->delay(10);
-
     _bus_sem = _bus->get_semaphore();
+    hal.scheduler->suspend_timer_procs();
+
     if (!_bus_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
         hal.scheduler->panic(PSTR("Failed to get HMC5843 semaphore"));
     }

--- a/libraries/AP_Compass/AP_Compass_HMC5843.h
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.h
@@ -12,7 +12,7 @@
 class AP_Compass_HMC5843 : public AP_Compass_Backend
 {
 private:
-    float               calibration[3] = {0};
+    float               _scaling[3] = {0};
     bool                _initialised;
     bool                read_raw(void);
     uint8_t             _base_config;

--- a/libraries/AP_Compass/AP_Compass_HMC5843.h
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.h
@@ -12,7 +12,7 @@
 class AP_Compass_HMC5843 : public AP_Compass_Backend
 {
 private:
-    float               calibration[3];
+    float               calibration[3] = {0};
     bool                _initialised;
     bool                read_raw(void);
     uint8_t             _base_config;
@@ -20,6 +20,7 @@ private:
     bool                read_register(uint8_t address, uint8_t *value);
     bool                write_register(uint8_t address, uint8_t value);
 
+    bool                _calibrate(uint8_t calibration_gain, uint16_t expected_x, uint16_t expected_yz, float gain_multiple);
     bool                _detect_version();
 
     uint32_t            _retry_time; // when unhealthy the millis() value to retry at

--- a/libraries/AP_Compass/AP_Compass_HMC5843.h
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.h
@@ -19,6 +19,9 @@ private:
     bool                re_initialise(void);
     bool                read_register(uint8_t address, uint8_t *value);
     bool                write_register(uint8_t address, uint8_t value);
+
+    bool                _detect_version();
+
     uint32_t            _retry_time; // when unhealthy the millis() value to retry at
     AP_HAL::Semaphore*  _i2c_sem;
 

--- a/libraries/AP_Compass/AP_Compass_HMC5843.h
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.h
@@ -61,6 +61,10 @@ public:
 class AP_HMC5843_SerialBus
 {
 public:
+    struct PACKED raw_value {
+        uint8_t val[6];
+    };
+
     virtual ~AP_HMC5843_SerialBus() { };
     virtual void set_high_speed(bool val) = 0;
     virtual uint8_t register_read(uint8_t reg, uint8_t *buf, uint8_t size) = 0;

--- a/libraries/AP_Compass/Compass.cpp
+++ b/libraries/AP_Compass/Compass.cpp
@@ -347,6 +347,8 @@ void Compass::_detect_backends(void)
     _add_backend(AP_Compass_HIL::detect(*this));
 #elif HAL_COMPASS_DEFAULT == HAL_COMPASS_HMC5843
     _add_backend(AP_Compass_HMC5843::detect_i2c(*this, hal.i2c));
+#elif HAL_COMPASS_DEFAULT == HAL_COMPASS_HMC5843_MPU6000
+    _add_backend(AP_Compass_HMC5843::detect_mpu6000(*this));
 #elif  HAL_COMPASS_DEFAULT == HAL_COMPASS_AK8963_I2C && HAL_INS_AK8963_I2C_BUS == 1
     _add_backend(AP_Compass_AK8963::detect_i2c(*this, hal.i2c1,
                                                HAL_COMPASS_AK8963_I2C_ADDR));

--- a/libraries/AP_Compass/Compass.cpp
+++ b/libraries/AP_Compass/Compass.cpp
@@ -348,7 +348,8 @@ void Compass::_detect_backends(void)
 #elif HAL_COMPASS_DEFAULT == HAL_COMPASS_HMC5843
     _add_backend(AP_Compass_HMC5843::detect(*this));
 #elif  HAL_COMPASS_DEFAULT == HAL_COMPASS_AK8963_I2C && HAL_INS_AK8963_I2C_BUS == 1
-    _add_backend(AP_Compass_AK8963::detect_i2c1(*this));
+    _add_backend(AP_Compass_AK8963::detect_i2c(*this, hal.i2c1,
+                                               HAL_COMPASS_AK8963_I2C_ADDR));
 #elif HAL_COMPASS_DEFAULT == HAL_COMPASS_PX4 || HAL_COMPASS_DEFAULT == HAL_COMPASS_VRBRAIN
     _add_backend(AP_Compass_PX4::detect(*this));
 #else

--- a/libraries/AP_Compass/Compass.cpp
+++ b/libraries/AP_Compass/Compass.cpp
@@ -341,12 +341,12 @@ void Compass::_detect_backends(void)
     }
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_LINUX && CONFIG_HAL_BOARD_SUBTYPE != HAL_BOARD_SUBTYPE_LINUX_NONE && CONFIG_HAL_BOARD_SUBTYPE != HAL_BOARD_SUBTYPE_LINUX_BEBOP
-    _add_backend(AP_Compass_HMC5843::detect(*this));
+    _add_backend(AP_Compass_HMC5843::detect_i2c(*this, hal.i2c));
     _add_backend(AP_Compass_AK8963::detect_mpu9250(*this));
 #elif HAL_COMPASS_DEFAULT == HAL_COMPASS_HIL
     _add_backend(AP_Compass_HIL::detect(*this));
 #elif HAL_COMPASS_DEFAULT == HAL_COMPASS_HMC5843
-    _add_backend(AP_Compass_HMC5843::detect(*this));
+    _add_backend(AP_Compass_HMC5843::detect_i2c(*this, hal.i2c));
 #elif  HAL_COMPASS_DEFAULT == HAL_COMPASS_AK8963_I2C && HAL_INS_AK8963_I2C_BUS == 1
     _add_backend(AP_Compass_AK8963::detect_i2c(*this, hal.i2c1,
                                                HAL_COMPASS_AK8963_I2C_ADDR));

--- a/libraries/AP_Compass/Compass.h
+++ b/libraries/AP_Compass/Compass.h
@@ -252,7 +252,7 @@ private:
     uint8_t register_compass(void);
 
     // load backend drivers
-    void _add_backend(AP_Compass_Backend *(detect)(Compass &));
+    void _add_backend(AP_Compass_Backend *backend);
     void _detect_backends(void);
 
     // backend objects

--- a/libraries/AP_HAL/AP_HAL_Boards.h
+++ b/libraries/AP_HAL/AP_HAL_Boards.h
@@ -84,6 +84,7 @@
 #define HAL_COMPASS_VRBRAIN   4
 #define HAL_COMPASS_AK8963_MPU9250 5
 #define HAL_COMPASS_AK8963_I2C  6
+#define HAL_COMPASS_HMC5843_MPU6000 7
 
 /**
    CPU classes, used to select if CPU intensive algorithms should be used

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1501,6 +1501,20 @@ void AP_InertialSensor::set_delta_angle(uint8_t instance, const Vector3f &deltaa
     }
 }
 
+/*
+ * Get an AuxiliaryBus on the backend identified by @backend_id
+ */
+AuxiliaryBus *AP_InertialSensor::get_auxiliar_bus(int16_t backend_id)
+{
+    _detect_backends();
+
+    AP_InertialSensor_Backend *backend = _find_backend(backend_id);
+    if (backend == NULL)
+        return NULL;
+
+    return backend->get_auxiliar_bus();
+}
+
 #if INS_VIBRATION_CHECK
 // calculate vibration levels and check for accelerometer clipping (called by a backends)
 void AP_InertialSensor::calc_vibration_and_clipping(uint8_t instance, const Vector3f &accel, float dt)

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -299,6 +299,8 @@ const AP_Param::GroupInfo AP_InertialSensor::var_info[] PROGMEM = {
     AP_GROUPEND
 };
 
+AP_InertialSensor *AP_InertialSensor::_s_instance = nullptr;
+
 AP_InertialSensor::AP_InertialSensor() :
     _gyro_count(0),
     _accel_count(0),
@@ -314,6 +316,10 @@ AP_InertialSensor::AP_InertialSensor() :
     _backends_detected(false),
     _dataflash(NULL)
 {
+    if (_s_instance) {
+        hal.scheduler->panic(PSTR("Too many inertial sensors"));
+    }
+    _s_instance = this;
     AP_Param::setup_object_defaults(this, var_info);        
     for (uint8_t i=0; i<INS_MAX_BACKENDS; i++) {
         _backends[i] = NULL;
@@ -337,6 +343,15 @@ AP_InertialSensor::AP_InertialSensor() :
     memset(_delta_angle_valid,0,sizeof(_delta_angle_valid));
 }
 
+/*
+ * Get the AP_InertialSensor singleton
+ */
+AP_InertialSensor *AP_InertialSensor::get_instance()
+{
+    if (!_s_instance)
+        _s_instance = new AP_InertialSensor();
+    return _s_instance;
+}
 
 /*
   register a new gyro instance

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1,5 +1,7 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
 
+#include <assert.h>
+
 #include <AP_Progmem/AP_Progmem.h>
 #include "AP_InertialSensor.h"
 
@@ -374,6 +376,23 @@ void AP_InertialSensor::_start_backends()
     if (_gyro_count == 0 || _accel_count == 0) {
         hal.scheduler->panic(PSTR("INS needs at least 1 gyro and 1 accel"));
     }
+}
+
+/* Find a backend that has already been succesfully detected */
+AP_InertialSensor_Backend *AP_InertialSensor::_find_backend(int16_t backend_id)
+{
+    assert(_backends_detected);
+
+    for (uint8_t i = 0; i < _backend_count; i++) {
+        int16_t id = _backends[i]->get_id();
+
+        if (id < 0 || id != backend_id)
+            continue;
+
+        return _backends[i];
+    }
+
+    return nullptr;
 }
 
 void

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -309,6 +309,7 @@ AP_InertialSensor::AP_InertialSensor() :
     _hil_mode(false),
     _calibrating(false),
     _log_raw_data(false),
+    _backends_detected(false),
     _dataflash(NULL)
 {
     AP_Param::setup_object_defaults(this, var_info);        
@@ -357,6 +358,24 @@ uint8_t AP_InertialSensor::register_accel(void)
     return _accel_count++;
 }
 
+/*
+ * Start all backends for gyro and accel measurements. It automatically calls
+ * _detect_backends() if it has not been called already.
+ */
+void AP_InertialSensor::_start_backends()
+
+{
+    _detect_backends();
+
+    for (uint8_t i = 0; i < _backend_count; i++) {
+        _backends[i]->start();
+    }
+
+    if (_gyro_count == 0 || _accel_count == 0) {
+        hal.scheduler->panic(PSTR("INS needs at least 1 gyro and 1 accel"));
+    }
+}
+
 void
 AP_InertialSensor::init( Start_style style,
                          Sample_rate sample_rate)
@@ -365,8 +384,7 @@ AP_InertialSensor::init( Start_style style,
     _sample_rate = sample_rate;
 
     if (_gyro_count == 0 && _accel_count == 0) {
-        // detect available backends. Only called once
-        _detect_backends();
+        _start_backends();
     }
 
     // initialise accel scale if need be. This is needed as we can't
@@ -420,6 +438,11 @@ void AP_InertialSensor::_add_backend(AP_InertialSensor_Backend *backend)
 void 
 AP_InertialSensor::_detect_backends(void)
 {
+    if (_backends_detected)
+        return;
+
+    _backends_detected = true;
+
     if (_hil_mode) {
         _add_backend(AP_InertialSensor_HIL::detect(*this));
         return;
@@ -446,9 +469,7 @@ AP_InertialSensor::_detect_backends(void)
     #error Unrecognised HAL_INS_TYPE setting
 #endif
 
-    if (_backend_count == 0 ||
-        _gyro_count == 0 ||
-        _accel_count == 0) {
+    if (_backend_count == 0) {
         hal.scheduler->panic(PSTR("No INS backends available"));
     }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -240,6 +240,7 @@ private:
     // load backend drivers
     void _add_backend(AP_InertialSensor_Backend *backend);
     void _detect_backends(void);
+    void _start_backends();
 
     // gyro initialisation
     void _init_gyro();
@@ -330,6 +331,8 @@ private:
 
     // should we log raw accel/gyro data?
     bool _log_raw_data:1;
+
+    bool _backends_detected:1;
 
     // the delta time in seconds for the last sample
     float _delta_time;

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -241,6 +241,7 @@ private:
     void _add_backend(AP_InertialSensor_Backend *backend);
     void _detect_backends(void);
     void _start_backends();
+    AP_InertialSensor_Backend *_find_backend(int16_t backend_id);
 
     // gyro initialisation
     void _init_gyro();

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -33,6 +33,7 @@
 #include <Filter/LowPassFilter.h>
 
 class AP_InertialSensor_Backend;
+class AuxiliaryBus;
 
 /*
   forward declare DataFlash class. We can't include DataFlash.h
@@ -234,6 +235,8 @@ public:
     void set_delta_time(float delta_time);
     void set_delta_velocity(uint8_t instance, float deltavt, const Vector3f &deltav);
     void set_delta_angle(uint8_t instance, const Vector3f &deltaa);
+
+    AuxiliaryBus *get_auxiliar_bus(int16_t backend_id);
 
 private:
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -54,6 +54,7 @@ class AP_InertialSensor
 
 public:
     AP_InertialSensor();
+    static AP_InertialSensor *get_instance();
 
     enum Start_style {
         COLD_START = 0,
@@ -372,6 +373,8 @@ private:
     } _hil {};
 
     DataFlash_Class *_dataflash;
+
+    static AP_InertialSensor *_s_instance;
 };
 
 #include "AP_InertialSensor_Backend.h"

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -63,6 +63,8 @@ public:
      */
     int16_t product_id(void) const { return _product_id; }
 
+    int16_t get_id() const { return _id; }
+
 protected:
     // access to frontend
     AP_InertialSensor &_imu;
@@ -93,6 +95,9 @@ protected:
 
     // backend should fill in its product ID from AP_PRODUCT_ID_*
     int16_t _product_id;
+
+    // backend unique identifier or -1 if backend doesn't identify itself
+    int16_t _id = -1;
 
     // return the default filter frequency in Hz for the sample rate
     uint8_t _accel_filter_cutoff(void) const { return _imu._accel_filter_cutoff; }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -53,6 +53,12 @@ public:
     virtual bool gyro_sample_available() = 0;
 
     /*
+     * Configure and start all sensors. The empty implementation allows
+     * subclasses to already start the sensors when it's detected
+     */
+    virtual void start() { }
+
+    /*
       return the product ID
      */
     int16_t product_id(void) const { return _product_id; }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -24,6 +24,8 @@
 #ifndef __AP_INERTIALSENSOR_BACKEND_H__
 #define __AP_INERTIALSENSOR_BACKEND_H__
 
+class AuxiliaryBus;
+
 class AP_InertialSensor_Backend
 {
 public:
@@ -57,6 +59,11 @@ public:
      * subclasses to already start the sensors when it's detected
      */
     virtual void start() { }
+
+    /*
+     * Return an AuxiliaryBus if backend has another bus it is able to export
+     */
+    virtual AuxiliaryBus *get_auxiliar_bus() { return nullptr; }
 
     /*
       return the product ID

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -227,7 +227,7 @@ void AP_MPU6000_BusDriver_SPI::read_burst(uint8_t *samples,
                                          AP_HAL::DigitalSource *_drdy_pin,
                                          uint8_t &n_samples)
 {
-    /* one resister address followed by seven 2-byte registers */
+    /* one register address followed by seven 2-byte registers */
     struct PACKED {
         uint8_t cmd;
         uint8_t int_status;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -397,6 +397,7 @@ AP_InertialSensor_MPU6000::AP_InertialSensor_MPU6000(AP_InertialSensor &imu, AP_
 AP_InertialSensor_MPU6000::~AP_InertialSensor_MPU6000()
 {
     delete _bus;
+    delete _samples;
 }
 
 /* Detect the sensor on SPI bus. It must have a corresponding device on

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -223,9 +223,9 @@ void AP_MPU6000_BusDriver_SPI::set_bus_speed(AP_HAL::SPIDeviceDriver::bus_speed 
     _spi->set_bus_speed(speed);
 }
 
-void AP_MPU6000_BusDriver_SPI::read_burst(uint8_t *samples,
-                                         AP_HAL::DigitalSource *_drdy_pin,
-                                         uint8_t &n_samples)
+void AP_MPU6000_BusDriver_SPI::read_data_transaction(uint8_t *samples,
+                                                     AP_HAL::DigitalSource *_drdy_pin,
+                                                     uint8_t &n_samples)
 {
     /* one register address followed by seven 2-byte registers */
     struct PACKED {
@@ -305,9 +305,9 @@ void AP_MPU6000_BusDriver_I2C::write8(uint8_t reg, uint8_t val)
 void AP_MPU6000_BusDriver_I2C::set_bus_speed(AP_HAL::SPIDeviceDriver::bus_speed speed)
 {}
 
-void AP_MPU6000_BusDriver_I2C::read_burst(uint8_t *samples,
-                                          AP_HAL::DigitalSource *_drdy_pin,
-                                          uint8_t &n_samples)
+void AP_MPU6000_BusDriver_I2C::read_data_transaction(uint8_t *samples,
+                                                     AP_HAL::DigitalSource *_drdy_pin,
+                                                     uint8_t &n_samples)
 {
 	uint16_t bytes_read;
     uint8_t ret = 0;
@@ -579,9 +579,9 @@ void AP_InertialSensor_MPU6000::_poll_data(void)
 {
     if (!_bus_sem->take_nonblocking()) {
         return;
-    }   
+    }
     if (_fifo_mode || _data_ready()) {
-        _read_data_transaction(); 
+        _read_data_transaction();
     }
     _bus_sem->give();
 }
@@ -622,7 +622,7 @@ void AP_InertialSensor_MPU6000::_read_data_transaction()
 {
     uint8_t n_samples;
 
-    _bus->read_burst(_samples, _drdy_pin, n_samples);
+    _bus->read_data_transaction(_samples, _drdy_pin, n_samples);
     _accumulate(_samples, n_samples);
 }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.h
@@ -34,6 +34,10 @@ public:
     virtual ~AP_MPU6000_BusDriver() { };
     virtual void init(bool &fifo_mode, uint8_t &max_samples) = 0;
     virtual void read8(uint8_t reg, uint8_t *val) = 0;
+
+    /// Copy data from the device to @p buf starting at @p reg with @size
+    /// length.
+    virtual void read_block(uint8_t reg, uint8_t *buf, uint32_t size) = 0;
     virtual void write8(uint8_t reg, uint8_t val) = 0;
     virtual void set_bus_speed(AP_HAL::SPIDeviceDriver::bus_speed speed) = 0;
     virtual void read_data_transaction(uint8_t* samples,
@@ -76,6 +80,7 @@ private:
     void    _read_data_transaction();
     bool    _data_ready();
     void    _poll_data(void);
+    void    _read_block(uint8_t reg, uint8_t *buf, uint32_t size);
     uint8_t _register_read( uint8_t reg);
     void    _register_write( uint8_t reg, uint8_t val );
     void    _register_write_check(uint8_t reg, uint8_t val);
@@ -120,6 +125,7 @@ public:
     AP_MPU6000_BusDriver_SPI(void);
     void init(bool &fifo_mode, uint8_t &max_samples);
     void read8(uint8_t reg, uint8_t *val);
+    void read_block(uint8_t reg, uint8_t *buf, uint32_t size) override;
     void write8(uint8_t reg, uint8_t val);
     void set_bus_speed(AP_HAL::SPIDeviceDriver::bus_speed speed);
     void read_data_transaction(uint8_t* samples,
@@ -140,6 +146,7 @@ public:
     AP_MPU6000_BusDriver_I2C(AP_HAL::I2CDriver *i2c, uint8_t addr);
     void init(bool &fifo_mode, uint8_t &max_samples);
     void read8(uint8_t reg, uint8_t *val);
+    void read_block(uint8_t reg, uint8_t *buf, uint32_t size) override;
     void write8(uint8_t reg, uint8_t val);
     void set_bus_speed(AP_HAL::SPIDeviceDriver::bus_speed speed);
     void read_data_transaction(uint8_t* samples,

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.h
@@ -32,7 +32,8 @@ class AP_MPU6000_BusDriver
 {
 public:
     virtual ~AP_MPU6000_BusDriver() { };
-    virtual void init(bool &fifo_mode, uint8_t &max_samples) = 0;
+    virtual void init() = 0;
+    virtual void start(bool &fifo_mode, uint8_t &max_samples) = 0;
     virtual void read8(uint8_t reg, uint8_t *val) = 0;
 
     /// Copy data from the device to @p buf starting at @p reg with @size
@@ -62,9 +63,12 @@ public:
     bool gyro_sample_available(void) { return _sum_count >= _sample_count; }
     bool accel_sample_available(void) { return _sum_count >= _sample_count; }
 
+    void start() override;
+
 private:
     static AP_InertialSensor_Backend *_detect(AP_InertialSensor &_imu,
-                                              AP_MPU6000_BusDriver *bus);
+                                              AP_MPU6000_BusDriver *bus,
+                                              int16_t id = -1);
 
 #if MPU6000_DEBUG
     void _dump_registers(void);
@@ -123,7 +127,8 @@ class AP_MPU6000_BusDriver_SPI : public AP_MPU6000_BusDriver
 {
 public:
     AP_MPU6000_BusDriver_SPI(void);
-    void init(bool &fifo_mode, uint8_t &max_samples);
+    void init();
+    void start(bool &fifo_mode, uint8_t &max_samples);
     void read8(uint8_t reg, uint8_t *val);
     void read_block(uint8_t reg, uint8_t *buf, uint32_t size) override;
     void write8(uint8_t reg, uint8_t val);
@@ -144,7 +149,8 @@ class AP_MPU6000_BusDriver_I2C : public AP_MPU6000_BusDriver
 {
 public:
     AP_MPU6000_BusDriver_I2C(AP_HAL::I2CDriver *i2c, uint8_t addr);
-    void init(bool &fifo_mode, uint8_t &max_samples);
+    void init();
+    void start(bool &fifo_mode, uint8_t &max_samples);
     void read8(uint8_t reg, uint8_t *val);
     void read_block(uint8_t reg, uint8_t *buf, uint32_t size) override;
     void write8(uint8_t reg, uint8_t val);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.h
@@ -111,7 +111,7 @@ private:
 #endif
     volatile uint16_t _sum_count;
     bool _fifo_mode;
-    uint8_t *_samples;
+    uint8_t *_samples = nullptr;
 };
 
 class AP_MPU6000_BusDriver_SPI : public AP_MPU6000_BusDriver

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.h
@@ -36,7 +36,7 @@ public:
     virtual void read8(uint8_t reg, uint8_t *val) = 0;
     virtual void write8(uint8_t reg, uint8_t val) = 0;
     virtual void set_bus_speed(AP_HAL::SPIDeviceDriver::bus_speed speed) = 0;
-    virtual void read_burst(uint8_t* samples,
+    virtual void read_data_transaction(uint8_t* samples,
                             AP_HAL::DigitalSource *_drdy_pin,
                             uint8_t &n_samples) = 0;
     virtual AP_HAL::Semaphore* get_semaphore() = 0;
@@ -122,9 +122,9 @@ public:
     void read8(uint8_t reg, uint8_t *val);
     void write8(uint8_t reg, uint8_t val);
     void set_bus_speed(AP_HAL::SPIDeviceDriver::bus_speed speed);
-    void read_burst(uint8_t* samples,
-                    AP_HAL::DigitalSource *_drdy_pin,
-                    uint8_t &n_samples);
+    void read_data_transaction(uint8_t* samples,
+                               AP_HAL::DigitalSource *_drdy_pin,
+                               uint8_t &n_samples);
     AP_HAL::Semaphore* get_semaphore();
 
 private:
@@ -142,9 +142,9 @@ public:
     void read8(uint8_t reg, uint8_t *val);
     void write8(uint8_t reg, uint8_t val);
     void set_bus_speed(AP_HAL::SPIDeviceDriver::bus_speed speed);
-    void read_burst(uint8_t* samples,
-                    AP_HAL::DigitalSource *_drdy_pin,
-                    uint8_t &n_samples);
+    void read_data_transaction(uint8_t* samples,
+                               AP_HAL::DigitalSource *_drdy_pin,
+                               uint8_t &n_samples);
     AP_HAL::Semaphore* get_semaphore();
 
 private:

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
@@ -257,7 +257,7 @@ bool AP_InertialSensor_MPU9250::initialize_driver_state() {
         _register_write(spi, MPUREG_USER_CTRL, BIT_USER_CTRL_I2C_IF_DIS);
 
         // Wake up device and select GyroZ clock. Note that the
-        // MPU6000 starts up in sleep mode, and it can take some time
+        // MPU9250 starts up in sleep mode, and it can take some time
         // for it to come out of sleep
         _register_write(spi, MPUREG_PWR_MGMT_1, BIT_PWR_MGMT_1_CLK_ZGYRO);
         hal.scheduler->delay(5);
@@ -378,7 +378,7 @@ void AP_InertialSensor_MPU9250::_poll_data(void)
  */
 void AP_InertialSensor_MPU9250::_read_data_transaction() 
 {
-    /* one resister address followed by seven 2-byte registers */
+    /* one register address followed by seven 2-byte registers */
     struct PACKED {
         uint8_t cmd;
         uint8_t int_status;

--- a/libraries/AP_InertialSensor/AuxiliaryBus.cpp
+++ b/libraries/AP_InertialSensor/AuxiliaryBus.cpp
@@ -5,7 +5,7 @@
 #include "AuxiliaryBus.h"
 
 AuxiliaryBusSlave::AuxiliaryBusSlave(AuxiliaryBus &bus, uint8_t addr,
-                                   uint8_t instance)
+                                     uint8_t instance)
     : _bus(bus)
     , _addr(addr)
     , _instance(instance)
@@ -83,7 +83,7 @@ AuxiliaryBusSlave *AuxiliaryBus::request_next_slave(uint8_t addr)
  * Return 0 on success or < 0 on error.
  */
 int AuxiliaryBus::register_periodic_read(AuxiliaryBusSlave *slave, uint8_t reg,
-                                        uint8_t size)
+                                         uint8_t size)
 {
     assert(slave->_instance == _n_slaves);
     assert(_n_slaves < _max_slaves);

--- a/libraries/AP_InertialSensor/AuxiliaryBus.cpp
+++ b/libraries/AP_InertialSensor/AuxiliaryBus.cpp
@@ -1,0 +1,101 @@
+#include <assert.h>
+#include <errno.h>
+#include <stdlib.h>
+
+#include "AuxiliaryBus.h"
+
+AuxiliaryBusSlave::AuxiliaryBusSlave(AuxiliaryBus &bus, uint8_t addr,
+                                   uint8_t instance)
+    : _bus(bus)
+    , _addr(addr)
+    , _instance(instance)
+{
+}
+
+AuxiliaryBusSlave::~AuxiliaryBusSlave()
+{
+}
+
+AuxiliaryBus::AuxiliaryBus(AP_InertialSensor_Backend &backend, uint8_t max_slaves)
+    : _max_slaves(max_slaves)
+    , _ins_backend(backend)
+{
+    _slaves = (AuxiliaryBusSlave**) calloc(max_slaves, sizeof(AuxiliaryBusSlave*));
+}
+
+AuxiliaryBus::~AuxiliaryBus()
+{
+    for (int i = _n_slaves - 1; i >= 0; i--) {
+        delete _slaves[i];
+    }
+    free(_slaves);
+}
+
+/*
+ * Get the next available slave for the sensor exposing this AuxiliaryBus.
+ * If a new slave cannot be registered or instantiated, `nullptr` is returned.
+ * Otherwise a new slave is returned, but it's not registered (and therefore
+ * not owned by the AuxiliaryBus).
+ *
+ * After using the slave, if it's not registered for a periodic read it must
+ * be destroyed.
+ *
+ * @addr: the address of this slave in the bus
+ *
+ * Return a new slave if successful or `nullptr` otherwise.
+ */
+AuxiliaryBusSlave *AuxiliaryBus::request_next_slave(uint8_t addr)
+{
+    if (_n_slaves == _max_slaves)
+        return nullptr;
+
+    AuxiliaryBusSlave *slave = _instantiate_slave(addr, _n_slaves);
+    if (!slave)
+        return nullptr;
+
+    return slave;
+}
+
+/*
+ * Register a periodic read. This should be called after the slave sensor is
+ * already configured and the only thing the master needs to do is to copy a
+ * set of registers from the slave to its own registers.
+ *
+ * The sample rate is hard-coded, depending on the sensor that exports this
+ * AuxiliaryBus.
+ *
+ * After this call the AuxiliaryBusSlave is owned by this object and should
+ * not be destroyed. A typical call chain to use a sensor in an AuxiliaryBus
+ * is (error checking omitted for brevity):
+ *
+ *      AuxiliaryBusSlave *slave = bus->request_next_slave(addr);
+ *      slave->passthrough_read(WHO_AM_I, buf, 1);
+ *      slave->passthrough_write(...);
+ *      slave->passthrough_write(...);
+ *      ...
+ *      bus->register_periodic_read(slave, SAMPLE_START_REG, SAMPLE_SIZE);
+ *
+ * @slave: the AuxiliaryBusSlave already configured to be in continuous mode
+ * @reg:   the first register of the block to use in each periodic transfer
+ * @size:  the block size, usually the size of the sample multiplied by the
+ *         number of axes in each sample.
+ *
+ * Return 0 on success or < 0 on error.
+ */
+int AuxiliaryBus::register_periodic_read(AuxiliaryBusSlave *slave, uint8_t reg,
+                                        uint8_t size)
+{
+    assert(slave->_instance == _n_slaves);
+    assert(_n_slaves < _max_slaves);
+
+    int r = _configure_periodic_read(slave, reg, size);
+    if (r < 0)
+        return r;
+
+    slave->_sample_reg_start = reg;
+    slave->_sample_size = size;
+    slave->_registered = true;
+    _slaves[_n_slaves++] = slave;
+
+    return 0;
+}

--- a/libraries/AP_InertialSensor/AuxiliaryBus.h
+++ b/libraries/AP_InertialSensor/AuxiliaryBus.h
@@ -1,0 +1,130 @@
+/// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+/*
+ * Copyright (C) 2015  Intel Corporation. All rights reserved.
+ *
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <inttypes.h>
+
+class AuxiliaryBus;
+class AP_InertialSensor_Backend;
+
+namespace AP_HAL {
+    class Semaphore;
+}
+
+class AuxiliaryBusSlave
+{
+    friend class AuxiliaryBus;
+
+public:
+    virtual ~AuxiliaryBusSlave();
+
+    /*
+     * Read a block of registers from the slave. This is a one-time read. Must
+     * be implemented by the sensor exposing the AuxiliaryBus.
+     *
+     * This method cannot be called after the periodic read is configured
+     * since the registers for the periodic read may be shared with the
+     * passthrough reads.
+     *
+     * @reg: the first register of the block to use in this one time transfer
+     * @buf: buffer in which to write the values read
+     * @size: the buffer size
+     *
+     * Return the number of bytes read on success or < 0 on error
+     */
+    virtual int passthrough_read(uint8_t reg, uint8_t *buf, uint8_t size) = 0;
+
+    /*
+     * Write a single value into a register of this slave. Must be implemented
+     * by the sensor exposing the AuxiliaryBus.
+     *
+     * This method cannot be called after the periodic read is configured
+     * since the registers for the periodic read may be shared with the
+     * passthrough writes.
+     *
+     * @reg: the register to use in this one time transfer
+     * @val: the value to write
+     *
+     * Return the number of bytes written on success or < 0 on error
+     */
+    virtual int passthrough_write(uint8_t reg, uint8_t val) = 0;
+
+    /*
+     * Read the block of registers that were read from the slave on the last
+     * time a periodic read occurred.
+     *
+     * This method must be called after the periodic read is configured and
+     * the buffer must be large enough to accomodate the size configured.
+     *
+     * @buf: buffer in which to write the values read
+     *
+     * Return the number of bytes read on success or < 0 on error
+     */
+    virtual int read(uint8_t *buf) = 0;
+
+protected:
+    /* Only AuxiliaryBus is able to create a slave */
+    AuxiliaryBusSlave(AuxiliaryBus &bus, uint8_t addr, uint8_t instance);
+
+    AuxiliaryBus &_bus;
+    uint8_t _addr = 0;
+    uint8_t _instance = 0;
+
+    uint8_t _sample_reg_start = 0;
+    uint8_t _sample_size = 0;
+
+    bool _registered = false;
+};
+
+class AuxiliaryBus
+{
+    friend class AP_InertialSensor_Backend;
+
+public:
+    AP_InertialSensor_Backend &get_backend() { return _ins_backend; }
+
+    AuxiliaryBusSlave *request_next_slave(uint8_t addr);
+    int register_periodic_read(AuxiliaryBusSlave *slave, uint8_t reg, uint8_t size);
+
+    /*
+     * Get the semaphore needed to call methods on the bus this sensor is on.
+     * Internally no locks are taken and it's the caller's duty to lock and
+     * unlock the bus as needed.
+     *
+     * This method must be implemented by the sensor exposing the
+     * AuxiliaryBus.
+     *
+     * Return the semaphore used protect transfers on the bus
+     */
+    virtual AP_HAL::Semaphore *get_semaphore() = 0;
+
+protected:
+    /* Only AP_InertialSensor_Backend is able to create a bus */
+    AuxiliaryBus(AP_InertialSensor_Backend &backend, uint8_t max_slaves);
+    virtual ~AuxiliaryBus();
+
+    virtual AuxiliaryBusSlave *_instantiate_slave(uint8_t addr, uint8_t instance) = 0;
+    virtual int _configure_periodic_read(AuxiliaryBusSlave *slave, uint8_t reg,
+                                         uint8_t size) = 0;
+
+    uint8_t _n_slaves = 0;
+    const uint8_t _max_slaves;
+    AuxiliaryBusSlave **_slaves;
+    AP_InertialSensor_Backend &_ins_backend;
+};


### PR DESCRIPTION
This pr came up a little bigger than I wanted, but here there's the necessary abstraction code to allow any sensor to be on the auxiliary bus (or almost any, given some HW limitations).

I also cherry-picked and fixed some commits from @staroselskii in #2599 - I didn't want to conflict with his changes and that pr is taking a lot of time to get integrated... I changed the commits a little bit and applied a fix for one of the changes.

This is tested on my minnowboardmax-based drone. It should be the only one affected since it's the only one to have a sensor on the auxiliary bus.

For later:
- convert the MPU9250 + AK8963 code to do the same thing... MPU9250 could even share lots of code with MPU6000 from what I see
- add a better abstraction for the *SerialBus* classes... they could be moved to AP_HAL so we don't need to create a class for each sensor we want on I2C, SPI or Auxiliary.