### PR TITLE
Fix copy usage rather than reference

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -30,6 +30,7 @@ class AP_InertialSensor_Backend
 {
 public:
     AP_InertialSensor_Backend(AP_InertialSensor &imu);
+    AP_InertialSensor_Backend(const AP_InertialSensor_Backend &that) = delete;
 
     // we declare a virtual destructor so that drivers can
     // override with a custom destructor if need be.

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -952,7 +952,7 @@ AP_MPU6000_AuxiliaryBusSlave::AP_MPU6000_AuxiliaryBusSlave(AuxiliaryBus &bus, ui
 int AP_MPU6000_AuxiliaryBusSlave::_set_passthrough(uint8_t reg, uint8_t size,
                                                   uint8_t *out)
 {
-    auto backend = AP_InertialSensor_MPU6000::from(_bus.get_backend());
+    auto &backend = AP_InertialSensor_MPU6000::from(_bus.get_backend());
     uint8_t addr;
 
     /* Ensure the slave read/write is disabled before changing the registers */
@@ -989,7 +989,7 @@ int AP_MPU6000_AuxiliaryBusSlave::passthrough_read(uint8_t reg, uint8_t *buf,
     /* wait the value to be read from the slave and read it back */
     hal.scheduler->delay(10);
 
-    auto backend = AP_InertialSensor_MPU6000::from(_bus.get_backend());
+    auto &backend = AP_InertialSensor_MPU6000::from(_bus.get_backend());
     backend._read_block(MPUREG_EXT_SENS_DATA_00 + _ext_sens_data, buf, size);
 
     /* disable new reads */
@@ -1012,7 +1012,7 @@ int AP_MPU6000_AuxiliaryBusSlave::passthrough_write(uint8_t reg, uint8_t val)
     /* wait the value to be written to the slave */
     hal.scheduler->delay(10);
 
-    auto backend = AP_InertialSensor_MPU6000::from(_bus.get_backend());
+    auto &backend = AP_InertialSensor_MPU6000::from(_bus.get_backend());
 
     /* disable new writes */
     backend._register_write(_mpu6000_ctrl, 0);
@@ -1027,7 +1027,7 @@ int AP_MPU6000_AuxiliaryBusSlave::read(uint8_t *buf)
         return -1;
     }
 
-    auto backend = AP_InertialSensor_MPU6000::from(_bus.get_backend());
+    auto &backend = AP_InertialSensor_MPU6000::from(_bus.get_backend());
     backend._read_block(MPUREG_EXT_SENS_DATA_00 + _ext_sens_data, buf, _sample_size);
 
     return 0;
@@ -1056,7 +1056,7 @@ AuxiliaryBusSlave *AP_MPU6000_AuxiliaryBus::_instantiate_slave(uint8_t addr, uin
 
 void AP_MPU6000_AuxiliaryBus::_configure_slaves()
 {
-    auto backend = AP_InertialSensor_MPU6000::from(_ins_backend);
+    auto &backend = AP_InertialSensor_MPU6000::from(_ins_backend);
 
     uint8_t user_ctrl;
     user_ctrl = backend._register_read(MPUREG_USER_CTRL);


### PR DESCRIPTION
This was supposed to take a reference rather than copying the backend. Also improve the code so we/I don't make that huge mistake again.