### PR TITLE
Unified delta angle and velocity calculation

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -353,6 +353,9 @@ AP_InertialSensor::AP_InertialSensor() :
 
         _accel_max_abs_offsets[i] = 3.5f;
         _accel_sample_rates[i] = 0;
+
+        _delta_velocity_acc[i].zero();
+        _delta_velocity_acc_dt[i] = 0;
     }
 #if INS_VIBRATION_CHECK
     for (uint8_t i=0; i<INS_VIBRATION_CHECK_INSTANCES; i++) {

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -353,8 +353,8 @@ AP_InertialSensor::AP_InertialSensor() :
 
         _accel_max_abs_offsets[i] = 3.5f;
 
-        _accel_sample_rates[i] = 0;
-        _gyro_sample_rates[i] = 0;
+        _accel_raw_sample_rates[i] = 0;
+        _gyro_raw_sample_rates[i] = 0;
 
         _delta_velocity_acc[i].zero();
         _delta_velocity_acc_dt[i] = 0;

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1291,6 +1291,12 @@ void AP_InertialSensor::update(void)
             _backends[i]->update();
         }
 
+        // clear accumulators
+        for (uint8_t i = 0; i < INS_MAX_INSTANCES; i++) {
+            _delta_velocity_acc[i].zero();
+            _delta_velocity_acc_dt[i] = 0;
+        }
+
         // adjust health status if a sensor has a non-zero error count
         // but another sensor doesn't. 
         bool have_zero_accel_error_count = false;

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -352,7 +352,9 @@ AP_InertialSensor::AP_InertialSensor() :
 #endif
 
         _accel_max_abs_offsets[i] = 3.5f;
+
         _accel_sample_rates[i] = 0;
+        _gyro_sample_rates[i] = 0;
 
         _delta_velocity_acc[i].zero();
         _delta_velocity_acc_dt[i] = 0;

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1295,6 +1295,7 @@ void AP_InertialSensor::update(void)
         for (uint8_t i = 0; i < INS_MAX_INSTANCES; i++) {
             _delta_velocity_acc[i].zero();
             _delta_velocity_acc_dt[i] = 0;
+            _delta_angle_acc[i].zero();
         }
 
         // adjust health status if a sensor has a non-zero error count

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -358,6 +358,10 @@ AP_InertialSensor::AP_InertialSensor() :
 
         _delta_velocity_acc[i].zero();
         _delta_velocity_acc_dt[i] = 0;
+
+        _delta_angle_acc[i].zero();
+        _last_delta_angle[i].zero();
+        _last_raw_gyro[i].zero();
     }
 #if INS_VIBRATION_CHECK
     for (uint8_t i=0; i<INS_VIBRATION_CHECK_INSTANCES; i++) {

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -287,6 +287,10 @@ private:
     Vector3f _delta_velocity[INS_MAX_INSTANCES];
     float _delta_velocity_dt[INS_MAX_INSTANCES];
     bool _delta_velocity_valid[INS_MAX_INSTANCES];
+    // delta velocity accumulator
+    Vector3f _delta_velocity_acc[INS_MAX_INSTANCES];
+    // time accumulator for delta velocity accumulator
+    float _delta_velocity_acc_dt[INS_MAX_INSTANCES];
 
     // Most recent gyro reading
     Vector3f _gyro[INS_MAX_INSTANCES];

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -296,6 +296,9 @@ private:
     Vector3f _gyro[INS_MAX_INSTANCES];
     Vector3f _delta_angle[INS_MAX_INSTANCES];
     bool _delta_angle_valid[INS_MAX_INSTANCES];
+    Vector3f _delta_angle_acc[INS_MAX_INSTANCES];
+    Vector3f _last_delta_angle[INS_MAX_INSTANCES];
+    Vector3f _last_raw_gyro[INS_MAX_INSTANCES];
 
     // product id
     AP_Int16 _product_id;

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -312,8 +312,8 @@ private:
     float _accel_max_abs_offsets[INS_MAX_INSTANCES];
 
     // accelerometer and gyro raw sample rate in units of Hz
-    uint32_t _accel_sample_rates[INS_MAX_INSTANCES];
-    uint32_t _gyro_sample_rates[INS_MAX_INSTANCES];
+    uint32_t _accel_raw_sample_rates[INS_MAX_INSTANCES];
+    uint32_t _gyro_raw_sample_rates[INS_MAX_INSTANCES];
 
     // temperatures for an instance if available
     float _temperature[INS_MAX_INSTANCES];

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -308,8 +308,9 @@ private:
     // accelerometer max absolute offsets to be used for calibration
     float _accel_max_abs_offsets[INS_MAX_INSTANCES];
 
-    // accelerometer sample rate in units of Hz
+    // accelerometer and gyro raw sample rate in units of Hz
     uint32_t _accel_sample_rates[INS_MAX_INSTANCES];
+    uint32_t _gyro_sample_rates[INS_MAX_INSTANCES];
 
     // temperatures for an instance if available
     float _temperature[INS_MAX_INSTANCES];

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -53,14 +53,6 @@ void AP_InertialSensor_Backend::_publish_gyro(uint8_t instance, const Vector3f &
     _imu._gyro_healthy[instance] = true;
 }
 
-void AP_InertialSensor_Backend::_publish_delta_velocity(uint8_t instance, const Vector3f &delta_velocity, float dt)
-{
-    // publish delta velocity
-    _imu._delta_velocity[instance] = delta_velocity;
-    _imu._delta_velocity_dt[instance] = dt;
-    _imu._delta_velocity_valid[instance] = true;
-}
-
 /*
   rotate accel vector, scale and add the accel offset
  */

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -53,6 +53,11 @@ void AP_InertialSensor_Backend::_publish_gyro(uint8_t instance, const Vector3f &
     _imu._gyro_healthy[instance] = true;
 }
 
+void AP_InertialSensor_Backend::_notify_new_gyro_raw_sample(uint8_t instance,
+                                                            const Vector3f &gyro)
+{
+}
+
 /*
   rotate accel vector, scale and add the accel offset
  */

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -37,13 +37,6 @@ void AP_InertialSensor_Backend::_rotate_and_correct_gyro(uint8_t instance, Vecto
     gyro.rotate(_imu._board_orientation);
 }
 
-void AP_InertialSensor_Backend::_publish_delta_angle(uint8_t instance, const Vector3f &delta_angle)
-{
-    // publish delta angle
-    _imu._delta_angle[instance] = delta_angle;
-    _imu._delta_angle_valid[instance] = true;
-}
-
 /*
   rotate gyro vector and add the gyro offset
  */

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -116,6 +116,12 @@ void AP_InertialSensor_Backend::_set_accel_error_count(uint8_t instance, uint32_
     _imu._accel_error_count[instance] = error_count;
 }
 
+void AP_InertialSensor_Backend::_set_gyro_sample_rate(uint8_t instance,
+                                                      uint32_t rate)
+{
+    _imu._gyro_raw_sample_rates[instance] = rate;
+}
+
 // set gyro error_count
 void AP_InertialSensor_Backend::_set_gyro_error_count(uint8_t instance, uint32_t error_count)
 {

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -45,7 +45,7 @@ void AP_InertialSensor_Backend::_publish_gyro(uint8_t instance, const Vector3f &
     _imu._gyro[instance] = gyro;
     _imu._gyro_healthy[instance] = true;
 
-    if (_imu._gyro_sample_rates[instance] <= 0) {
+    if (_imu._gyro_raw_sample_rates[instance] <= 0) {
         return;
     }
 
@@ -60,11 +60,11 @@ void AP_InertialSensor_Backend::_notify_new_gyro_raw_sample(uint8_t instance,
 {
     float dt;
 
-    if (_imu._gyro_sample_rates[instance] <= 0) {
+    if (_imu._gyro_raw_sample_rates[instance] <= 0) {
         return;
     }
 
-    dt = 1.0f / _imu._gyro_sample_rates[instance];
+    dt = 1.0f / _imu._gyro_raw_sample_rates[instance];
 
     // compute delta angle
     Vector3f delta_angle = (gyro + _imu._last_raw_gyro[instance]) * 0.5f * dt;
@@ -98,7 +98,7 @@ void AP_InertialSensor_Backend::_publish_accel(uint8_t instance, const Vector3f 
     _imu._accel[instance] = accel;
     _imu._accel_healthy[instance] = true;
 
-    if (_imu._accel_sample_rates[instance] <= 0) {
+    if (_imu._accel_raw_sample_rates[instance] <= 0) {
         return;
     }
 
@@ -115,11 +115,11 @@ void AP_InertialSensor_Backend::_notify_new_accel_raw_sample(uint8_t instance,
 {
     float dt;
 
-    if (_imu._accel_sample_rates[instance] <= 0) {
+    if (_imu._accel_raw_sample_rates[instance] <= 0) {
         return;
     }
 
-    dt = 1.0f / _imu._accel_sample_rates[instance];
+    dt = 1.0f / _imu._accel_raw_sample_rates[instance];
 
 #if INS_VIBRATION_CHECK
     _imu.calc_vibration_and_clipping(instance, accel, dt);
@@ -136,10 +136,10 @@ void AP_InertialSensor_Backend::_set_accel_max_abs_offset(uint8_t instance,
     _imu._accel_max_abs_offsets[instance] = max_offset;
 }
 
-void AP_InertialSensor_Backend::_set_accel_sample_rate(uint8_t instance,
-                                                       uint32_t rate)
+void AP_InertialSensor_Backend::_set_accel_raw_sample_rate(uint8_t instance,
+                                                           uint32_t rate)
 {
-    _imu._accel_sample_rates[instance] = rate;
+    _imu._accel_raw_sample_rates[instance] = rate;
 }
 
 // set accelerometer error_count
@@ -148,8 +148,8 @@ void AP_InertialSensor_Backend::_set_accel_error_count(uint8_t instance, uint32_
     _imu._accel_error_count[instance] = error_count;
 }
 
-void AP_InertialSensor_Backend::_set_gyro_sample_rate(uint8_t instance,
-                                                      uint32_t rate)
+void AP_InertialSensor_Backend::_set_gyro_raw_sample_rate(uint8_t instance,
+                                                          uint32_t rate)
 {
     _imu._gyro_raw_sample_rates[instance] = rate;
 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -52,7 +52,6 @@ void AP_InertialSensor_Backend::_publish_gyro(uint8_t instance, const Vector3f &
     // publish delta angle
     _imu._delta_angle[instance] = _imu._delta_angle_acc[instance];
     _imu._delta_angle_valid[instance] = true;
-    _imu._delta_angle_acc[instance].zero();
 }
 
 void AP_InertialSensor_Backend::_notify_new_gyro_raw_sample(uint8_t instance,

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -106,8 +106,6 @@ void AP_InertialSensor_Backend::_publish_accel(uint8_t instance, const Vector3f 
     _imu._delta_velocity[instance] = _imu._delta_velocity_acc[instance];
     _imu._delta_velocity_dt[instance] = _imu._delta_velocity_acc_dt[instance];
     _imu._delta_velocity_valid[instance] = true;
-    _imu._delta_velocity_acc[instance].zero();
-    _imu._delta_velocity_acc_dt[instance] = 0;
 }
 
 void AP_InertialSensor_Backend::_notify_new_accel_raw_sample(uint8_t instance,

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -51,11 +51,50 @@ void AP_InertialSensor_Backend::_publish_gyro(uint8_t instance, const Vector3f &
 {
     _imu._gyro[instance] = gyro;
     _imu._gyro_healthy[instance] = true;
+
+    if (_imu._gyro_sample_rates[instance] <= 0) {
+        return;
+    }
+
+    // publish delta angle
+    _imu._delta_angle[instance] = _imu._delta_angle_acc[instance];
+    _imu._delta_angle_valid[instance] = true;
+    _imu._delta_angle_acc[instance].zero();
 }
 
 void AP_InertialSensor_Backend::_notify_new_gyro_raw_sample(uint8_t instance,
                                                             const Vector3f &gyro)
 {
+    float dt;
+
+    if (_imu._gyro_sample_rates[instance] <= 0) {
+        return;
+    }
+
+    dt = 1.0f / _imu._gyro_sample_rates[instance];
+
+    // compute delta angle
+    Vector3f delta_angle = (gyro + _imu._last_raw_gyro[instance]) * 0.5f * dt;
+
+    // compute coning correction
+    // see page 26 of:
+    // Tian et al (2010) Three-loop Integration of GPS and Strapdown INS with Coning and Sculling Compensation
+    // Available: http://www.sage.unsw.edu.au/snap/publications/tian_etal2010b.pdf
+    // see also examples/coning.py
+    Vector3f delta_coning = (_imu._delta_angle_acc[instance] +
+                             _imu._last_delta_angle[instance] * (1.0f / 6.0f));
+    delta_coning = delta_coning % delta_angle;
+    delta_coning *= 0.5f;
+
+    // integrate delta angle accumulator
+    // the angles and coning corrections are accumulated separately in the
+    // referenced paper, but in simulation little difference was found between
+    // integrating together and integrating separately (see examples/coning.py)
+    _imu._delta_angle_acc[instance] += delta_angle + delta_coning;
+
+    // save previous delta angle for coning correction
+    _imu._last_delta_angle[instance] = delta_angle;
+    _imu._last_raw_gyro[instance] = gyro;
 }
 
 /*

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -68,17 +68,37 @@ void AP_InertialSensor_Backend::_publish_accel(uint8_t instance, const Vector3f 
 {
     _imu._accel[instance] = accel;
     _imu._accel_healthy[instance] = true;
+
+    if (_imu._accel_sample_rates[instance] <= 0) {
+        return;
+    }
+
+    // publish delta velocity
+    _imu._delta_velocity[instance] = _imu._delta_velocity_acc[instance];
+    _imu._delta_velocity_dt[instance] = _imu._delta_velocity_acc_dt[instance];
+    _imu._delta_velocity_valid[instance] = true;
+    _imu._delta_velocity_acc[instance].zero();
+    _imu._delta_velocity_acc_dt[instance] = 0;
 }
 
 void AP_InertialSensor_Backend::_notify_new_accel_raw_sample(uint8_t instance,
                                                              const Vector3f &accel)
 {
-#if INS_VIBRATION_CHECK
-    if (_imu._accel_sample_rates[instance] > 0) {
-        float dt = 1.0f / _imu._accel_sample_rates[instance];
-        _imu.calc_vibration_and_clipping(instance, accel, dt);
+    float dt;
+
+    if (_imu._accel_sample_rates[instance] <= 0) {
+        return;
     }
+
+    dt = 1.0f / _imu._accel_sample_rates[instance];
+
+#if INS_VIBRATION_CHECK
+    _imu.calc_vibration_and_clipping(instance, accel, dt);
 #endif
+
+    // delta velocity
+    _imu._delta_velocity_acc[instance] += accel * dt;
+    _imu._delta_velocity_acc_dt[instance] += dt;
 }
 
 void AP_InertialSensor_Backend::_set_accel_max_abs_offset(uint8_t instance,

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -84,6 +84,12 @@ protected:
     // rotate gyro vector, offset and publish
     void _publish_gyro(uint8_t instance, const Vector3f &gyro);
 
+    // this should be called every time a new gyro raw sample is available -
+    // be it published or not
+    // the sample is raw in the sense that it's not filtered yet, but it must
+    // be rotated and corrected (_rotate_and_correct_gyro)
+    void _notify_new_gyro_raw_sample(uint8_t instance, const Vector3f &accel);
+
     // rotate accel vector, scale, offset and publish
     void _publish_accel(uint8_t instance, const Vector3f &accel);
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -79,8 +79,6 @@ protected:
     void _rotate_and_correct_accel(uint8_t instance, Vector3f &accel);
     void _rotate_and_correct_gyro(uint8_t instance, Vector3f &gyro);
 
-    void _publish_delta_angle(uint8_t instance, const Vector3f &delta_angle);
-
     // rotate gyro vector, offset and publish
     void _publish_gyro(uint8_t instance, const Vector3f &gyro);
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -108,6 +108,12 @@ protected:
         return _imu._accel_sample_rates[instance];
     }
 
+    // set gyroscope sample rate
+    void _set_gyro_sample_rate(uint8_t instance, uint32_t rate);
+    uint32_t _gyro_sample_rate(uint8_t instance) const {
+        return _imu._gyro_sample_rates[instance];
+    }
+
     // publish a temperature value
     void _publish_temperature(uint8_t instance, float temperature);
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -100,16 +100,16 @@ protected:
     // set accelerometer max absolute offset for calibration
     void _set_accel_max_abs_offset(uint8_t instance, float offset);
 
-    // set accelerometer sample rate
-    void _set_accel_sample_rate(uint8_t instance, uint32_t rate);
-    uint32_t _accel_sample_rate(uint8_t instance) const {
-        return _imu._accel_sample_rates[instance];
+    // set accelerometer raw sample rate
+    void _set_accel_raw_sample_rate(uint8_t instance, uint32_t rate);
+    uint32_t _accel_raw_sample_rate(uint8_t instance) const {
+        return _imu._accel_raw_sample_rates[instance];
     }
 
-    // set gyroscope sample rate
-    void _set_gyro_sample_rate(uint8_t instance, uint32_t rate);
-    uint32_t _gyro_sample_rate(uint8_t instance) const {
-        return _imu._gyro_sample_rates[instance];
+    // set gyroscope raw sample rate
+    void _set_gyro_raw_sample_rate(uint8_t instance, uint32_t rate);
+    uint32_t _gyro_raw_sample_rate(uint8_t instance) const {
+        return _imu._gyro_raw_sample_rates[instance];
     }
 
     // publish a temperature value

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -79,7 +79,6 @@ protected:
     void _rotate_and_correct_accel(uint8_t instance, Vector3f &accel);
     void _rotate_and_correct_gyro(uint8_t instance, Vector3f &gyro);
 
-    void _publish_delta_velocity(uint8_t instance, const Vector3f &delta_velocity, float dt);
     void _publish_delta_angle(uint8_t instance, const Vector3f &delta_angle);
 
     // rotate gyro vector, offset and publish

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Flymaple.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Flymaple.cpp
@@ -245,6 +245,7 @@ void AP_InertialSensor_Flymaple::_accumulate(void)
         // Adjust for chip scaling to get radians/sec
         gyro *= FLYMAPLE_GYRO_SCALE_R_S;
         _rotate_and_correct_gyro(_gyro_instance, gyro);
+        _notify_new_gyro_raw_sample(_gyro_instance, gyro);
         _gyro_filtered = _gyro_filter.apply(gyro);
         _have_gyro_sample = true;
         _last_gyro_timestamp = now;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.cpp
@@ -321,6 +321,7 @@ void AP_InertialSensor_L3G4200D::_accumulate(void)
                 // Adjust for chip scaling to get radians/sec
                 gyro *= L3G4200D_GYRO_SCALE_R_S;
                 _rotate_and_correct_gyro(_gyro_instance, gyro);
+                _notify_new_gyro_raw_sample(_gyro_instance, gyro);
                 _data[_data_idx].gyro_filtered = _gyro_filter.apply(gyro);
                 _have_gyro_sample = true;
             }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
@@ -757,6 +757,7 @@ void AP_InertialSensor_LSM9DS0::_read_data_transaction_g()
     Vector3f gyro_data(raw_data.x, -raw_data.y, -raw_data.z);
     gyro_data *= _gyro_scale;
     _rotate_and_correct_gyro(_gyro_instance, gyro_data);
+    _notify_new_gyro_raw_sample(_gyro_instance, gyro_data);
     _gyro_filtered = _gyro_filter.apply(gyro_data);
     _gyro_sample_available = true;
 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -768,6 +768,7 @@ void AP_InertialSensor_MPU6000::_accumulate(uint8_t *samples, uint8_t n_samples)
         _rotate_and_correct_gyro(_gyro_instance, gyro);
 
         _notify_new_accel_raw_sample(_accel_instance, accel);
+        _notify_new_gyro_raw_sample(_gyro_instance, gyro);
 
 #if MPU6000_FAST_SAMPLING
         _accel_filtered = _accel_filter.apply(accel);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -628,6 +628,7 @@ void AP_InertialSensor_MPU6000::start()
     _accel_instance = _imu.register_accel();
 
     _set_accel_raw_sample_rate(_accel_instance, 1000);
+    _set_gyro_raw_sample_rate(_gyro_instance, 1000);
 
     hal.scheduler->resume_timer_procs();
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -627,7 +627,7 @@ void AP_InertialSensor_MPU6000::start()
     _gyro_instance = _imu.register_gyro();
     _accel_instance = _imu.register_accel();
 
-    _set_accel_sample_rate(_accel_instance, 1000);
+    _set_accel_raw_sample_rate(_accel_instance, 1000);
 
     hal.scheduler->resume_timer_procs();
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9150.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9150.cpp
@@ -1098,6 +1098,7 @@ void AP_InertialSensor_MPU9150::_accumulate(void)
         gyro = Vector3f(gyro_x, gyro_y, gyro_z);
         gyro *= MPU9150_GYRO_SCALE_2000;
         _rotate_and_correct_gyro(_gyro_instance, gyro);
+        _notify_new_gyro_raw_sample(_gyro_instance, gyro);
         _gyro_filtered = _gyro_filter.apply(gyro);
 
         _have_sample_available = true;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
@@ -404,6 +404,7 @@ void AP_InertialSensor_MPU9250::_read_data_transaction()
     gyro *= GYRO_SCALE;
     gyro.rotate(_default_rotation);
     _rotate_and_correct_gyro(_gyro_instance, gyro);
+    _notify_new_gyro_raw_sample(_gyro_instance, gyro);
 
 
     // update the shared buffer

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
@@ -315,7 +315,7 @@ bool AP_InertialSensor_MPU9250::_init_sensor(void)
     // start the timer process to read samples
     hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&AP_InertialSensor_MPU9250::_poll_data, void));
 
-    _set_accel_sample_rate(_accel_instance, DEFAULT_SAMPLE_RATE);
+    _set_accel_raw_sample_rate(_accel_instance, DEFAULT_SAMPLE_RATE);
 
 #if MPU9250_DEBUG
     _dump_registers(_spi);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
@@ -316,6 +316,7 @@ bool AP_InertialSensor_MPU9250::_init_sensor(void)
     hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&AP_InertialSensor_MPU9250::_poll_data, void));
 
     _set_accel_raw_sample_rate(_accel_instance, DEFAULT_SAMPLE_RATE);
+    _set_gyro_raw_sample_rate(_gyro_instance, DEFAULT_SAMPLE_RATE);
 
 #if MPU9250_DEBUG
     _dump_registers(_spi);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
@@ -161,7 +161,7 @@ bool AP_InertialSensor_PX4::_init_sensor(void)
         if (samplerate < 100 || samplerate > 10000) {
             hal.scheduler->panic("Invalid accel sample rate");
         }
-        _set_accel_sample_rate(_accel_instance[i], (uint32_t) samplerate);
+        _set_accel_raw_sample_rate(_accel_instance[i], (uint32_t) samplerate);
         _accel_sample_time[i] = 1.0f / samplerate;
     }
 
@@ -186,7 +186,7 @@ bool AP_InertialSensor_PX4::_init_sensor(void)
 void AP_InertialSensor_PX4::_set_accel_filter_frequency(uint8_t filter_hz)
 {
     for (uint8_t i=0; i<_num_accel_instances; i++) {
-        float samplerate = _accel_sample_rate(_accel_instance[i]);
+        float samplerate = _accel_raw_sample_rate(_accel_instance[i]);
         _accel_filter[i].set_cutoff_frequency(samplerate, filter_hz);
     }
 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
@@ -122,6 +122,7 @@ bool AP_InertialSensor_PX4::_init_sensor(void)
         if (samplerate < 100 || samplerate > 10000) {
             hal.scheduler->panic("Invalid gyro sample rate");
         }
+        _set_gyro_raw_sample_rate(_gyro_instance[i], (uint32_t)samplerate);
         _gyro_sample_time[i] = 1.0f / samplerate;
     }
 
@@ -197,7 +198,7 @@ void AP_InertialSensor_PX4::_set_accel_filter_frequency(uint8_t filter_hz)
 void AP_InertialSensor_PX4::_set_gyro_filter_frequency(uint8_t filter_hz)
 {
     for (uint8_t i=0; i<_num_gyro_instances; i++) {
-        float samplerate = 1.0f / _gyro_sample_time[i];
+        float samplerate = _gyro_raw_sample_rate(_gyro_instance[i]);
         _gyro_filter[i].set_cutoff_frequency(samplerate, filter_hz);
     }
 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
@@ -296,6 +296,7 @@ void AP_InertialSensor_PX4::_new_gyro_sample(uint8_t i, gyro_report &gyro_report
 
     // apply corrections
     _rotate_and_correct_gyro(frontend_instance, gyro);
+    _notify_new_gyro_raw_sample(frontend_instance, gyro);
 
     // apply filter for control path
     _gyro_in[i] = _gyro_filter[i].apply(gyro);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_PX4.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_PX4.h
@@ -79,8 +79,6 @@ private:
     LowPassFilter2pVector3f _gyro_filter[INS_MAX_INSTANCES];
 
     Vector3f _delta_angle_accumulator[INS_MAX_INSTANCES];
-    Vector3f _delta_velocity_accumulator[INS_MAX_INSTANCES];
-    float _delta_velocity_dt[INS_MAX_INSTANCES];
     Vector3f _last_delAng[INS_MAX_INSTANCES];
     Vector3f _last_gyro[INS_MAX_INSTANCES];
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_PX4.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_PX4.h
@@ -78,10 +78,6 @@ private:
     LowPassFilter2pVector3f _accel_filter[INS_MAX_INSTANCES];
     LowPassFilter2pVector3f _gyro_filter[INS_MAX_INSTANCES];
 
-    Vector3f _delta_angle_accumulator[INS_MAX_INSTANCES];
-    Vector3f _last_delAng[INS_MAX_INSTANCES];
-    Vector3f _last_gyro[INS_MAX_INSTANCES];
-
 #ifdef AP_INERTIALSENSOR_PX4_DEBUG
     uint32_t _gyro_meas_count[INS_MAX_INSTANCES];
     uint32_t _accel_meas_count[INS_MAX_INSTANCES];


### PR DESCRIPTION
As @tridge asked in one of the comments in #2796, this PR moves the calculation of delta angle and velocity from the code specific for PX4 to a common place.

I have enabled that for PX4 (the one that was already doing the calculation) and also for MPU9250 and MPU6000 (the IMUs we've been using here).

This passed travis build and I can run ArduCopter with these patches. However I'm not sure on how to validate this. Any idea?