### PR TITLE
AP_L1_Control: prefer into-wind when doing waypoint u-turn

### DIFF
--- a/libraries/AP_L1_Control/AP_L1_Control.h
+++ b/libraries/AP_L1_Control/AP_L1_Control.h
@@ -50,6 +50,7 @@ public:
 	void update_heading_hold(int32_t navigation_heading_cd);
 	void update_level_flight(void);
 	bool reached_loiter_target(void);
+	float get_wind_delta(Vector3f wind_raw);
 
     // set the default NAVL1_PERIOD
     void set_default_period(float period) {
@@ -92,6 +93,12 @@ private:
 	// L1 tracking loop damping ratio
 	AP_Float _L1_damping;
 
+    // L1 control wind angle threshold
+    AP_Int16 _wind_angle_thresh;
+
+    // direction of counter-intuitive into the wind turn. Positive is clockwise, zero means normal direction behavior
+    int32_t _direction_sign = 0;
+
     // previous value of cross-track velocity
     float _last_Nu;
 
@@ -100,6 +107,9 @@ private:
 
     // prevent indecision in waypoint tracking
     void _prevent_indecision(float &Nu);
+
+    void prefer_turn_into_wind(float &Nu2);
+
 };
 
 


### PR DESCRIPTION
Issue is discussed here: https://github.com/diydrones/ardupilot/issues/2222

New param NAVL1_ANGLE_THR, default 0 (disabled but suggest 120), in degrees. This value is the angle threshold where the wind vector is considered to force a turn direction which favors into-the-wind. Into-wind is favored when turn angle for next waypoint is greater than this value.

In an example of a 175 degree u-turn, without wind we take the shortest path which is to the right. With a left to right cross-wind we would have normally taken the shorter run-path (right) but then get blown downwind which causes a larger crosstrack error than anticipated resulting in a longer ground-path and longer line acquisition. This also cases with-wind flight briefly dropping our airspeed. When taking a cross-wind into the direction decision we will prefer to turn into the wind, a left. In the case of a very strong wind we would essentially spin in place creating a much shorter ground path as well as maintaining a safer airspeed.