### PR TITLE
Rover: Enable reading RSSI value from PWM channel value.

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -44,6 +44,38 @@ const AP_Param::Info Rover::var_info[] PROGMEM = {
     // @User: Standard
     GSCALAR(rssi_pin,            "RSSI_PIN",         -1),
 
+    // @Param: RSSI_RANGE
+    // @DisplayName: Receiver RSSI voltage range
+    // @Description: Receiver RSSI voltage range
+    // @Units: Volt
+    // @Values: 3.3:3.3V, 5:5V
+    // @User: Standard
+    GSCALAR(rssi_range,          "RSSI_RANGE",         5.0f),
+
+    // @Param: RSSI_CHANNEL
+    // @DisplayName: Receiver RSSI channel number
+    // @Description: The channel number where RSSI will be output by the radio receiver.
+    // @Units: 
+    // @Values: 0:Disabled,1:Channel1,2:Channel2,3:Channel3,4:Channel4,5:Channel5,6:Channel6,7:Channel7,8:Channel8
+    // @User: Standard
+    GSCALAR(rssi_channel,          "RSSI_CHANNEL",         0),
+    
+    // @Param: RSSI_CHAN_LOW
+    // @DisplayName: Receiver RSSI PWM low value
+    // @Description: This is the PWM value that the radio receiver will put on the RSSI_CHANNEL when the signal strength is the weakest. Since some radio receivers put out inverted values from what you might otherwise expect, this isn't necessarily a lower value than RSSI_CHAN_HIGH. 
+    // @Units: Microseconds
+    // @Range: 0 2000
+    // @User: Standard
+    GSCALAR(rssi_channel_low_pwm_value, "RSSI_CHAN_LOW", 1000), 
+    
+    // @Param: RSSI_CHAN_HIGH
+    // @DisplayName: Receiver RSSI PWM high value
+    // @Description: This is the PPM value that the radio receiver will put on the RSSI_CHANNEL when the signal strength is the strongest. Since some radio receivers put out inverted values from what you might otherwise expect, this isn't necessarily a higher value than RSSI_CHAN_LOW. 
+    // @Units: Microseconds
+    // @Range: 0 2000
+    // @User: Standard
+    GSCALAR(rssi_channel_high_pwm_value, "RSSI_CHAN_HIGH", 2000),  
+        
     // @Param: SYSID_THIS_MAV
     // @DisplayName: MAVLink system ID of this vehicle
     // @Description: Allows setting an individual MAVLink system id for this vehicle to distinguish it from others on the same network

--- a/APMrover2/Parameters.h
+++ b/APMrover2/Parameters.h
@@ -54,7 +54,14 @@ public:
         k_param_serial0_baud,   // deprecated, can be deleted
         k_param_serial1_baud,   // deprecated, can be deleted
         k_param_serial2_baud,   // deprecated, can be deleted
-
+        
+        //
+        // 70: RSSI
+        //
+        k_param_rssi_range = 70,
+        k_param_rssi_channel,
+        k_param_rssi_channel_low_pwm_value,
+        k_param_rssi_channel_high_pwm_value, 
 
         // 110: Telemetry control
         //
@@ -72,7 +79,7 @@ public:
         k_param_serial_manager,     // serial manager library
         k_param_cli_enabled,
         k_param_gcs3,
-        k_param_gcs_pid_mask,
+        k_param_gcs_pid_mask, // 124
 
         //
         // 130: Sensor parameters
@@ -205,7 +212,13 @@ public:
 
     // IO pins
     AP_Int8     rssi_pin;
-
+    
+    // RSSI
+    AP_Float        rssi_range;                             // allows to set max voltage for rssi pin such as 5.0, 3.3 etc. 
+    AP_Int8         rssi_channel;                           // allows rssi to be read from given channel as PWM value
+    AP_Int16        rssi_channel_low_pwm_value;             // PWM value for weakest rssi signal
+    AP_Int16        rssi_channel_high_pwm_value;            // PWM value for strongest rssi signal 
+    
     // braking
     AP_Int8     braking_percent;
     AP_Float    braking_speederr;

--- a/APMrover2/sensors.cpp
+++ b/APMrover2/sensors.cpp
@@ -1,6 +1,7 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
 
 #include "Rover.h"
+#include <RC_Channel/RC_Channel.h>     // RC Channel Library
 
 void Rover::init_barometer(void)
 {
@@ -25,9 +26,7 @@ void Rover::read_battery(void)
 // RC_CHANNELS_SCALED message
 void Rover::read_receiver_rssi(void)
 {
-    rssi_analog_source->set_pin(g.rssi_pin);
-    float ret = rssi_analog_source->voltage_average() * 50;
-    receiver_rssi = constrain_int16(ret, 0, 255);
+    receiver_rssi = RC_Channel::read_receiver_rssi(g.rssi_pin, g.rssi_range, rssi_analog_source, g.rssi_channel, g.rssi_channel_low_pwm_value, g.rssi_channel_high_pwm_value);
 }
 
 // read the sonars


### PR DESCRIPTION
Rover: Enable reading RSSI value from PWM channel value. Supports inverted channel values (EzUHF) and user-defined ranges.