### PR TITLE
Plane: CONTINUE_AND_CHANGE_ALT behavior change

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -511,7 +511,9 @@ void Plane::handle_auto_mode(void)
     default:
         // we are doing normal AUTO flight, the special cases
         // are for takeoff and landing
-        steer_state.hold_course_cd = -1;
+        if (nav_cmd_id != MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT) {
+            steer_state.hold_course_cd = -1;
+        }
         auto_state.land_complete = false;
         calc_nav_roll();
         calc_nav_pitch();

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -151,6 +151,11 @@ float wrap_180_cd_float(float angle);
 float wrap_PI(float angle_in_radians);
 
 /*
+ * check if lat and lng match. Ignore altitude and options
+ */
+bool locations_are_same(const struct Location &loc1, const struct Location &loc2);
+
+/*
   print a int32_t lat/long in decimal degrees
  */
 void print_latlon(AP_HAL::BetterStream *s, int32_t lat_or_lon);

--- a/libraries/AP_Math/location.cpp
+++ b/libraries/AP_Math/location.cpp
@@ -223,6 +223,13 @@ float wrap_PI(float angle_in_radians)
 }
 
 /*
+  return true if lat and lng match. Ignores altitude and options
+ */
+bool locations_are_same(const struct Location &loc1, const struct Location &loc2) {
+    return (loc1.lat == loc2.lat) && (loc1.lng == loc2.lng);
+}
+
+/*
   print a int32_t lat/long in decimal degrees
  */
 void print_latlon(AP_HAL::BetterStream *s, int32_t lat_or_lon)

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -536,7 +536,7 @@ bool AP_Mission::mavlink_to_mission_cmd(const mavlink_mission_item_t& packet, AP
         break;
 
     case MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT:           // MAV ID: 30
-        copy_location = true;                           // only using alt
+        copy_location = true;                           // lat/lng used for heading lock
         cmd.p1 = packet.param1;                         // Climb/Descend
                         // 0 = Neutral, cmd complete at +/- 5 of indicated alt.
                         // 1 = Climb, cmd complete at or above indicated alt.
@@ -867,7 +867,7 @@ bool AP_Mission::mission_cmd_to_mavlink(const AP_Mission::Mission_Command& cmd, 
         break;
 
     case MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT:           // MAV ID: 30
-        copy_location = true;                           //only using alt
+        copy_location = true;                           // lat/lng used for heading lock
         packet.param1 = cmd.p1;                         // Climb/Descend
                         // 0 = Neutral, cmd complete at +/- 5 of indicated alt.
                         // 1 = Climb, cmd complete at or above indicated alt.


### PR DESCRIPTION
Instead of trying to hold a navigation bearing with two waypoints, hold a steering heading like takeoff. This allows it to work the same way but without depending on previous and next waypoints. Please review @mday299 .