### PR TITLE
Plane: post "Distance from LAND point" on every land

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -466,6 +466,9 @@ private:
         
         // last time is_flying() returned true in milliseconds
         uint32_t last_flying_ms;
+
+        // once landed, post some landing statistics to the GCS
+        bool post_landing_stats;
     } auto_state;
 
     // true if we are in an auto-throttle mode, which means

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -28,6 +28,9 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
         // start non-idle
         auto_state.idle_mode = false;
         
+        // once landed, post some landing statistics to the GCS
+        auto_state.post_landing_stats = false;
+
         gcs_send_text_fmt(PSTR("Executing nav command ID #%i"),cmd.id);
     } else {
         gcs_send_text_fmt(PSTR("Executing command ID #%i"),cmd.id);

--- a/ArduPlane/landing.cpp
+++ b/ArduPlane/landing.cpp
@@ -49,6 +49,7 @@ bool Plane::verify_land()
         (fabsf(auto_state.sink_rate) < 0.2f && !is_flying())) {
 
         if (!auto_state.land_complete) {
+            auto_state.post_landing_stats = true;
             if (!is_flying() && (millis()-auto_state.last_flying_ms) > 3000) {
                 gcs_send_text_fmt(PSTR("Flare crash detected: speed=%.1f"), (double)gps.ground_speed());
             } else {
@@ -79,6 +80,13 @@ bool Plane::verify_land()
                     land_bearing_cd*0.01f, 
                     get_distance(prev_WP_loc, current_loc) + 200);
     nav_controller->update_waypoint(prev_WP_loc, land_WP_loc);
+
+    // once landed and stationary, post some statistics
+    // this is done before disarm_if_autoland_complete() so that it happens on the next loop after the disarm
+    if (auto_state.post_landing_stats && !arming.is_armed()) {
+        auto_state.post_landing_stats = false;
+        gcs_send_text_fmt(PSTR("Distance from LAND point=%.2fm"), get_distance(current_loc, next_WP_loc));
+    }
 
     // check if we should auto-disarm after a confirmed landing
     disarm_if_autoland_complete();


### PR DESCRIPTION
Waits until disarm after a land and prints to the GCS, for example, "Distance from LAND point=12.34m". This is useful for gathering statistical info for landings. This could be done by a GCS or companion computer but this will allow it to be stored on the DF log as a MSG.