### PR TITLE
Switch git submodule URL to HTTPS and add missing prerequisites on Ubuntu

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "modules/PX4Firmware"]
 	path = modules/PX4Firmware
-	url = git://github.com/diydrones/PX4Firmware.git
+	url = https://github.com/diydrones/PX4Firmware.git
 [submodule "modules/PX4NuttX"]
 	path = modules/PX4NuttX
-	url = git://github.com/diydrones/PX4NuttX.git
+	url = https://github.com/diydrones/PX4NuttX.git
 [submodule "modules/uavcan"]
 	path = modules/uavcan
-	url = git://github.com/diydrones/uavcan.git
+	url = https://github.com/diydrones/uavcan.git

--- a/Tools/scripts/install-prereqs-ubuntu.sh
+++ b/Tools/scripts/install-prereqs-ubuntu.sh
@@ -7,10 +7,10 @@ OPT="/opt"
 BASE_PKGS="gawk make git arduino-core curl"
 SITL_PKGS="g++ python-pip python-matplotlib python-serial python-wxgtk2.8 python-scipy python-opencv python-numpy python-pyparsing ccache realpath"
 AVR_PKGS="gcc-avr binutils-avr avr-libc"
-PYTHON_PKGS="pymavlink MAVProxy droneapi"
+PYTHON_PKGS="pymavlink MAVProxy droneapi catkin_pkg"
 PX4_PKGS="python-serial python-argparse openocd flex bison libncurses5-dev \
           autoconf texinfo build-essential libftdi-dev libtool zlib1g-dev \
-          zip genromfs"
+          zip genromfs python-empy"
 BEBOP_PKGS="g++-arm-linux-gnueabihf"
 UBUNTU64_PKGS="libc6:i386 libgcc1:i386 gcc-4.6-base:i386 libstdc++5:i386 libstdc++6:i386"
 ASSUME_YES=false


### PR DESCRIPTION
While trying to build the PX4-v2 firmware on a clean Ubuntu 14.04 machine, I came around two bugs. 

The first one is that the GIT protocol is blocked by our enterprise proxy, so I had to change the URL for submodules to HTTPS instead of GIT, which is more portable. 

The second one is that there was some Ubuntu/Python packages missing to successfully build the PX4-v2 firmware.