### PR TITLE
Rover: Fixed a build issue on Windows with the new RPM library

### DIFF
--- a/APMrover2/make.inc
+++ b/APMrover2/make.inc
@@ -54,4 +54,5 @@ LIBRARIES += AP_BattMonitor
 LIBRARIES += AP_OpticalFlow
 LIBRARIES += AP_RSSI
 LIBRARIES += AP_Declination
+LIBRARIES += AP_RPM
 


### PR DESCRIPTION
The AP_RPM library needed to be added to make.inc for the sitl build
to work correctly on Windows.  Thanks to Zach for solving the issue
in this discussion
http://diydrones.com/group/ardurover-user-group/forum/topics/rover-sitl-build-failed?commentId=705844%3AComment%3A2109049&xg_source=msg_com_gr_forum