### PR TITLE
AP_Baro_MS5611: Suspend timer when init to prevent other SPI drivers grabbing the bus.

### DIFF
--- a/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
+++ b/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
@@ -223,11 +223,11 @@ void HAL_Linux::init(int argc,char* const argv[]) const
 #else
     i2c->begin();
 #endif
+    spi->init(NULL);
     rcout->init(NULL);
     rcin->init(NULL);
     uartA->begin(115200);    
     uartE->begin(115200);    
-    spi->init(NULL);
     analogin->init(NULL);
     utilInstance.init(argc+gopt.optind-1, &argv[gopt.optind-1]);
 }


### PR DESCRIPTION
1. AP_Baro_MS5611: Suspend timer when init to prevent other SPI drivers grabbing the bus.
Sometimes there is a "PANIC: AP_Baro_MS56XX: failed to take serial semaphore for init" message when starting the program. Because spi is blocked by other drivers.

2. HAL_Linux_Class: Init spi before rcin & rcout, because raspilot rcin & rcout use spi.