### PR TITLE
MS5611: better error handling

### DIFF
--- a/libraries/AP_Baro/AP_Baro_MS5611.cpp
+++ b/libraries/AP_Baro/AP_Baro_MS5611.cpp
@@ -76,10 +76,11 @@ uint32_t AP_SerialBus_SPI::read_24bits(uint8_t reg)
     return (((uint32_t)rx[1])<<16) | (((uint32_t)rx[2])<<8) | ((uint32_t)rx[3]);
 }
 
-void AP_SerialBus_SPI::write(uint8_t reg)
+bool AP_SerialBus_SPI::write(uint8_t reg)
 {
     uint8_t tx[1] = { reg };
     _spi->transaction(tx, NULL, 1);
+    return true;
 }
 
 bool AP_SerialBus_SPI::sem_take_blocking() 
@@ -132,9 +133,9 @@ uint32_t AP_SerialBus_I2C::read_24bits(uint8_t reg)
     return 0;
 }
 
-void AP_SerialBus_I2C::write(uint8_t reg)
+bool AP_SerialBus_I2C::write(uint8_t reg)
 {
-    _i2c->write(_addr, 1, &reg);
+    return _i2c->write(_addr, 1, &reg) == 0;
 }
 
 bool AP_SerialBus_I2C::sem_take_blocking() 

--- a/libraries/AP_Baro/AP_Baro_MS5611.cpp
+++ b/libraries/AP_Baro/AP_Baro_MS5611.cpp
@@ -282,9 +282,11 @@ void AP_Baro_MS56XX::_timer(void)
                 _s_D2 >>= 1;
                 _d2_count = 16;
             }
+
+            if (_serial->write(CMD_CONVERT_D1_OSR4096)) {      // Command to read pressure
+                _state++;
+            }
         }
-        _state++;
-        _serial->write(CMD_CONVERT_D1_OSR4096);      // Command to read pressure
     } else {
         uint32_t d1 = _serial->read_24bits(0);;
         if (d1 != 0) {
@@ -301,13 +303,16 @@ void AP_Baro_MS56XX::_timer(void)
             }
             // Now a new reading exists
             _updated = true;
-        }
-        _state++;
-        if (_state == 5) {
-            _serial->write(CMD_CONVERT_D2_OSR4096); // Command to read temperature
-            _state = 0;
-        } else {
-            _serial->write(CMD_CONVERT_D1_OSR4096); // Command to read pressure
+
+            if (_state == 4) {
+                if (_serial->write(CMD_CONVERT_D2_OSR4096)) { // Command to read temperature
+                    _state = 0;
+                }
+            } else {
+                if (_serial->write(CMD_CONVERT_D1_OSR4096)) { // Command to read pressure
+                    _state++;
+                }
+            }
         }
     }
 

--- a/libraries/AP_Baro/AP_Baro_MS5611.h
+++ b/libraries/AP_Baro/AP_Baro_MS5611.h
@@ -20,7 +20,7 @@ public:
     virtual uint32_t read_24bits(uint8_t reg) = 0;
 
     /** Write to a register with no data. */
-    virtual void write(uint8_t reg) = 0;
+    virtual bool write(uint8_t reg) = 0;
 
     /** Acquire the internal semaphore for this device.
      * take_nonblocking should be used from the timer process,
@@ -41,7 +41,7 @@ public:
     uint16_t read_16bits(uint8_t reg);
     uint32_t read_24bits(uint8_t reg);
     uint32_t read_adc(uint8_t reg);
-    void write(uint8_t reg);
+    bool write(uint8_t reg);
     bool sem_take_nonblocking();
     bool sem_take_blocking();
     void sem_give();
@@ -61,7 +61,7 @@ public:
     void init();
     uint16_t read_16bits(uint8_t reg);
     uint32_t read_24bits(uint8_t reg);
-    void write(uint8_t reg);
+    bool write(uint8_t reg);
     bool sem_take_nonblocking();
     bool sem_take_blocking();
     void sem_give();

--- a/libraries/AP_HAL/SPIDriver.h
+++ b/libraries/AP_HAL/SPIDriver.h
@@ -20,7 +20,7 @@ class AP_HAL::SPIDeviceDriver {
 public:
     virtual void init() = 0;
     virtual AP_HAL::Semaphore* get_semaphore() = 0;
-    virtual void transaction(const uint8_t *tx, uint8_t *rx, uint16_t len) = 0;
+    virtual bool transaction(const uint8_t *tx, uint8_t *rx, uint16_t len) = 0;
 
     virtual void cs_assert() = 0;
     virtual void cs_release() = 0;

--- a/libraries/AP_HAL_AVR/SPIDevice_SPI0.cpp
+++ b/libraries/AP_HAL_AVR/SPIDevice_SPI0.cpp
@@ -109,7 +109,7 @@ void AVRSPI0DeviceDriver::transfer(const uint8_t *tx, uint16_t len) {
     }
 }
 
-void AVRSPI0DeviceDriver::transaction(const uint8_t *tx, uint8_t *rx,
+bool AVRSPI0DeviceDriver::transaction(const uint8_t *tx, uint8_t *rx,
         uint16_t len) {
     _cs_assert();
     if (rx == NULL) {
@@ -128,6 +128,7 @@ void AVRSPI0DeviceDriver::transaction(const uint8_t *tx, uint8_t *rx,
         }
     }
     _cs_release();
+    return true;
 }
 
 void AVRSPI0DeviceDriver::cs_assert() {

--- a/libraries/AP_HAL_AVR/SPIDevice_SPI2.cpp
+++ b/libraries/AP_HAL_AVR/SPIDevice_SPI2.cpp
@@ -97,7 +97,7 @@ void AVRSPI2DeviceDriver::_transfer17(const uint8_t *tx, uint8_t *rx)
     TRANSFER1(16);
 }
 
-void AVRSPI2DeviceDriver::transaction(const uint8_t *tx, uint8_t *rx,
+bool AVRSPI2DeviceDriver::transaction(const uint8_t *tx, uint8_t *rx,
         uint16_t len) {
     _cs_assert();
     if (rx == NULL) {
@@ -116,6 +116,7 @@ void AVRSPI2DeviceDriver::transaction(const uint8_t *tx, uint8_t *rx,
         }
     }
     _cs_release();
+    return true;
 }
 
 void AVRSPI2DeviceDriver::cs_assert() {

--- a/libraries/AP_HAL_AVR/SPIDevice_SPI3.cpp
+++ b/libraries/AP_HAL_AVR/SPIDevice_SPI3.cpp
@@ -91,7 +91,7 @@ void AVRSPI3DeviceDriver::_transfer(const uint8_t *data, uint16_t len) {
     }
 }
 
-void AVRSPI3DeviceDriver::transaction(const uint8_t *tx, uint8_t *rx,
+bool AVRSPI3DeviceDriver::transaction(const uint8_t *tx, uint8_t *rx,
         uint16_t len) {
     _cs_assert();
     if (rx == NULL) {
@@ -102,6 +102,7 @@ void AVRSPI3DeviceDriver::transaction(const uint8_t *tx, uint8_t *rx,
         }
     }
     _cs_release();
+    return true;
 }
 
 void AVRSPI3DeviceDriver::cs_assert() {

--- a/libraries/AP_HAL_AVR/SPIDevices.h
+++ b/libraries/AP_HAL_AVR/SPIDevices.h
@@ -23,7 +23,7 @@ public:
     void init();
     AP_HAL::Semaphore* get_semaphore();
 
-    void transaction(const uint8_t *tx, uint8_t *rx, uint16_t len);
+    bool transaction(const uint8_t *tx, uint8_t *rx, uint16_t len);
 
     void cs_assert();
     void cs_release();
@@ -64,7 +64,7 @@ public:
     void init();
     AP_HAL::Semaphore* get_semaphore();
 
-    void transaction(const uint8_t *tx, uint8_t *rx, uint16_t len);
+    bool transaction(const uint8_t *tx, uint8_t *rx, uint16_t len);
 
     void cs_assert();
     void cs_release();
@@ -100,7 +100,7 @@ public:
     void init();
     AP_HAL::Semaphore* get_semaphore();
 
-    void transaction(const uint8_t *tx, uint8_t *rx, uint16_t len);
+    bool transaction(const uint8_t *tx, uint8_t *rx, uint16_t len);
 
     void cs_assert();
     void cs_release();

--- a/libraries/AP_HAL_Empty/SPIDriver.cpp
+++ b/libraries/AP_HAL_Empty/SPIDriver.cpp
@@ -14,8 +14,10 @@ AP_HAL::Semaphore* EmptySPIDeviceDriver::get_semaphore()
     return &_semaphore;
 }
 
-void EmptySPIDeviceDriver::transaction(const uint8_t *tx, uint8_t *rx, uint16_t len)
-{}
+bool EmptySPIDeviceDriver::transaction(const uint8_t *tx, uint8_t *rx, uint16_t len)
+{
+    return true;
+}
 
 
 void EmptySPIDeviceDriver::cs_assert()

--- a/libraries/AP_HAL_Empty/SPIDriver.h
+++ b/libraries/AP_HAL_Empty/SPIDriver.h
@@ -10,7 +10,7 @@ public:
     EmptySPIDeviceDriver();
     void init();
     AP_HAL::Semaphore* get_semaphore();
-    void transaction(const uint8_t *tx, uint8_t *rx, uint16_t len);
+    bool transaction(const uint8_t *tx, uint8_t *rx, uint16_t len);
 
     void cs_assert();
     void cs_release();

--- a/libraries/AP_HAL_FLYMAPLE/SPIDriver.cpp
+++ b/libraries/AP_HAL_FLYMAPLE/SPIDriver.cpp
@@ -48,7 +48,7 @@ AP_HAL::Semaphore* FLYMAPLESPIDeviceDriver::get_semaphore()
     return &_semaphore;
 }
 
-void FLYMAPLESPIDeviceDriver::transaction(const uint8_t *tx, uint8_t *rx, uint16_t len)
+bool FLYMAPLESPIDeviceDriver::transaction(const uint8_t *tx, uint8_t *rx, uint16_t len)
 {
     cs_assert();
     if (rx == NULL) {
@@ -61,6 +61,7 @@ void FLYMAPLESPIDeviceDriver::transaction(const uint8_t *tx, uint8_t *rx, uint16
         }
     }
     cs_release();
+    return true;
 }
 
 

--- a/libraries/AP_HAL_FLYMAPLE/SPIDriver.h
+++ b/libraries/AP_HAL_FLYMAPLE/SPIDriver.h
@@ -29,7 +29,7 @@ public:
     FLYMAPLESPIDeviceDriver();
     void init();
     AP_HAL::Semaphore* get_semaphore();
-    void transaction(const uint8_t *tx, uint8_t *rx, uint16_t len);
+    bool transaction(const uint8_t *tx, uint8_t *rx, uint16_t len);
 
     void cs_assert();
     void cs_release();

--- a/libraries/AP_HAL_Linux/SPIDriver.h
+++ b/libraries/AP_HAL_Linux/SPIDriver.h
@@ -21,7 +21,7 @@ public:
     LinuxSPIDeviceDriver(uint16_t bus, uint16_t subdev, enum AP_HAL::SPIDevice type, uint8_t mode, uint8_t bitsPerWord, int16_t cs_pin, uint32_t lowspeed, uint32_t highspeed);
     void init();
     AP_HAL::Semaphore *get_semaphore();
-    void transaction(const uint8_t *tx, uint8_t *rx, uint16_t len);
+    bool transaction(const uint8_t *tx, uint8_t *rx, uint16_t len);
 
     void cs_assert();
     void cs_release();
@@ -55,7 +55,7 @@ public:
 
     static void cs_assert(enum AP_HAL::SPIDevice type);
     static void cs_release(enum AP_HAL::SPIDevice type);
-    static void transaction(LinuxSPIDeviceDriver &driver, const uint8_t *tx, uint8_t *rx, uint16_t len);
+    static bool transaction(LinuxSPIDeviceDriver &driver, const uint8_t *tx, uint8_t *rx, uint16_t len);
 
 private:
     static LinuxSPIDeviceDriver _device[];


### PR DESCRIPTION
The fix is on the last commit in which we only change state if the I2C/SPI transaction didn't give an error. In order to do that we need to change the signature of the method in the SPI backend (and adapt the subclasses) in order to return if the transaction was successful.