### PR TITLE
Fix warnings

### DIFF
--- a/libraries/AP_HAL_Linux/RCOutput_PCA9685.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_PCA9685.cpp
@@ -192,11 +192,11 @@ void LinuxRCOutput_PCA9685::write(uint8_t ch, uint16_t period_us)
     else
         length = round((period_us * 4096) / (1000000.f / _frequency)) - 1;
 
-    uint8_t data[2] = {length & 0xFF, length >> 8};
-    uint8_t status = hal.i2c->writeRegisters(_addr,
-                                             PCA9685_RA_LED0_OFF_L + 4 * (ch + _channel_offset),
-                                             2,
-                                             data);
+    length = htole16(length);
+    hal.i2c->writeRegisters(_addr,
+                            PCA9685_RA_LED0_OFF_L + 4 * (ch + _channel_offset),
+                            2,
+                            (uint8_t *)&length);
 
     _pulses_buffer[ch] = period_us;
 

--- a/libraries/AP_Menu/AP_Menu.cpp
+++ b/libraries/AP_Menu/AP_Menu.cpp
@@ -84,7 +84,7 @@ Menu::_check_for_input(void)
 void
 Menu::_display_prompt(void)
 {
-    _port->printf_P(PSTR("%S] "), FPSTR(_prompt));    
+    _port->printf_P(PSTR("%S] "), _prompt);
 }
 
 // run the menu
@@ -231,7 +231,7 @@ Menu::_help(void)
     _port->println_P(PSTR("Commands:"));
     for (i = 0; i < _entries; i++) {
 		hal.scheduler->delay(10);
-        _port->printf_P(PSTR("  %S\n"), FPSTR(_commands[i].command));
+        _port->printf_P(PSTR("  %S\n"), _commands[i].command);
 	}
 }
 

--- a/libraries/AP_Menu/AP_Menu.h
+++ b/libraries/AP_Menu/AP_Menu.h
@@ -126,7 +126,7 @@ private:
     ///
     int8_t                  _call(uint8_t n, uint8_t argc);
 
-    const char *            _prompt;                                                    ///< prompt to display
+    const prog_char *       _prompt;                                                    ///< prompt to display
     const command *         _commands;                                                  ///< array of commands
     const uint8_t           _entries;                                                   ///< size of the menu
     const preprompt         _ppfunc;                                                    ///< optional pre-prompt action


### PR DESCRIPTION
This fixes the 2 files that make compilation warnings on the bebop build.
One is about the use of FPSTR, the other about an i2c command formating.
Review is off-course appreciated in case there is something that I have missed.