### PR TITLE
Support for IMU Heating

### DIFF
--- a/libraries/AP_HAL/AP_HAL_Boards.h
+++ b/libraries/AP_HAL/AP_HAL_Boards.h
@@ -89,6 +89,9 @@
 #define HAL_COMPASS_HMC5843_MPU6000 7
 #define HAL_COMPASS_RASPILOT  8
 
+// Heat Types
+#define HAL_LINUX_HEAT_PWM 1
+
 /**
    CPU classes, used to select if CPU intensive algorithms should be used
 
@@ -228,6 +231,12 @@
 #define HAL_BARO_MS5607_I2C_BUS 1
 #define HAL_BARO_MS5607_I2C_ADDR 0x77
 #define HAL_BARO_DEFAULT HAL_BARO_MS5607
+#define HAL_UTILS_HEAT HAL_LINUX_HEAT_PWM
+#define HAL_LINUX_HEAT_PWM_SYSFS_DIR "/sys/class/pwm/pwm_6"
+#define HAL_LINUX_HEAT_KP 20000
+#define HAL_LINUX_HEAT_KI 6
+#define HAL_LINUX_HEAT_PERIOD_NS 125000
+#define HAL_LINUX_HEAT_TARGET_TEMP 50
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO
 #define HAL_BOARD_LOG_DIRECTORY "/var/APM/logs"
 #define HAL_BOARD_TERRAIN_DIRECTORY "/var/APM/terrain"

--- a/libraries/AP_HAL/Util.h
+++ b/libraries/AP_HAL/Util.h
@@ -81,6 +81,9 @@ public:
      */
     virtual AP_HAL::Stream *get_shell_stream() { return NULL; }
 
+    /* Support for an imu heating system */
+    virtual void set_imu_temp(float current) {}
+
 protected:
     // we start soft_armed false, so that actuators don't send any
     // values until the vehicle code has fully started

--- a/libraries/AP_HAL_Linux/AP_HAL_Linux_Namespace.h
+++ b/libraries/AP_HAL_Linux/AP_HAL_Linux_Namespace.h
@@ -40,6 +40,8 @@ namespace Linux {
     class LinuxUtil;
     class LinuxUtilRPI;
     class ToneAlarm;					//limit the scope of ToneAlarm driver to Linux_HAL only
+    class LinuxHeat;
+    class LinuxHeatPwm;
 }
 
 #endif // __AP_HAL_LINUX_NAMESPACE_H__

--- a/libraries/AP_HAL_Linux/AP_HAL_Linux_Private.h
+++ b/libraries/AP_HAL_Linux/AP_HAL_Linux_Private.h
@@ -32,6 +32,8 @@
 #include "ToneAlarmDriver.h"
 #include "Util.h"
 #include "Util_RPI.h"
+#include "Heat.h"
+#include "Heat_Pwm.h"
 
 #endif // __AP_HAL_LINUX_PRIVATE_H__
 

--- a/libraries/AP_HAL_Linux/Heat.h
+++ b/libraries/AP_HAL_Linux/Heat.h
@@ -1,0 +1,24 @@
+// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __HEAT_H__
+#define __HEAT_H__
+
+class Linux::LinuxHeat {
+public:
+    virtual void set_imu_temp(float current) { }
+};
+#endif

--- a/libraries/AP_HAL_Linux/Heat_Pwm.cpp
+++ b/libraries/AP_HAL_Linux/Heat_Pwm.cpp
@@ -1,0 +1,139 @@
+// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <AP_HAL/AP_HAL.h>
+
+#if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BEBOP
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <linux/limits.h>
+#include <string.h>
+#include <math.h>
+#include <stdlib.h>
+#include "Heat_Pwm.h"
+
+extern const AP_HAL::HAL& hal;
+
+#define HEAT_PWM_DUTY "duty_ns"
+#define HEAT_PWM_PERIOD "period_ns"
+#define HEAT_PWM_RUN "run"
+
+using namespace Linux;
+
+/*
+ * Constructor :
+ * argument : pwm_sysfs_path is the path to the pwm directory,
+ * i.e /sys/class/pwm/pwm_6 on the bebop
+ */
+LinuxHeatPwm::LinuxHeatPwm(const char* pwm_sysfs_path, float Kp, float Ki, uint32_t period_ns, float target) :
+    _Kp(Kp),
+    _Ki(Ki),
+    _period_ns(period_ns),
+    _target(target)
+{
+    char *duty_path;
+    char *period_path;
+    char *run_path;
+
+    if (asprintf(&duty_path, "%s/%s", pwm_sysfs_path, HEAT_PWM_DUTY) == -1) {
+        hal.scheduler->panic("HeatPwm not enough memory\n");
+    }
+    _duty_fd = open(duty_path, O_RDWR);
+    if (_duty_fd == -1) {
+        perror("opening duty");
+        hal.scheduler->panic("Error Initializing Pwm heat\n");
+    }
+    free(duty_path);
+
+    if (asprintf(&period_path, "%s/%s", pwm_sysfs_path, HEAT_PWM_PERIOD) == -1) {
+        hal.scheduler->panic("HeatPwm not enough memory\n");
+    }
+    _period_fd = open(period_path, O_RDWR);
+    if (_period_fd == -1) {
+        perror("opening period");
+        hal.scheduler->panic("Error Initializing Pwm heat\n");
+    }
+    free(period_path);
+
+    if (asprintf(&run_path, "%s/%s", pwm_sysfs_path, HEAT_PWM_RUN) == -1) {
+        hal.scheduler->panic("HeatPwm not enough memory\n");
+    }
+    _run_fd = open(run_path, O_RDWR);
+    if (_run_fd == -1) {
+        perror("opening run");
+        hal.scheduler->panic("Error Initializing Pwm heat\n");
+    }
+    free(run_path);
+
+    _set_period(_period_ns);
+    _set_duty(0);
+    _set_run();
+}
+
+void LinuxHeatPwm::set_imu_temp(float current)
+{
+    float error, output;
+
+    if (hal.scheduler->millis() - _last_temp_update < 5) {
+        return;
+    }
+
+    /* minimal PI algo without dt */
+    error = _target - current;
+    /* Don't accumulate errors if the integrated error is superior
+     * to the max duty cycle(pwm_period)
+     */
+    if ((fabsf(_sum_error) * _Ki < _period_ns)) {
+        _sum_error = _sum_error + error;
+    }
+
+    output = _Kp*error + _Ki * _sum_error;
+
+    if (output > _period_ns) {
+        output = _period_ns;
+    } else if (output < 0) {
+        output = 0;
+    }
+
+    _set_duty(output);
+    _last_temp_update = hal.scheduler->millis();
+}
+
+void LinuxHeatPwm::_set_duty(uint32_t duty)
+{
+    if (dprintf(_duty_fd, "0x%x", duty) < 0) {
+        perror("pwm set_duty");
+    }
+}
+
+void LinuxHeatPwm::_set_period(uint32_t period)
+{
+    if (dprintf(_period_fd, "0x%x", period) < 0) {
+        perror("pwm set_period");
+    }
+}
+
+void LinuxHeatPwm::_set_run()
+{
+    if (dprintf(_run_fd, "1") < 0) {
+        perror("pwm set_run");
+    }
+}
+
+#endif

--- a/libraries/AP_HAL_Linux/Heat_Pwm.h
+++ b/libraries/AP_HAL_Linux/Heat_Pwm.h
@@ -1,0 +1,43 @@
+// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __HEAT_PWM_H__
+#define __HEAT_PWM_H__
+
+#include "AP_HAL_Linux.h"
+#include "Heat.h"
+
+class Linux::LinuxHeatPwm : public Linux::LinuxHeat {
+public:
+    LinuxHeatPwm(const char* pwm_sysfs_path, float Kp, float Ki,uint32_t period_ns, float target);
+    void set_imu_temp(float current)override;
+
+private:
+    int _duty_fd = -1;
+    int _period_fd = -1;
+    int _run_fd = -1;
+    uint32_t _last_temp_update = 0;
+    float _Kp;
+    float _Ki;
+    uint32_t _period_ns;
+    float _sum_error;
+    float _target;
+
+    void _set_duty(uint32_t duty);
+    void _set_period(uint32_t period);
+    void _set_run();
+};
+#endif

--- a/libraries/AP_HAL_Linux/Util.cpp
+++ b/libraries/AP_HAL_Linux/Util.cpp
@@ -11,11 +11,38 @@
 extern const AP_HAL::HAL& hal;
 
 #include "Util.h"
+#include "Heat_Pwm.h"
+
 using namespace Linux;
 
 
 static int state;
 ToneAlarm LinuxUtil::_toneAlarm;
+
+void LinuxUtil::init(int argc, char * const *argv) {
+    saved_argc = argc;
+    saved_argv = argv;
+
+#ifdef HAL_UTILS_HEAT
+#if HAL_UTILS_HEAT == HAL_LINUX_HEAT_PWM
+    _heat = new Linux::LinuxHeatPwm(HAL_LINUX_HEAT_PWM_SYSFS_DIR,
+                            HAL_LINUX_HEAT_KP,
+                            HAL_LINUX_HEAT_KI,
+                            HAL_LINUX_HEAT_PERIOD_NS,
+                            HAL_LINUX_HEAT_TARGET_TEMP);
+#else
+    #error Unrecognized Heat
+#endif // #if
+#else
+    _heat = new Linux::LinuxHeat();
+#endif // #ifdef
+}
+
+void LinuxUtil::set_imu_temp(float current)
+{
+    _heat->set_imu_temp(current);
+}
+
 /**
    return commandline arguments, if available
 */

--- a/libraries/AP_HAL_Linux/Util.h
+++ b/libraries/AP_HAL_Linux/Util.h
@@ -12,12 +12,7 @@ public:
         return static_cast<LinuxUtil*>(util);
     }
 
-    void init(int argc, char * const *argv) {
-        saved_argc = argc;
-        saved_argv = argv;
-    }
-
-
+    void init(int argc, char * const *argv);
     bool run_debug_shell(AP_HAL::BetterStream *stream) { return false; }
 
     /**
@@ -41,9 +36,11 @@ public:
     void set_custom_terrain_directory(const char *_custom_terrain_directory) { custom_terrain_directory = _custom_terrain_directory; }
 
     bool is_chardev_node(const char *path);
+    void set_imu_temp(float current);
 
 private:
     static Linux::ToneAlarm _toneAlarm;
+    Linux::LinuxHeat *_heat;
     int saved_argc;
     char* const *saved_argv;
     const char* custom_log_directory = NULL;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -679,6 +679,8 @@ bool AP_InertialSensor_MPU6000::update( void )
     _publish_accel(_accel_instance, accel);
     _publish_gyro(_gyro_instance, gyro);
     _publish_temperature(_accel_instance, temp);
+    /* give the temperature to the control loop in order to keep it constant*/
+    hal.util->set_imu_temp(temp);
 
 #if MPU6000_FAST_SAMPLING
     if (_last_accel_filter_hz != _accel_filter_cutoff()) {

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -295,9 +295,8 @@ void AP_MPU6000_BusDriver_SPI::read_data_transaction(uint8_t *samples,
     }
 
     n_samples = 1;
-    /* remove temperature and cmd from data sample */
-    memcpy(&samples[0], &rx.d[0], 6);
-    memcpy(&samples[6], &rx.d[8], 6);
+    /* remove cmd from data sample */
+    memcpy(&samples[0], &rx.d[0], 14);
 
     return;
 }
@@ -328,7 +327,7 @@ void AP_MPU6000_BusDriver_I2C::start(bool &fifo_mode, uint8_t &max_samples)
     // enable fifo mode
     fifo_mode = true;
     write8(MPUREG_FIFO_EN, BIT_XG_FIFO_EN | BIT_YG_FIFO_EN |
-                           BIT_ZG_FIFO_EN | BIT_ACCEL_FIFO_EN);
+                           BIT_ZG_FIFO_EN | BIT_ACCEL_FIFO_EN | BIT_TEMP_FIFO_EN);
     write8(MPUREG_USER_CTRL, BIT_USER_CTRL_FIFO_RESET | BIT_USER_CTRL_SIG_COND_RESET);
     write8(MPUREG_USER_CTRL, BIT_USER_CTRL_FIFO_EN);
     /* maximum number of samples read by a burst
@@ -336,6 +335,7 @@ void AP_MPU6000_BusDriver_I2C::start(bool &fifo_mode, uint8_t &max_samples)
      * gyro_x
      * gyro_y
      * gyro_z
+     * temperature
      * accel_x
      * accel_y
      * accel_z
@@ -444,6 +444,7 @@ AP_InertialSensor_MPU6000::AP_InertialSensor_MPU6000(AP_InertialSensor &imu, AP_
 #if MPU6000_FAST_SAMPLING
     _accel_filter(1000, 15),
     _gyro_filter(1000, 15),
+    _temp_filter(1000, 1),
 #else
     _sample_count(0),
     _accel_sum(),
@@ -651,27 +652,33 @@ bool AP_InertialSensor_MPU6000::update( void )
     // we have a full set of samples
     uint16_t num_samples;
     Vector3f accel, gyro;
+    float temp;
 
     hal.scheduler->suspend_timer_procs();
 #if MPU6000_FAST_SAMPLING
     gyro = _gyro_filtered;
     accel = _accel_filtered;
+    temp = _temp_filtered;
     num_samples = 1;
 #else
     gyro(_gyro_sum.x, _gyro_sum.y, _gyro_sum.z);
     accel(_accel_sum.x, _accel_sum.y, _accel_sum.z);
+    temp = _temp_sum;
     num_samples = _sum_count;
     _accel_sum.zero();
     _gyro_sum.zero();
+    _temp_sum = 0;
 #endif
     _sum_count = 0;
     hal.scheduler->resume_timer_procs();
 
     gyro /= num_samples;
     accel /= num_samples;
+    temp /= num_samples;
 
     _publish_accel(_accel_instance, accel);
     _publish_gyro(_gyro_instance, gyro);
+    _publish_temperature(_accel_instance, temp);
 
 #if MPU6000_FAST_SAMPLING
     if (_last_accel_filter_hz != _accel_filter_cutoff()) {
@@ -745,16 +752,21 @@ void AP_InertialSensor_MPU6000::_accumulate(uint8_t *samples, uint8_t n_samples)
     for(uint8_t i=0; i < n_samples; i++) {
         uint8_t *data = samples + MPU6000_SAMPLE_SIZE * i;
         Vector3f accel, gyro;
+        float temp;
 
         accel = Vector3f(int16_val(data, 1),
                          int16_val(data, 0),
                          -int16_val(data, 2));
         accel *= MPU6000_ACCEL_SCALE_1G;
 
-        gyro = Vector3f(int16_val(data, 4),
-                        int16_val(data, 3),
-                        -int16_val(data, 5));
+        gyro = Vector3f(int16_val(data, 5),
+                        int16_val(data, 4),
+                        -int16_val(data, 6));
         gyro *= _gyro_scale;
+
+        temp = int16_val(data, 3);
+        /* scaling/offset values from the datasheet */
+        temp = temp/340 + 36.53;
 
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_PXF
         accel.rotate(ROTATION_PITCH_180_YAW_90);
@@ -772,9 +784,11 @@ void AP_InertialSensor_MPU6000::_accumulate(uint8_t *samples, uint8_t n_samples)
 #if MPU6000_FAST_SAMPLING
         _accel_filtered = _accel_filter.apply(accel);
         _gyro_filtered = _gyro_filter.apply(gyro);
+        _temp_filtered = _temp_filter.apply(temp);
 #else
         _accel_sum += accel;
         _gyro_sum += gyro;
+        _temp_sum += temp;
 #endif
         _sum_count++;
 
@@ -783,6 +797,7 @@ void AP_InertialSensor_MPU6000::_accumulate(uint8_t *samples, uint8_t n_samples)
         // rollover - v unlikely
             _accel_sum.zero();
             _gyro_sum.zero();
+            _temp_sum = 0;
         }
 #endif
     }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.h
@@ -24,9 +24,10 @@
 #if MPU6000_FAST_SAMPLING
 #include <Filter/Filter.h>
 #include <Filter/LowPassFilter2p.h>
+#include <Filter/LowPassFilter.h>
 #endif
 
-#define MPU6000_SAMPLE_SIZE 12
+#define MPU6000_SAMPLE_SIZE 14
 #define MPU6000_MAX_FIFO_SAMPLES 3
 #define MAX_DATA_READ (MPU6000_MAX_FIFO_SAMPLES * MPU6000_SAMPLE_SIZE)
 
@@ -127,15 +128,19 @@ private:
 #if MPU6000_FAST_SAMPLING
     Vector3f _accel_filtered;
     Vector3f _gyro_filtered;
+    float    _temp_filtered;
 
     // Low Pass filters for gyro and accel
     LowPassFilter2pVector3f _accel_filter;
     LowPassFilter2pVector3f _gyro_filter;
+    LowPassFilter2pFloat    _temp_filter;
 #else
     // accumulation in timer - must be read with timer disabled
     // the sum of the values since last read
     Vector3l _accel_sum;
     Vector3l _gyro_sum;
+    int32_t  _temp_sum;
+
 #endif
     volatile uint16_t _sum_count;
     bool _fifo_mode;


### PR DESCRIPTION
On the bebop, in order to keep the IMU at a constant temperature, a heating resistor is used.
This pull request adds the support for that by  reading the temperature on the MPU6000, and then controlling a pwm duty cycle with a simplistic PI algorithm.
HAL::Heat has been added.
Linux::Heat_Pwm has been added to control the pwm with sysfs.
The constructor takes the sysfs path, PI coeffs, target temperature and pwm period as params.
The only method is called from the IMU driver : set_imu_temperature

Tests : This has been flight tested quicky on the bebop to make sure that the temperature stays constant and doesn't go crazy.

Restrictions:
The bebop runs a 3.4.11 linux kernel. The sysfs interface has changed since, but should still be compatible if the correct file names are provided.