### PR TITLE
AP_Compass: make all backends use milligauss as unit

### DIFF
--- a/APMrover2/test.cpp
+++ b/APMrover2/test.cpp
@@ -399,8 +399,8 @@ int8_t Rover::test_mag(uint8_t argc, const Menu::arg *argv)
         counter++;
         if (counter>20) {
             if (compass.healthy()) {
-                const Vector3f mag_ofs = compass.get_offsets_milligauss();
-                const Vector3f mag = compass.get_field_milligauss();
+                const Vector3f mag_ofs = compass.get_offsets();
+                const Vector3f mag = compass.get_field();
                 cliSerial->printf_P(PSTR("Heading: %ld, XYZ: %.0f, %.0f, %.0f,\tXYZoff: %6.2f, %6.2f, %6.2f\n"),
                                     (wrap_360_cd(ToDeg(heading) * 100)) /100,
                                     (double)mag.x, (double)mag.y, (double)mag.z,

--- a/ArduCopter/compassmot.cpp
+++ b/ArduCopter/compassmot.cpp
@@ -124,7 +124,7 @@ uint8_t Copter::mavlink_compassmot(mavlink_channel_t chan)
     // store initial x,y,z compass values
     // initialise interference percentage
     for (uint8_t i=0; i<compass.get_count(); i++) {
-        compass_base[i] = compass.get_field_milligauss(i);
+        compass_base[i] = compass.get_field(i);
         interference_pct[i] = 0.0f;
     }
 
@@ -167,7 +167,7 @@ uint8_t Copter::mavlink_compassmot(mavlink_channel_t chan)
         // if throttle is near zero, update base x,y,z values
         if (throttle_pct <= 0.0f) {
             for (uint8_t i=0; i<compass.get_count(); i++) {
-                compass_base[i] = compass_base[i] * 0.99f + compass.get_field_milligauss(i) * 0.01f;
+                compass_base[i] = compass_base[i] * 0.99f + compass.get_field(i) * 0.01f;
             }
 
             // causing printing to happen as soon as throttle is lifted
@@ -175,7 +175,7 @@ uint8_t Copter::mavlink_compassmot(mavlink_channel_t chan)
 
             // calculate diff from compass base and scale with throttle
             for (uint8_t i=0; i<compass.get_count(); i++) {
-                motor_impact[i] = compass.get_field_milligauss(i) - compass_base[i];
+                motor_impact[i] = compass.get_field(i) - compass_base[i];
             }
 
             // throttle based compensation

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -358,7 +358,7 @@ bool Copter::pre_arm_checks(bool display_failure)
         }
 
         // check for unreasonable compass offsets
-        Vector3f offsets = compass.get_offsets_milligauss();
+        Vector3f offsets = compass.get_offsets();
         if(offsets.length() > COMPASS_OFFSETS_MAX) {
             if (display_failure) {
                 gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Compass offsets too high"));
@@ -367,7 +367,7 @@ bool Copter::pre_arm_checks(bool display_failure)
         }
 
         // check for unreasonable mag field length
-        float mag_field = compass.get_field_milligauss().length();
+        float mag_field = compass.get_field().length();
         if (mag_field > COMPASS_MAGFIELD_EXPECTED*1.65f || mag_field < COMPASS_MAGFIELD_EXPECTED*0.35f) {
             if (display_failure) {
                 gcs_send_text_P(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Check mag field"));

--- a/ArduCopter/setup.cpp
+++ b/ArduCopter/setup.cpp
@@ -450,7 +450,7 @@ void Copter::report_compass()
     // mag offsets
     Vector3f offsets;
     for (uint8_t i=0; i<compass.get_count(); i++) {
-        offsets = compass.get_offsets_milligauss(i);
+        offsets = compass.get_offsets(i);
         // mag offsets
         cliSerial->printf_P(PSTR("Mag%d off: %4.4f, %4.4f, %4.4f\n"),
                         (int)i,

--- a/ArduCopter/test.cpp
+++ b/ArduCopter/test.cpp
@@ -116,8 +116,8 @@ int8_t Copter::test_compass(uint8_t argc, const Menu::arg *argv)
             counter++;
             if (counter>20) {
                 if (compass.healthy()) {
-                    const Vector3f &mag_ofs = compass.get_offsets_milligauss();
-                    const Vector3f &mag = compass.get_field_milligauss();
+                    const Vector3f &mag_ofs = compass.get_offsets();
+                    const Vector3f &mag = compass.get_field();
                     cliSerial->printf_P(PSTR("Heading: %ld, XYZ: %.0f, %.0f, %.0f,\tXYZoff: %6.2f, %6.2f, %6.2f\n"),
                                         (wrap_360_cd(ToDeg(heading) * 100)) /100,
                                         (double)mag.x,

--- a/ArduPlane/test.cpp
+++ b/ArduPlane/test.cpp
@@ -463,8 +463,8 @@ int8_t Plane::test_mag(uint8_t argc, const Menu::arg *argv)
             counter++;
             if (counter>20) {
                 if (compass.healthy()) {
-                    const Vector3f &mag_ofs = compass.get_offsets_milligauss();
-                    const Vector3f &mag = compass.get_field_milligauss();
+                    const Vector3f &mag_ofs = compass.get_offsets();
+                    const Vector3f &mag = compass.get_field();
                     cliSerial->printf_P(PSTR("Heading: %ld, XYZ: %.0f, %.0f, %.0f,\tXYZoff: %6.2f, %6.2f, %6.2f\n"),
                                         (wrap_360_cd(ToDeg(heading) * 100)) /100,
                                         (double)mag.x, (double)mag.y, (double)mag.z,

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -276,7 +276,7 @@ AP_AHRS_DCM::normalize(void)
 float
 AP_AHRS_DCM::yaw_error_compass(void)
 {
-    const Vector3f &mag = _compass->get_field_milligauss();
+    const Vector3f &mag = _compass->get_field();
     // get the mag vector in the earth frame
     Vector2f rb = _dcm_matrix.mulXY(mag);
 

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -256,7 +256,7 @@ bool AP_Arming::compass_checks(bool report)
         }
 
         // check for unreasonable compass offsets
-        Vector3f offsets = _compass.get_offsets_milligauss();
+        Vector3f offsets = _compass.get_offsets();
         if (offsets.length() > 600) {
             if (report) {
                 GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: Compass offsets too high"));
@@ -271,7 +271,7 @@ bool AP_Arming::compass_checks(bool report)
 #endif
 
         // check for unreasonable mag field length
-        float mag_field = _compass.get_field_milligauss().length();
+        float mag_field = _compass.get_field().length();
         if (mag_field > COMPASS_MAGFIELD_EXPECTED*1.65f || mag_field < COMPASS_MAGFIELD_EXPECTED*0.35f) {
             if (report) {
                 GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: Check mag field"));

--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -180,8 +180,6 @@ bool AP_Compass_AK8963::init()
     set_dev_id(_compass_instance, _bus->get_dev_id());
     hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&AP_Compass_AK8963::_update, void));
 
-    set_milligauss_ratio(_compass_instance, 1.0f);
-    
     _bus_sem->give();
     hal.scheduler->resume_timer_procs();
 

--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -211,9 +211,6 @@ void AP_Compass_AK8963::read()
 
     _reset_filter();
     hal.scheduler->resume_timer_procs();
-    _make_factory_sensitivity_adjustment(field);
-    _make_adc_sensitivity_adjustment(field);
-
     publish_filtered_field(field, _compass_instance);
 }
 
@@ -279,6 +276,9 @@ void AP_Compass_AK8963::_update()
     }
 
     raw_field = Vector3f(mag_x, mag_y, mag_z);
+
+    _make_factory_sensitivity_adjustment(raw_field);
+    _make_adc_sensitivity_adjustment(raw_field);
     raw_field *= AK8963_MILLIGAUSS_SCALE;
 
     // rotate raw_field from sensor frame to body frame

--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -79,6 +79,8 @@
 #endif
 #endif
 
+#define AK8963_MILLIGAUSS_SCALE 10.0f
+
 extern const AP_HAL::HAL& hal;
 
 AP_Compass_AK8963::AP_Compass_AK8963(Compass &compass, AP_AK8963_SerialBus *bus) :
@@ -178,7 +180,7 @@ bool AP_Compass_AK8963::init()
     set_dev_id(_compass_instance, _bus->get_dev_id());
     hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&AP_Compass_AK8963::_update, void));
 
-    set_milligauss_ratio(_compass_instance, 10.0f);
+    set_milligauss_ratio(_compass_instance, 1.0f);
     
     _bus_sem->give();
     hal.scheduler->resume_timer_procs();
@@ -277,7 +279,8 @@ void AP_Compass_AK8963::_update()
     }
 
     raw_field = Vector3f(mag_x, mag_y, mag_z);
-    
+    raw_field *= AK8963_MILLIGAUSS_SCALE;
+
     // rotate raw_field from sensor frame to body frame
     rotate_field(raw_field, _compass_instance);
 

--- a/libraries/AP_Compass/AP_Compass_Backend.cpp
+++ b/libraries/AP_Compass/AP_Compass_Backend.cpp
@@ -21,6 +21,8 @@ AP_Compass_Backend::AP_Compass_Backend(Compass &compass) :
  * 4. publish_unfiltered_field - this (optionally) provides a corrected
  *      point sample for fusion into the EKF
  * 5. publish_filtered_field - legacy filtered magnetic field
+ *
+ * All those functions expect the mag field to be in milligauss.
  */
 
 void AP_Compass_Backend::rotate_field(Vector3f &mag, uint8_t instance)

--- a/libraries/AP_Compass/AP_Compass_Backend.cpp
+++ b/libraries/AP_Compass/AP_Compass_Backend.cpp
@@ -141,9 +141,3 @@ void AP_Compass_Backend::set_external(uint8_t instance, bool external)
 {
     _compass._state[instance].external.set(external);
 }
-
-// set ratio to convert to milligauss
-void AP_Compass_Backend::set_milligauss_ratio(uint8_t instance, float ratio)
-{
-    _compass._state[instance].milligauss_ratio = ratio;
-}

--- a/libraries/AP_Compass/AP_Compass_Backend.h
+++ b/libraries/AP_Compass/AP_Compass_Backend.h
@@ -73,9 +73,6 @@ protected:
     // set external state for an instance
     void set_external(uint8_t instance, bool external);
 
-    // set ratio to convert to milligauss
-    void set_milligauss_ratio(uint8_t instance, float ratio);
-    
     // access to frontend
     Compass &_compass;
 

--- a/libraries/AP_Compass/AP_Compass_Backend.h
+++ b/libraries/AP_Compass/AP_Compass_Backend.h
@@ -56,6 +56,8 @@ protected:
      * 4. publish_unfiltered_field - this (optionally) provides a corrected
      *      point sample for fusion into the EKF
      * 5. publish_filtered_field - legacy filtered magnetic field
+     *
+     * All those functions expect the mag field to be in milligauss.
      */
 
     void rotate_field(Vector3f &mag, uint8_t instance);

--- a/libraries/AP_Compass/AP_Compass_HIL.cpp
+++ b/libraries/AP_Compass/AP_Compass_HIL.cpp
@@ -53,7 +53,6 @@ AP_Compass_HIL::init(void)
     // register two compass instances
     for (uint8_t i=0; i<HIL_NUM_COMPASSES; i++) {
         _compass_instance[i] = register_compass();
-        set_milligauss_ratio(_compass_instance[i], 1.0f);
     }
     return true;
 }

--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -332,8 +332,6 @@ AP_Compass_HMC5843::init()
     _compass_instance = register_compass();
     set_dev_id(_compass_instance, _product_id);
 
-    set_milligauss_ratio(_compass_instance, 1.0f);
-
 #if CONFIG_HAL_BOARD == HAL_BOARD_LINUX && CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_RASPILOT
     set_external(_compass_instance, true);
 #endif

--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -417,20 +417,9 @@ bool AP_Compass_HMC5843::_calibrate(uint8_t calibration_gain,
     }
 
     if (good_count >= 5) {
-        /*
-          The use of _gain_multiple below is incorrect, as the gain
-          difference between 2.5Ga mode and 1Ga mode is already taken
-          into account by the expected_x and expected_yz values.  We
-          are not going to fix it however as it would mean all
-          APM1/APM2 users redoing their compass calibration. The
-          impact is that the values we report on APM1/APM2 are lower
-          than they should be (by a multiple of about 0.6). This
-          doesn't have any impact other than the learned compass
-          offsets
-         */
-        _scaling[0] = _scaling[0] * _gain_multiple / good_count;
-        _scaling[1] = _scaling[1] * _gain_multiple / good_count;
-        _scaling[2] = _scaling[2] * _gain_multiple / good_count;
+        _scaling[0] = _scaling[0] / good_count;
+        _scaling[1] = _scaling[1] / good_count;
+        _scaling[2] = _scaling[2] / good_count;
         success = true;
     } else {
         /* best guess */

--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -200,6 +200,7 @@ void AP_Compass_HMC5843::accumulate(void)
 	  // accumulate more than 8 before a read
        // get raw_field - sensor frame, uncorrected
        Vector3f raw_field = Vector3f(_mag_x, _mag_y, _mag_z);
+       raw_field *= _gain_multiple;
 
        // rotate raw_field from sensor frame to body frame
        rotate_field(raw_field, _compass_instance);
@@ -269,7 +270,7 @@ AP_Compass_HMC5843::init()
     uint8_t calibration_gain = 0x20;
     uint16_t expected_x = 715;
     uint16_t expected_yz = 715;
-    _gain_multiple = 1.0;
+    _gain_multiple = (1.0f / 1300) * 1000;
 
     _bus_sem = _bus->get_semaphore();
     hal.scheduler->suspend_timer_procs();
@@ -298,7 +299,7 @@ AP_Compass_HMC5843::init()
          */
         expected_x = 766;
         expected_yz  = 713;
-        _gain_multiple = 660.0f / 1090;  // adjustment for runtime vs calibration gain
+        _gain_multiple = (1.0f / 1090) * 1000;
     }
 
     if (!_calibrate(calibration_gain, expected_x, expected_yz)) {
@@ -331,7 +332,7 @@ AP_Compass_HMC5843::init()
     _compass_instance = register_compass();
     set_dev_id(_compass_instance, _product_id);
 
-    set_milligauss_ratio(_compass_instance, 1.0f / _gain_multiple);
+    set_milligauss_ratio(_compass_instance, 1.0f);
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_LINUX && CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_RASPILOT
     set_external(_compass_instance, true);

--- a/libraries/AP_Compass/AP_Compass_HMC5843.h
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.h
@@ -31,7 +31,9 @@ private:
     bool                read_register(uint8_t address, uint8_t *value);
     bool                write_register(uint8_t address, uint8_t value);
 
-    bool                _calibrate(uint8_t calibration_gain, uint16_t expected_x, uint16_t expected_yz);
+    bool                _calibrate(uint8_t calibration_gain,
+                                   uint16_t expected_x,
+                                   uint16_t expected_yz);
     bool                _detect_version();
 
     uint32_t            _retry_time; // when unhealthy the millis() value to retry at

--- a/libraries/AP_Compass/AP_Compass_LSM303D.cpp
+++ b/libraries/AP_Compass/AP_Compass_LSM303D.cpp
@@ -341,8 +341,6 @@ AP_Compass_LSM303D::init()
 
     hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&AP_Compass_LSM303D::_update, void));
 
-    set_milligauss_ratio(_compass_instance, 1.0f);
-
     _spi_sem->give();
     hal.scheduler->resume_timer_procs();
     _initialised = true;

--- a/libraries/AP_Compass/AP_Compass_PX4.cpp
+++ b/libraries/AP_Compass/AP_Compass_PX4.cpp
@@ -96,7 +96,6 @@ bool AP_Compass_PX4::init(void)
         _count[i] = 0;
         _sum[i].zero();
 
-        set_milligauss_ratio(_instance[i], 1.0f);
     }
 
     // give the driver a chance to run, and gather one sample

--- a/libraries/AP_Compass/Compass.cpp
+++ b/libraries/AP_Compass/Compass.cpp
@@ -635,7 +635,7 @@ Compass::calculate_heading(const Matrix3f &dcm_matrix) const
     float cos_pitch_sq = 1.0f-(dcm_matrix.c.x*dcm_matrix.c.x);
 
     // Tilt compensated magnetic field Y component:
-    const Vector3f &field = get_field_milligauss();
+    const Vector3f &field = get_field();
 
     float headY = field.y * dcm_matrix.c.z - field.z * dcm_matrix.c.y;
 
@@ -676,7 +676,7 @@ bool Compass::configured(uint8_t i)
     }
 
     // exit immediately if all offsets (mG) are zero
-    if (is_zero(get_offsets_milligauss(i).length())) {
+    if (is_zero(get_offsets(i).length())) {
         return false;
     }
 
@@ -784,7 +784,7 @@ void Compass::motor_compensation_type(const uint8_t comp_type)
 
 bool Compass::consistent() const
 {
-    Vector3f primary_mag_field = get_field_milligauss();
+    Vector3f primary_mag_field = get_field();
     Vector3f primary_mag_field_norm;
 
     if (!primary_mag_field.is_zero()) {
@@ -804,7 +804,7 @@ bool Compass::consistent() const
 
     for (uint8_t i=0; i<get_count(); i++) {
         if (use_for_yaw(i)) {
-            Vector3f mag_field = get_field_milligauss(i);
+            Vector3f mag_field = get_field(i);
             Vector3f mag_field_norm;
 
             if (!mag_field.is_zero()) {

--- a/libraries/AP_Compass/Compass.cpp
+++ b/libraries/AP_Compass/Compass.cpp
@@ -16,19 +16,19 @@ const AP_Param::GroupInfo Compass::var_info[] PROGMEM = {
     // index 0 was used for the old orientation matrix
 
     // @Param: OFS_X
-    // @DisplayName: Compass offsets on the X axis
+    // @DisplayName: Compass offsets in milligauss on the X axis
     // @Description: Offset to be added to the compass x-axis values to compensate for metal in the frame
     // @Range: -400 400
     // @Increment: 1
 
     // @Param: OFS_Y
-    // @DisplayName: Compass offsets on the Y axis
+    // @DisplayName: Compass offsets in milligauss on the Y axis
     // @Description: Offset to be added to the compass y-axis values to compensate for metal in the frame
     // @Range: -400 400
     // @Increment: 1
 
     // @Param: OFS_Z
-    // @DisplayName: Compass offsets on the Z axis
+    // @DisplayName: Compass offsets in milligauss on the Z axis
     // @Description: Offset to be added to the compass z-axis values to compensate for metal in the frame
     // @Range: -400 400
     // @Increment: 1
@@ -108,19 +108,19 @@ const AP_Param::GroupInfo Compass::var_info[] PROGMEM = {
 
 #if COMPASS_MAX_INSTANCES > 1
     // @Param: OFS2_X
-    // @DisplayName: Compass2 offsets on the X axis
+    // @DisplayName: Compass2 offsets in milligauss on the X axis
     // @Description: Offset to be added to compass2's x-axis values to compensate for metal in the frame
     // @Range: -400 400
     // @Increment: 1
 
     // @Param: OFS2_Y
-    // @DisplayName: Compass2 offsets on the Y axis
+    // @DisplayName: Compass2 offsets in milligauss on the Y axis
     // @Description: Offset to be added to compass2's y-axis values to compensate for metal in the frame
     // @Range: -400 400
     // @Increment: 1
 
     // @Param: OFS2_Z
-    // @DisplayName: Compass2 offsets on the Z axis
+    // @DisplayName: Compass2 offsets in milligauss on the Z axis
     // @Description: Offset to be added to compass2's z-axis values to compensate for metal in the frame
     // @Range: -400 400
     // @Increment: 1
@@ -158,19 +158,19 @@ const AP_Param::GroupInfo Compass::var_info[] PROGMEM = {
 
 #if COMPASS_MAX_INSTANCES > 2
     // @Param: OFS3_X
-    // @DisplayName: Compass3 offsets on the X axis
+    // @DisplayName: Compass3 offsets in milligauss on the X axis
     // @Description: Offset to be added to compass3's x-axis values to compensate for metal in the frame
     // @Range: -400 400
     // @Increment: 1
 
     // @Param: OFS3_Y
-    // @DisplayName: Compass3 offsets on the Y axis
+    // @DisplayName: Compass3 offsets in milligauss on the Y axis
     // @Description: Offset to be added to compass3's y-axis values to compensate for metal in the frame
     // @Range: -400 400
     // @Increment: 1
 
     // @Param: OFS3_Z
-    // @DisplayName: Compass3 offsets on the Z axis
+    // @DisplayName: Compass3 offsets in milligauss on the Z axis
     // @Description: Offset to be added to compass3's z-axis values to compensate for metal in the frame
     // @Range: -400 400
     // @Increment: 1

--- a/libraries/AP_Compass/Compass.h
+++ b/libraries/AP_Compass/Compass.h
@@ -92,14 +92,14 @@ public:
     /// Sets offset x/y/z values.
     ///
     /// @param  i                   compass instance
-    /// @param  offsets             Offsets to the raw mag_ values.
+    /// @param  offsets             Offsets to the raw mag_ values in milligauss.
     ///
     void set_offsets(uint8_t i, const Vector3f &offsets);
 
     /// Sets and saves the compass offset x/y/z values.
     ///
     /// @param  i                   compass instance
-    /// @param  offsets             Offsets to the raw mag_ values.
+    /// @param  offsets             Offsets to the raw mag_ values in milligauss.
     ///
     void set_and_save_offsets(uint8_t i, const Vector3f &offsets);
     void set_and_save_diagonals(uint8_t i, const Vector3f &diagonals);
@@ -118,7 +118,7 @@ public:
     // return the number of compass instances
     uint8_t get_count(void) const { return _compass_count; }
 
-    /// Return the current field as a Vector3f
+    /// Return the current field as a Vector3f in milligauss
     const Vector3f &get_field(uint8_t i) const { return _state[i].field; }
     const Vector3f &get_field(void) const { return get_field(get_primary()); }
 
@@ -178,7 +178,7 @@ public:
 
     /// Returns the current offset values
     ///
-    /// @returns                    The current compass offsets.
+    /// @returns                    The current compass offsets in milligauss.
     ///
     const Vector3f &get_offsets(uint8_t i) const { return _state[i].offset; }
     const Vector3f &get_offsets(void) const { return get_offsets(get_primary()); }
@@ -193,9 +193,9 @@ public:
     /// Program new offset values.
     ///
     /// @param  i                   compass instance
-    /// @param  x                   Offset to the raw mag_x value.
-    /// @param  y                   Offset to the raw mag_y value.
-    /// @param  z                   Offset to the raw mag_z value.
+    /// @param  x                   Offset to the raw mag_x value in milligauss.
+    /// @param  y                   Offset to the raw mag_y value in milligauss.
+    /// @param  z                   Offset to the raw mag_z value in milligauss.
     ///
     void set_and_save_offsets(uint8_t i, int x, int y, int z) {
         set_and_save_offsets(i, Vector3f(x, y, z));
@@ -255,7 +255,7 @@ public:
 
     /// Returns the current motor compensation offset values
     ///
-    /// @returns                    The current compass offsets.
+    /// @returns                    The current compass offsets in milligauss.
     ///
     const Vector3f &get_motor_offsets(uint8_t i) const { return _state[i].motor_offset; }
     const Vector3f &get_motor_offsets(void) const { return get_motor_offsets(get_primary()); }

--- a/libraries/AP_Compass/Compass.h
+++ b/libraries/AP_Compass/Compass.h
@@ -119,9 +119,9 @@ public:
     uint8_t get_count(void) const { return _compass_count; }
 
     /// Return the current field as a Vector3f
-    const Vector3f &get_field(uint8_t i) const { return _state[i].field; }
+    const Vector3f &get_field(uint8_t i) const { return _state[i].field * _state[i].milligauss_ratio; }
     const Vector3f &get_field(void) const { return get_field(get_primary()); }
-    const Vector3f get_field_milligauss(uint8_t i) const { return get_field(i) * _state[i].milligauss_ratio; }
+    const Vector3f get_field_milligauss(uint8_t i) const { return get_field(i); }
     const Vector3f get_field_milligauss(void) const { return get_field_milligauss(get_primary()); }
 
     // raw/unfiltered measurement interface
@@ -182,9 +182,9 @@ public:
     ///
     /// @returns                    The current compass offsets.
     ///
-    const Vector3f &get_offsets(uint8_t i) const { return _state[i].offset; }
+    const Vector3f &get_offsets(uint8_t i) const { return _state[i].offset * _state[i].milligauss_ratio; }
     const Vector3f &get_offsets(void) const { return get_offsets(get_primary()); }
-    const Vector3f get_offsets_milligauss(uint8_t i) const { return get_offsets(i) * _state[i].milligauss_ratio; }
+    const Vector3f get_offsets_milligauss(uint8_t i) const { return get_offsets(i); }
     const Vector3f get_offsets_milligauss(void) const { return get_offsets_milligauss(get_primary()); }
 
     /// Sets the initial location used to get declination

--- a/libraries/AP_Compass/Compass.h
+++ b/libraries/AP_Compass/Compass.h
@@ -119,7 +119,7 @@ public:
     uint8_t get_count(void) const { return _compass_count; }
 
     /// Return the current field as a Vector3f
-    const Vector3f &get_field(uint8_t i) const { return _state[i].field * _state[i].milligauss_ratio; }
+    const Vector3f &get_field(uint8_t i) const { return _state[i].field; }
     const Vector3f &get_field(void) const { return get_field(get_primary()); }
 
     // raw/unfiltered measurement interface
@@ -180,7 +180,7 @@ public:
     ///
     /// @returns                    The current compass offsets.
     ///
-    const Vector3f &get_offsets(uint8_t i) const { return _state[i].offset * _state[i].milligauss_ratio; }
+    const Vector3f &get_offsets(uint8_t i) const { return _state[i].offset; }
     const Vector3f &get_offsets(void) const { return get_offsets(get_primary()); }
 
     /// Sets the initial location used to get declination
@@ -391,7 +391,6 @@ private:
 
         // corrected magnetic field strength
         Vector3f    field;
-        float       milligauss_ratio;
 
         // when we last got data
         uint32_t    last_update_ms;

--- a/libraries/AP_Compass/Compass.h
+++ b/libraries/AP_Compass/Compass.h
@@ -121,8 +121,6 @@ public:
     /// Return the current field as a Vector3f
     const Vector3f &get_field(uint8_t i) const { return _state[i].field * _state[i].milligauss_ratio; }
     const Vector3f &get_field(void) const { return get_field(get_primary()); }
-    const Vector3f get_field_milligauss(uint8_t i) const { return get_field(i); }
-    const Vector3f get_field_milligauss(void) const { return get_field_milligauss(get_primary()); }
 
     // raw/unfiltered measurement interface
     uint32_t raw_meas_time_us(uint8_t i) const { return _state[i].raw_meas_time_us; }
@@ -184,8 +182,6 @@ public:
     ///
     const Vector3f &get_offsets(uint8_t i) const { return _state[i].offset * _state[i].milligauss_ratio; }
     const Vector3f &get_offsets(void) const { return get_offsets(get_primary()); }
-    const Vector3f get_offsets_milligauss(uint8_t i) const { return get_offsets(i); }
-    const Vector3f get_offsets_milligauss(void) const { return get_offsets_milligauss(get_primary()); }
 
     /// Sets the initial location used to get declination
     ///

--- a/libraries/AP_Compass/examples/AP_Compass_test/AP_Compass_test.cpp
+++ b/libraries/AP_Compass/examples/AP_Compass_test/AP_Compass_test.cpp
@@ -84,7 +84,7 @@ void loop()
         compass.learn_offsets();
 
         // capture min
-        const Vector3f &mag = compass.get_field_milligauss();
+        const Vector3f &mag = compass.get_field();
         if( mag.x < min[0] )
             min[0] = mag.x;
         if( mag.y < min[1] )

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -3837,10 +3837,10 @@ bool NavEKF::getMagOffsets(Vector3f &magOffsets) const
 {
     // compass offsets are valid if we have finalised magnetic field initialisation and magnetic field learning is not prohibited and primary compass is valid
     if (secondMagYawInit && (_magCal != 2) && _ahrs->get_compass()->healthy()) {
-        magOffsets = _ahrs->get_compass()->get_offsets_milligauss() - state.body_magfield*1000.0f;
+        magOffsets = _ahrs->get_compass()->get_offsets() - state.body_magfield*1000.0f;
         return true;
     } else {
-        magOffsets = _ahrs->get_compass()->get_offsets_milligauss();
+        magOffsets = _ahrs->get_compass()->get_offsets();
         return false;
     }
 }
@@ -4390,7 +4390,7 @@ void NavEKF::readMagData()
         lastMagUpdate = _ahrs->get_compass()->last_update_usec();
 
         // read compass data and scale to improve numerical conditioning
-        magData = _ahrs->get_compass()->get_field_milligauss() * 0.001f;
+        magData = _ahrs->get_compass()->get_field() * 0.001f;
 
         // check for consistent data between magnetometers
         consistentMagData = _ahrs->get_compass()->consistent();
@@ -4403,7 +4403,7 @@ void NavEKF::readMagData()
 
         // check if compass offsets have ben changed and adjust EKF bias states to maintain consistent innovations
         if (_ahrs->get_compass()->healthy()) {
-            Vector3f nowMagOffsets = _ahrs->get_compass()->get_offsets_milligauss();
+            Vector3f nowMagOffsets = _ahrs->get_compass()->get_offsets();
             bool changeDetected = (!is_equal(nowMagOffsets.x,lastMagOffsets.x) || !is_equal(nowMagOffsets.y,lastMagOffsets.y) || !is_equal(nowMagOffsets.z,lastMagOffsets.z));
             // Ignore bias changes before final mag field and yaw initialisation, as there may have been a compass calibration
             if (changeDetected && secondMagYawInit) {

--- a/libraries/AP_NavEKF/AP_SmallEKF.cpp
+++ b/libraries/AP_NavEKF/AP_SmallEKF.cpp
@@ -608,7 +608,7 @@ void SmallEKF::readMagData()
         lastMagUpdate = _ahrs.get_compass()->last_update_usec();
 
         // read compass data and scale to improve numerical conditioning
-        magData = _ahrs.get_compass()->get_field_milligauss();
+        magData = _ahrs.get_compass()->get_field();
 
         // let other processes know that new compass data has arrived
         newDataMag = true;

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -1529,7 +1529,7 @@ void DataFlash_Class::Log_Write_Current(const AP_BattMonitor &battery, int16_t t
 // Write a Compass packet
 void DataFlash_Class::Log_Write_Compass(const Compass &compass)
 {
-    const Vector3f &mag_field = compass.get_field_milligauss(0);
+    const Vector3f &mag_field = compass.get_field(0);
     const Vector3f &mag_offsets = compass.get_offsets(0);
     const Vector3f &mag_motor_offsets = compass.get_motor_offsets(0);   
     struct log_Compass pkt = {
@@ -1572,7 +1572,7 @@ void DataFlash_Class::Log_Write_Compass(const Compass &compass)
 #endif
 #if COMPASS_MAX_INSTANCES > 2
     if (compass.get_count() > 2) {
-        const Vector3f &mag_field3 = compass.get_field_milligauss(2);
+        const Vector3f &mag_field3 = compass.get_field(2);
         const Vector3f &mag_offsets3 = compass.get_offsets(2);
         const Vector3f &mag_motor_offsets3 = compass.get_motor_offsets(2);   
         struct log_Compass pkt3 = {

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1042,7 +1042,7 @@ void GCS_MAVLINK::send_raw_imu(const AP_InertialSensor &ins, const Compass &comp
     const Vector3f &gyro = ins.get_gyro(0);
     Vector3f mag;
     if (compass.get_count() >= 1) {
-        mag = compass.get_field_milligauss(0);
+        mag = compass.get_field(0);
     } else {
         mag.zero();
     }
@@ -1068,7 +1068,7 @@ void GCS_MAVLINK::send_raw_imu(const AP_InertialSensor &ins, const Compass &comp
     const Vector3f &accel2 = ins.get_accel(1);
     const Vector3f &gyro2 = ins.get_gyro(1);
     if (compass.get_count() >= 2) {
-        mag = compass.get_field_milligauss(1);
+        mag = compass.get_field(1);
     } else {
         mag.zero();
     }
@@ -1094,7 +1094,7 @@ void GCS_MAVLINK::send_raw_imu(const AP_InertialSensor &ins, const Compass &comp
     const Vector3f &accel3 = ins.get_accel(2);
     const Vector3f &gyro3 = ins.get_gyro(2);
     if (compass.get_count() >= 3) {
-        mag = compass.get_field_milligauss(2);
+        mag = compass.get_field(2);
     } else {
         mag.zero();
     }


### PR DESCRIPTION
Hi guys, this PR is making all compass backends use milligauss as mag field unit in order to keep measurements consistent across different sensors and also to fix calibration issues.

This PR also fix some issues found in the code:
 - HMC5843:
   - Fix _calibrate() function
   - Fix scale factor
 - AK8963:
    - Fix where to apply sensitivity measurements: the commit message explain my reasons

I tested with the mag sensors we have here, namely HMC5883L and AK8963. After these changes and calibration through Mission Planner the reported mag field length was in accordance with my geography location for both compasses.

***I couldn't test for the other backends, so I'd be grateful if developers with other sensors could test it :)***

@rmackay9 could you take a look?

Thank you!

Best regards,
Gustavo Sousa