### PR TITLE
Prevent failure to use GPS due to change in magnetic field after startup

### DIFF
--- a/libraries/AP_Compass/Compass.cpp
+++ b/libraries/AP_Compass/Compass.cpp
@@ -770,3 +770,80 @@ void Compass::motor_compensation_type(const uint8_t comp_type)
         }
     }
 }
+
+uint8_t Compass::get_use_mask() const
+{
+    uint8_t ret = 0;
+    for (uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
+        if (use_for_yaw(i)) {
+            ret |= 1 << i;
+        }
+    }
+    return ret;
+}
+
+bool Compass::consistent(uint8_t mask) const
+{
+    Vector3f primary_mag_field = get_field();
+    float primary_mag_field_mag = primary_mag_field.length();
+    Vector3f primary_mag_field_norm;
+
+    if (!is_zero(primary_mag_field_mag)) {
+        primary_mag_field_norm = primary_mag_field / primary_mag_field_mag;
+    } else {
+        return false;
+    }
+
+    Vector2f primary_mag_field_xy = Vector2f(primary_mag_field.x,primary_mag_field.y);
+    float primary_mag_field_xy_mag = primary_mag_field_xy.length();
+    Vector2f primary_mag_field_xy_norm;
+
+    if (!is_zero(primary_mag_field_xy_mag)) {
+        primary_mag_field_xy_norm = primary_mag_field_xy / primary_mag_field_xy_mag;
+    } else {
+        return false;
+    }
+
+    for (uint8_t i=0; i<COMPASS_MAX_INSTANCES; i++) {
+        if ((1<<i) & mask) {
+            Vector3f mag_field = get_field(i);
+            float mag_field_mag = mag_field.length();
+            Vector3f mag_field_norm;
+
+            if (!is_zero(mag_field_mag)) {
+                mag_field_norm = mag_field / mag_field_mag;
+            } else {
+                return false;
+            }
+
+            Vector2f mag_field_xy = Vector2f(mag_field.x,mag_field.y);
+            float mag_field_xy_mag = mag_field_xy.length();
+            Vector2f mag_field_xy_norm;
+
+            if (!is_zero(mag_field_xy_mag)) {
+                mag_field_xy_norm = mag_field_xy / mag_field_xy_mag;
+            } else {
+                return false;
+            }
+
+            float xyz_ang_diff = acosf(constrain_float(mag_field_norm * primary_mag_field_norm,-1.0f,1.0f));
+            float xy_ang_diff  = acosf(constrain_float(mag_field_xy_norm*primary_mag_field_xy_norm,-1.0f,1.0f));
+            float xy_len_diff  = (primary_mag_field_xy-mag_field_xy).length();
+
+            // check for gross misalignment on all axes
+            bool xyz_ang_diff_large = xyz_ang_diff > AP_COMPASS_MAX_XYZ_ANG_DIFF;
+
+            // check for an unacceptable angle difference on the xy plane
+            bool xy_ang_diff_large = xy_ang_diff > AP_COMPASS_MAX_XY_ANG_DIFF;
+
+            // check for an unacceptable length difference on the xy plane
+            bool xy_length_diff_large = xy_len_diff > AP_COMPASS_MAX_XY_LENGTH_DIFF;
+
+            // check for inconsistency in the XY plane
+            if (xyz_ang_diff_large || xy_ang_diff_large || xy_length_diff_large) {
+                return false;
+            }
+        }
+    }
+    return true;
+}

--- a/libraries/AP_Compass/Compass.h
+++ b/libraries/AP_Compass/Compass.h
@@ -49,6 +49,9 @@
 //MAXIMUM COMPASS REPORTS
 #define MAX_CAL_REPORTS 10
 #define CONTINUOUS_REPORTS 0
+#define AP_COMPASS_MAX_XYZ_ANG_DIFF radians(50.0f)
+#define AP_COMPASS_MAX_XY_ANG_DIFF radians(30.0f)
+#define AP_COMPASS_MAX_XY_LENGTH_DIFF 100.0f
 
 class Compass
 {
@@ -161,6 +164,10 @@ public:
 
     void send_mag_cal_progress(mavlink_channel_t chan);
     void send_mag_cal_report(mavlink_channel_t chan);
+
+    uint8_t get_use_mask() const;
+    bool consistent(uint8_t mask) const;
+    bool consistent() const { return consistent(get_use_mask()); }
 
     /// Return the health of a compass
     bool healthy(uint8_t i) const { return _state[i].healthy; }

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -5232,6 +5232,8 @@ bool NavEKF::calcGpsGoodToAlign(void)
         Vector3f eulerAngles;
         getEulerAngles(eulerAngles);
         state.quat = calcQuatAndFieldStates(eulerAngles.x, eulerAngles.y);
+        // reset timer to ensure that bad magnetometer data cannot cause a heading reset more often than every 5 seconds
+        magYawResetTimer_ms = imuSampleTime_ms;
     }
 
     // fail if magnetometer innovations are outside limits indicating bad yaw

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -4376,6 +4376,9 @@ void NavEKF::readMagData()
         // read compass data and scale to improve numerical conditioning
         magData = _ahrs->get_compass()->get_field_milligauss() * 0.001f;
 
+        // check for consistent data between magnetometers
+        consistentMagData = _ahrs->get_compass()->consistent();
+
         // get states stored at time closest to measurement time after allowance for measurement delay
         RecallStates(statesAtMagMeasTime, (imuSampleTime_ms - msecMagDelay));
 
@@ -4686,6 +4689,7 @@ void NavEKF::InitialiseVariables()
     ekfStartTime_ms = imuSampleTime_ms;
     lastGpsVelFail_ms = 0;
     lastGpsAidBadTime_ms = 0;
+    magYawResetTimer_ms = imuSampleTime_ms;
 
     // initialise other variables
     gpsNoiseScaler = 1.0f;
@@ -5218,6 +5222,18 @@ bool NavEKF::calcGpsGoodToAlign(void)
                            "GPS horiz error %.1f", (double)hAcc);
     }
     
+    // If we have good magnetometer consistency and bad innovations for longer than 5 seconds then we reset heading and field states
+    // This enables us to handle large changes to the external magnetic field environment that occur before arming
+    if ((magTestRatio.x <= 1.0f && magTestRatio.y <= 1.0f) || !consistentMagData) {
+        magYawResetTimer_ms = imuSampleTime_ms;
+    }
+    if (imuSampleTime_ms - magYawResetTimer_ms > 5000) {
+        // reset heading and field states
+        Vector3f eulerAngles;
+        getEulerAngles(eulerAngles);
+        state.quat = calcQuatAndFieldStates(eulerAngles.x, eulerAngles.y);
+    }
+
     // fail if magnetometer innovations are outside limits indicating bad yaw
     // with bad yaw we are unable to use GPS
     bool yawFail;

--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -685,6 +685,8 @@ private:
     bool useGpsVertVel;             // true if GPS vertical velocity should be used
     float yawResetAngle;            // Change in yaw angle due to last in-flight yaw reset in radians. A positive value means the yaw angle has increased.
     bool yawResetAngleWaiting;      // true when the yaw reset angle has been updated and has not been retrieved via the getLastYawResetAngle() function
+    uint32_t magYawResetTimer_ms;   // timer in msec used to track how long good magnetometer data is failing innovation consistency checks
+    bool consistentMagData;         // true when the magnetometers are passing consistency checks
 
     // Used by smoothing of state corrections
     Vector10 gpsIncrStateDelta;    // vector of corrections to attitude, velocity and position to be applied over the period between the current and next GPS measurement


### PR DESCRIPTION
These patches enable the EKF to reset its heading and magnetic field states if during pre-flight operation it detects that the magnetometers are consistent, but the innovations are poor. This could have been caused by a change in magnetic field after initialisation, e.g. power up in a truck flat-bed or near a source of magnetic interference before moving away to fly.