### PR TITLE
Gimbaled PrecLand

### DIFF
--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -135,7 +135,7 @@ void AC_PrecLand::calc_angles_and_pos(float alt_above_terrain_cm)
         return;
     }
 
-    // get body-frame angles to target from backend
+    // get angles to target from backend
     if (!_backend->get_angle_to_target(_angle_to_target.x, _angle_to_target.y)) {
         _have_estimate = false;
         return;

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -141,9 +141,18 @@ void AC_PrecLand::calc_angles_and_pos(float alt_above_terrain_cm)
         return;
     }
 
-    // subtract vehicle lean angles
-    float x_rad = _bf_angle_to_target.x - _ahrs.roll;
-    float y_rad = -_bf_angle_to_target.y + _ahrs.pitch;
+    float x_rad;
+    float y_rad;
+
+    if(_backend->get_frame_of_reference() == MAV_FRAME_LOCAL_NED){
+        //don't subtract vehicle lean angles
+        x_rad = _angle_to_target.x;
+        y_rad = -_angle_to_target.y;
+    }else{ // assume MAV_FRAME_BODY_NED (i.e. a hard-mounted sensor)
+        // subtract vehicle lean angles
+        x_rad = _angle_to_target.x - _ahrs.roll;
+        y_rad = -_angle_to_target.y + _ahrs.pitch;
+    }
 
     // rotate to earth-frame angles
     _ef_angle_to_target.x = y_rad*_ahrs.cos_yaw() - x_rad*_ahrs.sin_yaw();

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -124,7 +124,7 @@ Vector3f AC_PrecLand::get_target_shift(const Vector3f &orig_target)
 }
 
 // calc_angles_and_pos - converts sensor's body-frame angles to earth-frame angles and position estimate
-//  body-frame angles stored in _bf_angle_to_target
+//  raw sensor angles stored in _angle_to_target (might be in earth frame, or maybe body frame)
 //  earth-frame angles stored in _ef_angle_to_target
 //  position estimate is stored in _target_pos
 void AC_PrecLand::calc_angles_and_pos(float alt_above_terrain_cm)
@@ -136,7 +136,7 @@ void AC_PrecLand::calc_angles_and_pos(float alt_above_terrain_cm)
     }
 
     // get body-frame angles to target from backend
-    if (!_backend->get_angle_to_target(_bf_angle_to_target.x, _bf_angle_to_target.y)) {
+    if (!_backend->get_angle_to_target(_angle_to_target.x, _angle_to_target.y)) {
         _have_estimate = false;
         return;
     }

--- a/libraries/AC_PrecLand/AC_PrecLand.h
+++ b/libraries/AC_PrecLand/AC_PrecLand.h
@@ -62,7 +62,7 @@ public:
 
     // accessors for logging
     bool enabled() const { return _enabled; }
-    const Vector2f& last_bf_angle_to_target() const { return _bf_angle_to_target; }
+    const Vector2f& last_bf_angle_to_target() const { return _angle_to_target; }
     const Vector2f& last_ef_angle_to_target() const { return _ef_angle_to_target; }
     const Vector3f& last_target_pos_offset() const { return _target_pos_offset; }
 
@@ -94,7 +94,7 @@ private:
     float                       _dt;                // time difference (in seconds) between calls from the main program
 
     // output from sensor (stored for logging)
-    Vector2f                    _bf_angle_to_target;// last body-frame angle to target
+    Vector2f                    _angle_to_target;   // last raw sensor angle to target
     Vector2f                    _ef_angle_to_target;// last earth-frame angle to target
 
     // output from controller

--- a/libraries/AC_PrecLand/AC_PrecLand.h
+++ b/libraries/AC_PrecLand/AC_PrecLand.h
@@ -72,7 +72,7 @@ public:
 private:
 
     // calc_angles_and_pos - converts sensor's body-frame angles to earth-frame angles and position estimate
-    //  body-frame angles stored in _bf_angle_to_target
+    //  angles stored in _angle_to_target
     //  earth-frame angles stored in _ef_angle_to_target
     //  position estimate is stored in _target_pos
     void calc_angles_and_pos(float alt_above_terrain_cm);

--- a/libraries/AC_PrecLand/AC_PrecLand_Backend.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_Backend.h
@@ -29,10 +29,10 @@ public:
     // what frame of reference is our sensor reporting in?
     virtual MAV_FRAME get_frame_of_reference();
 
-    // get_angle_to_target - returns body frame angles (in radians) to target
+    // get_angle_to_target - returns angles (in radians) to target
     //  returns true if angles are available, false if not (i.e. no target)
-    //  x_angle_rad : body-frame roll direction, positive = target is to right (looking down)
-    //  y_angle_rad : body-frame pitch direction, postiive = target is forward (looking down)
+    //  x_angle_rad : roll direction, positive = target is to right (looking down)
+    //  y_angle_rad : pitch direction, postiive = target is forward (looking down)
     virtual bool get_angle_to_target(float &x_angle_rad, float &y_angle_rad) = 0;
 
     // handle_msg - parses a mavlink message from the companion computer

--- a/libraries/AC_PrecLand/AC_PrecLand_Backend.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_Backend.h
@@ -26,6 +26,8 @@ public:
     // update - give chance to driver to get updates from sensor
     //  returns true if new data available
     virtual bool update() = 0;
+    // what frame of reference is our sensor reporting in?
+    virtual MAV_FRAME get_frame_of_reference();
 
     // get_angle_to_target - returns body frame angles (in radians) to target
     //  returns true if angles are available, false if not (i.e. no target)

--- a/libraries/AC_PrecLand/AC_PrecLand_Companion.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_Companion.cpp
@@ -32,10 +32,10 @@ MAV_FRAME AC_PrecLand_Companion::get_frame_of_reference()
     return _frame;
 }
 
-// get_angle_to_target - returns body frame angles (in radians) to target
+// get_angle_to_target - returns angles (in radians) to target
 //  returns true if angles are available, false if not (i.e. no target)
-//  x_angle_rad : body-frame roll direction, positive = target is to right (looking down)
-//  y_angle_rad : body-frame pitch direction, postiive = target is forward (looking down)
+//  x_angle_rad : roll direction, positive = target is to right (looking down)
+//  y_angle_rad : pitch direction, postiive = target is forward (looking down)
 bool AC_PrecLand_Companion::get_angle_to_target(float &x_angle_rad, float &y_angle_rad)
 {
     if (_new_estimate){

--- a/libraries/AC_PrecLand/AC_PrecLand_Companion.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_Companion.cpp
@@ -16,6 +16,7 @@ void AC_PrecLand_Companion::init()
     // set healthy
     _state.healthy = true;
     _new_estimate = false;
+    _frame = MAV_FRAME_BODY_NED; // assume body until we get our first message that says otherwise
 }
 
 // update - give chance to driver to get updates from sensor
@@ -24,6 +25,11 @@ bool AC_PrecLand_Companion::update()
 {
     // Mavlink commands are received asynchronous so all new data is processed by handle_msg()
     return _new_estimate;
+}
+
+MAV_FRAME AC_PrecLand_Companion::get_frame_of_reference()
+{
+    return _frame;
 }
 
 // get_angle_to_target - returns body frame angles (in radians) to target
@@ -51,6 +57,7 @@ void AC_PrecLand_Companion::handle_msg(mavlink_message_t* msg)
     mavlink_msg_landing_target_decode(msg, &packet);
 
     _timestamp_us = packet.time_usec;
+    _frame = (MAV_FRAME) packet.frame;
     _angle_to_target.x = packet.angle_x;
     _angle_to_target.y = packet.angle_y;
     _distance_to_target = packet.distance;

--- a/libraries/AC_PrecLand/AC_PrecLand_Companion.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_Companion.cpp
@@ -33,8 +33,8 @@ bool AC_PrecLand_Companion::update()
 bool AC_PrecLand_Companion::get_angle_to_target(float &x_angle_rad, float &y_angle_rad)
 {
     if (_new_estimate){
-        x_angle_rad = _bf_angle_to_target.x;
-        y_angle_rad = _bf_angle_to_target.y;
+        x_angle_rad = _angle_to_target.x;
+        y_angle_rad = _angle_to_target.y;
 
         // reset and wait for new data
         _new_estimate = false;
@@ -51,8 +51,8 @@ void AC_PrecLand_Companion::handle_msg(mavlink_message_t* msg)
     mavlink_msg_landing_target_decode(msg, &packet);
 
     _timestamp_us = packet.time_usec;
-    _bf_angle_to_target.x = packet.angle_x;
-    _bf_angle_to_target.y = packet.angle_y;
+    _angle_to_target.x = packet.angle_x;
+    _angle_to_target.y = packet.angle_y;
     _distance_to_target = packet.distance;
     _state.healthy = true;
     _new_estimate = true;

--- a/libraries/AC_PrecLand/AC_PrecLand_Companion.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_Companion.h
@@ -27,10 +27,10 @@ public:
     // what frame of reference is our sensor reporting in?
     MAV_FRAME get_frame_of_reference();
 
-    // get_angle_to_target - returns body frame angles (in radians) to target
+    // get_angle_to_target - returns angles (in radians) to target
     //  returns true if angles are available, false if not (i.e. no target)
-    //  x_angle_rad : body-frame roll direction, positive = target is to right (looking down)
-    //  y_angle_rad : body-frame pitch direction, postiive = target is forward (looking down)
+    //  x_angle_rad : roll direction, positive = target is to right (looking down)
+    //  y_angle_rad : pitch direction, postiive = target is forward (looking down)
     bool get_angle_to_target(float &x_angle_rad, float &y_angle_rad);
 
     // handle_msg - parses a mavlink message from the companion computer
@@ -40,7 +40,7 @@ private:
 
     // output from camera
     MAV_FRAME           _frame;                 // what frame of reference is our sensor reporting in?
-    Vector2f            _angle_to_target;       // last body-frame angle to target
+    Vector2f            _angle_to_target;       // last angle to target
     float               _distance_to_target;    // distance from the camera to target in meters
     uint64_t            _timestamp_us;          // timestamp when the image was captured(synced via UAVCAN)
     bool                _new_estimate;          // true if new data from the camera has been received

--- a/libraries/AC_PrecLand/AC_PrecLand_Companion.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_Companion.h
@@ -37,7 +37,7 @@ public:
 private:
 
     // output from camera
-    Vector2f            _bf_angle_to_target;    // last body-frame angle to target
+    Vector2f            _angle_to_target;       // last body-frame angle to target
     float               _distance_to_target;    // distance from the camera to target in meters
     uint64_t            _timestamp_us;          // timestamp when the image was captured(synced via UAVCAN)
     bool                _new_estimate;          // true if new data from the camera has been received

--- a/libraries/AC_PrecLand/AC_PrecLand_Companion.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_Companion.h
@@ -24,6 +24,8 @@ public:
     // update - give chance to driver to get updates from sensor
     //  returns true if new data available
     bool update();
+    // what frame of reference is our sensor reporting in?
+    MAV_FRAME get_frame_of_reference();
 
     // get_angle_to_target - returns body frame angles (in radians) to target
     //  returns true if angles are available, false if not (i.e. no target)
@@ -37,6 +39,7 @@ public:
 private:
 
     // output from camera
+    MAV_FRAME           _frame;                 // what frame of reference is our sensor reporting in?
     Vector2f            _angle_to_target;       // last body-frame angle to target
     float               _distance_to_target;    // distance from the camera to target in meters
     uint64_t            _timestamp_us;          // timestamp when the image was captured(synced via UAVCAN)

--- a/libraries/AC_PrecLand/AC_PrecLand_IRLock.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_IRLock.h
@@ -28,6 +28,8 @@ public:
     // update - give chance to driver to get updates from sensor
     //  returns true if new data available
     bool update();
+    // IRLock is hard-mounted to the frame of the vehicle, so it will always be in body-frame
+    MAV_FRAME get_frame_of_reference() { return MAV_FRAME_BODY_NED; }
 
     // get_angle_to_target - returns body frame angles (in radians) to target
     //  returns true if angles are available, false if not (i.e. no target)


### PR DESCRIPTION
Adds support for `frame` within the `LANDING_TARGET` message.  This allows a companion computer to use the video feed from a gimbaled camera for landing.

@djnugent Would you mind testing your cool simulation to make sure I didn't break your thing?  Pretty sure I didn't, but I just want to be sure.