### PR TITLE
Give NAV_CONTINUE_AND_CHANGE_ALT command a parameter: climb/descend intent.

### DIFF
--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -379,6 +379,7 @@ void Plane::do_loiter_time(const AP_Mission::Mission_Command& cmd)
 void Plane::do_continue_and_change_alt(const AP_Mission::Mission_Command& cmd)
 {
     next_WP_loc.alt = cmd.content.location.alt + home.alt;
+    condition_value = cmd.p1;
     reset_offset_altitude();
 }
 
@@ -646,7 +647,17 @@ bool Plane::verify_RTL()
 
 bool Plane::verify_continue_and_change_alt()
 {
-    if (abs(adjusted_altitude_cm() - next_WP_loc.alt) <= 500) {
+    //climbing?
+    if (condition_value == 1 && adjusted_altitude_cm() >= next_WP_loc.alt) {
+        return true;
+    }
+    //descending?
+    else if (condition_value == 2 &&
+             adjusted_altitude_cm() <= next_WP_loc.alt) {
+        return true;
+    }    
+    //don't care if we're climbing or descending
+    else if (abs(adjusted_altitude_cm() - next_WP_loc.alt) <= 500) {
         return true;
     }
    

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -531,6 +531,10 @@ bool AP_Mission::mavlink_to_mission_cmd(const mavlink_mission_item_t& packet, AP
 
     case MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT:           // MAV ID: 30
         copy_location = true;                           // only using alt
+        cmd.p1 = packet.param1;                         // Climb/Descend
+                        // 0 = Neutral, cmd complete at +/- 5 of indicated alt.
+                        // 1 = Climb, cmd complete at or above indicated alt.
+                        // 2 = Descend, cmd complete at or below indicated alt.
         break;
 
     case MAV_CMD_NAV_LOITER_TO_ALT:                     // MAV ID: 31
@@ -849,7 +853,11 @@ bool AP_Mission::mission_cmd_to_mavlink(const AP_Mission::Mission_Command& cmd, 
         break;
 
     case MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT:           // MAV ID: 30
-        copy_location = true;                           //only using alt.
+        copy_location = true;                           //only using alt
+        packet.param1 = cmd.p1;                         // Climb/Descend
+                        // 0 = Neutral, cmd complete at +/- 5 of indicated alt.
+                        // 1 = Climb, cmd complete at or above indicated alt.
+                        // 2 = Descend, cmd complete at or below indicated alt.
         break;
 
     case MAV_CMD_NAV_LOITER_TO_ALT:                     // MAV ID: 31


### PR DESCRIPTION
This change gives NAV_CONTINUE_AND_CHANGE_ALT a parameter: the expected direction when changing altitude.  The value is stored at the first parameter, and values can be as follows:

0 = no expectation, command completes when within 5 m of altitude.
1 = climb expected, command completes at or above altitude.
2 = descent expected, command completes at or below altitude.

Our use case for this is on a Go Around.   Our main purpose for a Go Around is to have the plane climb away from people on the ground before executing any navigation behavior that would cause the plane to veer.  Hence, at the beginning of our Go Around mission segment we have a NAV_CONTINUE_AND_CLIMB with an altitude parameter that specifies how how to climb before moving to the next waypoint.   This usually works fine.

We have had times when a Go Around was called very early -- and the plane is already at a high enough altitude to be safe.  If the plane is at high enough altitude it will therefore continue on a straight course for much longer than we really intend.   

if the plane knows what the user intends when a NAV_CONTINUE_AND_CHANGE_ALT is used, then the command can potentially complete sooner and the plane will not continue on a straight longer than necessary.