### PR TITLE
scripts: Support to build for frame specific tags

### DIFF
--- a/Tools/scripts/build_binaries.sh
+++ b/Tools/scripts/build_binaries.sh
@@ -39,7 +39,8 @@ checkout() {
     vehicle="$1"
     tag="$2"
     board="$3"
-    echo "Trying checkout $vehicle $tag $board"
+    frame="$4"
+    echo "Trying checkout $vehicle $tag $board $frame"
     git stash
     if [ "$tag" = "latest" ]; then
 	vtag="master"
@@ -47,7 +48,19 @@ checkout() {
 	vtag="$vehicle-$tag"
     fi
 
-    # add board type specific branch extension
+    # try frame specific tag
+    if [ -n "$frame" ]; then
+        vtag2="$vtag-$frame"
+
+        git checkout -f "$vtag2" && {
+            echo "Using frame specific tag $vtag2"
+            [ -f $BASEDIR/.gitmodules ] && git submodule update
+            git log -1
+            return 0
+        }
+    fi
+
+    # try board type specific branch extension
     vtag2="$vtag"$(board_branch $board)
 
     git checkout -f "$vtag2" && {
@@ -64,7 +77,7 @@ checkout() {
         return 0
     }
 
-    echo "Failed to find tag for $vehicle $tag $board"
+    echo "Failed to find tag for $vehicle $tag $board $frame"
     return 1
 }
 
@@ -142,7 +155,7 @@ build_arduplane() {
     echo "Building ArduPlane $tag binaries from $(pwd)"
     pushd ArduPlane
     for b in apm1 apm2 navio pxf; do
-        checkout ArduPlane $tag $b || {
+        checkout ArduPlane $tag $b "" || {
             echo "Failed checkout of ArduPlane $b $tag"
             error_count=$((error_count+1))
             continue
@@ -162,10 +175,10 @@ build_arduplane() {
     done
     echo "Building ArduPlane PX4 binaries"
     ddir=$binaries/Plane/$hdate/PX4
-    checkout ArduPlane $tag PX4 || {
+    checkout ArduPlane $tag PX4 "" || {
         echo "Failed checkout of ArduPlane PX4 $tag"
         error_count=$((error_count+1))
-        checkout ArduPlane "latest" ""
+        checkout ArduPlane "latest" "" ""
         popd
         return
     }
@@ -173,7 +186,7 @@ build_arduplane() {
 	make px4 || {
             echo "Failed build of ArduPlane PX4 $tag"
             error_count=$((error_count+1))
-            checkout ArduPlane "latest" ""
+            checkout ArduPlane "latest" "" ""
             popd
             return
         }
@@ -186,7 +199,7 @@ build_arduplane() {
 	    copyit px4io-v2.elf $binaries/PX4IO/$hdate/PX4IO $tag
         fi
     }
-    checkout ArduPlane "latest" ""
+    checkout ArduPlane "latest" "" ""
     popd
 }
 
@@ -198,12 +211,12 @@ build_arducopter() {
     frames="quad tri hexa y6 octa octa-quad heli"
     for b in navio pxf; do
         for f in $frames; do
-            checkout ArduCopter $tag $b || {
-                echo "Failed checkout of ArduCopter $b $tag"
+            checkout ArduCopter $tag $b $f || {
+                echo "Failed checkout of ArduCopter $b $tag $f"
                 error_count=$((error_count+1))
                 continue
             }
-	    echo "Building ArduCopter $b binaries"
+	    echo "Building ArduCopter $b binaries $f"
 	    ddir=$binaries/Copter/$hdate/$b-$f
 	    skip_build $tag $ddir && continue
 	    make clean || continue
@@ -217,15 +230,14 @@ build_arducopter() {
 	    touch $binaries/Copter/$tag
         done
     done
-    checkout ArduCopter $tag PX4 || {
-        echo "Failed checkout of ArduCopter PX4 $tag"
-        error_count=$((error_count+1))
-        checkout ArduCopter "latest" ""
-        popd
-        return
-    }
-    rm -rf ../Build.ArduCopter
     for f in $frames; do
+        checkout ArduCopter $tag PX4 $f || {
+            echo "Failed checkout of ArduCopter PX4 $tag $f"
+            error_count=$((error_count+1))
+            checkout ArduCopter "latest" "" ""
+            continue
+        }
+        rm -rf ../Build.ArduCopter
 	echo "Building ArduCopter PX4-$f binaries"
 	ddir="$binaries/Copter/$hdate/PX4-$f"
 	skip_build $tag $ddir && continue
@@ -237,7 +249,7 @@ build_arducopter() {
 	copyit ArduCopter-v1.px4 $ddir $tag &&
 	copyit ArduCopter-v2.px4 $ddir $tag
     done
-    checkout ArduCopter "latest" ""
+    checkout ArduCopter "latest" "" ""
     popd
 }
 
@@ -248,7 +260,7 @@ build_rover() {
     pushd APMrover2
     for b in apm1 apm2 navio pxf; do
 	echo "Building APMrover2 $b binaries"
-        checkout APMrover2 $tag $b || continue
+        checkout APMrover2 $tag $b "" || continue
 	ddir=$binaries/Rover/$hdate/$b
 	skip_build $tag $ddir && continue
 	make clean || continue
@@ -263,8 +275,8 @@ build_rover() {
     done
     echo "Building APMrover2 PX4 binaries"
     ddir=$binaries/Rover/$hdate/PX4
-    checkout APMrover2 $tag PX4 || {
-        checkout APMrover2 "latest" ""
+    checkout APMrover2 $tag PX4 "" || {
+        checkout APMrover2 "latest" "" ""
         popd
         return
     }
@@ -272,14 +284,14 @@ build_rover() {
 	make px4 || {
             echo "Failed build of APMrover2 PX4 $tag"
             error_count=$((error_count+1))
-            checkout APMrover2 "latest" ""
+            checkout APMrover2 "latest" "" ""
             popd
             return
         }
 	copyit APMrover2-v1.px4 $binaries/Rover/$hdate/PX4 $tag &&
 	copyit APMrover2-v2.px4 $binaries/Rover/$hdate/PX4 $tag 
     }
-    checkout APMrover2 "latest" ""
+    checkout APMrover2 "latest" "" ""
     popd
 }
 
@@ -290,7 +302,7 @@ build_antennatracker() {
     pushd AntennaTracker
     for b in apm2; do
 	echo "Building AntennaTracker $b binaries"
-        checkout AntennaTracker $tag $b || continue
+        checkout AntennaTracker $tag $b "" || continue
 	ddir=$binaries/AntennaTracker/$hdate/$b
 	skip_build $tag $ddir && continue
 	make clean || continue
@@ -305,8 +317,8 @@ build_antennatracker() {
     done
     echo "Building AntennaTracker PX4 binaries"
     ddir=$binaries/AntennaTracker/$hdate/PX4
-    checkout AntennaTracker $tag PX4 || {
-        checkout AntennaTracker "latest" ""
+    checkout AntennaTracker $tag PX4 "" || {
+        checkout AntennaTracker "latest" "" ""
         popd
         return
     }
@@ -314,14 +326,14 @@ build_antennatracker() {
 	make px4 || {
             echo "Failed build of AntennaTracker PX4 $tag"
             error_count=$((error_count+1))
-            checkout AntennaTracker "latest" ""
+            checkout AntennaTracker "latest" "" ""
             popd
             return
         }
 	copyit AntennaTracker-v1.px4 $binaries/AntennaTracker/$hdate/PX4 $tag &&
 	copyit AntennaTracker-v2.px4 $binaries/AntennaTracker/$hdate/PX4 $tag 
     }
-    checkout AntennaTracker "latest" ""
+    checkout AntennaTracker "latest" "" ""
     popd
 }
 


### PR DESCRIPTION
The driver for this is to separate the Copter and TradHeli builds so
Copter and TradHeli do not have to be released at the same time.  This
will also work for all frame times but it is anticipated only required
by Heli.