### PR TITLE
Notify parameter changes

### DIFF
--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -164,10 +164,10 @@ void AP_Baro::update_calibration()
 {
     for (uint8_t i=0; i<_num_sensors; i++) {
         if (healthy(i)) {
-            sensors[i].ground_pressure.set(get_pressure(i));
+            sensors[i].ground_pressure.set_and_notify(get_pressure(i));
         }
         float last_temperature = sensors[i].ground_temperature;
-        sensors[i].ground_temperature.set(get_calibration_temperature(i));
+        sensors[i].ground_temperature.set_and_notify(get_calibration_temperature(i));
         if (fabsf(last_temperature - sensors[i].ground_temperature) > 3) {
             // reset _EAS2TAS to force it to recalculate. This happens
             // when a digital airspeed sensor comes online

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -28,6 +28,7 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_Math/AP_Math.h>
 #include <StorageManager/StorageManager.h>
+#include <GCS_MAVLink/GCS.h> // for send_parameter_value_all
 
 #include <math.h>
 #include <string.h>
@@ -717,11 +718,16 @@ bool AP_Param::save(bool force_save)
         ap = (const AP_Param *)((uintptr_t)ap) - (idx*sizeof(float));
     }
 
+    char name[AP_MAX_NAME_SIZE+1];
+    copy_name_info(info, ginfo, idx, name, sizeof(name), true);
+
     // scan EEPROM to find the right location
     uint16_t ofs;
     if (scan(&phdr, &ofs)) {
         // found an existing copy of the variable
         eeprom_write_check(ap, ofs+sizeof(phdr), type_size((enum ap_var_type)phdr.type));
+        GCS_MAVLINK::send_parameter_value_all(name, (enum ap_var_type)info->type,
+                                              cast_to_float((enum ap_var_type)phdr.type));
         return true;
     }
     if (ofs == (uint16_t) ~0) {
@@ -738,12 +744,14 @@ bool AP_Param::save(bool force_save)
             v2 = get_default_value(&info->def_value);
         }
         if (is_equal(v1,v2) && !force_save) {
+            GCS_MAVLINK::send_parameter_value_all(name, (enum ap_var_type)info->type, v2);
             return true;
         }
         if (phdr.type != AP_PARAM_INT32 &&
             (fabsf(v1-v2) < 0.0001f*fabsf(v1))) {
             // for other than 32 bit integers, we accept values within
             // 0.01 percent of the current value as being the same
+            GCS_MAVLINK::send_parameter_value_all(name, (enum ap_var_type)info->type, v2);
             return true;
         }
     }
@@ -758,6 +766,8 @@ bool AP_Param::save(bool force_save)
     write_sentinal(ofs + sizeof(phdr) + type_size((enum ap_var_type)phdr.type));
     eeprom_write_check(ap, ofs+sizeof(phdr), type_size((enum ap_var_type)phdr.type));
     eeprom_write_check(&phdr, ofs, sizeof(phdr));
+    GCS_MAVLINK::send_parameter_value_all(name, (enum ap_var_type)info->type,
+                                          cast_to_float((enum ap_var_type)phdr.type));
     return true;
 }
 

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -370,7 +370,7 @@ const struct AP_Param::Info *AP_Param::find_var_info_group(const struct GroupInf
 // find the info structure for a variable
 const struct AP_Param::Info *AP_Param::find_var_info(uint32_t *                 group_element,
                                                      const struct GroupInfo **  group_ret,
-                                                     uint8_t *                  idx)
+                                                     uint8_t *                  idx) const
 {
     for (uint8_t i=0; i<_num_vars; i++) {
         uint8_t type = PGM_UINT8(&_var_info[i].type);
@@ -529,6 +529,11 @@ void AP_Param::copy_name_token(const ParamToken &token, char *buffer, size_t buf
         Debug("no info found");
         return;
     }
+    copy_name_info(info, ginfo, idx, buffer, buffer_size, force_scalar);
+}
+
+void AP_Param::copy_name_info(const struct AP_Param::Info *info, const struct GroupInfo *ginfo, uint8_t idx, char *buffer, size_t buffer_size, bool force_scalar) const
+{
     strncpy_P(buffer, info->name, buffer_size);
     if (ginfo != NULL) {
         uint8_t len = strnlen(buffer, buffer_size);
@@ -680,6 +685,32 @@ AP_Param::find_object(const char *name)
         }
     }
     return NULL;
+}
+
+// notify GCS of current value of parameter
+void AP_Param::notify() const {
+    uint32_t group_element = 0;
+    const struct GroupInfo *ginfo;
+    uint8_t idx;
+
+    const struct AP_Param::Info *info = find_var_info(&group_element, &ginfo, &idx);
+    if (info == NULL) {
+        // this is probably very bad
+        return;
+    }
+
+    char name[AP_MAX_NAME_SIZE+1];
+    copy_name_info(info, ginfo, idx, name, sizeof(name), true);
+
+    uint32_t param_header_type;
+    if (ginfo != NULL) {
+        param_header_type = PGM_UINT8(&ginfo->type);
+    } else {
+        param_header_type = PGM_UINT8(&info->type);
+    }
+
+    GCS_MAVLINK::send_parameter_value_all(name, (enum ap_var_type)info->type,
+                                          cast_to_float((enum ap_var_type)param_header_type));
 }
 
 

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -141,6 +141,11 @@ public:
     /// @param	buffer			The destination buffer
     /// @param	bufferSize		Total size of the destination buffer.
     ///
+    void copy_name_info(const struct AP_Param::Info *info, const struct GroupInfo *ginfo, uint8_t idx, char *buffer, size_t bufferSize, bool force_scalar=false) const;
+    /// Copy the variable's name, prefixed by any containing group name, to a
+    /// buffer.
+    ///
+    /// Uses token to look up AP_Param::Info for the variable
     void copy_name_token(const ParamToken &token, char *buffer, size_t bufferSize, bool force_scalar=false) const;
 
     /// Find a variable by name.
@@ -170,6 +175,10 @@ public:
     /// @param  name            The full name of the variable to be found.
     ///
     static AP_Param * find_object(const char *name);
+
+    /// Notify GCS of current parameter value
+    ///
+    void notify() const;
 
     /// Save the current value of the variable to EEPROM.
     ///
@@ -311,7 +320,7 @@ private:
     const struct Info *         find_var_info(
                                     uint32_t *                group_element,
                                     const struct GroupInfo ** group_ret,
-                                    uint8_t *                 idx);
+                                    uint8_t *                 idx) const;
     const struct Info *			find_var_info_token(const ParamToken &token,
                                                     uint32_t *                 group_element,
                                                     const struct GroupInfo **  group_ret,
@@ -415,6 +424,13 @@ public:
     ///
     void set(const T &v) {
         _value = v;
+    }
+
+    /// Value setter - set value, tell GCS
+    ///
+    void set_and_notify(const T &v) {
+        set(v);
+        notify();
     }
 
     /// Combined set and save

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -160,13 +160,13 @@ public:
     // over active channels to send to all active channels    
     static uint8_t active_channel_mask(void) { return mavlink_active; }
 
-    /*
-      send a statustext message to all active MAVLink
-      connections. This function is static so it can be called from
-      any library
-    */
-    static void send_statustext_all(MAV_SEVERITY severity, const prog_char_t *fmt, ...);
+    /* the following functions are all static so they can be called
+     * from any library
+     */
 
+    // send a statustext message to all active MAVLink connections.
+    static void send_statustext_all(MAV_SEVERITY severity, const prog_char_t *fmt, ...);
+    static void send_parameter_value_all(const char *param_name, ap_var_type param_type, float param_value);
     /*
       send a MAVLink message to all components with this vehicle's system id
       This is a no-op if no routes to components have been learned
@@ -210,10 +210,10 @@ private:
     ///
     /// @return         The number of reportable parameters.
     ///
-    uint16_t                    _count_parameters(); ///< count reportable
+    static uint16_t             _count_parameters(); ///< count reportable
                                                      // parameters
 
-    uint16_t                    _parameter_count;   ///< cache of reportable
+    static uint16_t             _parameter_count;   ///< cache of reportable
                                                     // parameters
 
     mavlink_channel_t           chan;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -26,6 +26,7 @@ extern const AP_HAL::HAL& hal;
 
 uint32_t GCS_MAVLINK::last_radio_status_remrssi_ms;
 uint8_t GCS_MAVLINK::mavlink_active = 0;
+uint16_t GCS_MAVLINK::_parameter_count;
 
 GCS_MAVLINK::GCS_MAVLINK() :
     waypoint_receive_timeout(5000)
@@ -593,19 +594,6 @@ void GCS_MAVLINK::handle_param_set(mavlink_message_t *msg, DataFlash_Class *Data
 
     // save the change
     vp->save(force_save);
-
-    // Report back the new value if we accepted the change
-    // we send the value we actually set, which could be
-    // different from the value sent, in case someone sent
-    // a fractional value to an integer type
-    mavlink_msg_param_value_send_buf(
-        msg,
-        chan,
-        key,
-        vp->cast_to_float(var_type),
-        mav_var_type(var_type),
-        _count_parameters(),
-        -1);     // XXX we don't actually know what its index is...
 
     if (DataFlash != NULL) {
         DataFlash->Log_Write_Parameter(key, vp->cast_to_float(var_type));
@@ -1207,6 +1195,27 @@ void GCS_MAVLINK::send_statustext_all(MAV_SEVERITY severity, const prog_char_t *
                 mavlink_msg_statustext_send(chan,
                                             severity,
                                             msg2);
+            }
+        }
+    }
+}
+
+/*
+  send a parameter value message to all active MAVLink connections
+ */
+void GCS_MAVLINK::send_parameter_value_all(const char *param_name, ap_var_type param_type, float param_value)
+{
+    for (uint8_t i=0; i<MAVLINK_COMM_NUM_BUFFERS; i++) {
+        if ((1U<<i) & mavlink_active) {
+            mavlink_channel_t chan = (mavlink_channel_t)(MAVLINK_COMM_0+i);
+            if (comm_get_txspace(chan) >= MAVLINK_NUM_NON_PAYLOAD_BYTES + MAVLINK_MSG_ID_PARAM_VALUE_LEN) {
+                mavlink_msg_param_value_send(
+                    chan,
+                    param_name,
+                    param_value,
+                    mav_var_type(param_type),
+                    _count_parameters(),
+                    -1);
             }
         }
     }


### PR DESCRIPTION
Any parameters which are save()d get sent to the GCS.

Code may call "set_and_notify(v)" in place of "set(v)" to let GCS know of new values.

set() itself was called about 5 times/second in my testing - too much to be sending to all GCS.
