### PR TITLE
RCOutput: allow to update all channels at once

### DIFF
--- a/libraries/AP_HAL/RCOutput.cpp
+++ b/libraries/AP_HAL/RCOutput.cpp
@@ -1,0 +1,59 @@
+// -*- Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <AP_Progmem/AP_Progmem.h>
+
+#include "AP_HAL.h"
+#include "RCOutput.h"
+
+/*
+ * Write independent values for each the channel
+ *
+ * @channel_map: the motor-to-channel map with size specified by @len
+ * @enable_map:  the enable map with size specified by @len
+ * @enable_map:  the enable map with size specified by @len or NULL if all
+ *               channels are enabled
+ * @values:      the values to write to each channel
+ * @len:         the numer of channels being written
+ */
+void AP_HAL::RCOutput::write(const uint8_t *channel_map, const bool *enable_map,
+                             const int16_t *values, uint8_t len)
+{
+    for (uint8_t i = 0; i < len; i++) {
+        if (!enable_map || enable_map[i]) {
+            write(pgm_read_byte(&channel_map[i]), values[i]);
+        }
+    }
+}
+
+/*
+ * Write the same values for all the channels
+ *
+ * @channel_map: the motor-to-channel map with size specified by @len
+ * @enable_map:  the enable map with size specified by @len or NULL if all
+ *               channels are enabled
+ * @value:       the value to write to all channels
+ * @len:         the numer of channels being written
+ */
+void AP_HAL::RCOutput::write(const uint8_t *channel_map, const bool *enable_map,
+                             int16_t value, uint8_t len)
+{
+    for (uint8_t i = 0; i < len; i++) {
+        if (!enable_map || enable_map[i]) {
+            write(pgm_read_byte(&channel_map[i]), value);
+        }
+    }
+}

--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -45,6 +45,10 @@ public:
 
     /* Output, either single channel or bulk array of channels */
     virtual void     write(uint8_t ch, uint16_t period_us) = 0;
+    virtual void     write(const uint8_t *channel_map, const bool *enable_map,
+                           const int16_t *values, uint8_t len);
+    virtual void     write(const uint8_t *channel_map, const bool *enable_map,
+                           int16_t value, uint8_t len);
 
     /* Read back current output state, as either single channel or
      * array of channels. */

--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -45,7 +45,6 @@ public:
 
     /* Output, either single channel or bulk array of channels */
     virtual void     write(uint8_t ch, uint16_t period_us) = 0;
-    virtual void     write(uint8_t ch, uint16_t* period_us, uint8_t len) = 0;
 
     /* Read back current output state, as either single channel or
      * array of channels. */

--- a/libraries/AP_HAL_AVR/RCOutput.h
+++ b/libraries/AP_HAL_AVR/RCOutput.h
@@ -21,7 +21,6 @@ public:
 
     /* Output, either single channel or bulk array of channels */
     void     write(uint8_t ch, uint16_t period_ms);
-    void     write(uint8_t ch, uint16_t* period_ms, uint8_t len);
 
     /* Read back current output state, as either single channel or
      * array of channels. */
@@ -48,7 +47,6 @@ public:
 
     /* Output, either single channel or bulk array of channels */
     void     write(uint8_t ch, uint16_t period_us);
-    void     write(uint8_t ch, uint16_t* period_us, uint8_t len);
 
     /* Read back current output state, as either single channel or
      * array of channels starting at 0. */

--- a/libraries/AP_HAL_AVR/RCOutput_APM1.cpp
+++ b/libraries/AP_HAL_AVR/RCOutput_APM1.cpp
@@ -174,13 +174,6 @@ void APM1RCOutput::write(uint8_t ch, uint16_t period_us) {
     }
 }
 
-void APM1RCOutput::write(uint8_t ch, uint16_t* period_us, uint8_t len) {
-    for (int i = 0; i < len; i++) {
-        write(i + ch, period_us[i]); 
-    }
-}
-
-
 /* Read back current output state, as either single channel or
  * array of channels. */
 uint16_t APM1RCOutput::read(uint8_t ch) {

--- a/libraries/AP_HAL_AVR/RCOutput_APM2.cpp
+++ b/libraries/AP_HAL_AVR/RCOutput_APM2.cpp
@@ -165,13 +165,6 @@ void APM2RCOutput::write(uint8_t ch, uint16_t period_us) {
     }
 }
 
-void APM2RCOutput::write(uint8_t ch, uint16_t* period_us, uint8_t len) {
-    for (int i = 0; i < len; i++) {
-        write(i + ch, period_us[i]); 
-    }
-}
-
-
 /* Read back current output state, as either single channel or
  * array of channels. */
 uint16_t APM2RCOutput::read(uint8_t ch) {

--- a/libraries/AP_HAL_Empty/RCOutput.cpp
+++ b/libraries/AP_HAL_Empty/RCOutput.cpp
@@ -20,9 +20,6 @@ void EmptyRCOutput::disable_ch(uint8_t ch)
 void EmptyRCOutput::write(uint8_t ch, uint16_t period_us)
 {}
 
-void EmptyRCOutput::write(uint8_t ch, uint16_t* period_us, uint8_t len)
-{}
-
 uint16_t EmptyRCOutput::read(uint8_t ch) {
     return 900;
 }

--- a/libraries/AP_HAL_Empty/RCOutput.h
+++ b/libraries/AP_HAL_Empty/RCOutput.h
@@ -11,7 +11,6 @@ class Empty::EmptyRCOutput : public AP_HAL::RCOutput {
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
     void     write(uint8_t ch, uint16_t period_us);
-    void     write(uint8_t ch, uint16_t* period_us, uint8_t len);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
 };

--- a/libraries/AP_HAL_FLYMAPLE/RCOutput.cpp
+++ b/libraries/AP_HAL_FLYMAPLE/RCOutput.cpp
@@ -95,13 +95,7 @@ void FLYMAPLERCOutput::write(uint8_t ch, uint16_t period_us)
     pwmWrite(pin, (period_us * _clocks_per_msecond[ch]) / 1000);
 }
 
-void FLYMAPLERCOutput::write(uint8_t ch, uint16_t* period_us, uint8_t len)
-{
-    for (int i = 0; i < len; i++)
-        write(i + ch, period_us[i]); 
-}
-
-uint16_t FLYMAPLERCOutput::read(uint8_t ch) 
+uint16_t FLYMAPLERCOutput::read(uint8_t ch)
 {
     if (ch >= FLYMAPLE_RC_OUTPUT_NUM_CHANNELS)
 	return 0;

--- a/libraries/AP_HAL_FLYMAPLE/RCOutput.h
+++ b/libraries/AP_HAL_FLYMAPLE/RCOutput.h
@@ -30,7 +30,6 @@ class AP_HAL_FLYMAPLE_NS::FLYMAPLERCOutput : public AP_HAL::RCOutput {
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
     void     write(uint8_t ch, uint16_t period_us);
-    void     write(uint8_t ch, uint16_t* period_us, uint8_t len);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
 

--- a/libraries/AP_HAL_Linux/RCOutput_AioPRU.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_AioPRU.cpp
@@ -108,19 +108,6 @@ void LinuxRCOutput_AioPRU::write(uint8_t ch, uint16_t period_us)
    }
 }
 
-void LinuxRCOutput_AioPRU::write(uint8_t ch, uint16_t* period_us, uint8_t len)
-{
-   uint8_t i;
-
-   if(len > PWM_CHAN_COUNT) {
-      len = PWM_CHAN_COUNT;
-   }
-
-   for(i = 0; i < len; i++) {
-      write(ch + i, period_us[i]);
-   }
-}
-
 uint16_t LinuxRCOutput_AioPRU::read(uint8_t ch)
 {
    uint16_t ret = 0;

--- a/libraries/AP_HAL_Linux/RCOutput_AioPRU.h
+++ b/libraries/AP_HAL_Linux/RCOutput_AioPRU.h
@@ -26,7 +26,6 @@ class Linux::LinuxRCOutput_AioPRU : public AP_HAL::RCOutput {
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
     void     write(uint8_t ch, uint16_t period_us);
-    void     write(uint8_t ch, uint16_t* period_us, uint8_t len);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
 

--- a/libraries/AP_HAL_Linux/RCOutput_Bebop.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_Bebop.cpp
@@ -329,12 +329,6 @@ void LinuxRCOutput_Bebop::write(uint8_t ch, uint16_t period_us)
     }
 }
 
-void LinuxRCOutput_Bebop::write(uint8_t ch, uint16_t* period_us, uint8_t len)
-{
-    for (int i = 0; i < len; i++)
-        write(ch + i, period_us[i]);
-}
-
 uint16_t LinuxRCOutput_Bebop::read(uint8_t ch)
 {
     if (ch < BEBOP_BLDC_MOTORS_NUM) {

--- a/libraries/AP_HAL_Linux/RCOutput_Bebop.h
+++ b/libraries/AP_HAL_Linux/RCOutput_Bebop.h
@@ -56,7 +56,6 @@ public:
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
     void     write(uint8_t ch, uint16_t period_us);
-    void     write(uint8_t ch, uint16_t* period_us, uint8_t len);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
     void     set_esc_scaling(uint16_t min_pwm, uint16_t max_pwm);

--- a/libraries/AP_HAL_Linux/RCOutput_Navio.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_Navio.cpp
@@ -178,6 +178,55 @@ void LinuxRCOutput_Navio::write(uint8_t ch, uint16_t period_us)
     _i2c_sem->give();
 }
 
+void LinuxRCOutput_Navio::write(const uint8_t *channel_map, const bool *enable_map,
+                                const int16_t *values, uint8_t len)
+{
+    const unsigned int channels = len > PWM_CHAN_COUNT ? PWM_CHAN_COUNT : len;
+    uint8_t data[PWM_CHAN_COUNT * 4] = { };
+
+    if (!_i2c_sem->take_nonblocking())
+        return;
+
+    for (unsigned int i = 0; i < channels; i++) {
+        unsigned int ch;
+        uint16_t period_us;
+        uint16_t width;
+
+        ch = channel_map[i];
+
+        if (enable_map && !enable_map[ch])
+            continue;
+
+        period_us = values[i];
+        _pulses_buffer[ch] = period_us;
+
+        if (period_us == 0)
+            width = 0;
+        else
+            width = round((period_us * 4096) / (1000000.f / _frequency)) - 1;
+
+        uint8_t *d = &data[ch * 4 + 2];
+        *d++ = width && 0xFF;
+        *d = width >> 8;
+    }
+
+    hal.i2c->writeRegisters(PCA9685_ADDRESS, PCA9685_RA_LED0_ON_L + 4 * 3,
+                            sizeof(data), data);
+    _i2c_sem->give();
+
+}
+
+void LinuxRCOutput_Navio::write(const uint8_t *channel_map, const bool *enable_map,
+                                int16_t value, uint8_t len)
+{
+    int16_t v[PWM_CHAN_COUNT];
+
+    for (unsigned int i = 0; i < PWM_CHAN_COUNT && i < len; i++)
+        v[i] = value;
+
+    write(channel_map, enable_map, v, len);
+}
+
 uint16_t LinuxRCOutput_Navio::read(uint8_t ch)
 {
     return _pulses_buffer[ch];

--- a/libraries/AP_HAL_Linux/RCOutput_Navio.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_Navio.cpp
@@ -178,12 +178,6 @@ void LinuxRCOutput_Navio::write(uint8_t ch, uint16_t period_us)
     _i2c_sem->give();
 }
 
-void LinuxRCOutput_Navio::write(uint8_t ch, uint16_t* period_us, uint8_t len)
-{
-    for (int i = 0; i < len; i++)
-        write(ch + i, period_us[i]);
-}
-
 uint16_t LinuxRCOutput_Navio::read(uint8_t ch)
 {
     return _pulses_buffer[ch];

--- a/libraries/AP_HAL_Linux/RCOutput_Navio.h
+++ b/libraries/AP_HAL_Linux/RCOutput_Navio.h
@@ -15,6 +15,11 @@ class Linux::LinuxRCOutput_Navio : public AP_HAL::RCOutput {
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
     void     write(uint8_t ch, uint16_t period_us);
+    void     write(const uint8_t *channel_map, const bool *enable_map,
+                   const int16_t *values, uint8_t len) override;
+    void     write(const uint8_t *channel_map, const bool *enable_map,
+                   int16_t value, uint8_t len) override;
+
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
 

--- a/libraries/AP_HAL_Linux/RCOutput_Navio.h
+++ b/libraries/AP_HAL_Linux/RCOutput_Navio.h
@@ -15,7 +15,6 @@ class Linux::LinuxRCOutput_Navio : public AP_HAL::RCOutput {
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
     void     write(uint8_t ch, uint16_t period_us);
-    void     write(uint8_t ch, uint16_t* period_us, uint8_t len);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
 

--- a/libraries/AP_HAL_Linux/RCOutput_PRU.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_PRU.cpp
@@ -75,17 +75,6 @@ void LinuxRCOutput_PRU::write(uint8_t ch, uint16_t period_us)
     sharedMem_cmd->periodhi[chan_pru_map[ch]][1] = TICK_PER_US*period_us;
 }
 
-void LinuxRCOutput_PRU::write(uint8_t ch, uint16_t* period_us, uint8_t len)
-{
-    uint8_t i;
-    if(len>PWM_CHAN_COUNT){
-        len = PWM_CHAN_COUNT;
-    }
-    for(i=0;i<len;i++){
-        write(ch+i,period_us[i]);
-    }
-}
-
 uint16_t LinuxRCOutput_PRU::read(uint8_t ch)
 {
     return (sharedMem_cmd->hilo_read[chan_pru_map[ch]][1]/TICK_PER_US);

--- a/libraries/AP_HAL_Linux/RCOutput_PRU.h
+++ b/libraries/AP_HAL_Linux/RCOutput_PRU.h
@@ -22,7 +22,6 @@ class Linux::LinuxRCOutput_PRU : public AP_HAL::RCOutput {
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
     void     write(uint8_t ch, uint16_t period_us);
-    void     write(uint8_t ch, uint16_t* period_us, uint8_t len);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
 

--- a/libraries/AP_HAL_Linux/RCOutput_ZYNQ.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_ZYNQ.cpp
@@ -71,17 +71,6 @@ void LinuxRCOutput_ZYNQ::write(uint8_t ch, uint16_t period_us)
     sharedMem_cmd->periodhi[ch].hi = TICK_PER_US*period_us;
 }
 
-void LinuxRCOutput_ZYNQ::write(uint8_t ch, uint16_t* period_us, uint8_t len)
-{
-    uint8_t i;
-    if(len>PWM_CHAN_COUNT){
-        len = PWM_CHAN_COUNT;
-    }
-    for(i=0;i<len;i++){
-        write(ch+i,period_us[i]);
-    }
-}
-
 uint16_t LinuxRCOutput_ZYNQ::read(uint8_t ch)
 {
     return (sharedMem_cmd->periodhi[ch].hi/TICK_PER_US);

--- a/libraries/AP_HAL_Linux/RCOutput_ZYNQ.h
+++ b/libraries/AP_HAL_Linux/RCOutput_ZYNQ.h
@@ -21,7 +21,6 @@ class Linux::LinuxRCOutput_ZYNQ : public AP_HAL::RCOutput {
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
     void     write(uint8_t ch, uint16_t period_us);
-    void     write(uint8_t ch, uint16_t* period_us, uint8_t len);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
 

--- a/libraries/AP_HAL_PX4/RCOutput.cpp
+++ b/libraries/AP_HAL_PX4/RCOutput.cpp
@@ -235,13 +235,6 @@ void PX4RCOutput::write(uint8_t ch, uint16_t period_us)
     }
 }
 
-void PX4RCOutput::write(uint8_t ch, uint16_t* period_us, uint8_t len)
-{
-    for (uint8_t i=0; i<len; i++) {
-        write(i, period_us[i]);
-    }
-}
-
 uint16_t PX4RCOutput::read(uint8_t ch) 
 {
     if (ch >= PX4_NUM_OUTPUT_CHANNELS) {

--- a/libraries/AP_HAL_PX4/RCOutput.h
+++ b/libraries/AP_HAL_PX4/RCOutput.h
@@ -18,7 +18,6 @@ public:
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
     void     write(uint8_t ch, uint16_t period_us);
-    void     write(uint8_t ch, uint16_t* period_us, uint8_t len);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
     void     set_safety_pwm(uint32_t chmask, uint16_t period_us);

--- a/libraries/AP_HAL_SITL/RCOutput.cpp
+++ b/libraries/AP_HAL_SITL/RCOutput.cpp
@@ -28,11 +28,6 @@ void SITLRCOutput::write(uint8_t ch, uint16_t period_us)
     }
 }
 
-void SITLRCOutput::write(uint8_t ch, uint16_t* period_us, uint8_t len)
-{
-    memcpy(_sitlState->pwm_output+ch, period_us, len*sizeof(uint16_t));
-}
-
 uint16_t SITLRCOutput::read(uint8_t ch)
 {
     if (ch < SITL_NUM_CHANNELS) {

--- a/libraries/AP_HAL_SITL/RCOutput.h
+++ b/libraries/AP_HAL_SITL/RCOutput.h
@@ -18,7 +18,6 @@ public:
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
     void     write(uint8_t ch, uint16_t period_us);
-    void     write(uint8_t ch, uint16_t* period_us, uint8_t len);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
 

--- a/libraries/AP_HAL_VRBRAIN/RCOutput.cpp
+++ b/libraries/AP_HAL_VRBRAIN/RCOutput.cpp
@@ -182,13 +182,6 @@ void VRBRAINRCOutput::write(uint8_t ch, uint16_t period_us)
     }
 }
 
-void VRBRAINRCOutput::write(uint8_t ch, uint16_t* period_us, uint8_t len)
-{
-    for (uint8_t i=0; i<len; i++) {
-        write(i, period_us[i]);
-    }
-}
-
 uint16_t VRBRAINRCOutput::read(uint8_t ch)
 {
     if (ch >= VRBRAIN_NUM_OUTPUT_CHANNELS) {

--- a/libraries/AP_HAL_VRBRAIN/RCOutput.h
+++ b/libraries/AP_HAL_VRBRAIN/RCOutput.h
@@ -16,7 +16,6 @@ public:
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
     void     write(uint8_t ch, uint16_t period_us);
-    void     write(uint8_t ch, uint16_t* period_us, uint8_t len);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
     void     set_safety_pwm(uint32_t chmask, uint16_t period_us);

--- a/libraries/AP_Motors/AP_MotorsCoax.cpp
+++ b/libraries/AP_Motors/AP_MotorsCoax.cpp
@@ -111,10 +111,11 @@ void AP_MotorsCoax::enable()
 void AP_MotorsCoax::output_min()
 {
     // send minimum value to each motor
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]), _servo1.radio_trim);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]), _servo2.radio_trim);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]), _throttle_radio_min);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]), _throttle_radio_min);
+    int16_t values[4] = {
+        _servo1.radio_trim,  _servo2.radio_trim, _throttle_radio_min, _throttle_radio_min
+    };
+    hal.rcout->write(&_motor_to_channel_map[AP_MOTORS_MOT_1], nullptr, values,
+                     sizeof(values));
 }
 
 void AP_MotorsCoax::output_armed_not_stabilizing()
@@ -154,10 +155,11 @@ void AP_MotorsCoax::output_armed_not_stabilizing()
         motor_out = apply_thrust_curve_and_volt_scaling(motor_out, out_min, _throttle_radio_max);
     }
 
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]), _servo1.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]), _servo2.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]), motor_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]), motor_out);
+    int16_t values[4] = {
+        _servo1.radio_out, _servo2.radio_out, motor_out, motor_out
+    };
+    hal.rcout->write(&_motor_to_channel_map[AP_MOTORS_MOT_1], nullptr, values,
+                     sizeof(values));
 }
 
 // sends commands to the motors
@@ -212,10 +214,12 @@ void AP_MotorsCoax::output_armed_stabilizing()
     motor_out[AP_MOTORS_MOT_4] = max(motor_out[AP_MOTORS_MOT_4],    out_min);
 
     // send output to each motor
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]), _servo1.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]), _servo2.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]), motor_out[AP_MOTORS_MOT_3]);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]), motor_out[AP_MOTORS_MOT_4]);
+    int16_t values[4] = {
+        _servo1.radio_out, _servo2.radio_out,
+        motor_out[AP_MOTORS_MOT_3], motor_out[AP_MOTORS_MOT_3]
+    };
+    hal.rcout->write(&_motor_to_channel_map[AP_MOTORS_MOT_1], nullptr, values,
+                     sizeof(values));
 }
 
 // output_disarmed - sends commands to the motors

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -662,10 +662,12 @@ void AP_MotorsHeli::move_swash(int16_t roll_out, int16_t pitch_out, int16_t coll
     _servo_4.calc_pwm();
 
     // actually move the servos
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]), _servo_1.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]), _servo_2.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]), _servo_3.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]), _servo_4.radio_out);
+    int16_t values[4] = {
+        _servo_1.radio_out, _servo_2.radio_out,
+        _servo_3.radio_out, _servo_4.radio_out
+    };
+    hal.rcout->write(&_motor_to_channel_map[AP_MOTORS_MOT_1], nullptr, values,
+                     sizeof(values));
 
     // output gain to exernal gyro
     if (_tail_type == AP_MOTORS_HELI_TAILTYPE_SERVO_EXTGYRO) {

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -86,8 +86,6 @@ void AP_MotorsMatrix::enable()
 // output_min - sends minimum values out to the motors
 void AP_MotorsMatrix::output_min()
 {
-    int8_t i;
-
     // set limits flags
     limit.roll_pitch = true;
     limit.yaw = true;
@@ -95,11 +93,8 @@ void AP_MotorsMatrix::output_min()
     limit.throttle_upper = false;
 
     // fill the motor_out[] array for HIL use and send minimum value to each motor
-    for( i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++ ) {
-        if( motor_enabled[i] ) {
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[i]), _throttle_radio_min);
-        }
-    }
+    hal.rcout->write(&_motor_to_channel_map[0], motor_enabled, _throttle_radio_min,
+                     AP_MOTORS_MAX_NUM_MOTORS);
 }
 
 // get_motor_mask - returns a bitmask of which outputs are being used for motors (1 means being used)
@@ -159,11 +154,8 @@ void AP_MotorsMatrix::output_armed_not_stabilizing()
     }
 
     // send output to each motor
-    for( i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++ ) {
-        if( motor_enabled[i] ) {
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[i]), motor_out[i]);
-        }
-    }
+    hal.rcout->write(&_motor_to_channel_map[0], motor_enabled, motor_out,
+                     AP_MOTORS_MAX_NUM_MOTORS);
 }
 
 // output_armed - sends commands to the motors
@@ -355,11 +347,8 @@ void AP_MotorsMatrix::output_armed_stabilizing()
     }
 
     // send output to each motor
-    for( i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++ ) {
-        if( motor_enabled[i] ) {
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[i]), motor_out[i]);
-        }
-    }
+    hal.rcout->write(&_motor_to_channel_map[0], motor_enabled, motor_out,
+                     AP_MOTORS_MAX_NUM_MOTORS);
 }
 
 // output_disarmed - sends commands to the motors

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -378,10 +378,7 @@ void AP_MotorsMulticopter::throttle_pass_through(int16_t pwm)
 {
     if (armed()) {
         // send the pilot's input directly to each enabled motor
-        for (int16_t i=0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
-            if (motor_enabled[i]) {
-                hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[i]), pwm);
-            }
-        }
+        hal.rcout->write(&_motor_to_channel_map[0], motor_enabled, pwm,
+                         AP_MOTORS_MAX_NUM_MOTORS);
     }
 }

--- a/libraries/AP_Motors/AP_MotorsSingle.cpp
+++ b/libraries/AP_Motors/AP_MotorsSingle.cpp
@@ -116,10 +116,12 @@ void AP_MotorsSingle::enable()
 void AP_MotorsSingle::output_min()
 {
     // send minimum value to each motor
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]), _servo1.radio_trim);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]), _servo2.radio_trim);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]), _servo3.radio_trim);
-	hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]), _servo4.radio_trim);
+    int16_t values[4] = {
+        _servo1.radio_trim, _servo2.radio_trim,
+        _servo3.radio_trim, _servo4.radio_trim
+    };
+    hal.rcout->write(&_motor_to_channel_map[AP_MOTORS_MOT_1], nullptr, values,
+                     sizeof(values));
     hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_7]), _throttle_radio_min);
 }
 
@@ -172,10 +174,12 @@ void AP_MotorsSingle::output_armed_not_stabilizing()
         throttle_radio_output = apply_thrust_curve_and_volt_scaling(throttle_radio_output, out_min, _throttle_radio_max);
     }
 
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]), _servo1.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]), _servo2.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]), _servo3.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]), _servo4.radio_out);
+    int16_t values[4] = {
+        _servo1.radio_out, _servo2.radio_out,
+        _servo3.radio_out, _servo4.radio_out
+    };
+    hal.rcout->write(&_motor_to_channel_map[AP_MOTORS_MOT_1], nullptr, values,
+                     sizeof(values));
     hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_7]), throttle_radio_output);
 }
 
@@ -229,10 +233,12 @@ void AP_MotorsSingle::output_armed_stabilizing()
     _servo4.calc_pwm();
 
     // send output to each motor
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]), _servo1.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]), _servo2.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]), _servo3.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]), _servo4.radio_out);
+    int16_t values[4] = {
+        _servo1.radio_out, _servo2.radio_out,
+        _servo3.radio_out, _servo4.radio_out
+    };
+    hal.rcout->write(&_motor_to_channel_map[AP_MOTORS_MOT_1], nullptr, values,
+                     sizeof(values));
     hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_7]), throttle_radio_output);
 }
 


### PR DESCRIPTION
This pull request is actually divided in 2 parts: 
 1. The first 8 commits are just removing an unused method from every implementation
 2. The other commits are allowing to have an implementation that updates all motors at once.

(2) is implemented for RCOutput_Navio. It's quite critical on it to allow updating all motors at once because if we have more sensors on the same bus and the bus is busy when were are updating the motors it could happen that we update 1 motor and don't update the others. And it did happened for us, causing several crashes.

Consider the second part as an RFC since this specific implementation has not been tested. We have been flying for several months with another [hackish one](https://github.com/lucasdemarchi/ardupilot/commit/9568285d91615e5d9c92ca2d44317988049df7d4).

Do we still need the `_motor_to_channel_map` now that support for AVR is gone?

There would be some other ways to accomplish the same like having a `begin()` + `end()` methods. But I think this is better. Opinions?

Another thing I have to implement better here is to allow not having to update all 13 channels but rather just a set of them (the updated ones). It would be easier without the `_motor_to_channel_map` so I didn't do it yet while waiting for feedback.