### PR TITLE
scripts: install realpath

### DIFF
--- a/Tools/scripts/install-prereqs-ubuntu.sh
+++ b/Tools/scripts/install-prereqs-ubuntu.sh
@@ -5,7 +5,7 @@ CWD=$(pwd)
 OPT="/opt"
 
 BASE_PKGS="gawk make git arduino-core curl"
-SITL_PKGS="g++ python-pip python-matplotlib python-serial python-wxgtk2.8 python-scipy python-opencv python-numpy python-pyparsing ccache"
+SITL_PKGS="g++ python-pip python-matplotlib python-serial python-wxgtk2.8 python-scipy python-opencv python-numpy python-pyparsing ccache realpath"
 AVR_PKGS="gcc-avr binutils-avr avr-libc"
 PYTHON_PKGS="pymavlink MAVProxy droneapi"
 PX4_PKGS="python-serial python-argparse openocd flex bison libncurses5-dev \


### PR DESCRIPTION
The realpath tool may be missing on a Ubuntu distro and we use it in
sim_vehicle.sh.  Make sure it's also installed as part of sitl packages.

On Archlinux it's part of the coreutils package which is part of the
base group. Therefore it's guaranteed to be available.

Fix #2730.