### PR TITLE
Copter: Enable reading RSSI value from PWM channel value.

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -220,6 +220,30 @@ const AP_Param::Info Copter::var_info[] PROGMEM = {
     // @User: Standard
     GSCALAR(rssi_range,          "RSSI_RANGE",         5.0f),
 
+    // @Param: RSSI_CHANNEL
+    // @DisplayName: Receiver RSSI channel number
+    // @Description: The channel number where RSSI will be output by the radio receiver.
+    // @Units: 
+    // @Values: 0:Disabled,1:Channel1,2:Channel2,3:Channel3,4:Channel4,5:Channel5,6:Channel6,7:Channel7,8:Channel8
+    // @User: Standard
+    GSCALAR(rssi_channel,          "RSSI_CHANNEL",         0),
+    
+    // @Param: RSSI_CHAN_LOW
+    // @DisplayName: Receiver RSSI PWM low value
+    // @Description: This is the PWM value that the radio receiver will put on the RSSI_CHANNEL when the signal strength is the weakest. Since some radio receivers put out inverted values from what you might otherwise expect, this isn't necessarily a lower value than RSSI_CHAN_HIGH. 
+    // @Units: Microseconds
+    // @Range: 0 2000
+    // @User: Standard
+    GSCALAR(rssi_channel_low_pwm_value, "RSSI_CHAN_LOW", 1000), 
+    
+    // @Param: RSSI_CHAN_HIGH
+    // @DisplayName: Receiver RSSI PWM high value
+    // @Description: This is the PPM value that the radio receiver will put on the RSSI_CHANNEL when the signal strength is the strongest. Since some radio receivers put out inverted values from what you might otherwise expect, this isn't necessarily a higher value than RSSI_CHAN_LOW. 
+    // @Units: Microseconds
+    // @Range: 0 2000
+    // @User: Standard
+    GSCALAR(rssi_channel_high_pwm_value, "RSSI_CHAN_HIGH", 2000),  
+    
     // @Param: WP_YAW_BEHAVIOR
     // @DisplayName: Yaw behaviour during missions
     // @Description: Determines how the autopilot controls the yaw during missions and RTL

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -195,6 +195,13 @@ public:
         k_param_takeoff_trigger_dz,
         k_param_gcs3,
         k_param_gcs_pid_mask,    // 126
+        
+        //
+        // 130: RSSI
+        //
+        k_param_rssi_channel = 130,
+        k_param_rssi_channel_low_pwm_value,
+        k_param_rssi_channel_high_pwm_value,   // 132
 
         //
         // 135 : reserved for Solo until features merged with master
@@ -375,7 +382,11 @@ public:
     AP_Int16        rtl_climb_min;              // rtl minimum climb in cm
 
     AP_Int8         rssi_pin;
-    AP_Float        rssi_range;                 // allows to set max voltage for rssi pin such as 5.0, 3.3 etc. 
+    AP_Float        rssi_range;                     // allows to set max voltage for rssi pin such as 5.0, 3.3 etc. 
+    AP_Int8         rssi_channel;                   // allows rssi to be read from given channel as PWM value
+    AP_Int16        rssi_channel_low_pwm_value;     // PWM value for weakest rssi signal
+    AP_Int16        rssi_channel_high_pwm_value;    // PWM value for strongest rssi signal 
+    
     AP_Int8         wp_yaw_behavior;            // controls how the autopilot controls yaw during missions
     AP_Int8         rc_feel_rp;                 // controls vehicle response to user input with 0 being extremely soft and 100 begin extremely crisp
 

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -1,6 +1,7 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
 
 #include "Copter.h"
+#include <RC_Channel/RC_Channel.h>
 
 void Copter::init_barometer(bool full_calibration)
 {
@@ -171,14 +172,7 @@ void Copter::read_battery(void)
 // RC_CHANNELS_SCALED message
 void Copter::read_receiver_rssi(void)
 {
-    // avoid divide by zero
-    if (g.rssi_range <= 0) {
-        receiver_rssi = 0;
-    }else{
-        rssi_analog_source->set_pin(g.rssi_pin);
-        float ret = rssi_analog_source->voltage_average() * 255 / g.rssi_range;
-        receiver_rssi = constrain_int16(ret, 0, 255);
-    }
+    receiver_rssi = RC_Channel::read_receiver_rssi(g.rssi_pin, g.rssi_range, rssi_analog_source, g.rssi_channel, g.rssi_channel_low_pwm_value, g.rssi_channel_high_pwm_value);
 }
 
 #if EPM_ENABLED == ENABLED


### PR DESCRIPTION
Copter: Enable reading RSSI value from PWM channel value. Supports inverted channel values (EzUHF) and user-defined ranges. 