### PR TITLE
AP_HAL_Linux: Terminate pigpiod on startup (potential ressource confl.)

### DIFF
--- a/libraries/AP_HAL_Linux/RCInput_Navio.cpp
+++ b/libraries/AP_HAL_Linux/RCInput_Navio.cpp
@@ -395,9 +395,12 @@ LinuxRCInput_Navio::LinuxRCInput_Navio():
     int version = LinuxUtilRPI::from(hal.util)->get_rpi_version();
     set_physical_addresses(version);
 
-    //Init memory for buffer and for DMA control blocks. See comments in "init_ctrl_data()" to understand values "2" and "113"
+    // Init memory for buffer and for DMA control blocks. See comments in "init_ctrl_data()" to understand values "2" and "113"
     circle_buffer = new Memory_table(RCIN_NAVIO_BUFFER_LENGTH * 2, version);
     con_blocks = new Memory_table(RCIN_NAVIO_BUFFER_LENGTH * 113, version);
+    
+    // Attempt to kill all known conflicting ressources .. 
+    int ret = LinuxUtilRPI::from(hal.util)->terminate_process("pigpiod");
 }
 
 LinuxRCInput_Navio::~LinuxRCInput_Navio()

--- a/libraries/AP_HAL_Linux/Util_RPI.h
+++ b/libraries/AP_HAL_Linux/Util_RPI.h
@@ -1,6 +1,15 @@
 #pragma once
 
+#include <sys/types.h>
+#include <dirent.h>
+#include <unistd.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
 #include "Util.h"
+
 
 class Linux::LinuxUtilRPI : public Linux::LinuxUtil {
 public:
@@ -12,10 +21,15 @@ public:
 
     /* return the Raspberry Pi version */
     int get_rpi_version() const;
+    
+    /* kill pigpio if running */
+    int terminate_process(const char* name);
 
 protected:
     // Called in the constructor once
     int _check_rpi_version();
+    // Get state of pigpio
+    pid_t _find_process(const char* name);
 
 private:
     int _rpi_version = 0;


### PR DESCRIPTION
Noticed that pigpiod may run in parallel with the vehicle firmware and may lead to a ressource conflict.
I extended the RPi util the program now tries to kill pigpiod on startup of RCInput for navio.

Signed-off-by: dgrat <dgdanielf@gmail.com>