### PR TITLE
AP_Notify: Disable ToneAlarm for BBBMINI

### DIFF
--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -51,6 +51,9 @@ struct AP_Notify::notify_events_type AP_Notify::events;
         NavioLED_I2C navioled;
         ToshibaLED_I2C toshibaled;
         NotifyDevice *AP_Notify::_devices[] = {&boardled, &navioled, &toshibaled};
+    #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BBBMINI
+        ToshibaLED_I2C toshibaled;
+        NotifyDevice *AP_Notify::_devices[] = {&toshibaled};
     #else
         AP_BoardLED boardled;
         ToshibaLED_I2C toshibaled;


### PR DESCRIPTION
AP_Notify: Disable ToneAlarm for BBBMINI:
BBBMINI does not use ToneAlarm. This PR prevents the error message: `ToneAlarm: Error!! please check if PWM overlays are loaded correctlyAP_Notify: Failed to initialise ToneAlarm` on each start.