### PR TITLE
Parm log defaults

### DIFF
--- a/libraries/APM_Control/AP_AutoTune.cpp
+++ b/libraries/APM_Control/AP_AutoTune.cpp
@@ -267,12 +267,13 @@ void AP_AutoTune::check_save(void)
 /*
   log a parameter change from autotune
  */
-void AP_AutoTune::log_param_change(float v, const prog_char_t *suffix)
+void AP_AutoTune::log_param_change(const prog_char_t *suffix)
 {
     if (!dataflash.logging_started()) {
         return;
     }
     char key[AP_MAX_NAME_SIZE+1];
+    memset(key, '\0', sizeof(key));
     if (type == AUTOTUNE_ROLL) {
         strncpy_P(key, PSTR("RLL2SRV_"), 8);
         strncpy_P(&key[8], suffix, AP_MAX_NAME_SIZE-8);
@@ -280,8 +281,7 @@ void AP_AutoTune::log_param_change(float v, const prog_char_t *suffix)
         strncpy_P(key, PSTR("PTCH2SRV_"), 9);
         strncpy_P(&key[9], suffix, AP_MAX_NAME_SIZE-9);
     }
-    key[AP_MAX_NAME_SIZE] = 0;
-    dataflash.Log_Write_Parameter(key, v);
+    dataflash.Log_Write_Parameter(key);
 }
 
 /*
@@ -294,7 +294,7 @@ void AP_AutoTune::save_float_if_changed(AP_Float &v, float value, const prog_cha
     v.set(value);
     if (value <= 0 || fabsf((value-old_value)/value) > 0.001f) {
         v.save();
-        log_param_change(v.get(), suffix);
+        log_param_change(suffix);
     }
 }
 
@@ -307,7 +307,7 @@ void AP_AutoTune::save_int16_if_changed(AP_Int16 &v, int16_t value, const prog_c
     v.set(value);
     if (old_value != v.get()) {
         v.save();
-        log_param_change(v.get(), suffix);
+        log_param_change(suffix);
     }
 }
 

--- a/libraries/APM_Control/AP_AutoTune.h
+++ b/libraries/APM_Control/AP_AutoTune.h
@@ -96,7 +96,7 @@ private:
     void write_log_headers(void);
     void write_log(float servo, float demanded, float achieved);
 
-    void log_param_change(float v, const prog_char_t *suffix);
+    void log_param_change(const prog_char_t *suffix);
     void save_float_if_changed(AP_Float &v, float value, const prog_char_t *suffix);
     void save_int16_if_changed(AP_Int16 &v, int16_t value, const prog_char_t *suffix);        
 };

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -369,7 +369,7 @@ const struct AP_Param::Info *AP_Param::find_var_info_group(const struct GroupInf
 // find the info structure for a variable
 const struct AP_Param::Info *AP_Param::find_var_info(uint32_t *                 group_element,
                                                      const struct GroupInfo **  group_ret,
-                                                     uint8_t *                  idx)
+                                                     uint8_t *                  idx) const
 {
     for (uint8_t i=0; i<_num_vars; i++) {
         uint8_t type = PGM_UINT8(&_var_info[i].type);
@@ -1359,3 +1359,20 @@ float AP_Param::get_default_value(const float *def_value_ptr)
     return PGM_FLOAT(def_value_ptr);
 }
 
+/*
+ * returns default value for this parameter
+ */
+float AP_Param::get_default_value() const
+{
+    uint32_t group_element;
+    const struct GroupInfo *ginfo;
+    uint8_t idx;
+    const struct AP_Param::Info *info = find_var_info(&group_element, &ginfo, &idx);
+    float ret;
+    if (ginfo != NULL) {
+        ret = get_default_value(&ginfo->def_value);
+    } else {
+        ret = get_default_value(&info->def_value);
+    }
+    return ret;
+}

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -259,6 +259,9 @@ public:
     // check var table for consistency
     static bool             check_var_info(void);
 
+    // returns default value used for this parameter
+    float get_default_value() const;
+
 private:
     /// EEPROM header
     ///
@@ -311,7 +314,7 @@ private:
     const struct Info *         find_var_info(
                                     uint32_t *                group_element,
                                     const struct GroupInfo ** group_ret,
-                                    uint8_t *                 idx);
+                                    uint8_t *                 idx) const;
     const struct Info *			find_var_info_token(const ParamToken &token,
                                                     uint32_t *                 group_element,
                                                     const struct GroupInfo **  group_ret,

--- a/libraries/DataFlash/DataFlash.cpp
+++ b/libraries/DataFlash/DataFlash.cpp
@@ -12,15 +12,15 @@ void DataFlash_Class::set_mission(const AP_Mission *mission) {
 }
 
 // start functions pass straight through to backend:
-bool DataFlash_Class::WriteBlock(const void *pBuffer, uint16_t size) {
+bool DataFlash_Class::WriteBlock(const void *pBuffer, uint16_t size) const {
     return backend->WriteBlock(pBuffer, size);
 }
 
-bool DataFlash_Class::WriteCriticalBlock(const void *pBuffer, uint16_t size) {
+bool DataFlash_Class::WriteCriticalBlock(const void *pBuffer, uint16_t size) const {
     return backend->WriteCriticalBlock(pBuffer, size);
 }
 
-bool DataFlash_Class::WritePrioritisedBlock(const void *pBuffer, uint16_t size, bool is_critical) {
+bool DataFlash_Class::WritePrioritisedBlock(const void *pBuffer, uint16_t size, bool is_critical) const {
     return backend->WritePrioritisedBlock(pBuffer, size, is_critical);
 }
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -595,7 +595,7 @@ void GCS_MAVLINK::handle_param_set(mavlink_message_t *msg, DataFlash_Class *Data
         -1);     // XXX we don't actually know what its index is...
 
     if (DataFlash != NULL) {
-        DataFlash->Log_Write_Parameter(key, vp->cast_to_float(var_type));
+        DataFlash->Log_Write_Parameter(key);
     }
 }
 


### PR DESCRIPTION
Common cause of UAV failure is people playing with parameters and getting something not-quite-right.

Nice to know which parameters have been modified from their defaults, so these patches add the defaults to the PARM message.
