### PR TITLE
Warning related fixes

### DIFF
--- a/libraries/AP_GPS/AP_GPS_GSOF.cpp
+++ b/libraries/AP_GPS/AP_GPS_GSOF.cpp
@@ -244,11 +244,14 @@ AP_GPS_GSOF::process_message(void)
     //http://www.trimble.com/EC_ReceiverHelp/V4.19/en/GSOFmessages_Overview.htm
 
     if (gsof_msg.packettype == 0x40) { // GSOF
+#if gsof_DEBUGGING
         uint8_t trans_number = gsof_msg.data[0];
         uint8_t pageidx = gsof_msg.data[1];
         uint8_t maxpageidx = gsof_msg.data[2];
 
-        //Debug("GSOF page: " + pageidx + " of " + maxpageidx);
+        Debug("GSOF page: %u of %u (trans_number=%u)",
+              pageidx, maxpageidx, trans_number);
+#endif
 
         int valid = 0;
 

--- a/mk/board_native.mk
+++ b/mk/board_native.mk
@@ -12,7 +12,6 @@ DEFINES        +=   -DCONFIG_HAL_BOARD=$(HAL_BOARD) -DCONFIG_HAL_BOARD_SUBTYPE=$
 WARNFLAGS       =   -Wformat -Wall -Wshadow -Wpointer-arith -Wcast-align -Wno-unused-parameter -Wno-missing-field-initializers
 WARNFLAGS      +=   -Wwrite-strings -Wformat=2
 WARNFLAGSCXX    = -Wno-reorder \
-	-Werror=unused-but-set-variable
 	-Werror=format-security \
 	-Werror=array-bounds \
 	-Wfatal-errors \


### PR DESCRIPTION
Two minor fixes related to warnings: picking the correct ones for SITL and removing an unused variable warning.