### PR TITLE
RCOutput: allow to update all channels at once (v2)

### DIFF
--- a/APMrover2/failsafe.cpp
+++ b/APMrover2/failsafe.cpp
@@ -45,9 +45,10 @@ void Rover::failsafe_check()
         hal.rcin->clear_overrides();
         uint8_t start_ch = 0;
         for (uint8_t ch=start_ch; ch<4; ch++) {
-            hal.rcout->write(ch, hal.rcin->read(ch));
+            hal.rcout->write(ch, hal.rcin->read(ch), AP_HAL::RCOutput::FLAGS_ASYNC);
         }
         RC_Channel_aux::copy_radio_in_out(RC_Channel_aux::k_manual, true);
+        hal.rcout->flush();
     }
 }
 

--- a/APMrover2/test.cpp
+++ b/APMrover2/test.cpp
@@ -87,8 +87,10 @@ int8_t Rover::test_passthru(uint8_t argc, const Menu::arg *argv)
             for(int i = 0; i < 8; i++){
                 cliSerial->print(hal.rcin->read(i));	// Print channel values
                 cliSerial->print(",");
-                hal.rcout->write(i, hal.rcin->read(i)); // Copy input to Servos
+                // Copy input to servos
+                hal.rcout->write(i, hal.rcin->read(i), AP_HAL::RCOutput::FLAGS_ASYNC);
             }
+            hal.rcout->flush();
             cliSerial->println();
         }
         if (cliSerial->available() > 0){

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -850,7 +850,7 @@ private:
     void resetPerfData(void);
     void check_usb_mux(void);
     void print_comma(void);
-    void servo_write(uint8_t ch, uint16_t pwm);
+    void servo_write(uint8_t ch, uint16_t pwm, bool async = false);
     bool should_log(uint32_t mask);
     void frsky_telemetry_send(void);
     uint8_t throttle_percentage(void);

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -694,7 +694,7 @@ void Plane::print_comma(void)
 /*
   write to a servo
  */
-void Plane::servo_write(uint8_t ch, uint16_t pwm)
+void Plane::servo_write(uint8_t ch, uint16_t pwm, bool async)
 {
 #if HIL_SUPPORT
     if (g.hil_mode==1 && !g.hil_servos) {
@@ -704,8 +704,12 @@ void Plane::servo_write(uint8_t ch, uint16_t pwm)
         return;
     }
 #endif
+    int flags = 0;
+    if (async)
+        flags |= AP_HAL::RCOutput::FLAGS_ASYNC;
+
     hal.rcout->enable_ch(ch);
-    hal.rcout->write(ch, pwm);
+    hal.rcout->write(ch, pwm, flags);
 }
 
 /*

--- a/ArduPlane/test.cpp
+++ b/ArduPlane/test.cpp
@@ -93,8 +93,9 @@ int8_t Plane::test_passthru(uint8_t argc, const Menu::arg *argv)
             for(int16_t i = 0; i < 8; i++) {
                 cliSerial->print(hal.rcin->read(i));        // Print channel values
                 print_comma();
-                servo_write(i, hal.rcin->read(i)); // Copy input to Servos
+                servo_write(i, hal.rcin->read(i), true); // Copy input to Servos
             }
+            hal.rcout->flush();
             cliSerial->println();
         }
         if (cliSerial->available() > 0) {

--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -43,9 +43,8 @@ public:
     virtual void     enable_ch(uint8_t ch) = 0;
     virtual void     disable_ch(uint8_t ch) = 0;
 
-    /* Output, either single channel or bulk array of channels */
+    /* Output a single channel */
     virtual void     write(uint8_t ch, uint16_t period_us) = 0;
-    virtual void     write(uint8_t ch, uint16_t* period_us, uint8_t len) = 0;
 
     /* Read back current output state, as either single channel or
      * array of channels. */

--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -32,6 +32,10 @@
 
 class AP_HAL::RCOutput {
 public:
+    enum Flags {
+        FLAGS_ASYNC = 0x01,
+    };
+
     virtual void init(void* implspecific) = 0;
 
     /* Output freq (1/period) control */
@@ -43,8 +47,21 @@ public:
     virtual void     enable_ch(uint8_t ch) = 0;
     virtual void     disable_ch(uint8_t ch) = 0;
 
-    /* Output a single channel */
-    virtual void     write(uint8_t ch, uint16_t period_us) = 0;
+    /*
+     * Output a single channel. If @param flags does not contain FLAGS_ASYNC
+     * the write is considered synchronous, i.e. the value is automatically
+     * pushed to the underlying hardware. Subclasses may implement a different
+     * behavior for FLAGS_ASYNC in which updates are grouped until a
+     * synchronous write or a call to flush()
+     */
+    virtual void     write(uint8_t ch, uint16_t period_us, int flags = 0) = 0;
+
+    /*
+     * Flush pending data added with async write(). Default implementation
+     * does nothing and matches default write() behavior that all writes are
+     * synchronous
+     */
+    virtual void     flush() { }
 
     /* Read back current output state, as either single channel or
      * array of channels. */

--- a/libraries/AP_HAL/examples/RCInputToRCOutput/RCInputToRCOutput.cpp
+++ b/libraries/AP_HAL/examples/RCInputToRCOutput/RCInputToRCOutput.cpp
@@ -67,7 +67,7 @@ void loop(void)
     for(uint8_t i = 0; i < nchannels; i++) {
         uint16_t v = hal.rcin->read(i);
         if(last_value[i] != v) {
-            hal.rcout->write(i, v);
+            hal.rcout->write(i, v, AP_HAL::RCOutput::FLAGS_ASYNC);
             changed = true;
             last_value[i] = v;
         }
@@ -75,6 +75,7 @@ void loop(void)
             max_channels = i;
         }
     }
+    hal.rcout->flush();
     if(changed) {
         for(uint8_t i = 0; i < max_channels; i++) {
             hal.console->printf("%2u:%04u ", (unsigned)i + 1, (unsigned)last_value[i]);

--- a/libraries/AP_HAL_AVR/RCOutput.h
+++ b/libraries/AP_HAL_AVR/RCOutput.h
@@ -21,7 +21,6 @@ public:
 
     /* Output, either single channel or bulk array of channels */
     void     write(uint8_t ch, uint16_t period_ms);
-    void     write(uint8_t ch, uint16_t* period_ms, uint8_t len);
 
     /* Read back current output state, as either single channel or
      * array of channels. */
@@ -48,7 +47,6 @@ public:
 
     /* Output, either single channel or bulk array of channels */
     void     write(uint8_t ch, uint16_t period_us);
-    void     write(uint8_t ch, uint16_t* period_us, uint8_t len);
 
     /* Read back current output state, as either single channel or
      * array of channels starting at 0. */

--- a/libraries/AP_HAL_AVR/RCOutput.h
+++ b/libraries/AP_HAL_AVR/RCOutput.h
@@ -20,7 +20,7 @@ public:
     void     disable_ch(uint8_t ch);
 
     /* Output, either single channel or bulk array of channels */
-    void     write(uint8_t ch, uint16_t period_ms);
+    void     write(uint8_t ch, uint16_t period_ms, int flags = 0);
 
     /* Read back current output state, as either single channel or
      * array of channels. */
@@ -46,7 +46,7 @@ public:
     void     disable_ch(uint8_t ch);
 
     /* Output, either single channel or bulk array of channels */
-    void     write(uint8_t ch, uint16_t period_us);
+    void     write(uint8_t ch, uint16_t period_us, int flags = 0);
 
     /* Read back current output state, as either single channel or
      * array of channels starting at 0. */

--- a/libraries/AP_HAL_AVR/RCOutput_APM1.cpp
+++ b/libraries/AP_HAL_AVR/RCOutput_APM1.cpp
@@ -174,13 +174,6 @@ void APM1RCOutput::write(uint8_t ch, uint16_t period_us) {
     }
 }
 
-void APM1RCOutput::write(uint8_t ch, uint16_t* period_us, uint8_t len) {
-    for (int i = 0; i < len; i++) {
-        write(i + ch, period_us[i]); 
-    }
-}
-
-
 /* Read back current output state, as either single channel or
  * array of channels. */
 uint16_t APM1RCOutput::read(uint8_t ch) {

--- a/libraries/AP_HAL_AVR/RCOutput_APM1.cpp
+++ b/libraries/AP_HAL_AVR/RCOutput_APM1.cpp
@@ -154,7 +154,7 @@ static inline uint16_t constrain_period(uint16_t p) {
 }
 
 /* Output, either single channel or bulk array of channels */
-void APM1RCOutput::write(uint8_t ch, uint16_t period_us) {
+void APM1RCOutput::write(uint8_t ch, uint16_t period_us, int) {
     /* constrain, then scale from 1us resolution (input units)
      * to 0.5us (timer units) */
     uint16_t pwm = constrain_period(period_us) << 1;

--- a/libraries/AP_HAL_AVR/RCOutput_APM2.cpp
+++ b/libraries/AP_HAL_AVR/RCOutput_APM2.cpp
@@ -165,13 +165,6 @@ void APM2RCOutput::write(uint8_t ch, uint16_t period_us) {
     }
 }
 
-void APM2RCOutput::write(uint8_t ch, uint16_t* period_us, uint8_t len) {
-    for (int i = 0; i < len; i++) {
-        write(i + ch, period_us[i]); 
-    }
-}
-
-
 /* Read back current output state, as either single channel or
  * array of channels. */
 uint16_t APM2RCOutput::read(uint8_t ch) {

--- a/libraries/AP_HAL_AVR/RCOutput_APM2.cpp
+++ b/libraries/AP_HAL_AVR/RCOutput_APM2.cpp
@@ -146,7 +146,7 @@ static inline uint16_t constrain_period(uint16_t p) {
 }
 
 /* Output, either single channel or bulk array of channels */
-void APM2RCOutput::write(uint8_t ch, uint16_t period_us) {
+void APM2RCOutput::write(uint8_t ch, uint16_t period_us, int) {
     /* constrain, then scale from 1us resolution (input units)
      * to 0.5us (timer units) */
     uint16_t pwm = constrain_period(period_us) << 1;

--- a/libraries/AP_HAL_Empty/RCOutput.cpp
+++ b/libraries/AP_HAL_Empty/RCOutput.cpp
@@ -20,9 +20,6 @@ void EmptyRCOutput::disable_ch(uint8_t ch)
 void EmptyRCOutput::write(uint8_t ch, uint16_t period_us)
 {}
 
-void EmptyRCOutput::write(uint8_t ch, uint16_t* period_us, uint8_t len)
-{}
-
 uint16_t EmptyRCOutput::read(uint8_t ch) {
     return 900;
 }

--- a/libraries/AP_HAL_Empty/RCOutput.cpp
+++ b/libraries/AP_HAL_Empty/RCOutput.cpp
@@ -17,7 +17,7 @@ void EmptyRCOutput::enable_ch(uint8_t ch)
 void EmptyRCOutput::disable_ch(uint8_t ch)
 {}
 
-void EmptyRCOutput::write(uint8_t ch, uint16_t period_us)
+void EmptyRCOutput::write(uint8_t ch, uint16_t period_us, int)
 {}
 
 uint16_t EmptyRCOutput::read(uint8_t ch) {

--- a/libraries/AP_HAL_Empty/RCOutput.h
+++ b/libraries/AP_HAL_Empty/RCOutput.h
@@ -11,7 +11,6 @@ class Empty::EmptyRCOutput : public AP_HAL::RCOutput {
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
     void     write(uint8_t ch, uint16_t period_us);
-    void     write(uint8_t ch, uint16_t* period_us, uint8_t len);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
 };

--- a/libraries/AP_HAL_Empty/RCOutput.h
+++ b/libraries/AP_HAL_Empty/RCOutput.h
@@ -10,7 +10,7 @@ class Empty::EmptyRCOutput : public AP_HAL::RCOutput {
     uint16_t get_freq(uint8_t ch);
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
-    void     write(uint8_t ch, uint16_t period_us);
+    void     write(uint8_t ch, uint16_t period_us, int flags = 0);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
 };

--- a/libraries/AP_HAL_FLYMAPLE/RCOutput.cpp
+++ b/libraries/AP_HAL_FLYMAPLE/RCOutput.cpp
@@ -95,13 +95,7 @@ void FLYMAPLERCOutput::write(uint8_t ch, uint16_t period_us)
     pwmWrite(pin, (period_us * _clocks_per_msecond[ch]) / 1000);
 }
 
-void FLYMAPLERCOutput::write(uint8_t ch, uint16_t* period_us, uint8_t len)
-{
-    for (int i = 0; i < len; i++)
-        write(i + ch, period_us[i]); 
-}
-
-uint16_t FLYMAPLERCOutput::read(uint8_t ch) 
+uint16_t FLYMAPLERCOutput::read(uint8_t ch)
 {
     if (ch >= FLYMAPLE_RC_OUTPUT_NUM_CHANNELS)
 	return 0;

--- a/libraries/AP_HAL_FLYMAPLE/RCOutput.cpp
+++ b/libraries/AP_HAL_FLYMAPLE/RCOutput.cpp
@@ -87,7 +87,7 @@ void FLYMAPLERCOutput::disable_ch(uint8_t ch)
     pinMode(pin, INPUT);
 }
 
-void FLYMAPLERCOutput::write(uint8_t ch, uint16_t period_us)
+void FLYMAPLERCOutput::write(uint8_t ch, uint16_t period_us, int)
 {
     if (ch >= FLYMAPLE_RC_OUTPUT_NUM_CHANNELS)
 	return;

--- a/libraries/AP_HAL_FLYMAPLE/RCOutput.h
+++ b/libraries/AP_HAL_FLYMAPLE/RCOutput.h
@@ -30,7 +30,6 @@ class AP_HAL_FLYMAPLE_NS::FLYMAPLERCOutput : public AP_HAL::RCOutput {
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
     void     write(uint8_t ch, uint16_t period_us);
-    void     write(uint8_t ch, uint16_t* period_us, uint8_t len);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
 

--- a/libraries/AP_HAL_FLYMAPLE/RCOutput.h
+++ b/libraries/AP_HAL_FLYMAPLE/RCOutput.h
@@ -29,7 +29,7 @@ class AP_HAL_FLYMAPLE_NS::FLYMAPLERCOutput : public AP_HAL::RCOutput {
     uint16_t get_freq(uint8_t ch);
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
-    void     write(uint8_t ch, uint16_t period_us);
+    void     write(uint8_t ch, uint16_t period_us, int flags = 0);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
 

--- a/libraries/AP_HAL_FLYMAPLE/examples/RCPassthroughTest/RCPassthroughTest.cpp
+++ b/libraries/AP_HAL_FLYMAPLE/examples/RCPassthroughTest/RCPassthroughTest.cpp
@@ -35,12 +35,6 @@ void individualread(AP_HAL::RCInput* in, uint16_t* channels) {
 }
 
 
-void multiwrite(AP_HAL::RCOutput* out, uint16_t* channels) {
-    out->write(0, channels, 8);
-    /* Upper channels duplicate lower channels*/
-    out->write(8, channels, 8);
-}
-
 void individualwrite(AP_HAL::RCOutput* out, uint16_t* channels) {
     for (int ch = 0; ch < 8; ch++) {
         out->write(ch, channels[ch]); 
@@ -64,12 +58,7 @@ void loop (void) {
         if (ctr > 1000)  ctr = 0;
     }
 
-    /* Cycle between individual output and multichannel output */
-    if (ctr % 500 < 250) {
-        multiwrite(hal.rcout, channels);
-    } else {
-        individualwrite(hal.rcout, channels);
-    }
+    individualwrite(hal.rcout, channels);
 
 //    hal.gpio->write(13, 0);
     hal.scheduler->delay(4);

--- a/libraries/AP_HAL_FLYMAPLE/examples/RCPassthroughTest/RCPassthroughTest.cpp
+++ b/libraries/AP_HAL_FLYMAPLE/examples/RCPassthroughTest/RCPassthroughTest.cpp
@@ -35,6 +35,19 @@ void individualread(AP_HAL::RCInput* in, uint16_t* channels) {
 }
 
 
+void multiwrite(AP_HAL::RCOutput* out, uint16_t* channels) {
+    for (int ch = 0; ch < 8; ch++) {
+        out->write(ch, channels[ch], AP_HAL::RCOutput::FLAGS_ASYNC);
+    }
+    out->flush();
+
+    /* Upper channels duplicate lower channels*/
+    for (int ch = 8; ch < 16; ch++) {
+        out->write(ch, channels[ch], AP_HAL::RCOutput::FLAGS_ASYNC);
+    }
+    out->flush();
+}
+
 void individualwrite(AP_HAL::RCOutput* out, uint16_t* channels) {
     for (int ch = 0; ch < 8; ch++) {
         out->write(ch, channels[ch]); 
@@ -58,7 +71,12 @@ void loop (void) {
         if (ctr > 1000)  ctr = 0;
     }
 
-    individualwrite(hal.rcout, channels);
+    /* Cycle between individual output and multichannel output */
+    if (ctr % 500 < 250) {
+        multiwrite(hal.rcout, channels);
+    } else {
+        individualwrite(hal.rcout, channels);
+    }
 
 //    hal.gpio->write(13, 0);
     hal.scheduler->delay(4);

--- a/libraries/AP_HAL_Linux/RCOutput_AioPRU.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_AioPRU.cpp
@@ -108,19 +108,6 @@ void LinuxRCOutput_AioPRU::write(uint8_t ch, uint16_t period_us)
    }
 }
 
-void LinuxRCOutput_AioPRU::write(uint8_t ch, uint16_t* period_us, uint8_t len)
-{
-   uint8_t i;
-
-   if(len > PWM_CHAN_COUNT) {
-      len = PWM_CHAN_COUNT;
-   }
-
-   for(i = 0; i < len; i++) {
-      write(ch + i, period_us[i]);
-   }
-}
-
 uint16_t LinuxRCOutput_AioPRU::read(uint8_t ch)
 {
    uint16_t ret = 0;

--- a/libraries/AP_HAL_Linux/RCOutput_AioPRU.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_AioPRU.cpp
@@ -101,7 +101,7 @@ void LinuxRCOutput_AioPRU::disable_ch(uint8_t ch)
    }
 }
 
-void LinuxRCOutput_AioPRU::write(uint8_t ch, uint16_t period_us)
+void LinuxRCOutput_AioPRU::write(uint8_t ch, uint16_t period_us, int)
 {
    if(ch < PWM_CHAN_COUNT) {
       pwm->channel[ch].time_high = TICK_PER_US * period_us;

--- a/libraries/AP_HAL_Linux/RCOutput_AioPRU.h
+++ b/libraries/AP_HAL_Linux/RCOutput_AioPRU.h
@@ -26,7 +26,6 @@ class Linux::LinuxRCOutput_AioPRU : public AP_HAL::RCOutput {
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
     void     write(uint8_t ch, uint16_t period_us);
-    void     write(uint8_t ch, uint16_t* period_us, uint8_t len);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
 

--- a/libraries/AP_HAL_Linux/RCOutput_AioPRU.h
+++ b/libraries/AP_HAL_Linux/RCOutput_AioPRU.h
@@ -25,7 +25,7 @@ class Linux::LinuxRCOutput_AioPRU : public AP_HAL::RCOutput {
     uint16_t get_freq(uint8_t ch);
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
-    void     write(uint8_t ch, uint16_t period_us);
+    void     write(uint8_t ch, uint16_t period_us, int flags = 0);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
 

--- a/libraries/AP_HAL_Linux/RCOutput_Bebop.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_Bebop.cpp
@@ -329,12 +329,6 @@ void LinuxRCOutput_Bebop::write(uint8_t ch, uint16_t period_us)
     }
 }
 
-void LinuxRCOutput_Bebop::write(uint8_t ch, uint16_t* period_us, uint8_t len)
-{
-    for (int i = 0; i < len; i++)
-        write(ch + i, period_us[i]);
-}
-
 uint16_t LinuxRCOutput_Bebop::read(uint8_t ch)
 {
     if (ch < BEBOP_BLDC_MOTORS_NUM) {

--- a/libraries/AP_HAL_Linux/RCOutput_Bebop.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_Bebop.cpp
@@ -312,7 +312,7 @@ void LinuxRCOutput_Bebop::disable_ch(uint8_t ch)
     _stop_prop();
 }
 
-void LinuxRCOutput_Bebop::write(uint8_t ch, uint16_t period_us)
+void LinuxRCOutput_Bebop::write(uint8_t ch, uint16_t period_us, int)
 {
     if (ch >= BEBOP_BLDC_MOTORS_NUM)
         return;

--- a/libraries/AP_HAL_Linux/RCOutput_Bebop.h
+++ b/libraries/AP_HAL_Linux/RCOutput_Bebop.h
@@ -56,7 +56,6 @@ public:
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
     void     write(uint8_t ch, uint16_t period_us);
-    void     write(uint8_t ch, uint16_t* period_us, uint8_t len);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
     void     set_esc_scaling(uint16_t min_pwm, uint16_t max_pwm);

--- a/libraries/AP_HAL_Linux/RCOutput_Bebop.h
+++ b/libraries/AP_HAL_Linux/RCOutput_Bebop.h
@@ -55,7 +55,7 @@ public:
     uint16_t get_freq(uint8_t ch);
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
-    void     write(uint8_t ch, uint16_t period_us);
+    void     write(uint8_t ch, uint16_t period_us, int flags = 0);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
     void     set_esc_scaling(uint16_t min_pwm, uint16_t max_pwm);

--- a/libraries/AP_HAL_Linux/RCOutput_Navio.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_Navio.cpp
@@ -47,6 +47,7 @@
 using namespace Linux;
 
 #define PWM_CHAN_COUNT 13
+#define CHANNEL_OFFSET 3
 #define PCA9685_OUTPUT_ENABLE RPI_GPIO_27
 
 static const AP_HAL::HAL& hal = AP_HAL_BOARD_DRIVER;
@@ -150,30 +151,57 @@ void LinuxRCOutput_Navio::disable_ch(uint8_t ch)
     write(ch, 0);
 }
 
-void LinuxRCOutput_Navio::write(uint8_t ch, uint16_t period_us)
+/* calls to write() and flush() must occur on the same thread */
+void LinuxRCOutput_Navio::write(uint8_t ch, uint16_t period_us, int flags)
 {
-    if(ch >= PWM_CHAN_COUNT){
+    if (ch >= PWM_CHAN_COUNT) {
         return;
     }
-
-    if (!_i2c_sem->take_nonblocking()) {
-        return;
-    }
-
-    uint16_t length;
-
-    if (period_us == 0)
-        length = 0;
-    else
-        length = round((period_us * 4096) / (1000000.f / _frequency)) - 1;
-
-    uint8_t data[2] = {length & 0xFF, length >> 8};
-    uint8_t status = hal.i2c->writeRegisters(PCA9685_ADDRESS,
-                                             PCA9685_RA_LED0_OFF_L + 4 * (ch + 3),
-                                             2,
-                                             data);
 
     _pulses_buffer[ch] = period_us;
+    _pending_write_mask |= (1U << ch);
+
+    if (flags & AP_HAL::RCOutput::FLAGS_ASYNC)
+        return;
+
+    flush();
+}
+
+/* calls to write() and flush() must occur on the same thread */
+void LinuxRCOutput_Navio::flush()
+{
+    uint8_t data[PWM_CHAN_COUNT * 4] = { };
+    uint8_t max_ch, min_ch;
+
+    if (_pending_write_mask == 0)
+        return;
+
+    max_ch = (sizeof(unsigned) * 8) - __builtin_clz(_pending_write_mask);
+    min_ch = __builtin_ctz(_pending_write_mask);
+    _pending_write_mask = 0;
+
+    for (unsigned ch = min_ch; ch < max_ch; ch++) {
+        uint16_t width;
+
+        if (_pulses_buffer[ch] == 0)
+            width = 0;
+        else
+            width = round((_pulses_buffer[ch] * 4096) / (1000000.f / _frequency)) - 1;
+
+        uint8_t *d = &data[ch * 4 + 2];
+        *d++ = width && 0xFF;
+        *d = width >> 8;
+    }
+
+    if (!_i2c_sem->take(100)) {
+        hal.console->printf("RCOutput: Unable to get bus semaphore");
+        return;
+    }
+
+    hal.i2c->writeRegisters(PCA9685_ADDRESS,
+                            PCA9685_RA_LED0_ON_L + 4 * (CHANNEL_OFFSET + min_ch),
+                            (max_ch - min_ch) * 4,
+                            &data[min_ch * 4]);
 
     _i2c_sem->give();
 }

--- a/libraries/AP_HAL_Linux/RCOutput_Navio.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_Navio.cpp
@@ -178,12 +178,6 @@ void LinuxRCOutput_Navio::write(uint8_t ch, uint16_t period_us)
     _i2c_sem->give();
 }
 
-void LinuxRCOutput_Navio::write(uint8_t ch, uint16_t* period_us, uint8_t len)
-{
-    for (int i = 0; i < len; i++)
-        write(ch + i, period_us[i]);
-}
-
 uint16_t LinuxRCOutput_Navio::read(uint8_t ch)
 {
     return _pulses_buffer[ch];

--- a/libraries/AP_HAL_Linux/RCOutput_Navio.h
+++ b/libraries/AP_HAL_Linux/RCOutput_Navio.h
@@ -14,7 +14,8 @@ class Linux::LinuxRCOutput_Navio : public AP_HAL::RCOutput {
     uint16_t get_freq(uint8_t ch);
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
-    void     write(uint8_t ch, uint16_t period_us);
+    void     write(uint8_t ch, uint16_t period_us, int flags = 0) override;
+    void     flush() override;
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
 
@@ -25,6 +26,7 @@ private:
     AP_HAL::DigitalSource *enable_pin;
     uint16_t _frequency;
 
+    uint16_t _pending_write_mask;
     uint16_t *_pulses_buffer;
 };
 

--- a/libraries/AP_HAL_Linux/RCOutput_Navio.h
+++ b/libraries/AP_HAL_Linux/RCOutput_Navio.h
@@ -15,7 +15,6 @@ class Linux::LinuxRCOutput_Navio : public AP_HAL::RCOutput {
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
     void     write(uint8_t ch, uint16_t period_us);
-    void     write(uint8_t ch, uint16_t* period_us, uint8_t len);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
 

--- a/libraries/AP_HAL_Linux/RCOutput_PRU.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_PRU.cpp
@@ -75,17 +75,6 @@ void LinuxRCOutput_PRU::write(uint8_t ch, uint16_t period_us)
     sharedMem_cmd->periodhi[chan_pru_map[ch]][1] = TICK_PER_US*period_us;
 }
 
-void LinuxRCOutput_PRU::write(uint8_t ch, uint16_t* period_us, uint8_t len)
-{
-    uint8_t i;
-    if(len>PWM_CHAN_COUNT){
-        len = PWM_CHAN_COUNT;
-    }
-    for(i=0;i<len;i++){
-        write(ch+i,period_us[i]);
-    }
-}
-
 uint16_t LinuxRCOutput_PRU::read(uint8_t ch)
 {
     return (sharedMem_cmd->hilo_read[chan_pru_map[ch]][1]/TICK_PER_US);

--- a/libraries/AP_HAL_Linux/RCOutput_PRU.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_PRU.cpp
@@ -70,7 +70,7 @@ void LinuxRCOutput_PRU::disable_ch(uint8_t ch)
     sharedMem_cmd->enmask &= !(1U<<chan_pru_map[ch]);
 }
 
-void LinuxRCOutput_PRU::write(uint8_t ch, uint16_t period_us)
+void LinuxRCOutput_PRU::write(uint8_t ch, uint16_t period_us, int)
 {
     sharedMem_cmd->periodhi[chan_pru_map[ch]][1] = TICK_PER_US*period_us;
 }

--- a/libraries/AP_HAL_Linux/RCOutput_PRU.h
+++ b/libraries/AP_HAL_Linux/RCOutput_PRU.h
@@ -22,7 +22,6 @@ class Linux::LinuxRCOutput_PRU : public AP_HAL::RCOutput {
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
     void     write(uint8_t ch, uint16_t period_us);
-    void     write(uint8_t ch, uint16_t* period_us, uint8_t len);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
 

--- a/libraries/AP_HAL_Linux/RCOutput_PRU.h
+++ b/libraries/AP_HAL_Linux/RCOutput_PRU.h
@@ -21,7 +21,7 @@ class Linux::LinuxRCOutput_PRU : public AP_HAL::RCOutput {
     uint16_t get_freq(uint8_t ch);
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
-    void     write(uint8_t ch, uint16_t period_us);
+    void     write(uint8_t ch, uint16_t period_us, int flags = 0);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
 

--- a/libraries/AP_HAL_Linux/RCOutput_ZYNQ.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_ZYNQ.cpp
@@ -71,17 +71,6 @@ void LinuxRCOutput_ZYNQ::write(uint8_t ch, uint16_t period_us)
     sharedMem_cmd->periodhi[ch].hi = TICK_PER_US*period_us;
 }
 
-void LinuxRCOutput_ZYNQ::write(uint8_t ch, uint16_t* period_us, uint8_t len)
-{
-    uint8_t i;
-    if(len>PWM_CHAN_COUNT){
-        len = PWM_CHAN_COUNT;
-    }
-    for(i=0;i<len;i++){
-        write(ch+i,period_us[i]);
-    }
-}
-
 uint16_t LinuxRCOutput_ZYNQ::read(uint8_t ch)
 {
     return (sharedMem_cmd->periodhi[ch].hi/TICK_PER_US);

--- a/libraries/AP_HAL_Linux/RCOutput_ZYNQ.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_ZYNQ.cpp
@@ -66,7 +66,7 @@ void LinuxRCOutput_ZYNQ::disable_ch(uint8_t ch)
     // sharedMem_cmd->enmask &= !(1U<<chan_pru_map[ch]);
 }
 
-void LinuxRCOutput_ZYNQ::write(uint8_t ch, uint16_t period_us)
+void LinuxRCOutput_ZYNQ::write(uint8_t ch, uint16_t period_us, int)
 {
     sharedMem_cmd->periodhi[ch].hi = TICK_PER_US*period_us;
 }

--- a/libraries/AP_HAL_Linux/RCOutput_ZYNQ.h
+++ b/libraries/AP_HAL_Linux/RCOutput_ZYNQ.h
@@ -21,7 +21,6 @@ class Linux::LinuxRCOutput_ZYNQ : public AP_HAL::RCOutput {
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
     void     write(uint8_t ch, uint16_t period_us);
-    void     write(uint8_t ch, uint16_t* period_us, uint8_t len);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
 

--- a/libraries/AP_HAL_Linux/RCOutput_ZYNQ.h
+++ b/libraries/AP_HAL_Linux/RCOutput_ZYNQ.h
@@ -20,7 +20,7 @@ class Linux::LinuxRCOutput_ZYNQ : public AP_HAL::RCOutput {
     uint16_t get_freq(uint8_t ch);
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
-    void     write(uint8_t ch, uint16_t period_us);
+    void     write(uint8_t ch, uint16_t period_us, int flags = 0);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
 

--- a/libraries/AP_HAL_PX4/RCOutput.cpp
+++ b/libraries/AP_HAL_PX4/RCOutput.cpp
@@ -235,13 +235,6 @@ void PX4RCOutput::write(uint8_t ch, uint16_t period_us)
     }
 }
 
-void PX4RCOutput::write(uint8_t ch, uint16_t* period_us, uint8_t len)
-{
-    for (uint8_t i=0; i<len; i++) {
-        write(i, period_us[i]);
-    }
-}
-
 uint16_t PX4RCOutput::read(uint8_t ch) 
 {
     if (ch >= PX4_NUM_OUTPUT_CHANNELS) {

--- a/libraries/AP_HAL_PX4/RCOutput.cpp
+++ b/libraries/AP_HAL_PX4/RCOutput.cpp
@@ -217,7 +217,7 @@ void PX4RCOutput::force_safety_off(void)
     }
 }
 
-void PX4RCOutput::write(uint8_t ch, uint16_t period_us)
+void PX4RCOutput::write(uint8_t ch, uint16_t period_us, int)
 {
     if (ch >= _servo_count + _alt_servo_count) {
         return;

--- a/libraries/AP_HAL_PX4/RCOutput.h
+++ b/libraries/AP_HAL_PX4/RCOutput.h
@@ -18,7 +18,6 @@ public:
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
     void     write(uint8_t ch, uint16_t period_us);
-    void     write(uint8_t ch, uint16_t* period_us, uint8_t len);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
     void     set_safety_pwm(uint32_t chmask, uint16_t period_us);

--- a/libraries/AP_HAL_PX4/RCOutput.h
+++ b/libraries/AP_HAL_PX4/RCOutput.h
@@ -17,7 +17,7 @@ public:
     uint16_t get_freq(uint8_t ch);
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
-    void     write(uint8_t ch, uint16_t period_us);
+    void     write(uint8_t ch, uint16_t period_us, int flags = 0);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
     void     set_safety_pwm(uint32_t chmask, uint16_t period_us);

--- a/libraries/AP_HAL_SITL/RCOutput.cpp
+++ b/libraries/AP_HAL_SITL/RCOutput.cpp
@@ -28,11 +28,6 @@ void SITLRCOutput::write(uint8_t ch, uint16_t period_us)
     }
 }
 
-void SITLRCOutput::write(uint8_t ch, uint16_t* period_us, uint8_t len)
-{
-    memcpy(_sitlState->pwm_output+ch, period_us, len*sizeof(uint16_t));
-}
-
 uint16_t SITLRCOutput::read(uint8_t ch)
 {
     if (ch < SITL_NUM_CHANNELS) {

--- a/libraries/AP_HAL_SITL/RCOutput.cpp
+++ b/libraries/AP_HAL_SITL/RCOutput.cpp
@@ -21,7 +21,7 @@ void SITLRCOutput::enable_ch(uint8_t ch)
 void SITLRCOutput::disable_ch(uint8_t ch)
 {}
 
-void SITLRCOutput::write(uint8_t ch, uint16_t period_us)
+void SITLRCOutput::write(uint8_t ch, uint16_t period_us, int)
 {
     if (ch < SITL_NUM_CHANNELS) {
         _sitlState->pwm_output[ch] = period_us;

--- a/libraries/AP_HAL_SITL/RCOutput.h
+++ b/libraries/AP_HAL_SITL/RCOutput.h
@@ -18,7 +18,6 @@ public:
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
     void     write(uint8_t ch, uint16_t period_us);
-    void     write(uint8_t ch, uint16_t* period_us, uint8_t len);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
 

--- a/libraries/AP_HAL_SITL/RCOutput.h
+++ b/libraries/AP_HAL_SITL/RCOutput.h
@@ -17,7 +17,7 @@ public:
     uint16_t get_freq(uint8_t ch);
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
-    void     write(uint8_t ch, uint16_t period_us);
+    void     write(uint8_t ch, uint16_t period_us, int flags = 0);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
 

--- a/libraries/AP_HAL_VRBRAIN/RCOutput.cpp
+++ b/libraries/AP_HAL_VRBRAIN/RCOutput.cpp
@@ -182,13 +182,6 @@ void VRBRAINRCOutput::write(uint8_t ch, uint16_t period_us)
     }
 }
 
-void VRBRAINRCOutput::write(uint8_t ch, uint16_t* period_us, uint8_t len)
-{
-    for (uint8_t i=0; i<len; i++) {
-        write(i, period_us[i]);
-    }
-}
-
 uint16_t VRBRAINRCOutput::read(uint8_t ch)
 {
     if (ch >= VRBRAIN_NUM_OUTPUT_CHANNELS) {

--- a/libraries/AP_HAL_VRBRAIN/RCOutput.cpp
+++ b/libraries/AP_HAL_VRBRAIN/RCOutput.cpp
@@ -163,7 +163,7 @@ void VRBRAINRCOutput::force_safety_off(void)
     }
 }
 
-void VRBRAINRCOutput::write(uint8_t ch, uint16_t period_us)
+void VRBRAINRCOutput::write(uint8_t ch, uint16_t period_us, int)
 {
     if (ch >= _servo_count) {
         return;

--- a/libraries/AP_HAL_VRBRAIN/RCOutput.h
+++ b/libraries/AP_HAL_VRBRAIN/RCOutput.h
@@ -16,7 +16,6 @@ public:
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
     void     write(uint8_t ch, uint16_t period_us);
-    void     write(uint8_t ch, uint16_t* period_us, uint8_t len);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
     void     set_safety_pwm(uint32_t chmask, uint16_t period_us);

--- a/libraries/AP_HAL_VRBRAIN/RCOutput.h
+++ b/libraries/AP_HAL_VRBRAIN/RCOutput.h
@@ -15,7 +15,7 @@ public:
     uint16_t get_freq(uint8_t ch);
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
-    void     write(uint8_t ch, uint16_t period_us);
+    void     write(uint8_t ch, uint16_t period_us, int flags = 0);
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
     void     set_safety_pwm(uint32_t chmask, uint16_t period_us);

--- a/libraries/AP_Motors/AP_MotorsCoax.cpp
+++ b/libraries/AP_Motors/AP_MotorsCoax.cpp
@@ -86,14 +86,14 @@ void AP_MotorsCoax::set_update_rate( uint16_t speed_hz )
 
     // set update rate for the two motors
     uint32_t mask2 =
-        1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]) |
-        1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]) ;
+        1U << AP_MOTORS_MOT_3 |
+        1U << AP_MOTORS_MOT_4 ;
     hal.rcout->set_freq(mask2, _speed_hz);
 
     // set update rate for the two servos
     uint32_t mask =
-      1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]) |
-      1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]) ;
+      1U << AP_MOTORS_MOT_1 |
+      1U << AP_MOTORS_MOT_2 ;
     hal.rcout->set_freq(mask, _servo_speed);
 }
 
@@ -101,20 +101,20 @@ void AP_MotorsCoax::set_update_rate( uint16_t speed_hz )
 void AP_MotorsCoax::enable()
 {
     // enable output channels
-    hal.rcout->enable_ch(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]));
-    hal.rcout->enable_ch(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]));
-    hal.rcout->enable_ch(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]));
-    hal.rcout->enable_ch(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]));
+    hal.rcout->enable_ch(AP_MOTORS_MOT_1);
+    hal.rcout->enable_ch(AP_MOTORS_MOT_2);
+    hal.rcout->enable_ch(AP_MOTORS_MOT_3);
+    hal.rcout->enable_ch(AP_MOTORS_MOT_4);
 }
 
 // output_min - sends minimum values out to the motor and trim values to the servos
 void AP_MotorsCoax::output_min()
 {
     // send minimum value to each motor
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]), _servo1.radio_trim);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]), _servo2.radio_trim);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]), _throttle_radio_min);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]), _throttle_radio_min);
+    hal.rcout->write(AP_MOTORS_MOT_1, _servo1.radio_trim);
+    hal.rcout->write(AP_MOTORS_MOT_2, _servo2.radio_trim);
+    hal.rcout->write(AP_MOTORS_MOT_3, _throttle_radio_min);
+    hal.rcout->write(AP_MOTORS_MOT_4, _throttle_radio_min);
 }
 
 void AP_MotorsCoax::output_armed_not_stabilizing()
@@ -154,10 +154,10 @@ void AP_MotorsCoax::output_armed_not_stabilizing()
         motor_out = apply_thrust_curve_and_volt_scaling(motor_out, out_min, _throttle_radio_max);
     }
 
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]), _servo1.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]), _servo2.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]), motor_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]), motor_out);
+    hal.rcout->write(AP_MOTORS_MOT_1, _servo1.radio_out);
+    hal.rcout->write(AP_MOTORS_MOT_2, _servo2.radio_out);
+    hal.rcout->write(AP_MOTORS_MOT_3, motor_out);
+    hal.rcout->write(AP_MOTORS_MOT_4, motor_out);
 }
 
 // sends commands to the motors
@@ -212,10 +212,10 @@ void AP_MotorsCoax::output_armed_stabilizing()
     motor_out[AP_MOTORS_MOT_4] = max(motor_out[AP_MOTORS_MOT_4],    out_min);
 
     // send output to each motor
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]), _servo1.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]), _servo2.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]), motor_out[AP_MOTORS_MOT_3]);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]), motor_out[AP_MOTORS_MOT_4]);
+    hal.rcout->write(AP_MOTORS_MOT_1, _servo1.radio_out);
+    hal.rcout->write(AP_MOTORS_MOT_2, _servo2.radio_out);
+    hal.rcout->write(AP_MOTORS_MOT_3, motor_out[AP_MOTORS_MOT_3]);
+    hal.rcout->write(AP_MOTORS_MOT_4, motor_out[AP_MOTORS_MOT_4]);
 }
 
 // output_disarmed - sends commands to the motors
@@ -239,19 +239,19 @@ void AP_MotorsCoax::output_test(uint8_t motor_seq, int16_t pwm)
     switch (motor_seq) {
         case 1:
             // flap servo 1
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]), pwm);
+            hal.rcout->write(AP_MOTORS_MOT_1, pwm);
             break;
         case 2:
             // flap servo 2
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]), pwm);
+            hal.rcout->write(AP_MOTORS_MOT_2, pwm);
             break;
         case 3:
             // motor 1
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]), pwm);
+            hal.rcout->write(AP_MOTORS_MOT_3, pwm);
             break;
         case 4:
             // motor 2
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]), pwm);
+            hal.rcout->write(AP_MOTORS_MOT_4, pwm);
             break;
         default:
             // do nothing

--- a/libraries/AP_Motors/AP_MotorsCoax.cpp
+++ b/libraries/AP_Motors/AP_MotorsCoax.cpp
@@ -111,10 +111,11 @@ void AP_MotorsCoax::enable()
 void AP_MotorsCoax::output_min()
 {
     // send minimum value to each motor
-    hal.rcout->write(AP_MOTORS_MOT_1, _servo1.radio_trim);
-    hal.rcout->write(AP_MOTORS_MOT_2, _servo2.radio_trim);
-    hal.rcout->write(AP_MOTORS_MOT_3, _throttle_radio_min);
-    hal.rcout->write(AP_MOTORS_MOT_4, _throttle_radio_min);
+    hal.rcout->write(AP_MOTORS_MOT_1, _servo1.radio_trim, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_2, _servo2.radio_trim, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_3, _throttle_radio_min, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_4, _throttle_radio_min, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->flush();
 }
 
 void AP_MotorsCoax::output_armed_not_stabilizing()
@@ -154,10 +155,11 @@ void AP_MotorsCoax::output_armed_not_stabilizing()
         motor_out = apply_thrust_curve_and_volt_scaling(motor_out, out_min, _throttle_radio_max);
     }
 
-    hal.rcout->write(AP_MOTORS_MOT_1, _servo1.radio_out);
-    hal.rcout->write(AP_MOTORS_MOT_2, _servo2.radio_out);
-    hal.rcout->write(AP_MOTORS_MOT_3, motor_out);
-    hal.rcout->write(AP_MOTORS_MOT_4, motor_out);
+    hal.rcout->write(AP_MOTORS_MOT_1, _servo1.radio_out, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_2, _servo2.radio_out, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_3, motor_out, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_4, motor_out, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->flush();
 }
 
 // sends commands to the motors
@@ -212,10 +214,11 @@ void AP_MotorsCoax::output_armed_stabilizing()
     motor_out[AP_MOTORS_MOT_4] = max(motor_out[AP_MOTORS_MOT_4],    out_min);
 
     // send output to each motor
-    hal.rcout->write(AP_MOTORS_MOT_1, _servo1.radio_out);
-    hal.rcout->write(AP_MOTORS_MOT_2, _servo2.radio_out);
-    hal.rcout->write(AP_MOTORS_MOT_3, motor_out[AP_MOTORS_MOT_3]);
-    hal.rcout->write(AP_MOTORS_MOT_4, motor_out[AP_MOTORS_MOT_4]);
+    hal.rcout->write(AP_MOTORS_MOT_1, _servo1.radio_out, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_2, _servo2.radio_out, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_3, motor_out[AP_MOTORS_MOT_3], AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_4, motor_out[AP_MOTORS_MOT_4], AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->flush();
 }
 
 // output_disarmed - sends commands to the motors

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -662,10 +662,11 @@ void AP_MotorsHeli::move_swash(int16_t roll_out, int16_t pitch_out, int16_t coll
     _servo_4.calc_pwm();
 
     // actually move the servos
-    hal.rcout->write(AP_MOTORS_MOT_1, _servo_1.radio_out);
-    hal.rcout->write(AP_MOTORS_MOT_2, _servo_2.radio_out);
-    hal.rcout->write(AP_MOTORS_MOT_3, _servo_3.radio_out);
-    hal.rcout->write(AP_MOTORS_MOT_4, _servo_4.radio_out);
+    hal.rcout->write(AP_MOTORS_MOT_1, _servo_1.radio_out, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_2, _servo_2.radio_out, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_3, _servo_3.radio_out, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_4, _servo_4.radio_out, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->flush();
 
     // output gain to exernal gyro
     if (_tail_type == AP_MOTORS_HELI_TAILTYPE_SERVO_EXTGYRO) {

--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -237,8 +237,8 @@ void AP_MotorsHeli::Init()
     init_swash();
 
     // disable channels 7 and 8 from being used by RC_Channel_aux
-    RC_Channel_aux::disable_aux_channel(_motor_to_channel_map[AP_MOTORS_HELI_AUX]);
-    RC_Channel_aux::disable_aux_channel(_motor_to_channel_map[AP_MOTORS_HELI_RSC]);
+    RC_Channel_aux::disable_aux_channel(AP_MOTORS_HELI_AUX);
+    RC_Channel_aux::disable_aux_channel(AP_MOTORS_HELI_RSC);
 }
 
 // set update rate to motors - a value in hertz
@@ -249,10 +249,10 @@ void AP_MotorsHeli::set_update_rate( uint16_t speed_hz )
 
     // setup fast channels
     uint32_t mask = 
-        1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]) |
-        1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]) |
-        1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]) |
-        1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]);
+        1U << AP_MOTORS_MOT_1 |
+        1U << AP_MOTORS_MOT_2 |
+        1U << AP_MOTORS_MOT_3 |
+        1U << AP_MOTORS_MOT_4;
     hal.rcout->set_freq(mask, _speed_hz);
 }
 
@@ -260,10 +260,10 @@ void AP_MotorsHeli::set_update_rate( uint16_t speed_hz )
 void AP_MotorsHeli::enable()
 {
     // enable output channels
-    hal.rcout->enable_ch(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]));    // swash servo 1
-    hal.rcout->enable_ch(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]));    // swash servo 2
-    hal.rcout->enable_ch(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]));    // swash servo 3
-    hal.rcout->enable_ch(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]));    // yaw
+    hal.rcout->enable_ch(AP_MOTORS_MOT_1);    // swash servo 1
+    hal.rcout->enable_ch(AP_MOTORS_MOT_2);    // swash servo 2
+    hal.rcout->enable_ch(AP_MOTORS_MOT_3);    // swash servo 3
+    hal.rcout->enable_ch(AP_MOTORS_MOT_4);    // yaw
     hal.rcout->enable_ch(AP_MOTORS_HELI_AUX);                               // output for gyro gain or direct drive variable pitch tail motor
     hal.rcout->enable_ch(AP_MOTORS_HELI_RSC);                               // output for main rotor esc
 }
@@ -315,26 +315,26 @@ void AP_MotorsHeli::output_test(uint8_t motor_seq, int16_t pwm)
     switch (motor_seq) {
         case 1:
             // swash servo 1
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]), pwm);
+            hal.rcout->write(AP_MOTORS_MOT_1, pwm);
             break;
         case 2:
             // swash servo 2
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]), pwm);
+            hal.rcout->write(AP_MOTORS_MOT_2, pwm);
             break;
         case 3:
             // swash servo 3
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]), pwm);
+            hal.rcout->write(AP_MOTORS_MOT_3, pwm);
             break;
         case 4:
             // external gyro & tail servo
             if (_tail_type == AP_MOTORS_HELI_TAILTYPE_SERVO_EXTGYRO) {
                 write_aux(_ext_gyro_gain);
             }
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]), pwm);
+            hal.rcout->write(AP_MOTORS_MOT_4, pwm);
             break;
         case 5:
             // main rotor
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_HELI_RSC]), pwm);
+            hal.rcout->write(AP_MOTORS_HELI_RSC, pwm);
             break;
         default:
             // do nothing
@@ -662,10 +662,10 @@ void AP_MotorsHeli::move_swash(int16_t roll_out, int16_t pitch_out, int16_t coll
     _servo_4.calc_pwm();
 
     // actually move the servos
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]), _servo_1.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]), _servo_2.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]), _servo_3.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]), _servo_4.radio_out);
+    hal.rcout->write(AP_MOTORS_MOT_1, _servo_1.radio_out);
+    hal.rcout->write(AP_MOTORS_MOT_2, _servo_2.radio_out);
+    hal.rcout->write(AP_MOTORS_MOT_3, _servo_3.radio_out);
+    hal.rcout->write(AP_MOTORS_MOT_4, _servo_4.radio_out);
 
     // output gain to exernal gyro
     if (_tail_type == AP_MOTORS_HELI_TAILTYPE_SERVO_EXTGYRO) {

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -37,7 +37,7 @@ void AP_MotorsMatrix::Init()
 // set update rate to motors - a value in hertz
 void AP_MotorsMatrix::set_update_rate( uint16_t speed_hz )
 {
-    int8_t i;
+    uint8_t i;
 
     // record requested speed
     _speed_hz = speed_hz;
@@ -46,7 +46,7 @@ void AP_MotorsMatrix::set_update_rate( uint16_t speed_hz )
     uint32_t mask = 0;
     for( i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++ ) {
         if( motor_enabled[i] ) {
-		mask |= 1U << pgm_read_byte(&_motor_to_channel_map[i]);
+		mask |= 1U << i;
         }
     }
     hal.rcout->set_freq( mask, _speed_hz );
@@ -78,7 +78,7 @@ void AP_MotorsMatrix::enable()
     // enable output channels
     for( i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++ ) {
         if( motor_enabled[i] ) {
-            hal.rcout->enable_ch(pgm_read_byte(&_motor_to_channel_map[i]));
+            hal.rcout->enable_ch(i);
         }
     }
 }
@@ -97,7 +97,7 @@ void AP_MotorsMatrix::output_min()
     // fill the motor_out[] array for HIL use and send minimum value to each motor
     for( i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++ ) {
         if( motor_enabled[i] ) {
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[i]), _throttle_radio_min);
+            hal.rcout->write(i, _throttle_radio_min);
         }
     }
 }
@@ -117,7 +117,7 @@ uint16_t AP_MotorsMatrix::get_motor_mask()
 
 void AP_MotorsMatrix::output_armed_not_stabilizing()
 {
-    int8_t i;
+    uint8_t i;
     int16_t throttle_radio_output;                                  // total throttle pwm value, summed onto throttle channel minimum, typically ~1100-1900
     int16_t motor_out[AP_MOTORS_MAX_NUM_MOTORS];                    // final outputs sent to the motors
     int16_t out_min_pwm = _throttle_radio_min + _min_throttle;      // minimum pwm value we can send to the motors
@@ -161,7 +161,7 @@ void AP_MotorsMatrix::output_armed_not_stabilizing()
     // send output to each motor
     for( i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++ ) {
         if( motor_enabled[i] ) {
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[i]), motor_out[i]);
+            hal.rcout->write(i, motor_out[i]);
         }
     }
 }
@@ -357,7 +357,7 @@ void AP_MotorsMatrix::output_armed_stabilizing()
     // send output to each motor
     for( i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++ ) {
         if( motor_enabled[i] ) {
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[i]), motor_out[i]);
+            hal.rcout->write(i, motor_out[i]);
         }
     }
 }
@@ -383,7 +383,7 @@ void AP_MotorsMatrix::output_test(uint8_t motor_seq, int16_t pwm)
     for (uint8_t i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
         if (motor_enabled[i] && _test_order[i] == motor_seq) {
             // turn on this motor
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[i]), pwm);
+            hal.rcout->write(i, pwm);
         }
     }
 }
@@ -408,7 +408,7 @@ void AP_MotorsMatrix::add_motor_raw(int8_t motor_num, float roll_fac, float pitc
         _test_order[motor_num] = testing_order;
 
         // disable this channel from being used by RC_Channel_aux
-        RC_Channel_aux::disable_aux_channel(_motor_to_channel_map[motor_num]);
+        RC_Channel_aux::disable_aux_channel(motor_num);
     }
 }
 

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -97,9 +97,10 @@ void AP_MotorsMatrix::output_min()
     // fill the motor_out[] array for HIL use and send minimum value to each motor
     for( i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++ ) {
         if( motor_enabled[i] ) {
-            hal.rcout->write(i, _throttle_radio_min);
+            hal.rcout->write(i, _throttle_radio_min, AP_HAL::RCOutput::FLAGS_ASYNC);
         }
     }
+    hal.rcout->flush();
 }
 
 // get_motor_mask - returns a bitmask of which outputs are being used for motors (1 means being used)
@@ -161,9 +162,10 @@ void AP_MotorsMatrix::output_armed_not_stabilizing()
     // send output to each motor
     for( i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++ ) {
         if( motor_enabled[i] ) {
-            hal.rcout->write(i, motor_out[i]);
+            hal.rcout->write(i, motor_out[i], AP_HAL::RCOutput::FLAGS_ASYNC);
         }
     }
+    hal.rcout->flush();
 }
 
 // output_armed - sends commands to the motors
@@ -357,9 +359,10 @@ void AP_MotorsMatrix::output_armed_stabilizing()
     // send output to each motor
     for( i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++ ) {
         if( motor_enabled[i] ) {
-            hal.rcout->write(i, motor_out[i]);
+            hal.rcout->write(i, motor_out[i], AP_HAL::RCOutput::FLAGS_ASYNC);
         }
     }
+    hal.rcout->flush();
 }
 
 // output_disarmed - sends commands to the motors
@@ -383,9 +386,10 @@ void AP_MotorsMatrix::output_test(uint8_t motor_seq, int16_t pwm)
     for (uint8_t i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
         if (motor_enabled[i] && _test_order[i] == motor_seq) {
             // turn on this motor
-            hal.rcout->write(i, pwm);
+            hal.rcout->write(i, pwm, AP_HAL::RCOutput::FLAGS_ASYNC);
         }
     }
+    hal.rcout->flush();
 }
 
 // add_motor

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -378,9 +378,9 @@ void AP_MotorsMulticopter::throttle_pass_through(int16_t pwm)
 {
     if (armed()) {
         // send the pilot's input directly to each enabled motor
-        for (int16_t i=0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        for (uint16_t i=0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
             if (motor_enabled[i]) {
-                hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[i]), pwm);
+                hal.rcout->write(i, pwm);
             }
         }
     }

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -380,8 +380,9 @@ void AP_MotorsMulticopter::throttle_pass_through(int16_t pwm)
         // send the pilot's input directly to each enabled motor
         for (uint16_t i=0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
             if (motor_enabled[i]) {
-                hal.rcout->write(i, pwm);
+                hal.rcout->write(i, pwm, AP_HAL::RCOutput::FLAGS_ASYNC);
             }
         }
+        hal.rcout->flush();
     }
 }

--- a/libraries/AP_Motors/AP_MotorsSingle.cpp
+++ b/libraries/AP_Motors/AP_MotorsSingle.cpp
@@ -92,35 +92,35 @@ void AP_MotorsSingle::set_update_rate( uint16_t speed_hz )
 
     // set update rate for the 3 motors (but not the servo on channel 7)
     uint32_t mask = 
-	    1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]) |
-	    1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]) |
-	    1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]) |
-		1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]) ;
+        1U << AP_MOTORS_MOT_1 |
+        1U << AP_MOTORS_MOT_2 |
+        1U << AP_MOTORS_MOT_3 |
+        1U << AP_MOTORS_MOT_4 ;
     hal.rcout->set_freq(mask, _servo_speed);
-	uint32_t mask2 = 1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_7]);
-	hal.rcout->set_freq(mask2, _speed_hz);
+    uint32_t mask2 = 1U << AP_MOTORS_MOT_7;
+    hal.rcout->set_freq(mask2, _speed_hz);
 }
 
 // enable - starts allowing signals to be sent to motors
 void AP_MotorsSingle::enable()
 {
     // enable output channels
-    hal.rcout->enable_ch(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]));
-    hal.rcout->enable_ch(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]));
-    hal.rcout->enable_ch(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]));
-    hal.rcout->enable_ch(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]));
-	hal.rcout->enable_ch(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_7]));
+    hal.rcout->enable_ch(AP_MOTORS_MOT_1);
+    hal.rcout->enable_ch(AP_MOTORS_MOT_2);
+    hal.rcout->enable_ch(AP_MOTORS_MOT_3);
+    hal.rcout->enable_ch(AP_MOTORS_MOT_4);
+    hal.rcout->enable_ch(AP_MOTORS_MOT_7);
 }
 
 // output_min - sends minimum values out to the motor and trim values to the servos
 void AP_MotorsSingle::output_min()
 {
     // send minimum value to each motor
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]), _servo1.radio_trim);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]), _servo2.radio_trim);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]), _servo3.radio_trim);
-	hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]), _servo4.radio_trim);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_7]), _throttle_radio_min);
+    hal.rcout->write(AP_MOTORS_MOT_1, _servo1.radio_trim);
+    hal.rcout->write(AP_MOTORS_MOT_2, _servo2.radio_trim);
+    hal.rcout->write(AP_MOTORS_MOT_3, _servo3.radio_trim);
+    hal.rcout->write(AP_MOTORS_MOT_4, _servo4.radio_trim);
+    hal.rcout->write(AP_MOTORS_MOT_7, _throttle_radio_min);
 }
 
 // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
@@ -172,11 +172,11 @@ void AP_MotorsSingle::output_armed_not_stabilizing()
         throttle_radio_output = apply_thrust_curve_and_volt_scaling(throttle_radio_output, out_min, _throttle_radio_max);
     }
 
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]), _servo1.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]), _servo2.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]), _servo3.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]), _servo4.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_7]), throttle_radio_output);
+    hal.rcout->write(AP_MOTORS_MOT_1, _servo1.radio_out);
+    hal.rcout->write(AP_MOTORS_MOT_2, _servo2.radio_out);
+    hal.rcout->write(AP_MOTORS_MOT_3, _servo3.radio_out);
+    hal.rcout->write(AP_MOTORS_MOT_4, _servo4.radio_out);
+    hal.rcout->write(AP_MOTORS_MOT_7, throttle_radio_output);
 }
 
 // sends commands to the motors
@@ -229,11 +229,11 @@ void AP_MotorsSingle::output_armed_stabilizing()
     _servo4.calc_pwm();
 
     // send output to each motor
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]), _servo1.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]), _servo2.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]), _servo3.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]), _servo4.radio_out);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_7]), throttle_radio_output);
+    hal.rcout->write(AP_MOTORS_MOT_1, _servo1.radio_out);
+    hal.rcout->write(AP_MOTORS_MOT_2, _servo2.radio_out);
+    hal.rcout->write(AP_MOTORS_MOT_3, _servo3.radio_out);
+    hal.rcout->write(AP_MOTORS_MOT_4, _servo4.radio_out);
+    hal.rcout->write(AP_MOTORS_MOT_7, throttle_radio_output);
 }
 
 // output_disarmed - sends commands to the motors
@@ -257,23 +257,23 @@ void AP_MotorsSingle::output_test(uint8_t motor_seq, int16_t pwm)
     switch (motor_seq) {
         case 1:
             // flap servo 1
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]), pwm);
+            hal.rcout->write(AP_MOTORS_MOT_1, pwm);
             break;
         case 2:
             // flap servo 2
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]), pwm);
+            hal.rcout->write(AP_MOTORS_MOT_2, pwm);
             break;
         case 3:
             // flap servo 3
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_3]), pwm);
+            hal.rcout->write(AP_MOTORS_MOT_3, pwm);
             break;
         case 4:
             // flap servo 4
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]), pwm);
+            hal.rcout->write(AP_MOTORS_MOT_4, pwm);
             break;
         case 5:
             // spin main motor
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_7]), pwm);
+            hal.rcout->write(AP_MOTORS_MOT_7, pwm);
             break;
         default:
             // do nothing

--- a/libraries/AP_Motors/AP_MotorsSingle.cpp
+++ b/libraries/AP_Motors/AP_MotorsSingle.cpp
@@ -116,11 +116,12 @@ void AP_MotorsSingle::enable()
 void AP_MotorsSingle::output_min()
 {
     // send minimum value to each motor
-    hal.rcout->write(AP_MOTORS_MOT_1, _servo1.radio_trim);
-    hal.rcout->write(AP_MOTORS_MOT_2, _servo2.radio_trim);
-    hal.rcout->write(AP_MOTORS_MOT_3, _servo3.radio_trim);
-    hal.rcout->write(AP_MOTORS_MOT_4, _servo4.radio_trim);
-    hal.rcout->write(AP_MOTORS_MOT_7, _throttle_radio_min);
+    hal.rcout->write(AP_MOTORS_MOT_1, _servo1.radio_trim, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_2, _servo2.radio_trim, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_3, _servo3.radio_trim, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_4, _servo4.radio_trim, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_7, _throttle_radio_min, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->flush();
 }
 
 // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
@@ -172,11 +173,12 @@ void AP_MotorsSingle::output_armed_not_stabilizing()
         throttle_radio_output = apply_thrust_curve_and_volt_scaling(throttle_radio_output, out_min, _throttle_radio_max);
     }
 
-    hal.rcout->write(AP_MOTORS_MOT_1, _servo1.radio_out);
-    hal.rcout->write(AP_MOTORS_MOT_2, _servo2.radio_out);
-    hal.rcout->write(AP_MOTORS_MOT_3, _servo3.radio_out);
-    hal.rcout->write(AP_MOTORS_MOT_4, _servo4.radio_out);
-    hal.rcout->write(AP_MOTORS_MOT_7, throttle_radio_output);
+    hal.rcout->write(AP_MOTORS_MOT_1, _servo1.radio_out, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_2, _servo2.radio_out, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_3, _servo3.radio_out, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_4, _servo4.radio_out, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_7, throttle_radio_output, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->flush();
 }
 
 // sends commands to the motors
@@ -229,11 +231,12 @@ void AP_MotorsSingle::output_armed_stabilizing()
     _servo4.calc_pwm();
 
     // send output to each motor
-    hal.rcout->write(AP_MOTORS_MOT_1, _servo1.radio_out);
-    hal.rcout->write(AP_MOTORS_MOT_2, _servo2.radio_out);
-    hal.rcout->write(AP_MOTORS_MOT_3, _servo3.radio_out);
-    hal.rcout->write(AP_MOTORS_MOT_4, _servo4.radio_out);
-    hal.rcout->write(AP_MOTORS_MOT_7, throttle_radio_output);
+    hal.rcout->write(AP_MOTORS_MOT_1, _servo1.radio_out, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_2, _servo2.radio_out, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_3, _servo3.radio_out, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_4, _servo4.radio_out, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_7, throttle_radio_output, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->flush();
 }
 
 // output_disarmed - sends commands to the motors

--- a/libraries/AP_Motors/AP_MotorsTri.cpp
+++ b/libraries/AP_Motors/AP_MotorsTri.cpp
@@ -94,9 +94,9 @@ void AP_MotorsTri::set_update_rate( uint16_t speed_hz )
 
     // set update rate for the 3 motors (but not the servo on channel 7)
     uint32_t mask = 
-	    1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]) |
-	    1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]) |
-	    1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]);
+	    1U << AP_MOTORS_MOT_1 |
+	    1U << AP_MOTORS_MOT_2 |
+	    1U << AP_MOTORS_MOT_4;
     hal.rcout->set_freq(mask, _speed_hz);
 }
 
@@ -104,9 +104,9 @@ void AP_MotorsTri::set_update_rate( uint16_t speed_hz )
 void AP_MotorsTri::enable()
 {
     // enable output channels
-    hal.rcout->enable_ch(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]));
-    hal.rcout->enable_ch(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]));
-    hal.rcout->enable_ch(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]));
+    hal.rcout->enable_ch(AP_MOTORS_MOT_1);
+    hal.rcout->enable_ch(AP_MOTORS_MOT_2);
+    hal.rcout->enable_ch(AP_MOTORS_MOT_4);
     hal.rcout->enable_ch(AP_MOTORS_CH_TRI_YAW);
 }
 
@@ -117,9 +117,9 @@ void AP_MotorsTri::output_min()
     limit.throttle_lower = true;
 
     // send minimum value to each motor
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]), _throttle_radio_min);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]), _throttle_radio_min);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]), _throttle_radio_min);
+    hal.rcout->write(AP_MOTORS_MOT_1, _throttle_radio_min);
+    hal.rcout->write(AP_MOTORS_MOT_2, _throttle_radio_min);
+    hal.rcout->write(AP_MOTORS_MOT_4, _throttle_radio_min);
     hal.rcout->write(AP_MOTORS_CH_TRI_YAW, _yaw_servo_trim);
 }
 
@@ -128,9 +128,9 @@ void AP_MotorsTri::output_min()
 uint16_t AP_MotorsTri::get_motor_mask()
 {
     // tri copter uses channels 1,2,4 and 7
-    return (1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1])) |
-        (1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2])) |
-        (1U << pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4])) |
+    return (1U << AP_MOTORS_MOT_1) |
+        (1U << AP_MOTORS_MOT_2) |
+        (1U << AP_MOTORS_MOT_4) |
         (1U << AP_MOTORS_CH_TRI_YAW);
 }
 
@@ -172,9 +172,9 @@ void AP_MotorsTri::output_armed_not_stabilizing()
     }
 
     // send output to each motor
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]), motor_out[AP_MOTORS_MOT_1]);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]), motor_out[AP_MOTORS_MOT_2]);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]), motor_out[AP_MOTORS_MOT_4]);
+    hal.rcout->write(AP_MOTORS_MOT_1, motor_out[AP_MOTORS_MOT_1]);
+    hal.rcout->write(AP_MOTORS_MOT_2, motor_out[AP_MOTORS_MOT_2]);
+    hal.rcout->write(AP_MOTORS_MOT_4, motor_out[AP_MOTORS_MOT_4]);
 
     // send centering signal to yaw servo
     hal.rcout->write(AP_MOTORS_CH_TRI_YAW, _yaw_servo_trim);
@@ -285,9 +285,9 @@ void AP_MotorsTri::output_armed_stabilizing()
     }
 
     // send output to each motor
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]), motor_out[AP_MOTORS_MOT_1]);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]), motor_out[AP_MOTORS_MOT_2]);
-    hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]), motor_out[AP_MOTORS_MOT_4]);
+    hal.rcout->write(AP_MOTORS_MOT_1, motor_out[AP_MOTORS_MOT_1]);
+    hal.rcout->write(AP_MOTORS_MOT_2, motor_out[AP_MOTORS_MOT_2]);
+    hal.rcout->write(AP_MOTORS_MOT_4, motor_out[AP_MOTORS_MOT_4]);
 
     // send out to yaw command to tail servo
     hal.rcout->write(AP_MOTORS_CH_TRI_YAW, yaw_radio_output);
@@ -314,11 +314,11 @@ void AP_MotorsTri::output_test(uint8_t motor_seq, int16_t pwm)
     switch (motor_seq) {
         case 1:
             // front right motor
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_1]), pwm);
+            hal.rcout->write(AP_MOTORS_MOT_1, pwm);
             break;
         case 2:
             // back motor
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_4]), pwm);
+            hal.rcout->write(AP_MOTORS_MOT_4, pwm);
             break;
         case 3:
             // back servo
@@ -326,7 +326,7 @@ void AP_MotorsTri::output_test(uint8_t motor_seq, int16_t pwm)
             break;
         case 4:
             // front left motor
-            hal.rcout->write(pgm_read_byte(&_motor_to_channel_map[AP_MOTORS_MOT_2]), pwm);
+            hal.rcout->write(AP_MOTORS_MOT_2, pwm);
             break;
         default:
             // do nothing

--- a/libraries/AP_Motors/AP_MotorsTri.cpp
+++ b/libraries/AP_Motors/AP_MotorsTri.cpp
@@ -117,10 +117,11 @@ void AP_MotorsTri::output_min()
     limit.throttle_lower = true;
 
     // send minimum value to each motor
-    hal.rcout->write(AP_MOTORS_MOT_1, _throttle_radio_min);
-    hal.rcout->write(AP_MOTORS_MOT_2, _throttle_radio_min);
-    hal.rcout->write(AP_MOTORS_MOT_4, _throttle_radio_min);
-    hal.rcout->write(AP_MOTORS_CH_TRI_YAW, _yaw_servo_trim);
+    hal.rcout->write(AP_MOTORS_MOT_1, _throttle_radio_min, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_2, _throttle_radio_min, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_4, _throttle_radio_min, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_CH_TRI_YAW, _yaw_servo_trim, AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->flush();
 }
 
 // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
@@ -172,12 +173,14 @@ void AP_MotorsTri::output_armed_not_stabilizing()
     }
 
     // send output to each motor
-    hal.rcout->write(AP_MOTORS_MOT_1, motor_out[AP_MOTORS_MOT_1]);
-    hal.rcout->write(AP_MOTORS_MOT_2, motor_out[AP_MOTORS_MOT_2]);
-    hal.rcout->write(AP_MOTORS_MOT_4, motor_out[AP_MOTORS_MOT_4]);
+    hal.rcout->write(AP_MOTORS_MOT_1, motor_out[AP_MOTORS_MOT_1], AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_2, motor_out[AP_MOTORS_MOT_2], AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_4, motor_out[AP_MOTORS_MOT_4], AP_HAL::RCOutput::FLAGS_ASYNC);
 
     // send centering signal to yaw servo
-    hal.rcout->write(AP_MOTORS_CH_TRI_YAW, _yaw_servo_trim);
+    hal.rcout->write(AP_MOTORS_CH_TRI_YAW, _yaw_servo_trim, AP_HAL::RCOutput::FLAGS_ASYNC);
+
+    hal.rcout->flush();
 }
 
 // sends commands to the motors
@@ -285,12 +288,14 @@ void AP_MotorsTri::output_armed_stabilizing()
     }
 
     // send output to each motor
-    hal.rcout->write(AP_MOTORS_MOT_1, motor_out[AP_MOTORS_MOT_1]);
-    hal.rcout->write(AP_MOTORS_MOT_2, motor_out[AP_MOTORS_MOT_2]);
-    hal.rcout->write(AP_MOTORS_MOT_4, motor_out[AP_MOTORS_MOT_4]);
+    hal.rcout->write(AP_MOTORS_MOT_1, motor_out[AP_MOTORS_MOT_1], AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_2, motor_out[AP_MOTORS_MOT_2], AP_HAL::RCOutput::FLAGS_ASYNC);
+    hal.rcout->write(AP_MOTORS_MOT_4, motor_out[AP_MOTORS_MOT_4], AP_HAL::RCOutput::FLAGS_ASYNC);
 
     // send out to yaw command to tail servo
-    hal.rcout->write(AP_MOTORS_CH_TRI_YAW, yaw_radio_output);
+    hal.rcout->write(AP_MOTORS_CH_TRI_YAW, yaw_radio_output, AP_HAL::RCOutput::FLAGS_ASYNC);
+
+    hal.rcout->flush();
 }
 
 // output_disarmed - sends commands to the motors

--- a/libraries/AP_Motors/AP_Motors_Class.cpp
+++ b/libraries/AP_Motors/AP_Motors_Class.cpp
@@ -24,9 +24,6 @@
 #include <AP_HAL/AP_HAL.h>
 extern const AP_HAL::HAL& hal;
 
-// initialise motor map
-    const uint8_t AP_Motors::_motor_to_channel_map[AP_MOTORS_MAX_NUM_MOTORS] PROGMEM = {MOTOR_TO_CHANNEL_MAP};
-
 // Constructor
 AP_Motors::AP_Motors(uint16_t loop_rate, uint16_t speed_hz) :
     _roll_control_input(0.0f),

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -10,17 +10,15 @@
 #include <RC_Channel/RC_Channel.h>     // RC Channel Library
 #include <Filter/Filter.h>         // filter library
 
-// offsets for motors in motor_out, _motor_filtered and _motor_to_channel_map arrays
-#define AP_MOTORS_MOT_1 0
-#define AP_MOTORS_MOT_2 1
-#define AP_MOTORS_MOT_3 2
-#define AP_MOTORS_MOT_4 3
-#define AP_MOTORS_MOT_5 4
-#define AP_MOTORS_MOT_6 5
-#define AP_MOTORS_MOT_7 6
-#define AP_MOTORS_MOT_8 7
-
-#define MOTOR_TO_CHANNEL_MAP CH_1,CH_2,CH_3,CH_4,CH_5,CH_6,CH_7,CH_8
+// offsets for motors in motor_out and _motor_filtered arrays
+#define AP_MOTORS_MOT_1 0U
+#define AP_MOTORS_MOT_2 1U
+#define AP_MOTORS_MOT_3 2U
+#define AP_MOTORS_MOT_4 3U
+#define AP_MOTORS_MOT_5 4U
+#define AP_MOTORS_MOT_6 5U
+#define AP_MOTORS_MOT_7 6U
+#define AP_MOTORS_MOT_8 7U
 
 #define AP_MOTORS_MAX_NUM_MOTORS 8
 
@@ -143,9 +141,6 @@ protected:
         uint8_t frame_orientation  : 4;    // PLUS_FRAME 0, X_FRAME 1, V_FRAME 2, H_FRAME 3, NEW_PLUS_FRAME 10, NEW_X_FRAME, NEW_V_FRAME, NEW_H_FRAME
         uint8_t interlock          : 1;    // 1 if the motor interlock is enabled (i.e. motors run), 0 if disabled (motors don't run)
     } _flags;
-
-    // mapping of motor number (as received from upper APM code) to RC channel output - used to account for differences between APM1 and APM2
-    static const uint8_t _motor_to_channel_map[AP_MOTORS_MAX_NUM_MOTORS] PROGMEM;
 
     // internal variables
     float               _roll_control_input;        // desired roll control from attitude controllers, +/- 4500

--- a/libraries/RC_Channel/RC_Channel_aux.cpp
+++ b/libraries/RC_Channel/RC_Channel_aux.cpp
@@ -24,7 +24,7 @@ uint32_t RC_Channel_aux::_function_mask;
 
 /// map a function to a servo channel and output it
 void
-RC_Channel_aux::output_ch(void)
+RC_Channel_aux::output_ch(bool async)
 {
     // take care of two corner cases
     switch(function)
@@ -35,7 +35,10 @@ RC_Channel_aux::output_ch(void)
         radio_out = radio_in;
         break;
     }
-    hal.rcout->write(_ch_out, radio_out);
+    int flags = 0;
+    if (async)
+        flags |= AP_HAL::RCOutput::FLAGS_ASYNC;
+    hal.rcout->write(_ch_out, radio_out, flags);
 }
 
 /*
@@ -46,9 +49,10 @@ RC_Channel_aux::output_ch_all(void)
 {
     for (uint8_t i = 0; i < RC_AUX_MAX_CHANNELS; i++) {
         if (_aux_channels[i]) {
-            _aux_channels[i]->output_ch();
+            _aux_channels[i]->output_ch(true);
         }
-    }    
+    }
+    hal.rcout->flush();
 }
 
 /*

--- a/libraries/RC_Channel/RC_Channel_aux.h
+++ b/libraries/RC_Channel/RC_Channel_aux.h
@@ -74,8 +74,9 @@ public:
 
     AP_Int8         function;           ///< see Aux_servo_function_t enum
 
-    // output one auxillary channel
-    void            output_ch(void);
+    // output one auxillary channel - if async is set the caller must call
+    // flush() later
+    void            output_ch(bool async = false);
 
     // output all auxillary channels
     static void     output_ch_all(void);


### PR DESCRIPTION
This is the second version of #2737

diff from previous version:
 - add commits to remove _motor_to_channel_map
 - as suggested by @tridge, do not add a write() method passing a vector, but rather allow write() calls to be grouped
 - minimize the size of I2C transaction to PCA9685 by keeping track of maximum and minimum channels.

Now we have a `flags` parameter to `write()` to notify when the writes should be grouped. In this case it's sent to the hardware only when a `flush()` arrives or when there's another call to write() without the flag.

Default behavior is the synchronous write to keep the current behavior for other boards except navio. Maybe Bebop could also benefit from the flag, but this is not done.