### PR TITLE
git: Fetch git submodules with https instead of git protocol.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "modules/PX4Firmware"]
 	path = modules/PX4Firmware
-	url = git://github.com/diydrones/PX4Firmware.git
+	url = https://github.com/diydrones/PX4Firmware.git
 [submodule "modules/PX4NuttX"]
 	path = modules/PX4NuttX
-	url = git://github.com/diydrones/PX4NuttX.git
+	url = https://github.com/diydrones/PX4NuttX.git
 [submodule "modules/uavcan"]
 	path = modules/uavcan
-	url = git://github.com/diydrones/uavcan.git
+	url = https://github.com/diydrones/uavcan.git


### PR DESCRIPTION
Use HTTPS protocol instead of GIT protocol for git submodules. This allow users behind an enterprise firewall to fetch submodules.