### PR TITLE
Lightware serial support and PX4-I2C support

### DIFF
--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -144,7 +144,7 @@ private:
     AP_Baro barometer;
     Compass compass;
     AP_InertialSensor ins;
-    RangeFinder sonar;
+    RangeFinder sonar { serial_manager };
 
     // flight modes convenience array
     AP_Int8	*modes;

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -114,7 +114,7 @@ private:
 
     AP_InertialSensor ins;
 
-    RangeFinder rng;
+    RangeFinder rng {serial_manager};
 
 // Inertial Navigation EKF
 #if AP_AHRS_NAVEKF_AVAILABLE

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -178,7 +178,7 @@ private:
     AP_InertialSensor ins;
 
 #if CONFIG_SONAR == ENABLED
-    RangeFinder sonar;
+    RangeFinder sonar {serial_manager};
     bool sonar_enabled; // enable user switch for sonar
 #endif
 

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -191,7 +191,7 @@ private:
 
 #if RANGEFINDER_ENABLED == ENABLED
     // rangefinder
-    RangeFinder rangefinder;
+    RangeFinder rangefinder {serial_manager};
 
     struct {
         bool in_range;

--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -56,6 +56,7 @@
 #include <signal.h>
 #include <unistd.h>
 #include <AP_HAL/utility/getopt_cpp.h>
+#include <AP_SerialManager/AP_SerialManager.h>
 #include "Parameters.h"
 #include "VehicleType.h"
 #include "MsgHandler.h"
@@ -81,7 +82,8 @@ public:
     AP_Baro barometer;
     AP_GPS gps;
     Compass compass;
-    RangeFinder rng;
+    AP_SerialManager serial_manager;
+    RangeFinder rng {serial_manager};
     NavEKF EKF{&ahrs, barometer, rng};
     AP_AHRS_NavEKF ahrs {ins, barometer, gps, rng, EKF};
     AP_InertialNav_NavEKF inertial_nav{ahrs};

--- a/libraries/AP_HAL_PX4/AP_HAL_PX4_Namespace.h
+++ b/libraries/AP_HAL_PX4/AP_HAL_PX4_Namespace.h
@@ -14,6 +14,8 @@ namespace PX4 {
         class PX4GPIO;
         class PX4DigitalSource;
         class NSHShellStream;
+        class PX4I2CDriver;
+        class PX4_I2C;
 }
 
 #endif //__AP_HAL_PX4_NAMESPACE_H__

--- a/libraries/AP_HAL_PX4/HAL_PX4_Class.cpp
+++ b/libraries/AP_HAL_PX4/HAL_PX4_Class.cpp
@@ -15,6 +15,7 @@
 #include "AnalogIn.h"
 #include "Util.h"
 #include "GPIO.h"
+#include "I2CDriver.h"
 
 #include <AP_HAL_Empty/AP_HAL_Empty.h>
 #include <AP_HAL_Empty/AP_HAL_Empty_Private.h>
@@ -30,8 +31,7 @@
 
 using namespace PX4;
 
-static Empty::EmptySemaphore  i2cSemaphore;
-static Empty::EmptyI2CDriver  i2cDriver(&i2cSemaphore);
+static PX4I2CDriver i2cDriver;
 static Empty::EmptySPIDeviceManager spiDeviceManager;
 //static Empty::EmptyGPIO gpioDriver;
 

--- a/libraries/AP_HAL_PX4/I2CDriver.cpp
+++ b/libraries/AP_HAL_PX4/I2CDriver.cpp
@@ -1,0 +1,93 @@
+#include <AP_HAL/AP_HAL.h>
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_PX4
+
+#include "I2CDriver.h"
+#include <drivers/device/i2c.h>
+#include <arch/board/board.h>
+#include "board_config.h"
+
+extern const AP_HAL::HAL& hal;
+
+using namespace PX4;
+
+/*
+  wrapper class for I2C to expose protected functions from PX4Firmware
+ */
+class PX4::PX4_I2C : public device::I2C {
+public:
+    PX4_I2C(uint8_t bus);
+    bool do_transfer(uint8_t address, const uint8_t *send, uint32_t send_len, uint8_t *recv, uint32_t recv_len);
+};
+
+// constructor
+PX4_I2C::PX4_I2C(uint8_t bus) : 
+    I2C("AP_I2C", "/dev/api2c", bus, 0, 400000UL)
+{
+    /*
+      attach to the bus. Return value can be ignored as we have no probe function
+    */
+    init();
+}
+
+/*
+  main transfer function
+ */
+bool PX4_I2C::do_transfer(uint8_t address, const uint8_t *send, uint32_t send_len, uint8_t *recv, uint32_t recv_len)
+{
+    set_address(address);
+    return transfer(send, send_len, recv, recv_len) == OK;
+}
+
+
+// constructor for main i2c class
+PX4I2CDriver::PX4I2CDriver(void)
+{
+    px4_i2c = new PX4_I2C(PX4_I2C_BUS_EXPANSION);
+    if (px4_i2c == nullptr) {
+        hal.scheduler->panic("Unable to allocate PX4 I2C driver");
+    }
+}
+
+/* write: for i2c devices which do not obey register conventions */
+uint8_t PX4I2CDriver::write(uint8_t addr, uint8_t len, uint8_t* data)
+{
+    return px4_i2c->do_transfer(addr, data, len, nullptr, 0) ? 0:1;
+}
+
+/* writeRegister: write a single 8-bit value to a register */
+uint8_t PX4I2CDriver::writeRegister(uint8_t addr, uint8_t reg, uint8_t val)
+{
+    uint8_t d[2] = { reg, val };
+    return px4_i2c->do_transfer(addr, d, sizeof(d), nullptr, 0) ? 0:1;
+}
+
+/* writeRegisters: write bytes to contigious registers */
+uint8_t PX4I2CDriver::writeRegisters(uint8_t addr, uint8_t reg,
+                                     uint8_t len, uint8_t* data)
+{
+    return write(addr, 1, &reg) == 0 && write(addr, len, data) == 0;
+}
+
+/* read: for i2c devices which do not obey register conventions */
+uint8_t PX4I2CDriver::read(uint8_t addr, uint8_t len, uint8_t* data)
+{
+    return px4_i2c->do_transfer(addr, nullptr, 0, data, len) ? 0:1;
+}
+    
+/* readRegister: read from a device register - writes the register,
+ * then reads back an 8-bit value. */
+uint8_t PX4I2CDriver::readRegister(uint8_t addr, uint8_t reg, uint8_t* data)
+{
+    return px4_i2c->do_transfer(addr, &reg, 1, data, 1) ? 0:1;
+}
+
+/* readRegister: read contigious device registers - writes the first 
+ * register, then reads back multiple bytes */
+uint8_t PX4I2CDriver::readRegisters(uint8_t addr, uint8_t reg,
+                                    uint8_t len, uint8_t* data)
+{
+    return px4_i2c->do_transfer(addr, &reg, 1, data, len) ? 0:1;
+}
+
+#endif // CONFIG_HAL_BOARD

--- a/libraries/AP_HAL_PX4/I2CDriver.h
+++ b/libraries/AP_HAL_PX4/I2CDriver.h
@@ -1,0 +1,48 @@
+
+#ifndef __AP_HAL_PX4_I2CDRIVER_H__
+#define __AP_HAL_PX4_I2CDRIVER_H__
+
+#include "AP_HAL_PX4.h"
+#include <AP_HAL_Empty/AP_HAL_Empty.h>
+#include <AP_HAL_Empty/AP_HAL_Empty_Private.h>
+
+class PX4::PX4I2CDriver : public AP_HAL::I2CDriver {
+public:
+    PX4I2CDriver(void);
+
+    void begin() {}
+    void end() {}
+    void setTimeout(uint16_t ms) {}
+    void setHighSpeed(bool active) {}
+
+    /* write: for i2c devices which do not obey register conventions */
+    uint8_t write(uint8_t addr, uint8_t len, uint8_t* data);
+
+    /* writeRegister: write a single 8-bit value to a register */
+    uint8_t writeRegister(uint8_t addr, uint8_t reg, uint8_t val);
+
+    /* writeRegisters: write bytes to contigious registers */
+    uint8_t writeRegisters(uint8_t addr, uint8_t reg, uint8_t len, uint8_t* data);
+
+    /* read: for i2c devices which do not obey register conventions */
+    uint8_t read(uint8_t addr, uint8_t len, uint8_t* data);
+    
+    /* readRegister: read from a device register - writes the register,
+     * then reads back an 8-bit value. */
+    uint8_t readRegister(uint8_t addr, uint8_t reg, uint8_t* data);
+
+    /* readRegister: read contigious device registers - writes the first 
+     * register, then reads back multiple bytes */
+    uint8_t readRegisters(uint8_t addr, uint8_t reg, uint8_t len, uint8_t* data);
+    
+    uint8_t lockup_count() { return 0; }
+
+    AP_HAL::Semaphore* get_semaphore() { return &semaphore; }
+
+private:
+    // we use an empty semaphore as the underlying I2C class already has a semaphore
+    Empty::EmptySemaphore semaphore;
+    PX4_I2C *px4_i2c = nullptr;
+};
+
+#endif // __AP_HAL_PX4_I2CDRIVER_H__

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
@@ -1,0 +1,99 @@
+// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <AP_HAL/AP_HAL.h>
+#include "AP_RangeFinder_LightWareSerial.h"
+#include <AP_SerialManager/AP_SerialManager.h>
+#include <ctype.h>
+
+extern const AP_HAL::HAL& hal;
+
+/* 
+   The constructor also initialises the rangefinder. Note that this
+   constructor is not called until detect() returns true, so we
+   already know that we should setup the rangefinder
+*/
+AP_RangeFinder_LightWareSerial::AP_RangeFinder_LightWareSerial(RangeFinder &_ranger, uint8_t instance,
+                                                               RangeFinder::RangeFinder_State &_state,
+                                                               AP_SerialManager &serial_manager) :
+    AP_RangeFinder_Backend(_ranger, instance, _state)
+{
+    uart = serial_manager.find_serial(AP_SerialManager::SerialProtocol_Lidar, 0);
+    if (uart != nullptr) {
+        uart->begin(serial_manager.find_baudrate(AP_SerialManager::SerialProtocol_Lidar, 0));
+    }
+}
+
+/* 
+   detect if a Lightware rangefinder is connected. We'll detect by
+   trying to take a reading on Serial. If we get a result the sensor is
+   there.
+*/
+bool AP_RangeFinder_LightWareSerial::detect(RangeFinder &_ranger, uint8_t instance, AP_SerialManager &serial_manager)
+{
+    return serial_manager.find_serial(AP_SerialManager::SerialProtocol_Lidar, 0) != nullptr;
+}
+
+// read - return last value measured by sensor
+bool AP_RangeFinder_LightWareSerial::get_reading(uint16_t &reading_cm)
+{
+    if (uart == nullptr) {
+        return false;
+    }
+
+    // read any available lines from the lidar
+    float sum = 0;
+    uint16_t count = 0;
+    int16_t nbytes = uart->available();
+    while (nbytes-- > 0) {
+        char c = uart->read();
+        if (c == '\r') {
+            linebuf[linebuf_len] = 0;
+            sum += atof(linebuf);
+            count++;
+            linebuf_len = 0;
+        } else if (isdigit(c) || c == '.') {
+            linebuf[linebuf_len++] = c;
+            if (linebuf_len == sizeof(linebuf)) {
+                // too long, discard the line
+                linebuf_len = 0;
+            }
+        }
+    }
+
+    // we need to write a byte to prompt another reading
+    uart->write('\n');
+
+    if (count == 0) {
+        return false;
+    }
+    reading_cm = 100 * sum / count;
+    return true;
+}
+
+/* 
+   update the state of the sensor
+*/
+void AP_RangeFinder_LightWareSerial::update(void)
+{
+    if (get_reading(state.distance_cm)) {
+        // update range_valid state based on distance measured
+        last_reading_ms = hal.scheduler->millis();
+        update_status();
+    } else if (hal.scheduler->millis() - last_reading_ms > 200) {
+        set_status(RangeFinder::RangeFinder_NoData);
+    }
+}

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.h
@@ -1,0 +1,32 @@
+// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+
+#ifndef __AP_RANGEFINDER_LIGHTWARESERIAL_H__
+#define __AP_RANGEFINDER_LIGHTWARESERIAL_H__
+
+#include "RangeFinder.h"
+#include "RangeFinder_Backend.h"
+
+class AP_RangeFinder_LightWareSerial : public AP_RangeFinder_Backend
+{
+
+public:
+    // constructor
+    AP_RangeFinder_LightWareSerial(RangeFinder &ranger, uint8_t instance, RangeFinder::RangeFinder_State &_state,
+                                   AP_SerialManager &serial_manager);
+
+    // static detection function
+    static bool detect(RangeFinder &ranger, uint8_t instance, AP_SerialManager &serial_manager);
+
+    // update state
+    void update(void);
+
+private:
+    // get a reading
+    bool get_reading(uint16_t &reading_cm);
+
+    AP_HAL::UARTDriver *uart = nullptr;
+    uint32_t last_reading_ms = 0;
+    char linebuf[10];
+    uint8_t linebuf_len = 0;
+};
+#endif  // __AP_RANGEFINDER_LIGHTWARESERIAL_H__

--- a/libraries/AP_RangeFinder/RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/RangeFinder.cpp
@@ -29,7 +29,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] PROGMEM = {
     // @Param: _TYPE
     // @DisplayName: Rangefinder type
     // @Description: What type of rangefinder device that is connected
-    // @Values: 0:None,1:Analog,2:APM2-MaxbotixI2C,3:APM2-PulsedLightI2C,4:PX4-I2C,5:PX4-PWM,6:BBB-PRU
+    // @Values: 0:None,1:Analog,2:APM2-MaxbotixI2C,3:APM2-PulsedLightI2C,4:PX4-I2C,5:PX4-PWM,6:BBB-PRU,7:LightWareI2C,8:LightWareSerial
     AP_GROUPINFO("_TYPE",    0, RangeFinder, _type[0], 0),
 
     // @Param: _PIN
@@ -113,7 +113,7 @@ const AP_Param::GroupInfo RangeFinder::var_info[] PROGMEM = {
     // @Param: 2_TYPE
     // @DisplayName: Second Rangefinder type
     // @Description: What type of rangefinder device that is connected
-    // @Values: 0:None,1:Analog,2:APM2-MaxbotixI2C,3:APM2-PulsedLightI2C,4:PX4-I2C,5:PX4-PWM,6:BBB-PRU
+    // @Values: 0:None,1:Analog,2:APM2-MaxbotixI2C,3:APM2-PulsedLightI2C,4:PX4-I2C,5:PX4-PWM,6:BBB-PRU,7:LightWareI2C,8:LightWareSerial
     AP_GROUPINFO("2_TYPE",    12, RangeFinder, _type[1], 0),
 
     // @Param: 2_PIN

--- a/libraries/AP_RangeFinder/RangeFinder.h
+++ b/libraries/AP_RangeFinder/RangeFinder.h
@@ -21,6 +21,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
+#include <AP_SerialManager/AP_SerialManager.h>
 
 // Maximum number of range finder instances available on this platform
 #define RANGEFINDER_MAX_INSTANCES 2
@@ -35,7 +36,7 @@ class RangeFinder
 public:
     friend class AP_RangeFinder_Backend;
 
-    RangeFinder(void);
+    RangeFinder(AP_SerialManager &_serial_manager);
 
     // RangeFinder driver types
     enum RangeFinder_Type {
@@ -46,7 +47,8 @@ public:
         RangeFinder_TYPE_PX4    = 4,
         RangeFinder_TYPE_PX4_PWM= 5,
         RangeFinder_TYPE_BBB_PRU= 6,
-        RangeFinder_TYPE_LWI2C  = 7
+        RangeFinder_TYPE_LWI2C  = 7,
+        RangeFinder_TYPE_LWSER  = 8
     };
 
     enum RangeFinder_Function {
@@ -182,6 +184,7 @@ private:
     uint8_t primary_instance:2;
     uint8_t num_instances:2;
     float estimated_terrain_height;
+    AP_SerialManager &serial_manager;
 
     void detect_instance(uint8_t instance);
     void update_instance(uint8_t instance);  

--- a/libraries/AP_RangeFinder/examples/RFIND_test/RFIND_test.cpp
+++ b/libraries/AP_RangeFinder/examples/RFIND_test/RFIND_test.cpp
@@ -34,10 +34,12 @@
 #include <AP_Scheduler/AP_Scheduler.h>
 #include <AP_BattMonitor/AP_BattMonitor.h>
 #include <AP_Rally/AP_Rally.h>
+#include <AP_SerialManager/AP_SerialManager.h>
 
 const AP_HAL::HAL& hal = AP_HAL_BOARD_DRIVER;
 
-static RangeFinder sonar;
+static AP_SerialManager serial_manager;
+static RangeFinder sonar {serial_manager};
 
 void setup()
 {

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -37,7 +37,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] PROGMEM = {
     // @Param: 1_PROTOCOL
     // @DisplayName: Telem1 protocol selection
     // @Description: Control what protocol to use on the Telem1 port. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: 1:GCS Mavlink, 3:Frsky D-PORT, 4:Frsky S-PORT, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial
+    // @Values: 1:GCS Mavlink, 3:Frsky D-PORT, 4:Frsky S-PORT, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Lidar
     // @User: Standard
     AP_GROUPINFO("1_PROTOCOL",  1, AP_SerialManager, state[1].protocol, SerialProtocol_MAVLink),
 
@@ -51,7 +51,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] PROGMEM = {
     // @Param: 2_PROTOCOL
     // @DisplayName: Telemetry 2 protocol selection
     // @Description: Control what protocol to use on the Telem2 port. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: 1:GCS Mavlink, 3:Frsky D-PORT, 4:Frsky S-PORT, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial
+    // @Values: 1:GCS Mavlink, 3:Frsky D-PORT, 4:Frsky S-PORT, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Lidar
     // @User: Standard
     AP_GROUPINFO("2_PROTOCOL",  3, AP_SerialManager, state[2].protocol, SerialProtocol_MAVLink),
 
@@ -65,7 +65,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] PROGMEM = {
     // @Param: 3_PROTOCOL
     // @DisplayName: Serial 3 (GPS) protocol selection
     // @Description: Control what protocol Serial 3 (GPS) should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: 1:GCS Mavlink, 3:Frsky D-PORT, 4:Frsky S-PORT, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial
+    // @Values: 1:GCS Mavlink, 3:Frsky D-PORT, 4:Frsky S-PORT, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Lidar
     // @User: Standard
     AP_GROUPINFO("3_PROTOCOL",  5, AP_SerialManager, state[3].protocol, SerialProtocol_GPS),
 
@@ -79,7 +79,7 @@ const AP_Param::GroupInfo AP_SerialManager::var_info[] PROGMEM = {
     // @Param: 4_PROTOCOL
     // @DisplayName: Serial4 protocol selection
     // @Description: Control what protocol Serial4 port should be used for. Note that the Frsky options require external converter hardware. See the wiki for details.
-    // @Values: 1:GCS Mavlink, 3:Frsky D-PORT, 4:Frsky S-PORT, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial
+    // @Values: 1:GCS Mavlink, 3:Frsky D-PORT, 4:Frsky S-PORT, 5:GPS, 7:Alexmos Gimbal Serial, 8:SToRM32 Gimbal Serial, 9:Lidar
     // @User: Standard
     AP_GROUPINFO("4_PROTOCOL",  7, AP_SerialManager, state[4].protocol, SerialProtocol_GPS),
 

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -81,6 +81,7 @@ public:
         SerialProtocol_GPS2 = 6,        // do not use - use GPS and provide instance of 1
         SerialProtocol_AlexMos = 7,
         SerialProtocol_SToRM32 = 8,
+        SerialProtocol_Lidar = 9,
     };
 
     // Constructor


### PR DESCRIPTION
This adds support for the LightWare Lidar on serial ports, plus adds initial support for in-tree PX4 I2C drivers, which allows for the Lightware driver on I2C on Pixhawk
