### PR TITLE
Use method for downcast

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_Bebop.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Bebop.cpp
@@ -142,9 +142,8 @@ void AP_BattMonitor_Bebop::read(void)
     uint32_t tnow;
     BebopBLDC_ObsData data;
     float remaining, vbat, vbat_raw;
-    Linux::LinuxRCOutput_Bebop *rcout;
 
-    rcout = (Linux::LinuxRCOutput_Bebop *)hal.rcout;
+    auto rcout = Linux::LinuxRCOutput_Bebop::from(hal.rcout);
     tnow = hal.scheduler->micros();
 
     ret = rcout->read_obs_data(data);

--- a/libraries/AP_HAL_Linux/RCInput.h
+++ b/libraries/AP_HAL_Linux/RCInput.h
@@ -9,6 +9,11 @@
 class Linux::LinuxRCInput : public AP_HAL::RCInput {
 public:
     LinuxRCInput();
+
+    static LinuxRCInput *from(AP_HAL::RCInput *rcinput) {
+        return static_cast<LinuxRCInput*>(rcinput);
+    }
+
     virtual void init(void* machtnichts);
     bool new_input();
     uint8_t num_channels();

--- a/libraries/AP_HAL_Linux/RCOutput_Bebop.h
+++ b/libraries/AP_HAL_Linux/RCOutput_Bebop.h
@@ -50,6 +50,11 @@ public:
 class Linux::LinuxRCOutput_Bebop : public AP_HAL::RCOutput {
 public:
     LinuxRCOutput_Bebop();
+
+    static LinuxRCOutput_Bebop *from(AP_HAL::RCOutput *rcout) {
+        return static_cast<LinuxRCOutput_Bebop*>(rcout);
+    }
+
     void     init(void* dummy);
     void     set_freq(uint32_t chmask, uint16_t freq_hz);
     uint16_t get_freq(uint8_t ch);

--- a/libraries/AP_HAL_Linux/RPIOUARTDriver.h
+++ b/libraries/AP_HAL_Linux/RPIOUARTDriver.h
@@ -9,6 +9,11 @@
 class Linux::LinuxRPIOUARTDriver : public Linux::LinuxUARTDriver {
 public:
     LinuxRPIOUARTDriver();
+
+    static LinuxRPIOUARTDriver *from(AP_HAL::UARTDriver *uart) {
+        return static_cast<LinuxRPIOUARTDriver*>(uart);
+    }
+
     void begin(uint32_t b, uint16_t rxS, uint16_t txS);
     void _timer_tick(void);
     bool isExternal(void);

--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -341,7 +341,7 @@ void *LinuxScheduler::_rcin_thread(void *arg)
     }
     while (true) {
         sched->_microsleep(APM_LINUX_RCIN_PERIOD);
-        ((LinuxRCInput *)hal.rcin)->_timer_tick();
+        LinuxRCInput::from(hal.rcin)->_timer_tick();
     }
     return NULL;
 }
@@ -357,18 +357,17 @@ void *LinuxScheduler::_uart_thread(void* arg)
         sched->_microsleep(APM_LINUX_UART_PERIOD);
 
         // process any pending serial bytes
-        ((LinuxUARTDriver *)hal.uartA)->_timer_tick();
-        ((LinuxUARTDriver *)hal.uartB)->_timer_tick();
+        LinuxUARTDriver::from(hal.uartA)->_timer_tick();
+        LinuxUARTDriver::from(hal.uartB)->_timer_tick();
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_RASPILOT
         //SPI UART not use SPI
-        if ( ((LinuxRPIOUARTDriver *)hal.uartC)->isExternal() )
-        {
-            ((LinuxRPIOUARTDriver *)hal.uartC)->_timer_tick();
+        if (LinuxRPIOUARTDriver::from(hal.uartC)->isExternal()) {
+            LinuxRPIOUARTDriver::from(hal.uartC)->_timer_tick();
         }
 #else
-        ((LinuxUARTDriver *)hal.uartC)->_timer_tick();
+        LinuxUARTDriver::from(hal.uartC)->_timer_tick();
 #endif
-        ((LinuxUARTDriver *)hal.uartE)->_timer_tick();
+        LinuxUARTDriver::from(hal.uartE)->_timer_tick();
     }
     return NULL;
 }
@@ -384,7 +383,7 @@ void *LinuxScheduler::_tonealarm_thread(void* arg)
         sched->_microsleep(APM_LINUX_TONEALARM_PERIOD);
 
         // process tone command
-        ((LinuxUtil *)hal.util)->_toneAlarm_timer_tick();
+        LinuxUtil::from(hal.util)->_toneAlarm_timer_tick();
     }
     return NULL;
 }
@@ -400,7 +399,7 @@ void *LinuxScheduler::_io_thread(void* arg)
         sched->_microsleep(APM_LINUX_IO_PERIOD);
 
         // process any pending storage writes
-        ((LinuxStorage *)hal.storage)->_timer_tick();
+        LinuxStorage::from(hal.storage)->_timer_tick();
 
         // run registered IO procepsses
         sched->_run_io();

--- a/libraries/AP_HAL_Linux/Storage.h
+++ b/libraries/AP_HAL_Linux/Storage.h
@@ -16,13 +16,15 @@
 #define LINUX_STORAGE_LINE_SIZE (1<<LINUX_STORAGE_LINE_SHIFT)
 #define LINUX_STORAGE_NUM_LINES (LINUX_STORAGE_SIZE/LINUX_STORAGE_LINE_SIZE)
 
-class Linux::LinuxStorage : public AP_HAL::Storage 
+class Linux::LinuxStorage : public AP_HAL::Storage
 {
 public:
-    LinuxStorage() :
-	_fd(-1),
-	_dirty_mask(0)
-	{}
+    LinuxStorage() : _fd(-1),_dirty_mask(0) { }
+
+    static LinuxStorage *from(AP_HAL::Storage *storage) {
+        return static_cast<LinuxStorage*>(storage);
+    }
+
     void init(void* machtnichts) {}
     uint8_t  read_byte(uint16_t loc);
     uint16_t read_word(uint16_t loc);

--- a/libraries/AP_HAL_Linux/UARTDriver.h
+++ b/libraries/AP_HAL_Linux/UARTDriver.h
@@ -9,6 +9,11 @@
 class Linux::LinuxUARTDriver : public AP_HAL::UARTDriver {
 public:
     LinuxUARTDriver(bool default_console);
+
+    static LinuxUARTDriver *from(AP_HAL::UARTDriver *uart) {
+        return static_cast<LinuxUARTDriver*>(uart);
+    }
+
     /* Linux implementations of UARTDriver virtual methods */
     void begin(uint32_t b);
     void begin(uint32_t b, uint16_t rxS, uint16_t txS);

--- a/libraries/AP_HAL_Linux/Util.h
+++ b/libraries/AP_HAL_Linux/Util.h
@@ -8,6 +8,10 @@
 
 class Linux::LinuxUtil : public AP_HAL::Util {
 public:
+    static LinuxUtil *from(AP_HAL::Util *util) {
+        return static_cast<LinuxUtil*>(util);
+    }
+
     void init(int argc, char * const *argv) {
         saved_argc = argc;
         saved_argv = argv;

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -524,7 +524,7 @@ void SITL_State::init(int argc, char * const argv[])
     pwm_input[4] = pwm_input[7] = 1800;
     pwm_input[2] = pwm_input[5] = pwm_input[6] = 1000;
 
-    _scheduler = (SITLScheduler *)hal.scheduler;
+    _scheduler = SITLScheduler::from(hal.scheduler);
     _parse_command_line(argc, argv);
 }
 

--- a/libraries/AP_HAL_SITL/Scheduler.h
+++ b/libraries/AP_HAL_SITL/Scheduler.h
@@ -13,6 +13,10 @@
 class HALSITL::SITLScheduler : public AP_HAL::Scheduler {
 public:
     SITLScheduler(SITL_State *sitlState);
+    static SITLScheduler *from(AP_HAL::Scheduler *scheduler) {
+        return static_cast<SITLScheduler*>(scheduler);
+    }
+
     /* AP_HAL::Scheduler methods */
 
     void     init(void *unused);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -952,7 +952,7 @@ AP_MPU6000_AuxiliaryBusSlave::AP_MPU6000_AuxiliaryBusSlave(AuxiliaryBus &bus, ui
 int AP_MPU6000_AuxiliaryBusSlave::_set_passthrough(uint8_t reg, uint8_t size,
                                                   uint8_t *out)
 {
-    AP_InertialSensor_MPU6000 &backend = static_cast<AP_InertialSensor_MPU6000&>(_bus.get_backend());
+    auto backend = AP_InertialSensor_MPU6000::from(_bus.get_backend());
     uint8_t addr;
 
     /* Ensure the slave read/write is disabled before changing the registers */
@@ -989,7 +989,7 @@ int AP_MPU6000_AuxiliaryBusSlave::passthrough_read(uint8_t reg, uint8_t *buf,
     /* wait the value to be read from the slave and read it back */
     hal.scheduler->delay(10);
 
-    AP_InertialSensor_MPU6000 &backend = static_cast<AP_InertialSensor_MPU6000&>(_bus.get_backend());
+    auto backend = AP_InertialSensor_MPU6000::from(_bus.get_backend());
     backend._read_block(MPUREG_EXT_SENS_DATA_00 + _ext_sens_data, buf, size);
 
     /* disable new reads */
@@ -1012,7 +1012,7 @@ int AP_MPU6000_AuxiliaryBusSlave::passthrough_write(uint8_t reg, uint8_t val)
     /* wait the value to be written to the slave */
     hal.scheduler->delay(10);
 
-    AP_InertialSensor_MPU6000 &backend = static_cast<AP_InertialSensor_MPU6000&>(_bus.get_backend());
+    auto backend = AP_InertialSensor_MPU6000::from(_bus.get_backend());
 
     /* disable new writes */
     backend._register_write(_mpu6000_ctrl, 0);
@@ -1027,7 +1027,7 @@ int AP_MPU6000_AuxiliaryBusSlave::read(uint8_t *buf)
         return -1;
     }
 
-    AP_InertialSensor_MPU6000 &backend = static_cast<AP_InertialSensor_MPU6000&>(_bus.get_backend());
+    auto backend = AP_InertialSensor_MPU6000::from(_bus.get_backend());
     backend._read_block(MPUREG_EXT_SENS_DATA_00 + _ext_sens_data, buf, _sample_size);
 
     return 0;
@@ -1056,7 +1056,7 @@ AuxiliaryBusSlave *AP_MPU6000_AuxiliaryBus::_instantiate_slave(uint8_t addr, uin
 
 void AP_MPU6000_AuxiliaryBus::_configure_slaves()
 {
-    AP_InertialSensor_MPU6000 &backend = static_cast<AP_InertialSensor_MPU6000&>(_ins_backend);
+    auto backend = AP_InertialSensor_MPU6000::from(_ins_backend);
 
     uint8_t user_ctrl;
     user_ctrl = backend._register_read(MPUREG_USER_CTRL);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.h
@@ -65,6 +65,9 @@ public:
                                                  AP_HAL::I2CDriver *i2c,
                                                  uint8_t addr);
     static AP_InertialSensor_Backend *detect_spi(AP_InertialSensor &_imu);
+    static AP_InertialSensor_MPU6000 &from(AP_InertialSensor_Backend &backend) {
+        return static_cast<AP_InertialSensor_MPU6000&>(backend);
+    }
 
     /* update accel and gyro state */
     bool update();


### PR DESCRIPTION
Instead of just doing a static cast to the desired class, use a method
named "from". Pros:

  - When we have data shared on the parent class, the code is cleaner in
    child class when it needs to access this data. Almost all the data
    we use in AP_HAL benefits from this

  - There's a minimal type checking because now we are using a method
    that can only receive the type of the parent class

I saw more casts being while reviewing #2698.  There are probably more cases in the code base. I just selected a few to ask for opinions.