### PR TITLE
Plane: plane specific arming moved into Plane vehicle code

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -999,8 +999,8 @@ const AP_Param::Info Plane::var_info[] PROGMEM = {
 #endif
 
     // @Group: ARMING_
-    // @Path: ../libraries/AP_Arming/AP_Arming.cpp
-    GOBJECT(arming,                 "ARMING_", AP_Arming),
+    // @Path: arming_checks.cpp
+    GOBJECT(arming,                 "ARMING_", AP_Arming_Plane),
 
     // @Group: RELAY_
     // @Path: ../libraries/AP_Relay/AP_Relay.cpp

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -114,8 +114,13 @@ class AP_Arming_Plane : public AP_Arming
 public:
     AP_Arming_Plane(const AP_AHRS &ahrs_ref, const AP_Baro &baro, Compass &compass,
                     const enum HomeState &home_set, gcs_send_t_p gcs_send) :
-        AP_Arming(ahrs_ref, baro, compass, home_set, gcs_send) {}
+        AP_Arming(ahrs_ref, baro, compass, home_set, gcs_send) {
+            AP_Param::setup_object_defaults(this, var_info);
+    }
     bool pre_arm_checks(bool report);
+
+    // var_info for holding Parameter information
+    static const struct AP_Param::GroupInfo var_info[];
 };
 
 /*

--- a/ArduPlane/arming_checks.cpp
+++ b/ArduPlane/arming_checks.cpp
@@ -4,6 +4,21 @@
  */
 #include "Plane.h"
 
+const AP_Param::GroupInfo AP_Arming_Plane::var_info[] PROGMEM = {
+    // variables from parent vehicle
+    AP_NESTEDGROUPINFO(AP_Arming, 0),
+
+    // @Param: RUDDER
+    // @DisplayName: Rudder Arming
+    // @Description: Control arm/disarm by rudder input. When enabled arming is done with right rudder, disarming with left rudder. Rudder arming only works in manual throttle modes with throttle at zero
+    // @Values: 0:Disabled,1:ArmingOnly,2:ArmOrDisarm
+    // @User: Advanced
+    AP_GROUPINFO("RUDDER",       3,     AP_Arming_Plane,  rudder_arming_value,     ARMING_RUDDER_ARMONLY),
+
+    AP_GROUPEND
+};
+
+
 /*
   additional arming checks for plane
  */
@@ -11,6 +26,9 @@ bool AP_Arming_Plane::pre_arm_checks(bool report)
 {
     // call parent class checks
     bool ret = AP_Arming::pre_arm_checks(report);
+
+    // Check airspeed sensor
+    ret &= AP_Arming::airspeed_checks(report);
 
     if (plane.g.roll_limit_cd < 300) {
         if (report) {

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -34,13 +34,6 @@ const AP_Param::GroupInfo AP_Arming::var_info[] PROGMEM = {
     // @User: Advanced
     AP_GROUPINFO("CHECK",        2,     AP_Arming,  checks_to_perform,       ARMING_CHECK_ALL),
 
-    // @Param: RUDDER
-    // @DisplayName: Rudder Arming
-    // @Description: Control arm/disarm by rudder input. When enabled arming is done with right rudder, disarming with left rudder. Rudder arming only works in manual throttle modes with throttle at zero
-    // @Values: 0:Disabled,1:ArmingOnly,2:ArmOrDisarm
-    // @User: Advanced
-    AP_GROUPINFO("RUDDER",       3,     AP_Arming,  rudder_arming_value,     ARMING_RUDDER_ARMONLY),
-    
     AP_GROUPEND
 };
 
@@ -354,7 +347,6 @@ bool AP_Arming::pre_arm_checks(bool report)
     ret &= compass_checks(report);
     ret &= gps_checks(report);
     ret &= battery_checks(report);
-    ret &= airspeed_checks(report);
     ret &= logging_checks(report);
     ret &= manual_transmitter_checks(report);
 


### PR DESCRIPTION
Needed to move the plane centric arming code out of the AP_Arming library and into the plane vehicle code.