### PR TITLE
Plane & Copter: small change - added header include guards

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -1,4 +1,6 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+#ifndef _COPTER_H_
+#define _COPTER_H_
 
 #define THISFIRMWARE "APM:Copter V3.4-dev"
 #define FIRMWARE_VERSION 3,4,0,FIRMWARE_VERSION_TYPE_DEV
@@ -989,3 +991,5 @@ public:
 
 extern const AP_HAL::HAL& hal;
 extern Copter copter;
+
+#endif // _COPTER_H_

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1,4 +1,6 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+#ifndef _PLANE_H_
+#define _PLANE_H_
 
 #define THISFIRMWARE "ArduPlane V3.4.0beta1"
 #define FIRMWARE_VERSION 3,4,0,FIRMWARE_VERSION_TYPE_BETA
@@ -977,3 +979,5 @@ public:
 
 extern const AP_HAL::HAL& hal;
 extern Plane plane;
+
+#endif // _PLANE_H_


### PR DESCRIPTION
Not sure why the include guards aren't already there - I'm probably missing something.  The change still compiles and fly's.  Note that Rover already had them.