### PR TITLE
Add ability to read RSSI value from a PWM channel value

### DIFF
--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -44,6 +44,38 @@ const AP_Param::Info Rover::var_info[] PROGMEM = {
     // @User: Standard
     GSCALAR(rssi_pin,            "RSSI_PIN",         -1),
 
+    // @Param: RSSI_RANGE
+    // @DisplayName: Receiver RSSI voltage range
+    // @Description: Receiver RSSI voltage range
+    // @Units: Volt
+    // @Values: 3.3:3.3V, 5:5V
+    // @User: Standard
+    GSCALAR(rssi_range,          "RSSI_RANGE",         5.0f),
+
+    // @Param: RSSI_CHANNEL
+    // @DisplayName: Receiver RSSI channel number
+    // @Description: The channel number where RSSI will be output by the radio receiver.
+    // @Units: 
+    // @Values: 0:Disabled,1:Channel1,2:Channel2,3:Channel3,4:Channel4,5:Channel5,6:Channel6,7:Channel7,8:Channel8
+    // @User: Standard
+    GSCALAR(rssi_channel,          "RSSI_CHANNEL",         0),
+    
+    // @Param: RSSI_CHAN_LOW
+    // @DisplayName: Receiver RSSI PWM low value
+    // @Description: This is the PWM value that the radio receiver will put on the RSSI_CHANNEL when the signal strength is the weakest. Since some radio receivers put out inverted values from what you might otherwise expect, this isn't necessarily a lower value than RSSI_CHAN_HIGH. 
+    // @Units: Microseconds
+    // @Range: 0 2000
+    // @User: Standard
+    GSCALAR(rssi_channel_low_pwm_value, "RSSI_CHAN_LOW", 1000), 
+    
+    // @Param: RSSI_CHAN_HIGH
+    // @DisplayName: Receiver RSSI PWM high value
+    // @Description: This is the PPM value that the radio receiver will put on the RSSI_CHANNEL when the signal strength is the strongest. Since some radio receivers put out inverted values from what you might otherwise expect, this isn't necessarily a higher value than RSSI_CHAN_LOW. 
+    // @Units: Microseconds
+    // @Range: 0 2000
+    // @User: Standard
+    GSCALAR(rssi_channel_high_pwm_value, "RSSI_CHAN_HIGH", 2000),  
+        
     // @Param: SYSID_THIS_MAV
     // @DisplayName: MAVLink system ID of this vehicle
     // @Description: Allows setting an individual MAVLink system id for this vehicle to distinguish it from others on the same network

--- a/APMrover2/Parameters.h
+++ b/APMrover2/Parameters.h
@@ -54,7 +54,14 @@ public:
         k_param_serial0_baud,   // deprecated, can be deleted
         k_param_serial1_baud,   // deprecated, can be deleted
         k_param_serial2_baud,   // deprecated, can be deleted
-
+        
+        //
+        // 70: RSSI
+        //
+        k_param_rssi_range = 70,
+        k_param_rssi_channel,
+        k_param_rssi_channel_low_pwm_value,
+        k_param_rssi_channel_high_pwm_value, 
 
         // 110: Telemetry control
         //
@@ -72,7 +79,7 @@ public:
         k_param_serial_manager,     // serial manager library
         k_param_cli_enabled,
         k_param_gcs3,
-        k_param_gcs_pid_mask,
+        k_param_gcs_pid_mask, // 124
 
         //
         // 130: Sensor parameters
@@ -205,7 +212,13 @@ public:
 
     // IO pins
     AP_Int8     rssi_pin;
-
+    
+    // RSSI
+    AP_Float        rssi_range;                             // allows to set max voltage for rssi pin such as 5.0, 3.3 etc. 
+    AP_Int8         rssi_channel;                           // allows rssi to be read from given channel as PWM value
+    AP_Int16        rssi_channel_low_pwm_value;             // PWM value for weakest rssi signal
+    AP_Int16        rssi_channel_high_pwm_value;            // PWM value for strongest rssi signal 
+    
     // braking
     AP_Int8     braking_percent;
     AP_Float    braking_speederr;

--- a/APMrover2/sensors.cpp
+++ b/APMrover2/sensors.cpp
@@ -1,6 +1,7 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
 
 #include "Rover.h"
+#include <RC_Channel/RC_Channel.h>
 
 void Rover::init_barometer(void)
 {
@@ -25,9 +26,7 @@ void Rover::read_battery(void)
 // RC_CHANNELS_SCALED message
 void Rover::read_receiver_rssi(void)
 {
-    rssi_analog_source->set_pin(g.rssi_pin);
-    float ret = rssi_analog_source->voltage_average() * 50;
-    receiver_rssi = constrain_int16(ret, 0, 255);
+    receiver_rssi = RC_Channel::read_receiver_rssi(g.rssi_pin, g.rssi_range, rssi_analog_source, g.rssi_channel, g.rssi_channel_low_pwm_value, g.rssi_channel_high_pwm_value);
 }
 
 // read the sonars

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -220,6 +220,30 @@ const AP_Param::Info Copter::var_info[] PROGMEM = {
     // @User: Standard
     GSCALAR(rssi_range,          "RSSI_RANGE",         5.0f),
 
+    // @Param: RSSI_CHANNEL
+    // @DisplayName: Receiver RSSI channel number
+    // @Description: The channel number where RSSI will be output by the radio receiver.
+    // @Units: 
+    // @Values: 0:Disabled,1:Channel1,2:Channel2,3:Channel3,4:Channel4,5:Channel5,6:Channel6,7:Channel7,8:Channel8
+    // @User: Standard
+    GSCALAR(rssi_channel,          "RSSI_CHANNEL",         0),
+    
+    // @Param: RSSI_CHAN_LOW
+    // @DisplayName: Receiver RSSI PWM low value
+    // @Description: This is the PWM value that the radio receiver will put on the RSSI_CHANNEL when the signal strength is the weakest. Since some radio receivers put out inverted values from what you might otherwise expect, this isn't necessarily a lower value than RSSI_CHAN_HIGH. 
+    // @Units: Microseconds
+    // @Range: 0 2000
+    // @User: Standard
+    GSCALAR(rssi_channel_low_pwm_value, "RSSI_CHAN_LOW", 1000), 
+    
+    // @Param: RSSI_CHAN_HIGH
+    // @DisplayName: Receiver RSSI PWM high value
+    // @Description: This is the PPM value that the radio receiver will put on the RSSI_CHANNEL when the signal strength is the strongest. Since some radio receivers put out inverted values from what you might otherwise expect, this isn't necessarily a higher value than RSSI_CHAN_LOW. 
+    // @Units: Microseconds
+    // @Range: 0 2000
+    // @User: Standard
+    GSCALAR(rssi_channel_high_pwm_value, "RSSI_CHAN_HIGH", 2000),  
+    
     // @Param: WP_YAW_BEHAVIOR
     // @DisplayName: Yaw behaviour during missions
     // @Description: Determines how the autopilot controls the yaw during missions and RTL

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -195,6 +195,13 @@ public:
         k_param_takeoff_trigger_dz,
         k_param_gcs3,
         k_param_gcs_pid_mask,    // 126
+        
+        //
+        // 130: RSSI
+        //
+        k_param_rssi_channel = 130,
+        k_param_rssi_channel_low_pwm_value,
+        k_param_rssi_channel_high_pwm_value,   // 132
 
         //
         // 135 : reserved for Solo until features merged with master
@@ -375,7 +382,11 @@ public:
     AP_Int16        rtl_climb_min;              // rtl minimum climb in cm
 
     AP_Int8         rssi_pin;
-    AP_Float        rssi_range;                 // allows to set max voltage for rssi pin such as 5.0, 3.3 etc. 
+    AP_Float        rssi_range;                     // allows to set max voltage for rssi pin such as 5.0, 3.3 etc. 
+    AP_Int8         rssi_channel;                   // allows rssi to be read from given channel as PWM value
+    AP_Int16        rssi_channel_low_pwm_value;     // PWM value for weakest rssi signal
+    AP_Int16        rssi_channel_high_pwm_value;    // PWM value for strongest rssi signal 
+    
     AP_Int8         wp_yaw_behavior;            // controls how the autopilot controls yaw during missions
     AP_Int8         rc_feel_rp;                 // controls vehicle response to user input with 0 being extremely soft and 100 begin extremely crisp
 

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -1,6 +1,7 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
 
 #include "Copter.h"
+#include <RC_Channel/RC_Channel.h>
 
 void Copter::init_barometer(bool full_calibration)
 {
@@ -171,14 +172,7 @@ void Copter::read_battery(void)
 // RC_CHANNELS_SCALED message
 void Copter::read_receiver_rssi(void)
 {
-    // avoid divide by zero
-    if (g.rssi_range <= 0) {
-        receiver_rssi = 0;
-    }else{
-        rssi_analog_source->set_pin(g.rssi_pin);
-        float ret = rssi_analog_source->voltage_average() * 255 / g.rssi_range;
-        receiver_rssi = constrain_int16(ret, 0, 255);
-    }
+    receiver_rssi = RC_Channel::read_receiver_rssi(g.rssi_pin, g.rssi_range, rssi_analog_source, g.rssi_channel, g.rssi_channel_low_pwm_value, g.rssi_channel_high_pwm_value);
 }
 
 #if EPM_ENABLED == ENABLED

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -926,7 +926,31 @@ const AP_Param::Info Plane::var_info[] PROGMEM = {
     // @Values: 3.3:3.3V, 5.0:5V
     // @User: Standard
     GSCALAR(rssi_range,          "RSSI_RANGE",         5.0),
-
+    
+    // @Param: RSSI_CHANNEL
+    // @DisplayName: Receiver RSSI channel number
+    // @Description: The channel number where RSSI will be output by the radio receiver.
+    // @Units: 
+    // @Values: 0:Disabled,1:Channel1,2:Channel2,3:Channel3,4:Channel4,5:Channel5,6:Channel6,7:Channel7,8:Channel8
+    // @User: Standard
+    GSCALAR(rssi_channel,          "RSSI_CHANNEL",         0),
+    
+    // @Param: RSSI_CHAN_LOW
+    // @DisplayName: Receiver RSSI PWM low value
+    // @Description: This is the PWM value that the radio receiver will put on the RSSI_CHANNEL when the signal strength is the weakest. Since some radio receivers put out inverted values from what you might otherwise expect, this isn't necessarily a lower value than RSSI_CHAN_HIGH. 
+    // @Units: Microseconds
+    // @Range: 0 2000
+    // @User: Standard
+    GSCALAR(rssi_channel_low_pwm_value, "RSSI_CHAN_LOW", 1000), 
+    
+    // @Param: RSSI_CHAN_HIGH
+    // @DisplayName: Receiver RSSI PWM high value
+    // @Description: This is the PPM value that the radio receiver will put on the RSSI_CHANNEL when the signal strength is the strongest. Since some radio receivers put out inverted values from what you might otherwise expect, this isn't necessarily a higher value than RSSI_CHAN_LOW. 
+    // @Units: Microseconds
+    // @Range: 0 2000
+    // @User: Standard
+    GSCALAR(rssi_channel_high_pwm_value, "RSSI_CHAN_HIGH", 2000),  
+  
     // @Param: INVERTEDFLT_CH
     // @DisplayName: Inverted flight channel
     // @Description: A RC input channel number to enable inverted flight. If this is non-zero then the APM will monitor the corresponding RC input channel and will enable inverted flight when the channel goes above 1750.

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -139,6 +139,11 @@ public:
         k_param_rudder_only,
         k_param_gcs3,            // 93
         k_param_gcs_pid_mask,
+        
+        // 97: RSSI parameters
+        k_param_rssi_channel = 97,
+        k_param_rssi_channel_low_pwm_value,
+        k_param_rssi_channel_high_pwm_value,
 
         // 100: Arming parameters
         k_param_arming = 100,
@@ -460,7 +465,10 @@ public:
     AP_Int8 land_flap_percent;
     AP_Int8 takeoff_flap_percent;
     AP_Int8 rssi_pin;
-    AP_Float rssi_range;             // allows to set max voltage for rssi pin such as 5.0, 3.3 etc.     
+    AP_Float rssi_range;                             // allows to set max voltage for rssi pin such as 5.0, 3.3 etc. 
+    AP_Int8 rssi_channel;                            // allows rssi to be read from given channel as PWM value
+    AP_Int16 rssi_channel_low_pwm_value;             // PWM value for weakest rssi signal
+    AP_Int16 rssi_channel_high_pwm_value;            // PWM value for strongest rssi signal 
     AP_Int8 inverted_flight_ch;             // 0=disabled, 1-8 is channel for inverted flight trigger
     AP_Int8 stick_mixing;
     AP_Float takeoff_throttle_min_speed;

--- a/ArduPlane/sensors.cpp
+++ b/ArduPlane/sensors.cpp
@@ -1,6 +1,7 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
 
 #include "Plane.h"
+#include <RC_Channel/RC_Channel.h>
 
 void Plane::init_barometer(void)
 {
@@ -87,13 +88,6 @@ void Plane::read_battery(void)
 // RC_CHANNELS_SCALED message
 void Plane::read_receiver_rssi(void)
 {
-    // avoid divide by zero
-    if (g.rssi_range <= 0) {
-        receiver_rssi = 0;
-    }else{
-        rssi_analog_source->set_pin(g.rssi_pin);
-        float ret = rssi_analog_source->voltage_average() * 255 / g.rssi_range;
-        receiver_rssi = constrain_int16(ret, 0, 255);
-    }
+    receiver_rssi = RC_Channel::read_receiver_rssi(g.rssi_pin, g.rssi_range, rssi_analog_source, g.rssi_channel, g.rssi_channel_low_pwm_value, g.rssi_channel_high_pwm_value);
 }
 

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -521,3 +521,70 @@ uint16_t RC_Channel::get_limit_pwm(LimitValue limit) const
     // invalid limit value, return trim
     return radio_trim;
 }
+
+// read the receiver RSSI as an 8 bit number for MAVLink
+uint8_t RC_Channel::read_receiver_rssi(AP_Int8 rssi_pin, 
+                                  AP_Float rssi_range, 
+                                  AP_HAL::AnalogSource * rssi_analog_source, 
+                                  AP_Int8 rssi_channel, 
+                                  AP_Int16 rssi_channel_low_pwm_value, 
+                                  AP_Int16 rssi_channel_high_pwm_value) 
+{
+    // Default to 0 RSSI
+    uint8_t receiver_rssi = 0;
+            
+    // Pin-based RSSI takes precedence, since it was the first RSSI parameter
+    if (rssi_pin != -1)
+    {
+		receiver_rssi = read_pin_rssi(rssi_pin, rssi_range, rssi_analog_source);
+    // Otherwise, use RSSI from a channel        
+    } else if (rssi_channel != 0) {
+		receiver_rssi = read_channel_rssi(rssi_channel, rssi_channel_low_pwm_value, rssi_channel_high_pwm_value);
+    } 
+    return receiver_rssi;
+}
+					
+// read the RSSI value from an analog pin		
+uint8_t RC_Channel::read_pin_rssi(AP_Int8 rssi_pin, 
+							      AP_Float rssi_range, 
+							      AP_HAL::AnalogSource * rssi_analog_source)
+{
+	uint8_t pin_rssi = 0;	
+	
+	// avoid divide by zero
+	if (rssi_range > 0) {            
+		rssi_analog_source->set_pin(rssi_pin);
+		float ret = rssi_analog_source->voltage_average() * 255 / rssi_range;
+		pin_rssi = constrain_int16(ret, 0, 255);
+	}
+	return pin_rssi;
+}
+
+// read the RSSI value from a PWM value on a RC channel
+uint8_t RC_Channel::read_channel_rssi(AP_Int8 rssi_channel, 
+                                      AP_Int16 rssi_channel_low_pwm_value, 
+                                      AP_Int16 rssi_channel_high_pwm_value)
+{
+	uint8_t channel_rssi = 0;		
+	
+	int rssi_channel_value = hal.rcin->read(rssi_channel-1);
+	// Note that user-supplied PWM range may be inverted and we accommodate that here. 
+	//(Some radio receivers put out inverted PWM ranges for RSSI-type values).
+	bool pwm_range_is_inverted = (rssi_channel_high_pwm_value < rssi_channel_low_pwm_value);
+	// First, constrain to the possible PWM range - values outside are clipped to ends 
+	int rssi_channel_value_clipped = constrain_int16(rssi_channel_value, 
+													 pwm_range_is_inverted ? rssi_channel_high_pwm_value : rssi_channel_low_pwm_value, 
+													 pwm_range_is_inverted ? rssi_channel_low_pwm_value : rssi_channel_high_pwm_value);
+	// Then scale to 0-255 RSSI normally is presented in.
+	int rssi_channel_range = abs(rssi_channel_high_pwm_value - rssi_channel_low_pwm_value);
+	if (rssi_channel_range == 0) {
+		// User range isn't meaningful, return 0 for RSSI (and avoid divide by zero)
+		channel_rssi = 0;
+	} else {
+		float conversion_ratio = (float)255 / (float)rssi_channel_range;
+		int rssi_channel_offset = abs(rssi_channel_value_clipped - rssi_channel_low_pwm_value);
+		channel_rssi = (int)(rssi_channel_offset * conversion_ratio);
+		channel_rssi = constrain_int16(channel_rssi, 0, 255);
+	}   
+	return channel_rssi;
+}

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -72,6 +72,24 @@ public:
     // return a limit PWM value
     uint16_t    get_limit_pwm(LimitValue limit) const;
 
+    // read the receiver RSSI as an 8 bit number for MAVLink
+    static uint8_t read_receiver_rssi(AP_Int8 rssi_pin, 
+                                      AP_Float rssi_range, 
+                                      AP_HAL::AnalogSource * rssi_analog_source, 
+                                      AP_Int8 rssi_channel, 
+                                      AP_Int16 rssi_channel_low_pwm_value, 
+                                      AP_Int16 rssi_channel_high_pwm_value);
+							
+    // read the RSSI value from an analog pin								
+	static uint8_t read_pin_rssi(AP_Int8 rssi_pin, 
+					 		    AP_Float rssi_range, 
+							    AP_HAL::AnalogSource * rssi_analog_source);
+
+	// read the RSSI value from a PWM value on a RC channel
+	static uint8_t read_channel_rssi(AP_Int8 rssi_channel, 
+								     AP_Int16 rssi_channel_low_pwm_value, 
+								     AP_Int16 rssi_channel_high_pwm_value);
+        
     // pwm is stored here
     int16_t        radio_in;
 


### PR DESCRIPTION
Adding ability and controlling parameters for reading RSSI value from a PWM channel value. This is a feature supported by various radio receivers such as those running OpenLRSng, EzUHF, etc.

* Making library call for read_receiver_rssi. Centralizes reading PWM channel values for RSSI by the various vehicles. This follows the suggestion made by Tridge on #1712 about moving the RSSI code to RC_Channel, but it might well go in its own source file as well.

* Adding controlling parameters to each vehicle: 

* RSSI_CHANNEL: The channel number where RSSI will be output by the radio receiver.

* RSSI_CHAN_LOW: This is the PWM value that the radio receiver will put on the RSSI_CHANNEL when the signal strength is the weakest. Since some radio receivers put out inverted values from what you might otherwise expect, this isn't necessarily a lower value than RSSI_CHAN_HIGH.

* RSSI_CHAN_HIGH: This is the PPM value that the radio receiver will put on the RSSI_CHANNEL when the signal strength is the strongest. Since some radio receivers put out inverted values from what you might otherwise expect, this isn't necessarily a higher value than RSSI_CHAN_LOW. 

See also #2721; this PR anticipates the development of other RSSI methods.

Tested on Plane, Copter, and Rover.