### PR TITLE
STORM32 serial fix for firmware versions >= .78e

### DIFF
--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
@@ -151,11 +151,8 @@ void AP_Mount_SToRM32_serial::send_target_angles(float pitch_deg, float roll_deg
 {
 
     static cmd_set_angles_struct cmd_set_angles_data = {
-        0xFD,
+        0xFA,
         0x0E,
-        0x00,
-        0x52,
-        0x43,
         0x11,
         0, // pitch
         0, // roll

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
@@ -113,8 +113,9 @@ private:
     };
 
     struct PACKED SToRM32_reply_ack_struct {
-        uint8_t magic;
-        uint8_t something[5];
+        uint8_t byte1;
+        uint8_t byte2;
+        uint8_t byte3;
         uint8_t data;
         uint16_t crc;
     };
@@ -123,9 +124,6 @@ private:
         uint8_t byte1;
         uint8_t byte2;
         uint8_t byte3;
-        uint8_t byte4;
-        uint8_t byte5;
-        uint8_t byte6;
         float pitch;
         float roll;
         float yaw;


### PR DESCRIPTION
This fixes the structs to be compatible with the changes OlliW made to
the gimbal firmware.

I've tested with a build of 3.3rc9.

http://www.olliw.eu/storm32bgc-wiki/Serial_Communication