### PR TITLE
Remove use of APM_BUILD_TYPE() from AP_AHRS

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -188,7 +188,7 @@ private:
     // Inertial Navigation EKF
     NavEKF EKF{&ahrs, barometer, sonar};
     NavEKF2 EKF2{&ahrs, barometer, sonar};
-    AP_AHRS_NavEKF ahrs{ins, barometer, gps, sonar, EKF, EKF2};
+    AP_AHRS_NavEKF ahrs{ins, barometer, gps, sonar, EKF, EKF2, AP_AHRS_NavEKF::FLAG_ALWAYS_USE_EKF};
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     SITL sitl;

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -33,13 +33,6 @@
 
 #include <AP_OpticalFlow/AP_OpticalFlow.h>
 
-// Copter defaults to EKF on by default, all others off
-#if APM_BUILD_TYPE(APM_BUILD_ArduCopter)
-# define AHRS_EKF_USE_ALWAYS     1
-#else
-# define AHRS_EKF_USE_ALWAYS     0
-#endif
-
 #define AP_AHRS_TRIM_LIMIT 10.0f        // maximum trim angle in degrees
 #define AP_AHRS_RP_P_MIN   0.05f        // minimum value for AHRS_RP_P parameter
 #define AP_AHRS_YAW_P_MIN  0.05f        // minimum value for AHRS_YAW_P parameter

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -40,12 +40,6 @@
 # define AHRS_EKF_USE_ALWAYS     0
 #endif
 
-#if APM_BUILD_TYPE(APM_BUILD_ArduPlane)
-#define AHRS_EKF_USE_DEFAULT    1
-#else
-#define AHRS_EKF_USE_DEFAULT    0
-#endif
-
 #define AP_AHRS_TRIM_LIMIT 10.0f        // maximum trim angle in degrees
 #define AP_AHRS_RP_P_MIN   0.05f        // minimum value for AHRS_RP_P parameter
 #define AP_AHRS_YAW_P_MIN  0.05f        // minimum value for AHRS_YAW_P parameter

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -451,12 +451,9 @@ bool AP_AHRS_NavEKF::get_relative_position_NED(Vector3f &vec) const
 uint8_t AP_AHRS_NavEKF::ekf_type(void) const
 {
     uint8_t type = _ekf_type;
-#if AHRS_EKF_USE_ALWAYS
-    // on copters always use an EKF
-    if (type == 0) {
+    if (always_use_EKF() && type == 0) {
         type = 1;
     }
-#endif
 
     // check for invalid type
     if (type > 2) {
@@ -478,17 +475,15 @@ AP_AHRS_NavEKF::EKF_TYPE AP_AHRS_NavEKF::active_EKF_type(void) const
         if (!ekf1_started) {
             return EKF_TYPE_NONE;
         }
-#if AHRS_EKF_USE_ALWAYS
-        uint8_t ekf_faults;
-        EKF1.getFilterFaults(ekf_faults);
-        if (ekf_faults == 0) {
+        if (always_use_EKF()) {
+            uint8_t ekf_faults;
+            EKF1.getFilterFaults(ekf_faults);
+            if (ekf_faults == 0) {
+                ret = EKF_TYPE1;
+            }
+        } else if (EKF1.healthy()) {
             ret = EKF_TYPE1;
         }
-#else
-        if (EKF1.healthy()) {
-            ret = EKF_TYPE1;
-        }
-#endif
         break;
     }
 
@@ -497,17 +492,15 @@ AP_AHRS_NavEKF::EKF_TYPE AP_AHRS_NavEKF::active_EKF_type(void) const
         if (!ekf2_started) {
             return EKF_TYPE_NONE;
         }
-#if AHRS_EKF_USE_ALWAYS
-        uint8_t ekf2_faults;
-        EKF2.getFilterFaults(ekf2_faults);
-        if (ekf2_faults == 0) {
+        if (always_use_EKF()) {
+            uint8_t ekf2_faults;
+            EKF2.getFilterFaults(ekf2_faults);
+            if (ekf2_faults == 0) {
+                ret = EKF_TYPE2;
+            }
+        } else if (EKF2.healthy()) {
             ret = EKF_TYPE2;
         }
-#else
-        if (EKF2.healthy()) {
-            ret = EKF_TYPE2;
-        }
-#endif
         break;
     }
     }

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -35,12 +35,18 @@
 class AP_AHRS_NavEKF : public AP_AHRS_DCM
 {
 public:
+    enum Flags {
+        FLAG_NONE = 0,
+        FLAG_ALWAYS_USE_EKF = 0x1,
+    };
+
     // Constructor
     AP_AHRS_NavEKF(AP_InertialSensor &ins, AP_Baro &baro, AP_GPS &gps, RangeFinder &rng,
-                   NavEKF &_EKF1, NavEKF2 &_EKF2) :
+                   NavEKF &_EKF1, NavEKF2 &_EKF2, Flags flags = FLAG_NONE) :
         AP_AHRS_DCM(ins, baro, gps),
         EKF1(_EKF1),
-        EKF2(_EKF2)
+        EKF2(_EKF2),
+        _flags(flags)
     {
     }
 
@@ -160,6 +166,10 @@ private:
     enum EKF_TYPE {EKF_TYPE_NONE, EKF_TYPE1, EKF_TYPE2};
     EKF_TYPE active_EKF_type(void) const;
 
+    bool always_use_EKF() const {
+        return _flags & FLAG_ALWAYS_USE_EKF;
+    }
+
     NavEKF &EKF1;
     NavEKF2 &EKF2;
     bool ekf1_started = false;
@@ -172,6 +182,7 @@ private:
     Vector3f _accel_ef_ekf_blended;
     const uint16_t startup_delay_ms = 1000;
     uint32_t start_time_ms = 0;
+    Flags _flags;
 
     uint8_t ekf_type(void) const;
     void update_DCM(void);


### PR DESCRIPTION
The motivation is to move the vehicle specific code to the vehicle folders themselves.