### PR TITLE
Adding RSSI to logging

### DIFF
--- a/APMrover2/Log.cpp
+++ b/APMrover2/Log.cpp
@@ -348,6 +348,7 @@ void Rover::Log_Write_RC(void)
 {
     DataFlash.Log_Write_RCIN();
     DataFlash.Log_Write_RCOUT();
+    DataFlash.Log_Write_RSSI(rssi);
 }
 
 void Rover::Log_Write_Baro(void)

--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -374,6 +374,7 @@ void Copter::ten_hz_logging_loop()
     }
     if (should_log(MASK_LOG_RCIN)) {
         DataFlash.Log_Write_RCIN();
+        DataFlash.Log_Write_RSSI(rssi);
     }
     if (should_log(MASK_LOG_RCOUT)) {
         DataFlash.Log_Write_RCOUT();

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -442,6 +442,7 @@ void Plane::Log_Write_RC(void)
 {
     DataFlash.Log_Write_RCIN();
     DataFlash.Log_Write_RCOUT();
+    DataFlash.Log_Write_RSSI(rssi);
 }
 
 void Plane::Log_Write_Baro(void)

--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -11,6 +11,7 @@
 #include <AP_Param/AP_Param.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_InertialSensor/AP_InertialSensor.h>
+#include <AP_RSSI/AP_RSSI.h>
 #include <AP_Baro/AP_Baro.h>
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Vehicle/AP_Vehicle.h>
@@ -88,6 +89,7 @@ public:
     void Log_Write_Vibration(const AP_InertialSensor &ins);
     void Log_Write_RCIN(void);
     void Log_Write_RCOUT(void);
+    void Log_Write_RSSI(AP_RSSI &rssi);
     void Log_Write_Baro(AP_Baro &baro);
     void Log_Write_Power(void);
     void Log_Write_AHRS2(AP_AHRS &ahrs);
@@ -286,6 +288,12 @@ struct PACKED log_RCOUT {
     uint16_t chan10;
     uint16_t chan11;
     uint16_t chan12;
+};
+
+struct PACKED log_RSSI {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    float RXRSSI;
 };
 
 struct PACKED log_BARO {
@@ -697,6 +705,8 @@ Format characters in the format string for binary log messages
       "RCIN",  "Qhhhhhhhhhhhhhh",     "TimeUS,C1,C2,C3,C4,C5,C6,C7,C8,C9,C10,C11,C12,C13,C14" }, \
     { LOG_RCOUT_MSG, sizeof(log_RCOUT), \
       "RCOU",  "Qhhhhhhhhhhhh",     "TimeUS,Ch1,Ch2,Ch3,Ch4,Ch5,Ch6,Ch7,Ch8,Ch9,Ch10,Ch11,Ch12" }, \
+    { LOG_RSSI_MSG, sizeof(log_RSSI), \
+      "RSSI",  "Qf",     "TimeUS,RXRSSI" }, \
     { LOG_BARO_MSG, sizeof(log_BARO), \
       "BARO",  "Qffcf", "TimeUS,Alt,Press,Temp,CRt" }, \
     { LOG_POWR_MSG, sizeof(log_POWR), \
@@ -833,6 +843,7 @@ enum LogMessages {
     LOG_MESSAGE_MSG,
     LOG_RCIN_MSG,
     LOG_RCOUT_MSG,
+    LOG_RSSI_MSG,
     LOG_IMU2_MSG,
     LOG_BARO_MSG,
     LOG_POWR_MSG,

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -779,6 +779,17 @@ void DataFlash_Class::Log_Write_RCOUT(void)
     Log_Write_ESC();
 }
 
+// Write an RSSI packet
+void DataFlash_Class::Log_Write_RSSI(AP_RSSI &rssi)
+{
+    struct log_RSSI pkt = {
+        LOG_PACKET_HEADER_INIT(LOG_RSSI_MSG),
+        time_us       : hal.scheduler->micros64(),
+        RXRSSI        : rssi.read_receiver_rssi()
+    };
+    WriteBlock(&pkt, sizeof(pkt));
+}
+
 // Write a BARO packet
 void DataFlash_Class::Log_Write_Baro(AP_Baro &baro)
 {


### PR DESCRIPTION
Adding RSSI value to logging using new RSSI library.

Closes #2021. Closes  #2245. See also http://diydrones.com/forum/topics/is-rxrssi-not-being-logged-by-apm-at-all-1, and #2798, where @tridge asks for a log with rssi.

![rssidemo](https://cloud.githubusercontent.com/assets/7128339/9688363/95105e0c-52e3-11e5-9c4e-f5622825593a.png)