### PR TITLE
Plane: fix throttle when restarting mission in-flight with takeoff

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -573,12 +573,13 @@ bool Plane::suppress_throttle(void)
     if (control_mode==AUTO && 
         auto_state.takeoff_complete == false) {
 
+        uint32_t launch_duration_ms = ((int32_t)g.takeoff_throttle_delay)*100 + 2000;
         if (is_flying() &&
-            millis() - started_flying_ms > 5000 && // been flying >5s in any mode
+            millis() - started_flying_ms > max(launch_duration_ms,5000) && // been flying >5s in any mode
             adjusted_relative_altitude_cm() > 500) { // are >5m above AGL/home
             // we're already flying, do not suppress the throttle. We can get
             // stuck in this condition if we reset a mission and cmd 1 is takeoff
-            // but we're still flying around
+            // but we're currently flying around below the takeoff altitude
             throttle_suppressed = false;
             return false;
         }

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -574,7 +574,7 @@ bool Plane::suppress_throttle(void)
         auto_state.takeoff_complete == false) {
 
         if (is_flying() &&
-            millis() - auto_state.started_flying_in_auto_ms > 5000 && // been flying >5s
+            millis() - started_flying_ms > 5000 && // been flying >5s in any mode
             adjusted_relative_altitude_cm() > 500) { // are >5m above AGL/home
             // we're already flying, do not suppress the throttle. We can get
             // stuck in this condition if we reset a mission and cmd 1 is takeoff

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -572,6 +572,16 @@ bool Plane::suppress_throttle(void)
 
     if (control_mode==AUTO && 
         auto_state.takeoff_complete == false) {
+
+        if (is_flying() &&
+            millis() - auto_state.started_flying_in_auto_ms > 5000 && // been flying >5s
+            adjusted_relative_altitude_cm() > 500) { // are >5m above AGL/home
+            // we're already flying, do not suppress the throttle. We can get
+            // stuck in this condition if we reset a mission and cmd 1 is takeoff
+            // but we're still flying around
+            throttle_suppressed = false;
+            return false;
+        }
         if (auto_takeoff_check()) {
             // we're in auto takeoff 
             throttle_suppressed = false;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -506,6 +506,9 @@ private:
     // previous value of is_flying()
     bool previous_is_flying;
 
+    // time since started flying in any mode in milliseconds
+    uint32_t started_flying_ms;
+
     // Navigation control variables
     // The instantaneous desired bank angle.  Hundredths of a degree
     int32_t nav_roll_cd;

--- a/ArduPlane/is_flying.cpp
+++ b/ArduPlane/is_flying.cpp
@@ -98,6 +98,11 @@ void Plane::update_is_flying_5Hz(void)
 
         auto_state.last_flying_ms = now_ms;
 
+        if (!previous_is_flying) {
+            // just started flying in any mode
+            started_flying_ms = now_ms;
+        }
+
         if ((control_mode == AUTO) &&
             ((auto_state.started_flying_in_auto_ms == 0) || !previous_is_flying) ) {
 


### PR DESCRIPTION
fixes issue https://github.com/diydrones/ardupilot/issues/2778
When executing a takeoff, and the throttle is suppressed, but we're already flying, we should un-suppress the throttle. We can get into this situation if we reset the mission in-flight.

In addition to the usual acceleration check to un-suppress the throttle in takeoff, with this PR we also check for:
is_flying() == true
been flying in auto for >5s
AGL > 5m
