### PR TITLE
Add support for using SPI devices of the same type.

### DIFF
--- a/libraries/AP_HAL/SPIDriver.h
+++ b/libraries/AP_HAL/SPIDriver.h
@@ -8,7 +8,7 @@
 class AP_HAL::SPIDeviceManager {
 public:
     virtual void init(void *) = 0;
-    virtual AP_HAL::SPIDeviceDriver* device(enum AP_HAL::SPIDevice) = 0;
+    virtual AP_HAL::SPIDeviceDriver* device(enum AP_HAL::SPIDevice, uint8_t index = 0) = 0;
 };
 
 /**

--- a/libraries/AP_HAL_Empty/SPIDriver.cpp
+++ b/libraries/AP_HAL_Empty/SPIDriver.cpp
@@ -41,7 +41,7 @@ EmptySPIDeviceManager::EmptySPIDeviceManager()
 void EmptySPIDeviceManager::init(void *)
 {}
 
-AP_HAL::SPIDeviceDriver* EmptySPIDeviceManager::device(enum AP_HAL::SPIDevice)
+AP_HAL::SPIDeviceDriver* EmptySPIDeviceManager::device(enum AP_HAL::SPIDevice, uint8_t index)
 {
     return &_device;
 }

--- a/libraries/AP_HAL_Empty/SPIDriver.h
+++ b/libraries/AP_HAL_Empty/SPIDriver.h
@@ -24,7 +24,7 @@ class Empty::EmptySPIDeviceManager : public AP_HAL::SPIDeviceManager {
 public:
     EmptySPIDeviceManager();
     void init(void *);
-    AP_HAL::SPIDeviceDriver* device(enum AP_HAL::SPIDevice);
+    AP_HAL::SPIDeviceDriver* device(enum AP_HAL::SPIDevice, uint8_t index);
 private:
     EmptySPIDeviceDriver _device;
 };

--- a/libraries/AP_HAL_FLYMAPLE/SPIDriver.cpp
+++ b/libraries/AP_HAL_FLYMAPLE/SPIDriver.cpp
@@ -93,7 +93,7 @@ void FLYMAPLESPIDeviceManager::init(void *)
 {
 }
 
-AP_HAL::SPIDeviceDriver* FLYMAPLESPIDeviceManager::device(enum AP_HAL::SPIDevice)
+AP_HAL::SPIDeviceDriver* FLYMAPLESPIDeviceManager::device(enum AP_HAL::SPIDevice, uint8_t index)
 {
     _device.init(); // Defer this until GPIO pin 13 is set up else its a slave
     return &_device;

--- a/libraries/AP_HAL_FLYMAPLE/SPIDriver.h
+++ b/libraries/AP_HAL_FLYMAPLE/SPIDriver.h
@@ -43,7 +43,7 @@ class AP_HAL_FLYMAPLE_NS::FLYMAPLESPIDeviceManager : public AP_HAL::SPIDeviceMan
 public:
     FLYMAPLESPIDeviceManager();
     void init(void *);
-    AP_HAL::SPIDeviceDriver* device(enum AP_HAL::SPIDevice);
+    AP_HAL::SPIDeviceDriver* device(enum AP_HAL::SPIDevice, uint8_t index);
 private:
     FLYMAPLESPIDeviceDriver _device;
 };

--- a/libraries/AP_HAL_Linux/SPIDriver.cpp
+++ b/libraries/AP_HAL_Linux/SPIDriver.cpp
@@ -261,11 +261,16 @@ bool LinuxSPIDeviceManager::transaction(LinuxSPIDeviceDriver &driver, const uint
 /*
   return a SPIDeviceDriver for a particular device
  */
-AP_HAL::SPIDeviceDriver *LinuxSPIDeviceManager::device(enum AP_HAL::SPIDevice dev)
+AP_HAL::SPIDeviceDriver *LinuxSPIDeviceManager::device(enum AP_HAL::SPIDevice dev, uint8_t index)
 {
+    uint8_t count = 0;
     for (uint8_t i=0; i<LINUX_SPI_DEVICE_NUM_DEVICES; i++) {
         if (_device[i]._type == dev) {
-            return &_device[i];
+            if (count == index) {
+                return &_device[i];
+            } else {
+                count++;
+            }
         }
     }
     return NULL;

--- a/libraries/AP_HAL_Linux/SPIDriver.h
+++ b/libraries/AP_HAL_Linux/SPIDriver.h
@@ -49,7 +49,7 @@ private:
 class Linux::LinuxSPIDeviceManager : public AP_HAL::SPIDeviceManager {
 public:
     void init(void *);
-    AP_HAL::SPIDeviceDriver* device(enum AP_HAL::SPIDevice);
+    AP_HAL::SPIDeviceDriver* device(enum AP_HAL::SPIDevice, uint8_t index = 0);
 
     static AP_HAL::Semaphore *get_semaphore(uint16_t bus);
 


### PR DESCRIPTION
I am using my BBBMINI in dual MPU-9250 configuration. Until now, it is not possible to access the second MPU-9250 on the SPI bus with the device command. With this PR you can access more than one SPI device of the same type.