### PR TITLE
AP_Baro: Prevent busy waiting

### DIFF
--- a/libraries/AP_Baro/examples/BARO_generic/BARO_generic.cpp
+++ b/libraries/AP_Baro/examples/BARO_generic/BARO_generic.cpp
@@ -88,6 +88,8 @@ void loop()
                             barometer.get_climb_rate(),
                             (unsigned)read_time);
         hal.console->println();
+    } else {
+        hal.scheduler->delay(1);
     }
 }
 


### PR DESCRIPTION
This example use busy waiting which causes 100% cpu load and randomly throw "not healthy" messages. This PR prevent the busy waiting.