### PR TITLE
update gitignore for way.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,11 +59,14 @@ ArduCopter/mav.parm
 ArduCopter/terrain/*.DAT
 ArduCopter/test.ArduCopter/
 ArduCopter/test/*
+ArduCopter/way.txt
 ArduPlane/logs/
 ArduPlane/mav.parm
 ArduPlane/test/*
 ArduPlane/terrain/*.DAT
 ArduPlane/test.ArduPlane/
+ArduPlane/way.txt
+APMrover2/way.txt
 APMrover2/logs/
 APMrover2/mav.parm
 APMrover2/test.APMrover2/


### PR DESCRIPTION
This file "way.txt" is generated by SITL and should not be committed so it belongs in gitignore