### PR TITLE
HAL_Linux_Class: Fix the broken declare of "LinuxUtilRPI utilInstance…

### DIFF
--- a/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
+++ b/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
@@ -119,7 +119,7 @@ static Empty::EmptyRCOutput rcoutDriver;
 #endif
 
 static LinuxScheduler schedulerInstance;
-#if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO
+#if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO || CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_RASPILOT
 static LinuxUtilRPI utilInstance;
 #else
 static LinuxUtil utilInstance;


### PR DESCRIPTION
…" at building raspilot.