### PR TITLE
Vdop Logging and MAVLink Support

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -551,7 +551,7 @@ AP_GPS::send_mavlink_gps_raw(mavlink_channel_t chan)
         loc.lng,        // in 1E7 degrees
         loc.alt * 10UL, // in mm
         get_hdop(0),
-        65535,
+        get_vdop(0),
         ground_speed(0)*100,  // cm/s
         ground_course_cd(0), // 1/100 degrees,
         num_sats(0));
@@ -580,7 +580,7 @@ AP_GPS::send_mavlink_gps2_raw(mavlink_channel_t chan)
         loc.lng,
         loc.alt * 10UL,
         get_hdop(1),
-        65535,
+        get_vdop(1),
         ground_speed(1)*100,  // cm/s
         ground_course_cd(1), // 1/100 degrees,
         num_sats(1),

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -131,6 +131,7 @@ public:
         float ground_speed;                 ///< ground speed in m/sec
         int32_t ground_course_cd;           ///< ground course in 100ths of a degree
         uint16_t hdop;                      ///< horizontal dilution of precision in cm
+        uint16_t vdop;                      ///< vertical dilution of precision in cm
         uint8_t num_sats;                   ///< Number of visible satelites        
         Vector3f velocity;                  ///< 3D velocitiy in m/s, in NED format
         float speed_accuracy;

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -282,6 +282,14 @@ public:
         return get_hdop(primary_instance);
     }
 
+    // vertical dilution of precision
+    uint16_t get_vdop(uint8_t instance) const {
+        return _GPS_STATE(instance).vdop;
+    }
+    uint16_t get_vdop() const {
+        return get_vdop(primary_instance);
+    }
+
     // the time we got our last fix in system milliseconds. This is
     // used when calculating how far we might have moved since that fix
     uint32_t last_fix_time_ms(uint8_t instance) const {

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -582,8 +582,10 @@ AP_GPS_UBLOX::_parse_gps(void)
         Debug("MSG_DOP");
         noReceivedHdop = false;
         state.hdop        = _buffer.dop.hDOP;
+        state.vdop        = _buffer.dop.vDOP;
 #if UBLOX_FAKE_3DLOCK
         state.hdop = 130;
+        state.hdop = 170;
 #endif
         break;
     case MSG_SOL:

--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -211,6 +211,7 @@ struct PACKED log_GPS {
     uint16_t gps_week;
     uint8_t  num_sats;
     uint16_t hdop;
+    uint16_t vdop;
     int32_t  latitude;
     int32_t  longitude;
     int32_t  rel_altitude;
@@ -688,7 +689,7 @@ Format characters in the format string for binary log messages
     { LOG_PARAMETER_MSG, sizeof(log_Parameter), \
       "PARM", "QNf",        "TimeUS,Name,Value" },    \
     { LOG_GPS_MSG, sizeof(log_GPS), \
-      "GPS",  "QBIHBcLLeeEefB", "TimeUS,Status,GMS,GWk,NSats,HDop,Lat,Lng,RAlt,Alt,Spd,GCrs,VZ,U" }, \
+      "GPS",  "QBIHBccLLeeEefB", "TimeUS,Stat,GMS,GWk,NSat,EPH,EPV,Lat,Lng,RAlt,Alt,Spd,GCrs,VZ,U" }, \
     { LOG_IMU_MSG, sizeof(log_IMU), \
       "IMU",  "QffffffIIfBB",     "TimeUS,GyrX,GyrY,GyrZ,AccX,AccY,AccZ,ErrG,ErrA,Temp,GyHlt,AcHlt" }, \
     { LOG_MESSAGE_MSG, sizeof(log_Message), \

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -720,6 +720,7 @@ void DataFlash_Class::Log_Write_GPS(const AP_GPS &gps, uint8_t i, int32_t relati
         gps_week      : gps.time_week(i),
         num_sats      : gps.num_sats(i),
         hdop          : gps.get_hdop(i),
+        vdop          : gps.get_vdop(i),
         latitude      : loc.lat,
         longitude     : loc.lng,
         rel_altitude  : relative_alt,


### PR DESCRIPTION
Adds support for logging Vdop to dataflash and transmitting via MAVLink. The only driver that currently does it is the ublox driver. (Was a free add to the ublox driver as we are already requesting the relevant packet).

DO NOT MERGE YET. Was written while at the airport an unable to acquire a GPS lock. I know that it compiles, uploads and doesn't crash the autopilot, but I haven't been able to test it. (Particularly the logging aspect, I briefly saw a 1D fix here that makes me think the MAVLink portion is working). I just need to verify everything. (Or if someone else beats me to it).

This resolves #512