### PR TITLE
Unified vibration and clipping calculation for INS

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -344,6 +344,7 @@ AP_InertialSensor::AP_InertialSensor() :
 #endif
 
         _accel_max_abs_offsets[i] = 3.5f;
+        _accel_sample_rates[i] = 0;
     }
 #if INS_VIBRATION_CHECK
     for (uint8_t i=0; i<INS_VIBRATION_CHECK_INSTANCES; i++) {

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -308,6 +308,9 @@ private:
     // accelerometer max absolute offsets to be used for calibration
     float _accel_max_abs_offsets[INS_MAX_INSTANCES];
 
+    // accelerometer sample rate in units of Hz
+    uint32_t _accel_sample_rates[INS_MAX_INSTANCES];
+
     // temperatures for an instance if available
     float _temperature[INS_MAX_INSTANCES];
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -73,6 +73,12 @@ void AP_InertialSensor_Backend::_publish_accel(uint8_t instance, const Vector3f 
 void AP_InertialSensor_Backend::_notify_new_accel_raw_sample(uint8_t instance,
                                                              const Vector3f &accel)
 {
+#if INS_VIBRATION_CHECK
+    if (_imu._accel_sample_rates[instance] > 0) {
+        float dt = 1.0f / _imu._accel_sample_rates[instance];
+        _imu.calc_vibration_and_clipping(instance, accel, dt);
+    }
+#endif
 }
 
 void AP_InertialSensor_Backend::_set_accel_max_abs_offset(uint8_t instance,

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -76,6 +76,12 @@ void AP_InertialSensor_Backend::_set_accel_max_abs_offset(uint8_t instance,
     _imu._accel_max_abs_offsets[instance] = max_offset;
 }
 
+void AP_InertialSensor_Backend::_set_accel_sample_rate(uint8_t instance,
+                                                       uint32_t rate)
+{
+    _imu._accel_sample_rates[instance] = rate;
+}
+
 // set accelerometer error_count
 void AP_InertialSensor_Backend::_set_accel_error_count(uint8_t instance, uint32_t error_count)
 {

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -70,6 +70,11 @@ void AP_InertialSensor_Backend::_publish_accel(uint8_t instance, const Vector3f 
     _imu._accel_healthy[instance] = true;
 }
 
+void AP_InertialSensor_Backend::_notify_new_accel_raw_sample(uint8_t instance,
+                                                             const Vector3f &accel)
+{
+}
+
 void AP_InertialSensor_Backend::_set_accel_max_abs_offset(uint8_t instance,
                                                           float max_offset)
 {

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -47,14 +47,10 @@ void AP_InertialSensor_Backend::_publish_delta_angle(uint8_t instance, const Vec
 /*
   rotate gyro vector and add the gyro offset
  */
-void AP_InertialSensor_Backend::_publish_gyro(uint8_t instance, const Vector3f &gyro, bool rotate_and_correct)
+void AP_InertialSensor_Backend::_publish_gyro(uint8_t instance, const Vector3f &gyro)
 {
     _imu._gyro[instance] = gyro;
     _imu._gyro_healthy[instance] = true;
-
-    if (rotate_and_correct) {
-        _rotate_and_correct_gyro(instance, _imu._gyro[instance]);
-    }
 }
 
 void AP_InertialSensor_Backend::_publish_delta_velocity(uint8_t instance, const Vector3f &delta_velocity, float dt)
@@ -68,14 +64,10 @@ void AP_InertialSensor_Backend::_publish_delta_velocity(uint8_t instance, const 
 /*
   rotate accel vector, scale and add the accel offset
  */
-void AP_InertialSensor_Backend::_publish_accel(uint8_t instance, const Vector3f &accel, bool rotate_and_correct)
+void AP_InertialSensor_Backend::_publish_accel(uint8_t instance, const Vector3f &accel)
 {
     _imu._accel[instance] = accel;
     _imu._accel_healthy[instance] = true;
-
-    if (rotate_and_correct) {
-        _rotate_and_correct_accel(instance, _imu._accel[instance]);
-    }
 }
 
 void AP_InertialSensor_Backend::_set_accel_max_abs_offset(uint8_t instance,

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -88,6 +88,12 @@ protected:
     // rotate accel vector, scale, offset and publish
     void _publish_accel(uint8_t instance, const Vector3f &accel);
 
+    // this should be called every time a new accel raw sample is available -
+    // be it published or not
+    // the sample is raw in the sense that it's not filtered yet, but it must
+    // be rotated and corrected (_rotate_and_correct_accel)
+    void _notify_new_accel_raw_sample(uint8_t instance, const Vector3f &accel);
+
     // set accelerometer max absolute offset for calibration
     void _set_accel_max_abs_offset(uint8_t instance, float offset);
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -91,6 +91,12 @@ protected:
     // set accelerometer max absolute offset for calibration
     void _set_accel_max_abs_offset(uint8_t instance, float offset);
 
+    // set accelerometer sample rate
+    void _set_accel_sample_rate(uint8_t instance, uint32_t rate);
+    uint32_t _accel_sample_rate(uint8_t instance) const {
+        return _imu._accel_sample_rates[instance];
+    }
+
     // publish a temperature value
     void _publish_temperature(uint8_t instance, float temperature);
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -83,10 +83,10 @@ protected:
     void _publish_delta_angle(uint8_t instance, const Vector3f &delta_angle);
 
     // rotate gyro vector, offset and publish
-    void _publish_gyro(uint8_t instance, const Vector3f &gyro, bool rotate_and_correct = true);
+    void _publish_gyro(uint8_t instance, const Vector3f &gyro);
 
     // rotate accel vector, scale, offset and publish
-    void _publish_accel(uint8_t instance, const Vector3f &accel, bool rotate_and_correct = true);
+    void _publish_accel(uint8_t instance, const Vector3f &accel);
 
     // set accelerometer max absolute offset for calibration
     void _set_accel_max_abs_offset(uint8_t instance, float offset);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Flymaple.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Flymaple.cpp
@@ -225,6 +225,7 @@ void AP_InertialSensor_Flymaple::_accumulate(void)
         // Adjust for chip scaling to get m/s/s
         accel *= FLYMAPLE_ACCELEROMETER_SCALE_M_S;
         _rotate_and_correct_accel(_accel_instance, accel);
+        _notify_new_accel_raw_sample(_accel_instance, accel);
         _accel_filtered = _accel_filter.apply(accel);
         _have_accel_sample = true;
         _last_accel_timestamp = now;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Flymaple.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Flymaple.cpp
@@ -175,8 +175,8 @@ bool AP_InertialSensor_Flymaple::update(void)
     _have_accel_sample = false;
     hal.scheduler->resume_timer_procs();
 
-    _publish_accel(_accel_instance, accel, false);
-    _publish_gyro(_gyro_instance, gyro, false);
+    _publish_accel(_accel_instance, accel);
+    _publish_gyro(_gyro_instance, gyro);
 
     if (_last_filter_hz != _accel_filter_cutoff()) {
         _set_filter_frequency(_accel_filter_cutoff());

--- a/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.cpp
@@ -271,13 +271,8 @@ bool AP_InertialSensor_L3G4200D::update(void)
     _have_sample = false;
     pthread_spin_unlock(&_data_lock);
 
-    // Adjust for chip scaling to get m/s/s
-    accel *= ADXL345_ACCELEROMETER_SCALE_M_S;
-    _publish_accel(_accel_instance, accel);
-
-    // Adjust for chip scaling to get radians/sec
-    gyro *= L3G4200D_GYRO_SCALE_R_S;
-    _publish_gyro(_gyro_instance, gyro);
+    _publish_accel(_accel_instance, accel, false);
+    _publish_gyro(_gyro_instance, gyro, false);
 
     if (_last_filter_hz != _accel_filter_cutoff()) {
         _set_filter_frequency(_accel_filter_cutoff());
@@ -322,7 +317,11 @@ void AP_InertialSensor_L3G4200D::_accumulate(void)
         if (hal.i2c->readRegisters(L3G4200D_I2C_ADDRESS, L3G4200D_REG_XL | L3G4200D_REG_AUTO_INCREMENT, 
                                    sizeof(buffer), (uint8_t *)&buffer[0][0]) == 0) {
             for (uint8_t i=0; i<num_samples_available; i++) {
-                _data[_data_idx].gyro_filtered = _gyro_filter.apply(Vector3f(buffer[i][0], -buffer[i][1], -buffer[i][2]));
+                Vector3f gyro = Vector3f(buffer[i][0], -buffer[i][1], -buffer[i][2]);
+                // Adjust for chip scaling to get radians/sec
+                gyro *= L3G4200D_GYRO_SCALE_R_S;
+                _rotate_and_correct_gyro(_gyro_instance, gyro);
+                _data[_data_idx].gyro_filtered = _gyro_filter.apply(gyro);
                 _have_gyro_sample = true;
             }
         }
@@ -342,7 +341,11 @@ void AP_InertialSensor_L3G4200D::_accumulate(void)
                                            sizeof(buffer[0]), num_samples_available,
                                            (uint8_t *)&buffer[0][0]) == 0) {
             for (uint8_t i=0; i<num_samples_available; i++) {
-                _data[_data_idx].accel_filtered = _accel_filter.apply(Vector3f(buffer[i][0], -buffer[i][1], -buffer[i][2]));
+                Vector3f accel = Vector3f(buffer[i][0], -buffer[i][1], -buffer[i][2]);
+                // Adjust for chip scaling to get m/s/s
+                accel *= ADXL345_ACCELEROMETER_SCALE_M_S;
+                _rotate_and_correct_accel(_accel_instance, accel);
+                _data[_data_idx].accel_filtered = _accel_filter.apply(accel);
                 _have_accel_sample = true;
             }
         }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.cpp
@@ -345,6 +345,7 @@ void AP_InertialSensor_L3G4200D::_accumulate(void)
                 // Adjust for chip scaling to get m/s/s
                 accel *= ADXL345_ACCELEROMETER_SCALE_M_S;
                 _rotate_and_correct_accel(_accel_instance, accel);
+                _notify_new_accel_raw_sample(_accel_instance, accel);
                 _data[_data_idx].accel_filtered = _accel_filter.apply(accel);
                 _have_accel_sample = true;
             }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.cpp
@@ -271,8 +271,8 @@ bool AP_InertialSensor_L3G4200D::update(void)
     _have_sample = false;
     pthread_spin_unlock(&_data_lock);
 
-    _publish_accel(_accel_instance, accel, false);
-    _publish_gyro(_gyro_instance, gyro, false);
+    _publish_accel(_accel_instance, accel);
+    _publish_gyro(_gyro_instance, gyro);
 
     if (_last_filter_hz != _accel_filter_cutoff()) {
         _set_filter_frequency(_accel_filter_cutoff());

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
@@ -741,6 +741,7 @@ void AP_InertialSensor_LSM9DS0::_read_data_transaction_a()
     Vector3f accel_data(raw_data.x, -raw_data.y, -raw_data.z);
     accel_data *= _accel_scale;
     _rotate_and_correct_accel(_accel_instance, accel_data);
+    _notify_new_accel_raw_sample(_accel_instance, accel_data);
     _accel_filtered = _accel_filter.apply(accel_data);
     _accel_sample_available = true;
 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
@@ -765,8 +765,8 @@ bool AP_InertialSensor_LSM9DS0::update()
     _accel_sample_available = false;
     _gyro_sample_available = false;
 
-    _publish_gyro(_gyro_instance, _gyro_filtered, false);
-    _publish_accel(_accel_instance, _accel_filtered, false);
+    _publish_gyro(_gyro_instance, _gyro_filtered);
+    _publish_accel(_accel_instance, _accel_filtered);
 
     if (_last_accel_filter_hz != _accel_filter_cutoff()) {
         _set_accel_filter(_accel_filter_cutoff());

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
@@ -739,6 +739,8 @@ void AP_InertialSensor_LSM9DS0::_read_data_transaction_a()
     _accel_raw_data(&raw_data);
 
     Vector3f accel_data(raw_data.x, -raw_data.y, -raw_data.z);
+    accel_data *= _accel_scale;
+    _rotate_and_correct_accel(_accel_instance, accel_data);
     _accel_filtered = _accel_filter.apply(accel_data);
     _accel_sample_available = true;
 }
@@ -752,23 +754,19 @@ void AP_InertialSensor_LSM9DS0::_read_data_transaction_g()
     _gyro_raw_data(&raw_data);
 
     Vector3f gyro_data(raw_data.x, -raw_data.y, -raw_data.z);
+    gyro_data *= _gyro_scale;
+    _rotate_and_correct_gyro(_gyro_instance, gyro_data);
     _gyro_filtered = _gyro_filter.apply(gyro_data);
     _gyro_sample_available = true;
 }
 
 bool AP_InertialSensor_LSM9DS0::update()
 {
-    Vector3f gyro = _gyro_filtered;
-    Vector3f accel = _accel_filtered;
-
     _accel_sample_available = false;
     _gyro_sample_available = false;
 
-    accel *= _accel_scale;
-    gyro *= _gyro_scale;
-
-    _publish_gyro(_gyro_instance, gyro);
-    _publish_accel(_accel_instance, accel);
+    _publish_gyro(_gyro_instance, _gyro_filtered, false);
+    _publish_accel(_accel_instance, _accel_filtered, false);
 
     if (_last_accel_filter_hz != _accel_filter_cutoff()) {
         _set_accel_filter(_accel_filter_cutoff());

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -763,6 +763,8 @@ void AP_InertialSensor_MPU6000::_accumulate(uint8_t *samples, uint8_t n_samples)
         _rotate_and_correct_accel(_accel_instance, accel);
         _rotate_and_correct_gyro(_gyro_instance, gyro);
 
+        _notify_new_accel_raw_sample(_accel_instance, accel);
+
 #if MPU6000_FAST_SAMPLING
         _accel_filtered = _accel_filter.apply(accel);
         _gyro_filtered = _gyro_filter.apply(gyro);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -625,6 +625,8 @@ void AP_InertialSensor_MPU6000::start()
     _gyro_instance = _imu.register_gyro();
     _accel_instance = _imu.register_accel();
 
+    _set_accel_sample_rate(_accel_instance, 1000);
+
     hal.scheduler->resume_timer_procs();
 
     // start the timer process to read samples

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -666,8 +666,8 @@ bool AP_InertialSensor_MPU6000::update( void )
     gyro /= num_samples;
     accel /= num_samples;
 
-    _publish_accel(_accel_instance, accel, false);
-    _publish_gyro(_gyro_instance, gyro, false);
+    _publish_accel(_accel_instance, accel);
+    _publish_gyro(_gyro_instance, gyro);
 
 #if MPU6000_FAST_SAMPLING
     if (_last_accel_filter_hz != _accel_filter_cutoff()) {

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9150.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9150.cpp
@@ -1092,6 +1092,7 @@ void AP_InertialSensor_MPU9150::_accumulate(void)
         accel = Vector3f(accel_x, accel_y, accel_z);
         accel *= MPU9150_ACCEL_SCALE_2G;
         _rotate_and_correct_accel(_accel_instance, accel);
+        _notify_new_accel_raw_sample(_accel_instance, accel);
         _accel_filtered = _accel_filter.apply(accel);
 
         gyro = Vector3f(gyro_x, gyro_y, gyro_z);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9150.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9150.cpp
@@ -1116,8 +1116,8 @@ bool AP_InertialSensor_MPU9150::update(void)
     _have_sample_available = false;
     hal.scheduler->resume_timer_procs();
 
-    _publish_accel(_accel_instance, accel, false);
-    _publish_gyro(_gyro_instance, gyro, false);
+    _publish_accel(_accel_instance, accel);
+    _publish_gyro(_gyro_instance, gyro);
 
     if (_last_accel_filter_hz != _accel_filter_cutoff()) {
         _set_accel_filter_frequency(_accel_filter_cutoff());

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
@@ -330,8 +330,8 @@ bool AP_InertialSensor_MPU9250::update( void )
 
     _have_sample_available = false;
 
-    _publish_gyro(_gyro_instance, gyro, false);
-    _publish_accel(_accel_instance, accel, false);
+    _publish_gyro(_gyro_instance, gyro);
+    _publish_accel(_accel_instance, accel);
 
     if (_last_accel_filter_hz != _accel_filter_cutoff()) {
         _set_accel_filter(_accel_filter_cutoff());

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
@@ -315,6 +315,8 @@ bool AP_InertialSensor_MPU9250::_init_sensor(void)
     // start the timer process to read samples
     hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&AP_InertialSensor_MPU9250::_poll_data, void));
 
+    _set_accel_sample_rate(_accel_instance, DEFAULT_SAMPLE_RATE);
+
 #if MPU9250_DEBUG
     _dump_registers(_spi);
 #endif

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
@@ -159,6 +159,9 @@ extern const AP_HAL::HAL& hal;
 #define BITS_DLPF_CFG_2100HZ_NOLPF              0x07
 #define BITS_DLPF_CFG_MASK                              0x07
 
+#define DEFAULT_SMPLRT_DIV MPUREG_SMPLRT_1000HZ
+#define DEFAULT_SAMPLE_RATE (1000 / (DEFAULT_SMPLRT_DIV + 1))
+
 /*
  *  PS-MPU-9250A-00.pdf, page 8, lists LSB sensitivity of
  *  gyro as 16.4 LSB/DPS at scale factor of +/- 2000dps (FS_SEL==3)
@@ -178,8 +181,8 @@ AP_InertialSensor_MPU9250::AP_InertialSensor_MPU9250(AP_InertialSensor &imu) :
     _last_accel_filter_hz(-1),
     _last_gyro_filter_hz(-1),
     _shared_data_idx(0),
-    _accel_filter(1000, 15),
-    _gyro_filter(1000, 15),
+    _accel_filter(DEFAULT_SAMPLE_RATE, 15),
+    _gyro_filter(DEFAULT_SAMPLE_RATE, 15),
     _have_sample_available(false),
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_PXF
     _default_rotation(ROTATION_ROLL_180_YAW_270)
@@ -456,7 +459,7 @@ inline void AP_InertialSensor_MPU9250::_register_write(uint8_t reg, uint8_t val)
  */
 void AP_InertialSensor_MPU9250::_set_accel_filter(uint8_t filter_hz)
 {
-    _accel_filter.set_cutoff_frequency(1000, filter_hz);
+    _accel_filter.set_cutoff_frequency(DEFAULT_SAMPLE_RATE, filter_hz);
 }
 
 /*
@@ -464,7 +467,7 @@ void AP_InertialSensor_MPU9250::_set_accel_filter(uint8_t filter_hz)
  */
 void AP_InertialSensor_MPU9250::_set_gyro_filter(uint8_t filter_hz)
 {
-    _gyro_filter.set_cutoff_frequency(1000, filter_hz);
+    _gyro_filter.set_cutoff_frequency(DEFAULT_SAMPLE_RATE, filter_hz);
 }
 
 
@@ -493,7 +496,7 @@ bool AP_InertialSensor_MPU9250::_hardware_init(void)
 
     // set sample rate to 1kHz, and use the 2 pole filter to give the
     // desired rate
-    _register_write(MPUREG_SMPLRT_DIV, MPUREG_SMPLRT_1000HZ);
+    _register_write(MPUREG_SMPLRT_DIV, DEFAULT_SMPLRT_DIV);
     _register_write(MPUREG_GYRO_CONFIG, BITS_GYRO_FS_2000DPS);  // Gyro scale 2000º/s
 
     // RM-MPU-9250A-00.pdf, pg. 15, select accel full scale 16g

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
@@ -391,6 +391,7 @@ void AP_InertialSensor_MPU9250::_read_data_transaction()
     accel *= MPU9250_ACCEL_SCALE_1G;
     accel.rotate(_default_rotation);
     _rotate_and_correct_accel(_accel_instance, accel);
+    _notify_new_accel_raw_sample(_accel_instance, accel);
 
     gyro = Vector3f(int16_val(rx.v, 5),
                     int16_val(rx.v, 4),

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Oilpan.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Oilpan.cpp
@@ -105,7 +105,7 @@ bool AP_InertialSensor_Oilpan::update()
       _sensor_signs[1] * ( adc_values[1] - OILPAN_RAW_GYRO_OFFSET ) * _gyro_gain_y,
       _sensor_signs[2] * ( adc_values[2] - OILPAN_RAW_GYRO_OFFSET ) * _gyro_gain_z);
     _rotate_and_correct_gyro(_gyro_instance, v);
-    _publish_gyro(_gyro_instance, v, false);
+    _publish_gyro(_gyro_instance, v);
 
     // copy accels to frontend
     v(_sensor_signs[3] * (adc_values[3] - OILPAN_RAW_ACCEL_OFFSET),
@@ -113,7 +113,7 @@ bool AP_InertialSensor_Oilpan::update()
       _sensor_signs[5] * (adc_values[5] - OILPAN_RAW_ACCEL_OFFSET));
     v *= OILPAN_ACCEL_SCALE_1G;
     _rotate_and_correct_accel(_accel_instance, v);
-    _publish_accel(_accel_instance, v, false);
+    _publish_accel(_accel_instance, v);
 
     return true;
 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Oilpan.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Oilpan.cpp
@@ -104,14 +104,16 @@ bool AP_InertialSensor_Oilpan::update()
     v(_sensor_signs[0] * ( adc_values[0] - OILPAN_RAW_GYRO_OFFSET ) * _gyro_gain_x,
       _sensor_signs[1] * ( adc_values[1] - OILPAN_RAW_GYRO_OFFSET ) * _gyro_gain_y,
       _sensor_signs[2] * ( adc_values[2] - OILPAN_RAW_GYRO_OFFSET ) * _gyro_gain_z);
-    _publish_gyro(_gyro_instance, v);
+    _rotate_and_correct_gyro(_gyro_instance, v);
+    _publish_gyro(_gyro_instance, v, false);
 
     // copy accels to frontend
     v(_sensor_signs[3] * (adc_values[3] - OILPAN_RAW_ACCEL_OFFSET),
       _sensor_signs[4] * (adc_values[4] - OILPAN_RAW_ACCEL_OFFSET),
       _sensor_signs[5] * (adc_values[5] - OILPAN_RAW_ACCEL_OFFSET));
     v *= OILPAN_ACCEL_SCALE_1G;
-    _publish_accel(_accel_instance, v);
+    _rotate_and_correct_accel(_accel_instance, v);
+    _publish_accel(_accel_instance, v, false);
 
     return true;
 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
@@ -166,6 +166,7 @@ bool AP_InertialSensor_PX4::_init_sensor(void)
         if (samplerate < 100 || samplerate > 10000) {
             hal.scheduler->panic("Invalid accel sample rate");
         }
+        _set_accel_sample_rate(_accel_instance[i], (uint32_t) samplerate);
         _accel_sample_time[i] = 1.0f / samplerate;
     }
 
@@ -190,7 +191,7 @@ bool AP_InertialSensor_PX4::_init_sensor(void)
 void AP_InertialSensor_PX4::_set_accel_filter_frequency(uint8_t filter_hz)
 {
     for (uint8_t i=0; i<_num_accel_instances; i++) {
-        float samplerate = 1.0f / _accel_sample_time[i];
+        float samplerate = _accel_sample_rate(_accel_instance[i]);
         _accel_filter[i].set_cutoff_frequency(samplerate, filter_hz);
     }
 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
@@ -283,9 +283,6 @@ void AP_InertialSensor_PX4::_new_accel_sample(uint8_t i, accel_report &accel_rep
     // publish a temperature (for logging purposed only)
     _publish_temperature(frontend_instance, accel_report.temperature);
 
-    // check noise
-    _imu.calc_vibration_and_clipping(frontend_instance, accel, dt);
-
 #ifdef AP_INERTIALSENSOR_PX4_DEBUG
     _accel_dt_max[i] = max(_accel_dt_max[i],dt);
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
@@ -216,7 +216,7 @@ bool AP_InertialSensor_PX4::update(void)
         // calling _publish_accel sets the sensor healthy,
         // so we only want to do this if we have new data from it
         if (_last_accel_timestamp[k] != _last_accel_update_timestamp[k]) {
-            _publish_accel(_accel_instance[k], accel, false);
+            _publish_accel(_accel_instance[k], accel);
             _publish_delta_velocity(_accel_instance[k], _delta_velocity_accumulator[k], _delta_velocity_dt[k]);
             _last_accel_update_timestamp[k] = _last_accel_timestamp[k];
         }
@@ -227,7 +227,7 @@ bool AP_InertialSensor_PX4::update(void)
         // calling _publish_accel sets the sensor healthy,
         // so we only want to do this if we have new data from it
         if (_last_gyro_timestamp[k] != _last_gyro_update_timestamp[k]) {
-            _publish_gyro(_gyro_instance[k], gyro, false);
+            _publish_gyro(_gyro_instance[k], gyro);
             _publish_delta_angle(_gyro_instance[k], _delta_angle_accumulator[k]);
             _last_gyro_update_timestamp[k] = _last_gyro_timestamp[k];
         }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
@@ -259,6 +259,7 @@ void AP_InertialSensor_PX4::_new_accel_sample(uint8_t i, accel_report &accel_rep
 
     // apply corrections
     _rotate_and_correct_accel(frontend_instance, accel);
+    _notify_new_accel_raw_sample(frontend_instance, accel);
 
     // apply filter for control path
     _accel_in[i] = _accel_filter[i].apply(accel);


### PR DESCRIPTION
Hi guys!

This is a followup of #2658 . The idea is to have a common place for calculating vibration and clipping.

In this series of patches we do the following:
- Make changes on data sampling to accommodate unified accel vibration and clipping calculation
- Enable unified accel vibration and clipping calculation through
- Adapt PX4 ins to the new approach and also enable vibration and clipping for the IMUs MPU9250 and MPU6000 (people are welcome to enable for the remaining INSs as well :-) )