### PR TITLE
RCOutput: Grouped writes (v3)

### DIFF
--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -43,8 +43,30 @@ public:
     virtual void     enable_ch(uint8_t ch) = 0;
     virtual void     disable_ch(uint8_t ch) = 0;
 
-    /* Output a single channel */
+    /*
+     * Output a single channel, possibly grouped with previous writes if
+     * cork() has been called before.
+     */
     virtual void     write(uint8_t ch, uint16_t period_us) = 0;
+
+    /*
+     * Delay subsequent calls to write() going to the underlying hardware in
+     * order to group related writes together. When all the needed writes are
+     * done, call push() to commit the changes.
+     *
+     * This method is optional: if the subclass doesn't implement it all calls
+     * to write() are synchronous.
+     */
+    virtual void     cork() { }
+
+    /*
+     * Push pending changes to the underlying hardware. All changes between a
+     * call to cork() and push() are pushed together in a single transaction.
+     *
+     * This method is optional: if the subclass doesn't implement it all calls
+     * to write() are synchronous.
+     */
+    virtual void     push() { }
 
     /* Read back current output state, as either single channel or
      * array of channels. */

--- a/libraries/AP_HAL_Linux/RCOutput_Bebop.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_Bebop.cpp
@@ -319,14 +319,23 @@ void LinuxRCOutput_Bebop::write(uint8_t ch, uint16_t period_us)
 
     _request_period_us[ch] = period_us;
 
-    /* write command to motors only when all channels are set */
-    if (ch == (BEBOP_BLDC_MOTORS_NUM - 1)) {
-        pthread_mutex_lock(&_mutex);
-        memcpy(_period_us, _request_period_us, sizeof(_period_us));
-        pthread_cond_signal(&_cond);
-        pthread_mutex_unlock(&_mutex);
-        memset(_request_period_us, 0 ,sizeof(_request_period_us));
-    }
+    if (!_corking)
+        push();
+}
+
+void LinuxRCOutput_Bebop::cork()
+{
+    _corking = true;
+}
+
+void LinuxRCOutput_Bebop::push()
+{
+    _corking = false;
+    pthread_mutex_lock(&_mutex);
+    memcpy(_period_us, _request_period_us, sizeof(_period_us));
+    pthread_cond_signal(&_cond);
+    pthread_mutex_unlock(&_mutex);
+    memset(_request_period_us, 0 ,sizeof(_request_period_us));
 }
 
 uint16_t LinuxRCOutput_Bebop::read(uint8_t ch)

--- a/libraries/AP_HAL_Linux/RCOutput_Bebop.h
+++ b/libraries/AP_HAL_Linux/RCOutput_Bebop.h
@@ -61,6 +61,8 @@ public:
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
     void     write(uint8_t ch, uint16_t period_us);
+    void     cork() override;
+    void     push() override;
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
     void     set_esc_scaling(uint16_t min_pwm, uint16_t max_pwm);
@@ -75,6 +77,7 @@ private:
     uint16_t _min_pwm;
     uint16_t _max_pwm;
     uint8_t  _state;
+    bool     _corking = false;
 
     uint8_t _checksum(uint8_t *data, unsigned int len);
     void _start_prop();

--- a/libraries/AP_HAL_Linux/RCOutput_PCA9685.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_PCA9685.cpp
@@ -181,26 +181,62 @@ void LinuxRCOutput_PCA9685::write(uint8_t ch, uint16_t period_us)
         return;
     }
 
+    _pulses_buffer[ch] = period_us;
+    _pending_write_mask |= (1U << ch);
+
+    if (!_corking)
+        push();
+}
+
+void LinuxRCOutput_PCA9685::cork()
+{
+    _corking = true;
+}
+
+void LinuxRCOutput_PCA9685::push()
+{
+    _corking = false;
+
+    if (_pending_write_mask == 0)
+        return;
+
+    // Calculate the number of channels for this transfer.
+    uint8_t max_ch = (sizeof(unsigned) * 8) - __builtin_clz(_pending_write_mask);
+    uint8_t min_ch = __builtin_ctz(_pending_write_mask);
+
+    /*
+     * scratch buffer size is always for all the channels, but we write only
+     * from min_ch to max_ch
+     */
+    uint8_t data[PWM_CHAN_COUNT * 4] = { };
+
+    for (unsigned ch = min_ch; ch < max_ch; ch++) {
+        uint16_t period_us = _pulses_buffer[ch];
+        uint16_t length = 0;
+
+        if (period_us)
+            length = round((period_us * 4096) / (1000000.f / _frequency)) - 1;
+
+        uint8_t *d = &data[ch * 4];
+        *d++ = 0;
+        *d++ = 0;
+        *d++ = length & 0xFF;
+        *d++ = length >> 8;
+    }
+
     if (!_i2c_sem->take_nonblocking()) {
+        hal.console->printf("RCOutput: Unable to get bus semaphore");
         return;
     }
 
-    uint16_t length;
-
-    if (period_us == 0)
-        length = 0;
-    else
-        length = round((period_us * 4096) / (1000000.f / _frequency)) - 1;
-
-    uint8_t data[2] = {length & 0xFF, length >> 8};
-    uint8_t status = hal.i2c->writeRegisters(_addr,
-                                             PCA9685_RA_LED0_OFF_L + 4 * (ch + _channel_offset),
-                                             2,
-                                             data);
-
-    _pulses_buffer[ch] = period_us;
+    hal.i2c->writeRegisters(_addr,
+                            PCA9685_RA_LED0_ON_L + 4 * (_channel_offset + min_ch),
+                            (max_ch - min_ch) * 4,
+                            &data[min_ch * 4]);
 
     _i2c_sem->give();
+
+    _pending_write_mask = 0;
 }
 
 uint16_t LinuxRCOutput_PCA9685::read(uint8_t ch)

--- a/libraries/AP_HAL_Linux/RCOutput_PCA9685.h
+++ b/libraries/AP_HAL_Linux/RCOutput_PCA9685.h
@@ -20,6 +20,8 @@ class Linux::LinuxRCOutput_PCA9685 : public AP_HAL::RCOutput {
     void     enable_ch(uint8_t ch);
     void     disable_ch(uint8_t ch);
     void     write(uint8_t ch, uint16_t period_us);
+    void     cork() override;
+    void     push() override;
     uint16_t read(uint8_t ch);
     void     read(uint16_t* period_us, uint8_t len);
 
@@ -35,8 +37,10 @@ private:
 
     uint8_t _addr;
     bool _external_clock;
+    bool _corking = false;
     uint8_t _channel_offset;
     int16_t _oe_pin_number;
+    uint16_t _pending_write_mask;
 };
 
 #endif // __AP_HAL_LINUX_RCOUTPUT_PCA9685_H__

--- a/libraries/AP_Motors/AP_MotorsCoax.cpp
+++ b/libraries/AP_Motors/AP_MotorsCoax.cpp
@@ -111,10 +111,12 @@ void AP_MotorsCoax::enable()
 void AP_MotorsCoax::output_min()
 {
     // send minimum value to each motor
+    hal.rcout->cork();
     hal.rcout->write(AP_MOTORS_MOT_1, _servo1.radio_trim);
     hal.rcout->write(AP_MOTORS_MOT_2, _servo2.radio_trim);
     hal.rcout->write(AP_MOTORS_MOT_3, _throttle_radio_min);
     hal.rcout->write(AP_MOTORS_MOT_4, _throttle_radio_min);
+    hal.rcout->push();
 }
 
 void AP_MotorsCoax::output_armed_not_stabilizing()
@@ -154,10 +156,12 @@ void AP_MotorsCoax::output_armed_not_stabilizing()
         motor_out = apply_thrust_curve_and_volt_scaling(motor_out, out_min, _throttle_radio_max);
     }
 
+    hal.rcout->cork();
     hal.rcout->write(AP_MOTORS_MOT_1, _servo1.radio_out);
     hal.rcout->write(AP_MOTORS_MOT_2, _servo2.radio_out);
     hal.rcout->write(AP_MOTORS_MOT_3, motor_out);
     hal.rcout->write(AP_MOTORS_MOT_4, motor_out);
+    hal.rcout->push();
 }
 
 // sends commands to the motors
@@ -212,10 +216,12 @@ void AP_MotorsCoax::output_armed_stabilizing()
     motor_out[AP_MOTORS_MOT_4] = max(motor_out[AP_MOTORS_MOT_4],    out_min);
 
     // send output to each motor
+    hal.rcout->cork();
     hal.rcout->write(AP_MOTORS_MOT_1, _servo1.radio_out);
     hal.rcout->write(AP_MOTORS_MOT_2, _servo2.radio_out);
     hal.rcout->write(AP_MOTORS_MOT_3, motor_out[AP_MOTORS_MOT_3]);
     hal.rcout->write(AP_MOTORS_MOT_4, motor_out[AP_MOTORS_MOT_4]);
+    hal.rcout->push();
 }
 
 // output_disarmed - sends commands to the motors

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -445,13 +445,17 @@ void AP_MotorsHeli_Single::move_actuators(int16_t roll_out, int16_t pitch_out, i
     _swash_servo_2.calc_pwm();
     _swash_servo_3.calc_pwm();
 
+    hal.rcout->cork();
+
     // actually move the servos
     hal.rcout->write(AP_MOTORS_MOT_1, _swash_servo_1.radio_out);
     hal.rcout->write(AP_MOTORS_MOT_2, _swash_servo_2.radio_out);
     hal.rcout->write(AP_MOTORS_MOT_3, _swash_servo_3.radio_out);
- 
+
     // update the yaw rate using the tail rotor/servo
     move_yaw(yaw_out + yaw_offset);
+
+    hal.rcout->push();
 }
 
 // move_yaw

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -95,11 +95,13 @@ void AP_MotorsMatrix::output_min()
     limit.throttle_upper = false;
 
     // fill the motor_out[] array for HIL use and send minimum value to each motor
+    hal.rcout->cork();
     for( i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++ ) {
         if( motor_enabled[i] ) {
             hal.rcout->write(i, _throttle_radio_min);
         }
     }
+    hal.rcout->push();
 }
 
 // get_motor_mask - returns a bitmask of which outputs are being used for motors (1 means being used)
@@ -159,11 +161,13 @@ void AP_MotorsMatrix::output_armed_not_stabilizing()
     }
 
     // send output to each motor
+    hal.rcout->cork();
     for( i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++ ) {
         if( motor_enabled[i] ) {
             hal.rcout->write(i, motor_out[i]);
         }
     }
+    hal.rcout->push();
 }
 
 // output_armed - sends commands to the motors
@@ -355,11 +359,13 @@ void AP_MotorsMatrix::output_armed_stabilizing()
     }
 
     // send output to each motor
+    hal.rcout->cork();
     for( i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++ ) {
         if( motor_enabled[i] ) {
             hal.rcout->write(i, motor_out[i]);
         }
     }
+    hal.rcout->push();
 }
 
 // output_disarmed - sends commands to the motors
@@ -380,12 +386,14 @@ void AP_MotorsMatrix::output_test(uint8_t motor_seq, int16_t pwm)
     }
 
     // loop through all the possible orders spinning any motors that match that description
+    hal.rcout->cork();
     for (uint8_t i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
         if (motor_enabled[i] && _test_order[i] == motor_seq) {
             // turn on this motor
             hal.rcout->write(i, pwm);
         }
     }
+    hal.rcout->push();
 }
 
 // add_motor

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -378,10 +378,12 @@ void AP_MotorsMulticopter::throttle_pass_through(int16_t pwm)
 {
     if (armed()) {
         // send the pilot's input directly to each enabled motor
+        hal.rcout->cork();
         for (uint16_t i=0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
             if (motor_enabled[i]) {
                 hal.rcout->write(i, pwm);
             }
         }
+        hal.rcout->push();
     }
 }

--- a/libraries/AP_Motors/AP_MotorsSingle.cpp
+++ b/libraries/AP_Motors/AP_MotorsSingle.cpp
@@ -116,11 +116,13 @@ void AP_MotorsSingle::enable()
 void AP_MotorsSingle::output_min()
 {
     // send minimum value to each motor
+    hal.rcout->cork();
     hal.rcout->write(AP_MOTORS_MOT_1, _servo1.radio_trim);
     hal.rcout->write(AP_MOTORS_MOT_2, _servo2.radio_trim);
     hal.rcout->write(AP_MOTORS_MOT_3, _servo3.radio_trim);
     hal.rcout->write(AP_MOTORS_MOT_4, _servo4.radio_trim);
     hal.rcout->write(AP_MOTORS_MOT_7, _throttle_radio_min);
+    hal.rcout->push();
 }
 
 // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
@@ -172,11 +174,13 @@ void AP_MotorsSingle::output_armed_not_stabilizing()
         throttle_radio_output = apply_thrust_curve_and_volt_scaling(throttle_radio_output, out_min, _throttle_radio_max);
     }
 
+    hal.rcout->cork();
     hal.rcout->write(AP_MOTORS_MOT_1, _servo1.radio_out);
     hal.rcout->write(AP_MOTORS_MOT_2, _servo2.radio_out);
     hal.rcout->write(AP_MOTORS_MOT_3, _servo3.radio_out);
     hal.rcout->write(AP_MOTORS_MOT_4, _servo4.radio_out);
     hal.rcout->write(AP_MOTORS_MOT_7, throttle_radio_output);
+    hal.rcout->push();
 }
 
 // sends commands to the motors
@@ -229,11 +233,13 @@ void AP_MotorsSingle::output_armed_stabilizing()
     _servo4.calc_pwm();
 
     // send output to each motor
+    hal.rcout->cork();
     hal.rcout->write(AP_MOTORS_MOT_1, _servo1.radio_out);
     hal.rcout->write(AP_MOTORS_MOT_2, _servo2.radio_out);
     hal.rcout->write(AP_MOTORS_MOT_3, _servo3.radio_out);
     hal.rcout->write(AP_MOTORS_MOT_4, _servo4.radio_out);
     hal.rcout->write(AP_MOTORS_MOT_7, throttle_radio_output);
+    hal.rcout->push();
 }
 
 // output_disarmed - sends commands to the motors

--- a/libraries/AP_Motors/AP_MotorsTri.cpp
+++ b/libraries/AP_Motors/AP_MotorsTri.cpp
@@ -117,10 +117,12 @@ void AP_MotorsTri::output_min()
     limit.throttle_lower = true;
 
     // send minimum value to each motor
+    hal.rcout->cork();
     hal.rcout->write(AP_MOTORS_MOT_1, _throttle_radio_min);
     hal.rcout->write(AP_MOTORS_MOT_2, _throttle_radio_min);
     hal.rcout->write(AP_MOTORS_MOT_4, _throttle_radio_min);
     hal.rcout->write(AP_MOTORS_CH_TRI_YAW, _yaw_servo_trim);
+    hal.rcout->push();
 }
 
 // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
@@ -171,6 +173,8 @@ void AP_MotorsTri::output_armed_not_stabilizing()
         motor_out[AP_MOTORS_MOT_4] = apply_thrust_curve_and_volt_scaling(motor_out[AP_MOTORS_MOT_4], out_min, out_max);
     }
 
+    hal.rcout->cork();
+
     // send output to each motor
     hal.rcout->write(AP_MOTORS_MOT_1, motor_out[AP_MOTORS_MOT_1]);
     hal.rcout->write(AP_MOTORS_MOT_2, motor_out[AP_MOTORS_MOT_2]);
@@ -178,6 +182,8 @@ void AP_MotorsTri::output_armed_not_stabilizing()
 
     // send centering signal to yaw servo
     hal.rcout->write(AP_MOTORS_CH_TRI_YAW, _yaw_servo_trim);
+
+    hal.rcout->push();
 }
 
 // sends commands to the motors
@@ -284,6 +290,8 @@ void AP_MotorsTri::output_armed_stabilizing()
         motor_out[AP_MOTORS_MOT_4] = max(motor_out[AP_MOTORS_MOT_4],    out_min);
     }
 
+    hal.rcout->cork();
+
     // send output to each motor
     hal.rcout->write(AP_MOTORS_MOT_1, motor_out[AP_MOTORS_MOT_1]);
     hal.rcout->write(AP_MOTORS_MOT_2, motor_out[AP_MOTORS_MOT_2]);
@@ -291,6 +299,8 @@ void AP_MotorsTri::output_armed_stabilizing()
 
     // send out to yaw command to tail servo
     hal.rcout->write(AP_MOTORS_CH_TRI_YAW, yaw_radio_output);
+
+    hal.rcout->push();
 }
 
 // output_disarmed - sends commands to the motors


### PR DESCRIPTION
This is the third version of the pr to make the write to the motors be grouped when possible. Previous version is here: https://github.com/diydrones/ardupilot/pull/2754

This new version uses `cork()` and `push()` to mark which calls to rcout->write() are going to be grouped.  The idea for using the word word "cork" was given by @tridge since it's similar to what the TCP_CORK flag does (see http://linux.die.net/man/7/tcp). Contrary to the TCP flag though we don't set a time limit in which the changes are automatically "committed". In future we could make each vehicle to call `rcout->push()` in the end of their main loop, but this is something to discuss later and can be done on top.

It's allowed not to implement `cork()` and `push()`, in which case the behavior continues to be the previous one for them.  The only boards implementing this are the ones using PCA9685 and Bebop. Bebop has the added benefit now that it can use the motor test mavlink command since the number of motors is not hardcoded anymore (@jberaud, I implemented it, but couldn't really test).

@tridge is this sufficient to do a PX4 implementation on top?

I could fly fine with my quadcopter with MinnowBoard Max. Tests with other affected boards are appreciated (@staroselskii, navio in your case, @vmayoral erlebrain2 in your case).