### PR TITLE
Common units for compasses

### DIFF
--- a/APMrover2/test.cpp
+++ b/APMrover2/test.cpp
@@ -401,8 +401,8 @@ int8_t Rover::test_mag(uint8_t argc, const Menu::arg *argv)
         counter++;
         if (counter>20) {
             if (compass.healthy()) {
-                const Vector3f mag_ofs = compass.get_offsets();
-                const Vector3f mag = compass.get_field();
+                const Vector3f mag_ofs = compass.get_offsets_milligauss();
+                const Vector3f mag = compass.get_field_milligauss();
                 cliSerial->printf_P(PSTR("Heading: %ld, XYZ: %.0f, %.0f, %.0f,\tXYZoff: %6.2f, %6.2f, %6.2f\n"),
                                     (wrap_360_cd(ToDeg(heading) * 100)) /100,
                                     (double)mag.x, (double)mag.y, (double)mag.z,

--- a/ArduCopter/compassmot.cpp
+++ b/ArduCopter/compassmot.cpp
@@ -124,7 +124,7 @@ uint8_t Copter::mavlink_compassmot(mavlink_channel_t chan)
     // store initial x,y,z compass values
     // initialise interference percentage
     for (uint8_t i=0; i<compass.get_count(); i++) {
-        compass_base[i] = compass.get_field(i);
+        compass_base[i] = compass.get_field_milligauss(i);
         interference_pct[i] = 0.0f;
     }
 
@@ -167,7 +167,7 @@ uint8_t Copter::mavlink_compassmot(mavlink_channel_t chan)
         // if throttle is near zero, update base x,y,z values
         if (throttle_pct <= 0.0f) {
             for (uint8_t i=0; i<compass.get_count(); i++) {
-                compass_base[i] = compass_base[i] * 0.99f + compass.get_field(i) * 0.01f;
+                compass_base[i] = compass_base[i] * 0.99f + compass.get_field_milligauss(i) * 0.01f;
             }
 
             // causing printing to happen as soon as throttle is lifted
@@ -175,7 +175,7 @@ uint8_t Copter::mavlink_compassmot(mavlink_channel_t chan)
 
             // calculate diff from compass base and scale with throttle
             for (uint8_t i=0; i<compass.get_count(); i++) {
-                motor_impact[i] = compass.get_field(i) - compass_base[i];
+                motor_impact[i] = compass.get_field_milligauss(i) - compass_base[i];
             }
 
             // throttle based compensation

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -356,7 +356,7 @@ bool Copter::pre_arm_checks(bool display_failure)
         }
 
         // check for unreasonable compass offsets
-        Vector3f offsets = compass.get_offsets();
+        Vector3f offsets = compass.get_offsets_milligauss();
         if(offsets.length() > COMPASS_OFFSETS_MAX) {
             if (display_failure) {
                 gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Compass offsets too high"));
@@ -365,7 +365,7 @@ bool Copter::pre_arm_checks(bool display_failure)
         }
 
         // check for unreasonable mag field length
-        float mag_field = compass.get_field().length();
+        float mag_field = compass.get_field_milligauss().length();
         if (mag_field > COMPASS_MAGFIELD_EXPECTED*1.65f || mag_field < COMPASS_MAGFIELD_EXPECTED*0.35f) {
             if (display_failure) {
                 gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Check mag field"));
@@ -376,11 +376,11 @@ bool Copter::pre_arm_checks(bool display_failure)
 #if COMPASS_MAX_INSTANCES > 1
         // check all compasses point in roughly same direction
         if (compass.get_count() > 1) {
-            Vector3f prime_mag_vec = compass.get_field();
+            Vector3f prime_mag_vec = compass.get_field_milligauss();
             prime_mag_vec.normalize();
             for(uint8_t i=0; i<compass.get_count(); i++) {
                 // get next compass
-                Vector3f mag_vec = compass.get_field(i);
+                Vector3f mag_vec = compass.get_field_milligauss(i);
                 mag_vec.normalize();
                 Vector3f vec_diff = mag_vec - prime_mag_vec;
                 if (compass.use_for_yaw(i) && vec_diff.length() > COMPASS_ACCEPTABLE_VECTOR_DIFF) {

--- a/ArduCopter/setup.cpp
+++ b/ArduCopter/setup.cpp
@@ -450,7 +450,7 @@ void Copter::report_compass()
     // mag offsets
     Vector3f offsets;
     for (uint8_t i=0; i<compass.get_count(); i++) {
-        offsets = compass.get_offsets(i);
+        offsets = compass.get_offsets_milligauss(i);
         // mag offsets
         cliSerial->printf_P(PSTR("Mag%d off: %4.4f, %4.4f, %4.4f\n"),
                         (int)i,

--- a/ArduCopter/test.cpp
+++ b/ArduCopter/test.cpp
@@ -117,8 +117,8 @@ int8_t Copter::test_compass(uint8_t argc, const Menu::arg *argv)
             counter++;
             if (counter>20) {
                 if (compass.healthy()) {
-                    const Vector3f &mag_ofs = compass.get_offsets();
-                    const Vector3f &mag = compass.get_field();
+                    const Vector3f &mag_ofs = compass.get_offsets_milligauss();
+                    const Vector3f &mag = compass.get_field_milligauss();
                     cliSerial->printf_P(PSTR("Heading: %ld, XYZ: %.0f, %.0f, %.0f,\tXYZoff: %6.2f, %6.2f, %6.2f\n"),
                                         (wrap_360_cd(ToDeg(heading) * 100)) /100,
                                         (double)mag.x,

--- a/ArduPlane/test.cpp
+++ b/ArduPlane/test.cpp
@@ -465,8 +465,8 @@ int8_t Plane::test_mag(uint8_t argc, const Menu::arg *argv)
             counter++;
             if (counter>20) {
                 if (compass.healthy()) {
-                    const Vector3f &mag_ofs = compass.get_offsets();
-                    const Vector3f &mag = compass.get_field();
+                    const Vector3f &mag_ofs = compass.get_offsets_milligauss();
+                    const Vector3f &mag = compass.get_field_milligauss();
                     cliSerial->printf_P(PSTR("Heading: %ld, XYZ: %.0f, %.0f, %.0f,\tXYZoff: %6.2f, %6.2f, %6.2f\n"),
                                         (wrap_360_cd(ToDeg(heading) * 100)) /100,
                                         (double)mag.x, (double)mag.y, (double)mag.z,

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -276,7 +276,7 @@ AP_AHRS_DCM::normalize(void)
 float
 AP_AHRS_DCM::yaw_error_compass(void)
 {
-    const Vector3f &mag = _compass->get_field();
+    const Vector3f &mag = _compass->get_field_milligauss();
     // get the mag vector in the earth frame
     Vector2f rb = _dcm_matrix.mulXY(mag);
 

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -259,7 +259,7 @@ bool AP_Arming::compass_checks(bool report)
         }
 
         // check for unreasonable compass offsets
-        Vector3f offsets = _compass.get_offsets();
+        Vector3f offsets = _compass.get_offsets_milligauss();
         if (offsets.length() > 600) {
             if (report) {
                 gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Compass offsets too high"));
@@ -274,7 +274,7 @@ bool AP_Arming::compass_checks(bool report)
 #endif
 
         // check for unreasonable mag field length
-        float mag_field = _compass.get_field().length();
+        float mag_field = _compass.get_field_milligauss().length();
         if (mag_field > COMPASS_MAGFIELD_EXPECTED*1.65f || mag_field < COMPASS_MAGFIELD_EXPECTED*0.35f) {
             if (report) {
                 gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Check mag field"));

--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -214,6 +214,12 @@ void AP_Compass_AK8963::read()
     publish_filtered_field(field, _compass_instance);
 }
 
+float AP_Compass_AK8963::get_conversion_ratio(void)
+{
+    /* Convert from microTesla to milliGauss */
+    return 10.0f;
+}
+
 Vector3f AP_Compass_AK8963::_get_filtered_field() const
 {
     Vector3f field(_mag_x_accum, _mag_y_accum, _mag_z_accum);

--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -204,9 +204,11 @@ void AP_Compass_AK8963::read()
 
     hal.scheduler->suspend_timer_procs();
     auto field = _get_filtered_field();
+
     _reset_filter();
     hal.scheduler->resume_timer_procs();
     _make_factory_sensitivity_adjustment(field);
+    _make_adc_sensitivity_adjustment(field);
 
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BEBOP
     field.rotate(ROTATION_YAW_90);
@@ -232,6 +234,13 @@ void AP_Compass_AK8963::_reset_filter()
 {
     _mag_x_accum = _mag_y_accum = _mag_z_accum = 0;
     _accum_count = 0;
+}
+
+void AP_Compass_AK8963::_make_adc_sensitivity_adjustment(Vector3f& field) const
+{
+    static const float ADC_16BIT_RESOLUTION = 0.15f;
+
+    field *= ADC_16BIT_RESOLUTION;
 }
 
 void AP_Compass_AK8963::_make_factory_sensitivity_adjustment(Vector3f& field) const

--- a/libraries/AP_Compass/AP_Compass_AK8963.h
+++ b/libraries/AP_Compass/AP_Compass_AK8963.h
@@ -52,6 +52,7 @@ private:
     static AP_Compass_Backend *_detect(Compass &compass, AP_AK8963_SerialBus *bus);
 
     void _make_factory_sensitivity_adjustment(Vector3f& field) const;
+    void _make_adc_sensitivity_adjustment(Vector3f& field) const;
     Vector3f _get_filtered_field() const;
     void _reset_filter();
 

--- a/libraries/AP_Compass/AP_Compass_AK8963.h
+++ b/libraries/AP_Compass/AP_Compass_AK8963.h
@@ -46,6 +46,7 @@ public:
     bool        init(void);
     void        read(void);
     void        accumulate(void);
+    float       get_conversion_ratio(void) override;
 
 private:
     static AP_Compass_Backend *_detect(Compass &compass, AP_AK8963_SerialBus *bus);

--- a/libraries/AP_Compass/AP_Compass_Backend.cpp
+++ b/libraries/AP_Compass/AP_Compass_Backend.cpp
@@ -41,6 +41,11 @@ void AP_Compass_Backend::publish_raw_field(const Vector3f &mag, uint32_t time_us
 {
     Compass::mag_state &state = _compass._state[instance];
 
+    /* Update field in milligauss. Later this will be used throughout all codebase.
+     * We need this trick in order not to make users recalibrate their compasses.
+     * */
+    state.field_milligauss =  state.field * get_conversion_ratio();
+
     state.last_update_ms = hal.scheduler->millis();
     state.last_update_usec = hal.scheduler->micros();
     state.raw_field = mag;

--- a/libraries/AP_Compass/AP_Compass_Backend.h
+++ b/libraries/AP_Compass/AP_Compass_Backend.h
@@ -43,6 +43,8 @@ public:
     // backends
     virtual void accumulate(void) {};
 
+    virtual float get_conversion_ratio(void) = 0;
+
 protected:
 
     /*

--- a/libraries/AP_Compass/AP_Compass_HIL.cpp
+++ b/libraries/AP_Compass/AP_Compass_HIL.cpp
@@ -69,3 +69,8 @@ void AP_Compass_HIL::read()
         }
     }
 }
+
+float AP_Compass_HIL::get_conversion_ratio(void)
+{
+    return 1.0f;
+}

--- a/libraries/AP_Compass/AP_Compass_HIL.h
+++ b/libraries/AP_Compass/AP_Compass_HIL.h
@@ -16,6 +16,7 @@ public:
     AP_Compass_HIL(Compass &compass);
     void read(void);
     bool init(void);
+    float get_conversion_ratio(void) override;
 
     // detect the sensor
     static AP_Compass_Backend *detect(Compass &compass);

--- a/libraries/AP_Compass/AP_Compass_HMC5843.h
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.h
@@ -31,7 +31,7 @@ private:
     bool                read_register(uint8_t address, uint8_t *value);
     bool                write_register(uint8_t address, uint8_t value);
 
-    bool                _calibrate(uint8_t calibration_gain, uint16_t expected_x, uint16_t expected_yz, float gain_multiple);
+    bool                _calibrate(uint8_t calibration_gain, uint16_t expected_x, uint16_t expected_yz);
     bool                _detect_version();
 
     uint32_t            _retry_time; // when unhealthy the millis() value to retry at
@@ -48,6 +48,7 @@ private:
     uint8_t             _compass_instance;
     uint8_t             _product_id;
 
+    float               _gain_multiple;
 public:
     // detect the sensor
     static AP_Compass_Backend *detect_i2c(Compass &compass,
@@ -60,6 +61,7 @@ public:
     bool        init(void);
     void        read(void);
     void        accumulate(void);
+    float       get_conversion_ratio(void) override;
 };
 
 class AP_HMC5843_SerialBus

--- a/libraries/AP_Compass/AP_Compass_PX4.cpp
+++ b/libraries/AP_Compass/AP_Compass_PX4.cpp
@@ -159,4 +159,9 @@ void AP_Compass_PX4::accumulate(void)
     }
 }
 
+float AP_Compass_PX4::get_conversion_ratio(void)
+{
+    return 1.0f;
+}
+
 #endif // CONFIG_HAL_BOARD

--- a/libraries/AP_Compass/AP_Compass_PX4.h
+++ b/libraries/AP_Compass/AP_Compass_PX4.h
@@ -12,6 +12,7 @@ public:
     bool        init(void);
     void        read(void);
     void        accumulate(void);
+    float       get_conversion_ratio(void) override;
 
     AP_Compass_PX4(Compass &compass);
     // detect the sensor

--- a/libraries/AP_Compass/Compass.h
+++ b/libraries/AP_Compass/Compass.h
@@ -113,6 +113,8 @@ public:
     /// Return the current field as a Vector3f
     const Vector3f &get_field(uint8_t i) const { return _state[i].field; }
     const Vector3f &get_field(void) const { return get_field(get_primary()); }
+    const Vector3f &get_field_milligauss(uint8_t i) const { return _state[i].field_milligauss; }
+    const Vector3f &get_field_milligauss(void) const { return get_field_milligauss(get_primary()); }
 
     // raw/unfiltered measurement interface
     uint32_t raw_meas_time_us(uint8_t i) const { return _state[i].raw_meas_time_us; }
@@ -171,6 +173,8 @@ public:
     ///
     const Vector3f &get_offsets(uint8_t i) const { return _state[i].offset; }
     const Vector3f &get_offsets(void) const { return get_offsets(get_primary()); }
+    const Vector3f &get_offsets_milligauss(uint8_t i) const { return _state[i].offset_milligauss; }
+    const Vector3f &get_offsets_milligauss(void) const { return get_offsets_milligauss(get_primary()); }
 
     /// Sets the initial location used to get declination
     ///
@@ -360,6 +364,7 @@ private:
         AP_Vector3f offset;
         AP_Vector3f diagonals;
         AP_Vector3f offdiagonals;
+        Vector3f    offset_milligauss;
 
 #if COMPASS_MAX_INSTANCES > 1
         // device id detected at init.  
@@ -380,6 +385,7 @@ private:
 
         // corrected magnetic field strength
         Vector3f    field;
+        Vector3f    field_milligauss;
 
         // when we last got data
         uint32_t    last_update_ms;

--- a/libraries/AP_Compass/Compass.h
+++ b/libraries/AP_Compass/Compass.h
@@ -129,7 +129,7 @@ public:
     bool has_unfiltered_field() const { return has_unfiltered_field(get_primary()); }
 
     const Vector3f &get_raw_field(uint8_t i) const { return _state[i].raw_field; }
-    const Vector3f &get_raw_field(void) const { return get_unfiltered_field(get_primary()); }
+    const Vector3f &get_raw_field(void) const { return get_raw_field(get_primary()); }
 
     const Vector3f &get_unfiltered_field(uint8_t i) const { return _state[i].unfiltered_field; }
     const Vector3f &get_unfiltered_field(void) const { return get_unfiltered_field(get_primary()); }

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -3827,10 +3827,10 @@ bool NavEKF::getMagOffsets(Vector3f &magOffsets) const
 {
     // compass offsets are valid if we have finalised magnetic field initialisation and magnetic field learning is not prohibited and primary compass is valid
     if (secondMagYawInit && (_magCal != 2) && _ahrs->get_compass()->healthy()) {
-        magOffsets = _ahrs->get_compass()->get_offsets() - state.body_magfield*1000.0f;
+        magOffsets = _ahrs->get_compass()->get_offsets_milligauss() - state.body_magfield*1000.0f;
         return true;
     } else {
-        magOffsets = _ahrs->get_compass()->get_offsets();
+        magOffsets = _ahrs->get_compass()->get_offsets_milligauss();
         return false;
     }
 }
@@ -4378,7 +4378,7 @@ void NavEKF::readMagData()
         lastMagUpdate = _ahrs->get_compass()->last_update_usec();
 
         // read compass data and scale to improve numerical conditioning
-        magData = _ahrs->get_compass()->get_field() * 0.001f;
+        magData = _ahrs->get_compass()->get_field_milligauss() * 0.001f;
 
         // get states stored at time closest to measurement time after allowance for measurement delay
         RecallStates(statesAtMagMeasTime, (imuSampleTime_ms - msecMagDelay));
@@ -4388,7 +4388,7 @@ void NavEKF::readMagData()
 
         // check if compass offsets have ben changed and adjust EKF bias states to maintain consistent innovations
         if (_ahrs->get_compass()->healthy()) {
-            Vector3f nowMagOffsets = _ahrs->get_compass()->get_offsets();
+            Vector3f nowMagOffsets = _ahrs->get_compass()->get_offsets_milligauss();
             bool changeDetected = (!is_equal(nowMagOffsets.x,lastMagOffsets.x) || !is_equal(nowMagOffsets.y,lastMagOffsets.y) || !is_equal(nowMagOffsets.z,lastMagOffsets.z));
             // Ignore bias changes before final mag field and yaw initialisation, as there may have been a compass calibration
             if (changeDetected && secondMagYawInit) {

--- a/libraries/AP_NavEKF/AP_SmallEKF.cpp
+++ b/libraries/AP_NavEKF/AP_SmallEKF.cpp
@@ -640,7 +640,7 @@ void SmallEKF::readMagData()
         lastMagUpdate = _ahrs.get_compass()->last_update_usec();
 
         // read compass data and scale to improve numerical conditioning
-        magData = _ahrs.get_compass()->get_field();
+        magData = _ahrs.get_compass()->get_field_milligauss();
 
         // let other processes know that new compass data has arrived
         newDataMag = true;


### PR DESCRIPTION
The new PR instead of #2599. 

The new pair of methods (```get_offsets_milligauss()``` and ```get_field_milligauss()```) are introduced.
The callers that don't store offsets and don't send them via Mavlink use these new methods from now on. 
With these new methods we can make a transition to consistent common units across all compasses.

The code needs a review.

- ```Compass_learn.cpp``` has not been updated. It doesn't use getters for offsets and field.
- Plane and Rover code is not updated.

@lucasdemarchi @tridge @rmackay9 

I hope these are the changes you've discussed on the previous devcall.