### PR TITLE
HAL/AP_RSSI - Adding SBUS Link Quality to RSSI library

### DIFF
--- a/libraries/AP_HAL/RCInput.h
+++ b/libraries/AP_HAL/RCInput.h
@@ -30,6 +30,10 @@ public:
      * Return the number of valid channels in the last read
      */
     virtual uint8_t  num_channels() = 0;
+    
+    /* Return the Link Quality of the RC link. 0.0 = worst quality, 1.0 = best quality. 
+       Some platforms may not support this and will return 0.0 always. */
+    virtual float link_quality() = 0;
 
     /* Read a single channel at a time */
     virtual uint16_t read(uint8_t ch) = 0;

--- a/libraries/AP_HAL_AVR/RCInput.h
+++ b/libraries/AP_HAL_AVR/RCInput.h
@@ -37,6 +37,9 @@ public:
      */
     uint8_t num_channels();
 
+    /* Return the Link Quality of the RC link. 0.0 = worst quality, 1.0 = best quality. */
+    float link_quality();
+        
     /**
      * read(uint8_t):
      * Read a single channel at a time
@@ -82,6 +85,7 @@ class AP_HAL_AVR::APM2RCInput : public AP_HAL::RCInput {
     void     init(void* isrregistry);
     bool  new_input();
     uint8_t num_channels();
+    float link_quality();
     uint16_t read(uint8_t ch);
     uint8_t  read(uint16_t* periods, uint8_t len);
     bool set_overrides(int16_t *overrides, uint8_t len);

--- a/libraries/AP_HAL_AVR/RCInput_APM1.cpp
+++ b/libraries/AP_HAL_AVR/RCInput_APM1.cpp
@@ -102,6 +102,11 @@ bool APM1RCInput::new_input()
 
 uint8_t APM1RCInput::num_channels() { return _num_channels; }
 
+/* Return the Link Quality of the RC link. 0.0 = worst quality, 1.0 = best quality. */
+float APM1RCInput::link_quality() {
+    // Unimplemented
+    return 0.0f;
+}
 
 /* constrain captured pulse to be between min and max pulsewidth. */
 static inline uint16_t constrain_pulse(uint16_t p) {

--- a/libraries/AP_HAL_AVR/RCInput_APM2.cpp
+++ b/libraries/AP_HAL_AVR/RCInput_APM2.cpp
@@ -102,6 +102,12 @@ bool APM2RCInput::new_input()
 
 uint8_t APM2RCInput::num_channels() { return _num_channels; }
 
+/* Return the Link Quality of the RC link. 0.0 = worst quality, 1.0 = best quality. */
+float APM2RCInput::link_quality() {
+    // Unimplemented
+    return 0.0f;
+}
+
 /* constrain captured pulse to be between min and max pulsewidth. */
 static inline uint16_t constrain_pulse(uint16_t p) {
     if (p > RC_INPUT_MAX_PULSEWIDTH) return RC_INPUT_MAX_PULSEWIDTH;

--- a/libraries/AP_HAL_Empty/RCInput.cpp
+++ b/libraries/AP_HAL_Empty/RCInput.cpp
@@ -15,6 +15,10 @@ bool EmptyRCInput::new_input() {
 uint8_t EmptyRCInput::num_channels() {
     return 0;
 }
+    
+float EmptyRCInput::link_quality() {
+    return 0.0f;
+}
 
 uint16_t EmptyRCInput::read(uint8_t ch) {
     if (ch == 2) return 900; /* throttle should be low, for safety */

--- a/libraries/AP_HAL_Empty/RCInput.h
+++ b/libraries/AP_HAL_Empty/RCInput.h
@@ -10,6 +10,7 @@ public:
     void init(void* machtnichts);
     bool  new_input();
     uint8_t num_channels();
+    float link_quality();
     uint16_t read(uint8_t ch);
     uint8_t read(uint16_t* periods, uint8_t len);
 

--- a/libraries/AP_HAL_FLYMAPLE/RCInput.cpp
+++ b/libraries/AP_HAL_FLYMAPLE/RCInput.cpp
@@ -137,6 +137,12 @@ uint8_t FLYMAPLERCInput::num_channels() {
     return _valid_channels;
 }
 
+/* Return the Link Quality of the RC link. 0.0 = worst quality, 1.0 = best quality. */
+float FLYMAPLERCInput::link_quality() {
+    // Unimplemented
+    return 0.0f;
+}
+
 /* constrain captured pulse to be between min and max pulsewidth. */
 static inline uint16_t constrain_pulse(uint16_t p) {
     if (p > RC_INPUT_MAX_PULSEWIDTH) return RC_INPUT_MAX_PULSEWIDTH;

--- a/libraries/AP_HAL_FLYMAPLE/RCInput.h
+++ b/libraries/AP_HAL_FLYMAPLE/RCInput.h
@@ -31,6 +31,7 @@ public:
     void init(void* machtnichts);
     bool new_input();
     uint8_t num_channels();
+    float link_quality();
     uint16_t read(uint8_t ch);
     uint8_t read(uint16_t* periods, uint8_t len);
 

--- a/libraries/AP_HAL_Linux/RCInput.cpp
+++ b/libraries/AP_HAL_Linux/RCInput.cpp
@@ -42,6 +42,12 @@ uint8_t LinuxRCInput::num_channels()
     return _num_channels;
 }
 
+/* Return the Link Quality of the RC link. 0.0 = worst quality, 1.0 = best quality. */
+float LinuxRCInput::link_quality() {
+    // Unimplemented
+    return 0.0f;
+}
+
 uint16_t LinuxRCInput::read(uint8_t ch) 
 {
     new_rc_input = false;

--- a/libraries/AP_HAL_Linux/RCInput.h
+++ b/libraries/AP_HAL_Linux/RCInput.h
@@ -12,6 +12,7 @@ public:
     virtual void init(void* machtnichts);
     bool new_input();
     uint8_t num_channels();
+    float link_quality();
     uint16_t read(uint8_t ch);
     uint8_t read(uint16_t* periods, uint8_t len);
 

--- a/libraries/AP_HAL_PX4/RCInput.cpp
+++ b/libraries/AP_HAL_PX4/RCInput.cpp
@@ -41,6 +41,15 @@ uint8_t PX4RCInput::num_channels()
     return n;
 }
 
+float PX4RCInput::link_quality() 
+{
+    pthread_mutex_lock(&rcin_mutex);
+    float current_link_quality = _rcin.link_quality;
+    pthread_mutex_unlock(&rcin_mutex);
+    return current_link_quality;
+}
+
+
 uint16_t PX4RCInput::read(uint8_t ch) 
 {
 	if (ch >= RC_INPUT_MAX_CHANNELS) {

--- a/libraries/AP_HAL_PX4/RCInput.h
+++ b/libraries/AP_HAL_PX4/RCInput.h
@@ -12,6 +12,7 @@ public:
     void init(void* machtnichts);
     bool new_input();
     uint8_t num_channels();
+    float link_quality();
     uint16_t read(uint8_t ch);
     uint8_t read(uint16_t* periods, uint8_t len);
 

--- a/libraries/AP_HAL_SITL/RCInput.h
+++ b/libraries/AP_HAL_SITL/RCInput.h
@@ -16,6 +16,10 @@ public:
     uint8_t num_channels() {
         return 8;
     }
+    float link_quality() {
+        // Always perfect link in the simulator
+        return 1.0;
+    }    
     uint16_t read(uint8_t ch);
     uint8_t read(uint16_t* periods, uint8_t len);
 

--- a/libraries/AP_HAL_VRBRAIN/RCInput.cpp
+++ b/libraries/AP_HAL_VRBRAIN/RCInput.cpp
@@ -38,6 +38,10 @@ uint8_t VRBRAINRCInput::num_channels()
     return n;
 }
 
+float VRBRAINRCInput::link_quality() {
+    return 0.0f;
+}
+
 uint16_t VRBRAINRCInput::read(uint8_t ch)
 {
 	if (ch >= RC_INPUT_MAX_CHANNELS) {

--- a/libraries/AP_HAL_VRBRAIN/RCInput.h
+++ b/libraries/AP_HAL_VRBRAIN/RCInput.h
@@ -12,6 +12,7 @@ public:
     void init(void* machtnichts);
     bool new_input();
     uint8_t num_channels();
+    float link_quality();
     uint16_t read(uint8_t ch);
     uint8_t read(uint16_t* periods, uint8_t len);
 

--- a/libraries/AP_RSSI/AP_RSSI.cpp
+++ b/libraries/AP_RSSI/AP_RSSI.cpp
@@ -25,7 +25,7 @@ const AP_Param::GroupInfo AP_RSSI::var_info[] PROGMEM = {
     // @Param: RSSI_TYPE
     // @DisplayName: RSSI Type
     // @Description: Radio Receiver RSSI type. If your radio receiver supports RSSI of some kind, set it here, then set its associated RSSI_XXXXX parameters, if any.
-    // @Values: 0:Disabled,1:AnalogPin,2:RCChannelPwmValue
+    // @Values: 0:Disabled,1:AnalogPin,2:RCChannelPwmValue,3:SBUSLinkQuality (Pixhawk only)
     // @User: Standard
     AP_GROUPINFO("TYPE", 0, AP_RSSI, rssi_type,  0),
                 
@@ -78,6 +78,24 @@ const AP_Param::GroupInfo AP_RSSI::var_info[] PROGMEM = {
     // @User: Standard
     AP_GROUPINFO("CHAN_HIGH", 6, AP_RSSI, rssi_channel_high_pwm_value,  2000),
     
+    // @Param: RSSI_SBUS_LOW
+    // @DisplayName: Receiver SBUS Link Quality low value
+    // @Description: The lowest value expected from the SBUS Link Quality metric. This is normally 0.0, which would happen when there is no signal.
+    // @Units: Percent
+    // @Increment: 1
+    // @Range: 0 100
+    // @User: Standard
+    AP_GROUPINFO("SBUS_LOW", 7, AP_RSSI, rssi_sbus_low_value, 0),
+    
+    // @Param: RSSI_SBUS_HIGH
+    // @DisplayName: Receiver SBUS Link Quality high value
+    // @Description: The lowest value expected from the SBUS Link Quality metric. This can be as high as 1.0, but may be lower depending on your particular hardware, since a certain level of frames dropped may be normal even at short distances.
+    // @Units: Percent
+    // @Increment: 1
+    // @Range: 0 100
+    // @User: Standard
+    AP_GROUPINFO("SBUS_HIGH", 8, AP_RSSI, rssi_sbus_high_value, 100),
+          
     AP_GROUPEND
 };
 
@@ -120,6 +138,9 @@ float AP_RSSI::read_receiver_rssi()
         case RssiType::RSSI_RC_CHANNEL_VALUE :
             receiver_rssi = read_channel_rssi();
             break;
+        case RssiType::SBUS_LINK_QUALITY :
+            receiver_rssi = read_sbus_link_quality();
+            break;
         default :   
             receiver_rssi = 0.0f;      
     }    
@@ -152,6 +173,13 @@ float AP_RSSI::read_channel_rssi()
     int rssi_channel_value = hal.rcin->read(rssi_channel-1);
     float channel_rssi = scale_and_constrain_float_rssi(rssi_channel_value, rssi_channel_low_pwm_value, rssi_channel_high_pwm_value);
     return channel_rssi;    
+}
+
+// read the SBUS Link Quality
+float AP_RSSI::read_sbus_link_quality()
+{
+    float current_link_quality = hal.rcin->link_quality() * 100;
+    return scale_and_constrain_float_rssi(current_link_quality, rssi_sbus_low_value, rssi_sbus_high_value);
 }
 
 // Scale and constrain a float rssi value to 0.0 to 1.0 range 

--- a/libraries/AP_RSSI/AP_RSSI.cpp
+++ b/libraries/AP_RSSI/AP_RSSI.cpp
@@ -80,7 +80,7 @@ const AP_Param::GroupInfo AP_RSSI::var_info[] PROGMEM = {
     
     // @Param: RSSI_SBUS_LOW
     // @DisplayName: Receiver SBUS Link Quality low value
-    // @Description: The lowest value expected from the SBUS Link Quality metric. This is normally 0.0, which would happen when there is no signal.
+    // @Description: The lowest value expected from the SBUS Link Quality metric. This is normally 0, which would happen when there is no signal.
     // @Units: Percent
     // @Increment: 1
     // @Range: 0 100
@@ -89,7 +89,7 @@ const AP_Param::GroupInfo AP_RSSI::var_info[] PROGMEM = {
     
     // @Param: RSSI_SBUS_HIGH
     // @DisplayName: Receiver SBUS Link Quality high value
-    // @Description: The lowest value expected from the SBUS Link Quality metric. This can be as high as 1.0, but may be lower depending on your particular hardware, since a certain level of frames dropped may be normal even at short distances.
+    // @Description: The lowest value expected from the SBUS Link Quality metric. This can be as high as 100, but may be lower depending on your particular hardware, since a certain level of frames dropped may be normal even at short distances.
     // @Units: Percent
     // @Increment: 1
     // @Range: 0 100

--- a/libraries/AP_RSSI/AP_RSSI.h
+++ b/libraries/AP_RSSI/AP_RSSI.h
@@ -27,7 +27,8 @@ public:
     enum RssiType {
         RSSI_DISABLED           = 0x0000,
         RSSI_ANALOG_PIN         = 0x0001,
-        RSSI_RC_CHANNEL_VALUE   = 0x0002
+        RSSI_RC_CHANNEL_VALUE   = 0x0002,
+        SBUS_LINK_QUALITY       = 0x0003
     };
     
     // parameter block
@@ -40,7 +41,10 @@ public:
     AP_Float        rssi_analog_pin_range_high;             // Voltage value for strongest rssi signal
     AP_Int8         rssi_channel;                           // allows rssi to be read from given channel as PWM value
     AP_Int16        rssi_channel_low_pwm_value;             // PWM value for weakest rssi signal
-    AP_Int16        rssi_channel_high_pwm_value;            // PWM value for strongest rssi signal 
+    AP_Int16        rssi_channel_high_pwm_value;            // PWM value for strongest rssi signal         
+    AP_Int16        rssi_sbus_low_value;                    // Receiver SBUS Link Quality low value
+    AP_Int16        rssi_sbus_high_value;                   // Receiver SBUS Link Quality high value
+    
 
     // constructor
     AP_RSSI();
@@ -70,6 +74,9 @@ private:
 
     // read the RSSI value from a PWM value on a RC channel
     float read_channel_rssi();
+    
+    // read the SBUS Link Quality
+    float read_sbus_link_quality();
 
     // Scale and constrain a float rssi value to 0.0 to 1.0 range 
     float scale_and_constrain_float_rssi(float current_rssi_value, float low_rssi_range, float high_rssi_range);


### PR DESCRIPTION
This counts recent (about 0.7 seconds worth) of SBUS frames to see how many have been dropped, and calculates a Link Quality metric as a percentage of the possible total. This allows any SBUS radio receiver to offer an RSSI-type value to ArduPilot without resorting to additional channels or FrSky style telemetry wiring. 

AP_HAL has had one function added to the interface. It has been stubbed out everywhere except PX4, although there are other platforms that could likely support it - the Linux boards for example. 

Closes https://github.com/diydrones/ardupilot/issues/2721.
See also https://github.com/diydrones/PX4Firmware/pull/38.