### PR TITLE
AP_HAL_Linux: Make RCOutput_PCA9685 a bit more generic

### DIFF
--- a/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
+++ b/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
@@ -96,7 +96,7 @@ static LinuxRCOutput_AioPRU rcoutDriver;
   use the PCA9685 based RCOutput driver on Navio
  */
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO
-static LinuxRCOutput_PCA9685 rcoutDriver(true, 3, RPI_GPIO_27);
+static LinuxRCOutput_PCA9685 rcoutDriver(PCA9685_PRIMARY_ADDRESS, true, 3, RPI_GPIO_27);
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_ZYNQ
 static LinuxRCOutput_ZYNQ rcoutDriver;
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BEBOP

--- a/libraries/AP_HAL_Linux/RCOutput_PCA9685.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_PCA9685.cpp
@@ -54,7 +54,7 @@
 
 using namespace Linux;
 
-#define PWM_CHAN_COUNT 13
+#define PWM_CHAN_COUNT 16
 
 static const AP_HAL::HAL& hal = AP_HAL_BOARD_DRIVER;
 
@@ -64,7 +64,7 @@ LinuxRCOutput_PCA9685::LinuxRCOutput_PCA9685(bool external_clock,
     _i2c_sem(NULL),
     _enable_pin(NULL),
     _frequency(50),
-    _pulses_buffer(new uint16_t[PWM_CHAN_COUNT]),
+    _pulses_buffer(new uint16_t[PWM_CHAN_COUNT - channel_offset]),
     _external_clock(external_clock),
     _channel_offset(channel_offset),
     _oe_pin_number(oe_pin_number)
@@ -119,7 +119,7 @@ void LinuxRCOutput_PCA9685::set_freq(uint32_t chmask, uint16_t freq_hz)
 {
 
     /* Correctly finish last pulses */
-    for (int i = 0; i < PWM_CHAN_COUNT; i++) {
+    for (int i = 0; i < (PWM_CHAN_COUNT - _channel_offset); i++) {
         write(i, _pulses_buffer[i]);
     }
 
@@ -175,7 +175,7 @@ void LinuxRCOutput_PCA9685::disable_ch(uint8_t ch)
 
 void LinuxRCOutput_PCA9685::write(uint8_t ch, uint16_t period_us)
 {
-    if(ch >= PWM_CHAN_COUNT){
+    if (ch >= (PWM_CHAN_COUNT - _channel_offset)) {
         return;
     }
 

--- a/libraries/AP_HAL_Linux/RCOutput_PCA9685.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_PCA9685.cpp
@@ -60,7 +60,7 @@ static const AP_HAL::HAL& hal = AP_HAL_BOARD_DRIVER;
 
 LinuxRCOutput_PCA9685::LinuxRCOutput_PCA9685(bool external_clock,
                                              uint8_t channel_offset,
-                                             uint8_t oe_pin_number) :
+                                             int16_t oe_pin_number) :
     _i2c_sem(NULL),
     _enable_pin(NULL),
     _frequency(50),
@@ -95,9 +95,11 @@ void LinuxRCOutput_PCA9685::init(void* machtnicht)
     set_freq(0, 50);
 
     /* Enable PCA9685 PWM */
-    _enable_pin = hal.gpio->channel(_oe_pin_number);
-    _enable_pin->mode(HAL_GPIO_OUTPUT);
-    _enable_pin->write(0);
+    if (_oe_pin_number != -1) {
+        _enable_pin = hal.gpio->channel(_oe_pin_number);
+        _enable_pin->mode(HAL_GPIO_OUTPUT);
+        _enable_pin->write(0);
+    }
 }
 
 void LinuxRCOutput_PCA9685::reset_all_channels()

--- a/libraries/AP_HAL_Linux/RCOutput_PCA9685.h
+++ b/libraries/AP_HAL_Linux/RCOutput_PCA9685.h
@@ -6,8 +6,9 @@
 
 class Linux::LinuxRCOutput_PCA9685 : public AP_HAL::RCOutput {
     public:
+
     LinuxRCOutput_PCA9685(bool external_clock, uint8_t channel_offset,
-                          uint8_t oe_pin_number);
+                          int16_t oe_pin_number);
     ~LinuxRCOutput_PCA9685();
     void     init(void* machtnichts);
     void     reset_all_channels();
@@ -32,7 +33,7 @@ private:
 
     bool _external_clock;
     uint8_t _channel_offset;
-    uint8_t _oe_pin_number;
+    int16_t _oe_pin_number;
 };
 
 #endif // __AP_HAL_LINUX_RCOUTPUT_PCA9685_H__

--- a/libraries/AP_HAL_Linux/RCOutput_PCA9685.h
+++ b/libraries/AP_HAL_Linux/RCOutput_PCA9685.h
@@ -4,10 +4,13 @@
 
 #include "AP_HAL_Linux.h"
 
+#define PCA9685_PRIMARY_ADDRESS             0x40 // All address pins low, PCA9685 default
+#define PCA9685_SECONDARY_ADDRESS           0x41
+#define PCA9685_TERTIARY_ADDRESS            0x42
+
 class Linux::LinuxRCOutput_PCA9685 : public AP_HAL::RCOutput {
     public:
-
-    LinuxRCOutput_PCA9685(bool external_clock, uint8_t channel_offset,
+    LinuxRCOutput_PCA9685(uint8_t addr, bool external_clock, uint8_t channel_offset,
                           int16_t oe_pin_number);
     ~LinuxRCOutput_PCA9685();
     void     init(void* machtnichts);
@@ -31,6 +34,7 @@ private:
 
     uint16_t *_pulses_buffer;
 
+    uint8_t _addr;
     bool _external_clock;
     uint8_t _channel_offset;
     int16_t _oe_pin_number;


### PR DESCRIPTION
Makes RCOutput_PCA9685 a bit more generic and more suitable for boards other than the Navio+.

* Configurable I2C address.
* Allow full use of 16 channels.
* Don't use enable pin if we don't have to.