### PR TITLE
AP_Compass: Add support for more then one AK8963

### DIFF
--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -91,9 +91,9 @@ AP_Compass_AK8963::AP_Compass_AK8963(Compass &compass, AP_AK8963_SerialBus *bus)
     _reset_filter();
 }
 
-AP_Compass_Backend *AP_Compass_AK8963::detect_mpu9250(Compass &compass)
+AP_Compass_Backend *AP_Compass_AK8963::detect_mpu9250(Compass &compass, AP_HAL::SPIDeviceDriver *spi)
 {
-    AP_AK8963_SerialBus *bus = new AP_AK8963_SerialBus_MPU9250();
+    AP_AK8963_SerialBus *bus = new AP_AK8963_SerialBus_MPU9250(spi);
     if (!bus)
         return nullptr;
     return _detect(compass, bus);
@@ -402,9 +402,9 @@ void AP_Compass_AK8963::_dump_registers()
 }
 
 /* MPU9250 implementation of the AK8963 */
-AP_AK8963_SerialBus_MPU9250::AP_AK8963_SerialBus_MPU9250()
+AP_AK8963_SerialBus_MPU9250::AP_AK8963_SerialBus_MPU9250(AP_HAL::SPIDeviceDriver *spi)
 {
-    _spi = hal.spi->device(AP_HAL::SPIDevice_MPU9250);
+    _spi = spi;
 
     if (_spi == NULL) {
         hal.console->printf("Cannot get SPIDevice_MPU9250\n");

--- a/libraries/AP_Compass/AP_Compass_AK8963.h
+++ b/libraries/AP_Compass/AP_Compass_AK8963.h
@@ -35,7 +35,7 @@ public:
 class AP_Compass_AK8963 : public AP_Compass_Backend
 {
 public:
-    static AP_Compass_Backend *detect_mpu9250(Compass &compass);
+    static AP_Compass_Backend *detect_mpu9250(Compass &compass, AP_HAL::SPIDeviceDriver *spi);
     static AP_Compass_Backend *detect_i2c(Compass &compass,
                                           AP_HAL::I2CDriver *i2c,
                                           uint8_t addr);
@@ -85,7 +85,7 @@ private:
 class AP_AK8963_SerialBus_MPU9250: public AP_AK8963_SerialBus
 {
 public:
-    AP_AK8963_SerialBus_MPU9250();
+    AP_AK8963_SerialBus_MPU9250(AP_HAL::SPIDeviceDriver *spi);
     void register_read(uint8_t reg, uint8_t *value, uint8_t count);
     void register_write(uint8_t reg, uint8_t value);
     AP_HAL::Semaphore* get_semaphore();

--- a/libraries/AP_Compass/Compass.cpp
+++ b/libraries/AP_Compass/Compass.cpp
@@ -456,7 +456,7 @@ void Compass::_detect_backends(void)
     _add_backend(AP_Compass_LSM303D::detect_spi(*this));
 #elif CONFIG_HAL_BOARD == HAL_BOARD_LINUX && CONFIG_HAL_BOARD_SUBTYPE != HAL_BOARD_SUBTYPE_LINUX_NONE && CONFIG_HAL_BOARD_SUBTYPE != HAL_BOARD_SUBTYPE_LINUX_BEBOP
     _add_backend(AP_Compass_HMC5843::detect_i2c(*this, hal.i2c));
-    _add_backend(AP_Compass_AK8963::detect_mpu9250(*this));
+    _add_backend(AP_Compass_AK8963::detect_mpu9250(*this, hal.spi->device(AP_HAL::SPIDevice_MPU9250)));
 #elif HAL_COMPASS_DEFAULT == HAL_COMPASS_HIL
     _add_backend(AP_Compass_HIL::detect(*this));
 #elif HAL_COMPASS_DEFAULT == HAL_COMPASS_HMC5843


### PR DESCRIPTION
This PR make it possible to use more than one AK8963. Can be used in dual MPU9250 configuration.