### PR TITLE
Plane: Landing abort using rc input throttle >95%

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -494,15 +494,12 @@ void Plane::handle_auto_mode(void)
         nav_cmd_id = auto_rtl_command.id;
     }
 
-    switch(nav_cmd_id) {
-    case MAV_CMD_NAV_TAKEOFF:
+    if (nav_cmd_id == MAV_CMD_NAV_TAKEOFF ||
+        (nav_cmd_id == MAV_CMD_NAV_LAND && flight_stage == AP_SpdHgtControl::FLIGHT_LAND_ABORT)) {
         takeoff_calc_roll();
         takeoff_calc_pitch();
         calc_throttle();
-
-        break;
-
-    case MAV_CMD_NAV_LAND:
+    } else if (nav_cmd_id == MAV_CMD_NAV_LAND) {
         calc_nav_roll();
         calc_nav_pitch();
         
@@ -518,9 +515,7 @@ void Plane::handle_auto_mode(void)
             // zero throttle
             channel_throttle->servo_out = 0;
         }
-        break;
-        
-    default:
+    } else {
         // we are doing normal AUTO flight, the special cases
         // are for takeoff and landing
         steer_state.hold_course_cd = -1;
@@ -528,7 +523,6 @@ void Plane::handle_auto_mode(void)
         calc_nav_roll();
         calc_nav_pitch();
         calc_throttle();
-        break;
     }
 }
 
@@ -774,10 +768,12 @@ void Plane::update_navigation()
  */
 void Plane::set_flight_stage(AP_SpdHgtControl::FlightStage fs) 
 {
-    //if just now entering land flight stage
-    if (fs == AP_SpdHgtControl::FLIGHT_LAND_APPROACH &&
-        flight_stage != AP_SpdHgtControl::FLIGHT_LAND_APPROACH) {
+    if (fs == flight_stage) {
+        return;
+    }
 
+    switch (fs) {
+    case AP_SpdHgtControl::FLIGHT_LAND_APPROACH:
 #if GEOFENCE_ENABLED == ENABLED 
         if (g.fence_autoenable == 1) {
             if (! geofence_set_enabled(false, AUTO_TOGGLED)) {
@@ -793,8 +789,19 @@ void Plane::set_flight_stage(AP_SpdHgtControl::FlightStage fs)
             }
         }
 #endif
+        break;
+
+    case AP_SpdHgtControl::FLIGHT_LAND_ABORT:
+        gcs_send_text_fmt(PSTR("Landing aborted via throttle, climbing to %dm"), auto_state.takeoff_altitude_rel_cm/100);
+        break;
+
+    case AP_SpdHgtControl::FLIGHT_LAND_FINAL:
+    case AP_SpdHgtControl::FLIGHT_NORMAL:
+    case AP_SpdHgtControl::FLIGHT_TAKEOFF:
+        break;
     }
     
+
     flight_stage = fs;
 }
 
@@ -834,11 +841,18 @@ void Plane::update_flight_stage(void)
         if (control_mode==AUTO) {
             if (auto_state.takeoff_complete == false) {
                 set_flight_stage(AP_SpdHgtControl::FLIGHT_TAKEOFF);
-            } else if (mission.get_current_nav_cmd().id == MAV_CMD_NAV_LAND && 
-                       auto_state.land_complete == true) {
-                set_flight_stage(AP_SpdHgtControl::FLIGHT_LAND_FINAL);
             } else if (mission.get_current_nav_cmd().id == MAV_CMD_NAV_LAND) {
-                set_flight_stage(AP_SpdHgtControl::FLIGHT_LAND_APPROACH); 
+
+                if ((g.land_abort_throttle_enable && channel_throttle->control_in > 95) ||
+                        flight_stage == AP_SpdHgtControl::FLIGHT_LAND_ABORT){
+                    // abort mode is sticky, it must complete while executing NAV_LAND
+                    set_flight_stage(AP_SpdHgtControl::FLIGHT_LAND_ABORT);
+                } else if (auto_state.land_complete == true) {
+                    set_flight_stage(AP_SpdHgtControl::FLIGHT_LAND_FINAL);
+                } else {
+                    set_flight_stage(AP_SpdHgtControl::FLIGHT_LAND_APPROACH);
+                }
+
             } else {
                 set_flight_stage(AP_SpdHgtControl::FLIGHT_NORMAL);
             }

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -260,6 +260,14 @@ const AP_Param::Info Plane::var_info[] PROGMEM = {
     // @User: Advanced
     GSCALAR(land_disarm_delay,       "LAND_DISARMDELAY",  20),
 
+    // @Param: LAND_ABORT_THR
+    // @DisplayName: Landing abort using throttle
+    // @Description: Allow a landing abort to trigger with a throttle > 95%
+    // @Units: boolean
+    // @Range: 0 1
+    // @User: Advanced
+    GSCALAR(land_abort_throttle_enable,       "LAND_ABORT_THR",  0),
+
 	// @Param: NAV_CONTROLLER
 	// @DisplayName: Navigation controller selection
 	// @Description: Which navigation controller to enable. Currently the only navigation controller available is L1. From time to time other experimental controllers will be added which are selected using this parameter.

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -140,6 +140,7 @@ public:
         k_param_gcs3,            // 93
         k_param_gcs_pid_mask,
         k_param_crash_detection_enable,
+        k_param_land_abort_throttle_enable,
 
         // 97: RSSI
         k_param_rssi = 97,
@@ -449,6 +450,7 @@ public:
     AP_Int32 RTL_altitude_cm;
     AP_Float land_flare_alt;
     AP_Int8 land_disarm_delay;
+    AP_Int8 land_abort_throttle_enable;
     AP_Int32 min_gndspeed_cm;
     AP_Int16 pitch_trim_cd;
     AP_Int16 FBWB_min_altitude_cm;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -947,7 +947,7 @@ private:
     bool verify_command_callback(const AP_Mission::Mission_Command& cmd);
     void print_flight_mode(AP_HAL::BetterStream *port, uint8_t mode);
     void run_cli(AP_HAL::UARTDriver *port);
-    void restart_landing_sequence();
+    bool restart_landing_sequence();
     void log_init();
     uint32_t millis() const;
     uint32_t micros() const;

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -329,6 +329,7 @@ void Plane::do_takeoff(const AP_Mission::Mission_Command& cmd)
 
     // zero locked course
     steer_state.locked_course_err = 0;
+    steer_state.hold_course_cd = -1;
 }
 
 void Plane::do_nav_wp(const AP_Mission::Mission_Command& cmd)

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -329,7 +329,6 @@ void Plane::do_takeoff(const AP_Mission::Mission_Command& cmd)
 
     // zero locked course
     steer_state.locked_course_err = 0;
-    
 }
 
 void Plane::do_nav_wp(const AP_Mission::Mission_Command& cmd)
@@ -341,6 +340,19 @@ void Plane::do_land(const AP_Mission::Mission_Command& cmd)
 {
     auto_state.commanded_go_around = false;
     set_next_WP(cmd.content.location);
+
+    // configure abort altitude and pitch
+    // if NAV_LAND has an abort altitude then use it, else use last takeoff, else use 50m
+    if (cmd.p1 > 0) {
+        auto_state.takeoff_altitude_rel_cm = (int16_t)cmd.p1 * 100;
+    } else if (auto_state.takeoff_altitude_rel_cm <= 0) {
+        auto_state.takeoff_altitude_rel_cm = 3000;
+    }
+
+    if (auto_state.takeoff_pitch_cd <= 0) {
+        // If no takeoff command has ever been used, default to a conservative 10deg
+        auto_state.takeoff_pitch_cd = 1000;
+    }
 }
 
 void Plane::loiter_set_direction_wp(const AP_Mission::Mission_Command& cmd)

--- a/ArduPlane/is_flying.cpp
+++ b/ArduPlane/is_flying.cpp
@@ -57,6 +57,7 @@ void Plane::update_is_flying_5Hz(void)
                 }
                 break;
 
+            case AP_SpdHgtControl::FLIGHT_LAND_ABORT:
             case AP_SpdHgtControl::FLIGHT_NORMAL:
                 // TODO: detect ground impacts
                 break;
@@ -162,6 +163,7 @@ void Plane::crash_detection_update(void)
             }
             break;
 
+        case AP_SpdHgtControl::FLIGHT_LAND_ABORT:
         case AP_SpdHgtControl::FLIGHT_NORMAL:
             if (been_auto_flying) {
                 crashed = true;

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -528,6 +528,7 @@ bool AP_Mission::mavlink_to_mission_cmd(const mavlink_mission_item_t& packet, AP
 
     case MAV_CMD_NAV_LAND:                              // MAV ID: 21
         copy_location = true;
+        cmd.p1 = packet.param1;                         // abort target altitude(m)  (plane only)
         break;
 
     case MAV_CMD_NAV_TAKEOFF:                           // MAV ID: 22
@@ -859,6 +860,7 @@ bool AP_Mission::mission_cmd_to_mavlink(const AP_Mission::Mission_Command& cmd, 
 
     case MAV_CMD_NAV_LAND:                              // MAV ID: 21
         copy_location = true;
+        packet.param1 = cmd.p1;                        // abort target altitude(m)  (plane only)
         break;
 
     case MAV_CMD_NAV_TAKEOFF:                           // MAV ID: 22

--- a/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
+++ b/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
@@ -32,7 +32,8 @@ public:
 		FLIGHT_NORMAL        = 1,
 		FLIGHT_TAKEOFF       = 2,
 		FLIGHT_LAND_APPROACH = 3,
-		FLIGHT_LAND_FINAL    = 4
+        FLIGHT_LAND_FINAL    = 4,
+        FLIGHT_LAND_ABORT    = 5
 	};
 
 	// Update of the pitch and throttle demands


### PR DESCRIPTION
- Abort auto-landing when RC throttle input > 95%. 
- Uses new param LAND_ABORT_THR default is 0 (disabled)

I'm not happy with the name of this param, I'm more than happy to change it if someone has a better suggestion.

To work properly this depends on https://github.com/diydrones/ardupilot/pull/2269 but it is otherwise inert without it.