### PR TITLE
Copter: mission_set_current can t restart a mission

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1223,6 +1223,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
         case MAV_CMD_MISSION_START:
             if (copter.motors.armed() && copter.set_mode(AUTO)) {
                 copter.set_auto_armed(true);
+                copter.mission.start_or_resume();
                 result = MAV_RESULT_ACCEPTED;
             }
             break;


### PR DESCRIPTION
bug fix for issue: Copter: mission_set_current can t restart a mission #2584
https://github.com/diydrones/ardupilot/issues/2584
I verified the proposed correction in SITL.
Tools/scripts/build_all.sh is happy, no error reported.