### PR TITLE
AP_Arming: add voltage and compass checks ahead of integration with Copter

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -142,12 +142,6 @@ bool AP_Arming::ins_checks(bool report)
             }
             return false;
         }
-        if (!ahrs.healthy()) {
-            if (report) {
-                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: AHRS not healthy"));
-            }
-            return false;
-        }
         if (!ins.accel_calibrated_ok_all()) {
             if (report) {
                 GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: 3D accel cal needed"));
@@ -206,6 +200,12 @@ bool AP_Arming::ins_checks(bool report)
             }
         }
 #endif
+        if (!ahrs.healthy()) {
+            if (report) {
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: AHRS not healthy"));
+            }
+            return false;
+        }
     }
 
     return true;

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -144,12 +144,7 @@ bool AP_Arming::ins_checks(bool report)
         }
         if (!ahrs.healthy()) {
             if (report) {
-                const char *reason = ahrs.prearm_failure_reason();
-                if (reason) {
-                    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: %s"), reason);
-                } else {
-                    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: AHRS not healthy"));
-                }
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: AHRS not healthy"));
             }
             return false;
         }

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -41,39 +41,40 @@ const AP_Param::GroupInfo AP_Arming::var_info[] PROGMEM = {
 //The function point is particularly hacky, hacky, tacky
 //but I don't want to reimplement messaging to GCS at the moment:
 AP_Arming::AP_Arming(const AP_AHRS &ahrs_ref, const AP_Baro &baro, Compass &compass,
-                     const enum HomeState &home_set)
-    : armed(false)
-   , logging_available(false)
-   , arming_method(NONE)
-   , ahrs(ahrs_ref)
-   , barometer(baro)
-   , _compass(compass)
-   , home_is_set(home_set)
+                     const enum HomeState &home_set) :
+    ahrs(ahrs_ref),
+    barometer(baro),
+    _compass(compass),
+    home_is_set(home_set),
+    armed(false),
+    logging_available(false),
+    arming_method(NONE)
 {
     AP_Param::setup_object_defaults(this, var_info);
     memset(last_accel_pass_ms, 0, sizeof(last_accel_pass_ms));
     memset(last_gyro_pass_ms, 0, sizeof(last_gyro_pass_ms));
 }
 
-bool AP_Arming::is_armed() 
+bool AP_Arming::is_armed()
 { 
     return require == NONE || armed; 
 }
 
-uint16_t AP_Arming::get_enabled_checks() 
+uint16_t AP_Arming::get_enabled_checks()
 {
     return checks_to_perform;
 }
 
-void AP_Arming::set_enabled_checks(uint16_t ap) {
+void AP_Arming::set_enabled_checks(uint16_t ap)
+{
     checks_to_perform = ap;
 }
 
-bool AP_Arming::barometer_checks(bool report) 
+bool AP_Arming::barometer_checks(bool report)
 {
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
         (checks_to_perform & ARMING_CHECK_BARO)) {
-        if (! barometer.healthy()) {
+        if (!barometer.healthy()) {
             if (report) {
                 GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: Barometer not healthy!"));
             }
@@ -84,7 +85,7 @@ bool AP_Arming::barometer_checks(bool report)
     return true;
 }
 
-bool AP_Arming::airspeed_checks(bool report) 
+bool AP_Arming::airspeed_checks(bool report)
 {
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
         (checks_to_perform & ARMING_CHECK_AIRSPEED)) {
@@ -104,7 +105,7 @@ bool AP_Arming::airspeed_checks(bool report)
     return true;
 }
 
-bool AP_Arming::logging_checks(bool report) 
+bool AP_Arming::logging_checks(bool report)
 {
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
         (checks_to_perform & ARMING_CHECK_LOGGING)) {
@@ -118,12 +119,12 @@ bool AP_Arming::logging_checks(bool report)
     return true;
 }
 
-bool AP_Arming::ins_checks(bool report) 
+bool AP_Arming::ins_checks(bool report)
 {
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
         (checks_to_perform & ARMING_CHECK_INS)) {
         const AP_InertialSensor &ins = ahrs.get_ins();
-        if (! ins.get_gyro_health_all()) {
+        if (!ins.get_gyro_health_all()) {
             if (report) {
                 GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: gyros not healthy!"));
             }
@@ -135,7 +136,7 @@ bool AP_Arming::ins_checks(bool report)
             }
             return false;
         }
-        if (! ins.get_accel_health_all()) {
+        if (!ins.get_accel_health_all()) {
             if (report) {
                 GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: accels not healthy!"));
             }
@@ -215,7 +216,7 @@ bool AP_Arming::ins_checks(bool report)
     return true;
 }
 
-bool AP_Arming::compass_checks(bool report) 
+bool AP_Arming::compass_checks(bool report)
 {
     if ((checks_to_perform) & ARMING_CHECK_ALL ||
         (checks_to_perform) & ARMING_CHECK_COMPASS) {
@@ -240,7 +241,7 @@ bool AP_Arming::compass_checks(bool report)
         }
 
         //check if compass is calibrating
-        if(_compass.is_calibrating()) {
+        if (_compass.is_calibrating()) {
             if (report) {
                 GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("Arm: Compass calibration running"));
             }
@@ -248,7 +249,7 @@ bool AP_Arming::compass_checks(bool report)
         }
 
         //check if compass has calibrated and requires reboot
-        if(_compass.compass_cal_requires_reboot()) {
+        if (_compass.compass_cal_requires_reboot()) {
             if (report) {
                 GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: Compass calibrated requires reboot"));
             }
@@ -284,7 +285,7 @@ bool AP_Arming::compass_checks(bool report)
     return true;
 }
 
-bool AP_Arming::gps_checks(bool report) 
+bool AP_Arming::gps_checks(bool report)
 {
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
         (checks_to_perform & ARMING_CHECK_GPS)) {
@@ -297,20 +298,20 @@ bool AP_Arming::gps_checks(bool report)
                 GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: Bad GPS Position"));
             }
             return false;
-        }      
+        }
     }
 
     return true;
 }
 
-bool AP_Arming::battery_checks(bool report) 
+bool AP_Arming::battery_checks(bool report)
 {
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
         (checks_to_perform & ARMING_CHECK_BATTERY)) {
 
         if (AP_Notify::flags.failsafe_battery) {
             if (report) {
-                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: Battery failsafe on."));
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: Battery failsafe on"));
             }
             return false;
         }
@@ -332,7 +333,7 @@ bool AP_Arming::hardware_safety_check(bool report)
     return true;
 }
 
-bool AP_Arming::manual_transmitter_checks(bool report) 
+bool AP_Arming::manual_transmitter_checks(bool report)
 {
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
         (checks_to_perform & ARMING_CHECK_RC)) {
@@ -352,7 +353,7 @@ bool AP_Arming::manual_transmitter_checks(bool report)
     return true;
 }
 
-bool AP_Arming::pre_arm_checks(bool report) 
+bool AP_Arming::pre_arm_checks(bool report)
 {
     bool ret = true;
     if (armed || require == NONE) {
@@ -374,7 +375,7 @@ bool AP_Arming::pre_arm_checks(bool report)
 }
 
 //returns true if arming occured successfully
-bool AP_Arming::arm(uint8_t method) 
+bool AP_Arming::arm(uint8_t method)
 {
     if (armed) { //already armed
         return false;
@@ -408,7 +409,7 @@ bool AP_Arming::arm(uint8_t method)
 //returns true if disarming occurred successfully
 bool AP_Arming::disarm() 
 {
-    if (! armed) { // already disarmed
+    if (!armed) { // already disarmed
         return false;
     }
     armed = false;
@@ -425,4 +426,3 @@ AP_Arming::ArmingRequired AP_Arming::arming_required()
 {
     return (AP_Arming::ArmingRequired)require.get();
 }
-

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -76,7 +76,7 @@ bool AP_Arming::barometer_checks(bool report)
         (checks_to_perform & ARMING_CHECK_BARO)) {
         if (!barometer.healthy()) {
             if (report) {
-                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: Barometer not healthy!"));
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: Barometer not healthy"));
             }
             return false;
         }
@@ -126,19 +126,19 @@ bool AP_Arming::ins_checks(bool report)
         const AP_InertialSensor &ins = ahrs.get_ins();
         if (!ins.get_gyro_health_all()) {
             if (report) {
-                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: gyros not healthy!"));
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: gyros not healthy"));
             }
             return false;
         }
         if (!ins.gyro_calibrated_ok_all()) {
             if (report) {
-                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: gyros not calibrated!"));
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: gyros not calibrated"));
             }
             return false;
         }
         if (!ins.get_accel_health_all()) {
             if (report) {
-                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: accels not healthy!"));
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: accels not healthy"));
             }
             return false;
         }
@@ -148,7 +148,7 @@ bool AP_Arming::ins_checks(bool report)
                 if (reason) {
                     GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: %s"), reason);
                 } else {
-                    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: AHRS not healthy!"));
+                    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: AHRS not healthy"));
                 }
             }
             return false;
@@ -228,7 +228,7 @@ bool AP_Arming::compass_checks(bool report)
 
         if (!_compass.healthy()) {
             if (report) {
-                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: Compass not healthy!"));
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: Compass not healthy"));
             }
             return false;
         }

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -38,7 +38,8 @@ const AP_Param::GroupInfo AP_Arming::var_info[] PROGMEM = {
     // @DisplayName: Arm Checks to Peform (bitmask)
     // @Description: Checks prior to arming motor. This is a bitmask of checks that will be performed befor allowing arming. The default is no checks, allowing arming at any time. You can select whatever checks you prefer by adding together the values of each check type to set this parameter. For example, to only allow arming when you have GPS lock and no RC failsafe you would set ARMING_CHECK to 72. For most users it is recommended that you set this to 1 to enable all checks.
     // @Values: 0:None,1:All,2:Barometer,4:Compass,8:GPS,16:INS(INertial Sensors - accels & gyros),32:Parameters(unused),64:RC Failsafe,128:Board voltage,256:Battery Level,512:Airspeed,1024:LoggingAvailable
-    // @User: Advanced
+    // @Bitmask: 0:All,1:Barometer,2:Compass,3:GPS,4:INS,5:Parameters,6:RC,7:Board voltage,8:Battery Level,9:Airspeed,10:Logging Available
+    // @User: Standard
     AP_GROUPINFO("CHECK",        2,     AP_Arming,  checks_to_perform,       ARMING_CHECK_ALL),
 
     AP_GROUPEND

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -74,7 +74,7 @@ bool AP_Arming::barometer_checks(bool report)
 {
     if ((checks_to_perform & ARMING_CHECK_ALL) ||
         (checks_to_perform & ARMING_CHECK_BARO)) {
-        if (!barometer.healthy()) {
+        if (!barometer.all_healthy()) {
             if (report) {
                 GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: Barometer not healthy"));
             }

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -18,6 +18,9 @@
 #include <AP_Notify/AP_Notify.h>
 #include <GCS_MAVLink/GCS.h>
 
+#define AP_ARMING_COMPASS_OFFSETS_MAX   600
+#define AP_ARMING_COMPASS_MAGFIELD_MIN  185     // 0.35 * 530 milligauss
+#define AP_ARMING_COMPASS_MAGFIELD_MAX  875     // 1.65 * 530 milligauss
 #define AP_ARMING_BOARD_VOLTAGE_MIN     4.3f
 #define AP_ARMING_BOARD_VOLTAGE_MAX     5.8f
 
@@ -256,28 +259,29 @@ bool AP_Arming::compass_checks(bool report)
 
         // check for unreasonable compass offsets
         Vector3f offsets = _compass.get_offsets_milligauss();
-        if (offsets.length() > 600) {
+        if (offsets.length() > AP_ARMING_COMPASS_OFFSETS_MAX) {
             if (report) {
                 GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: Compass offsets too high"));
             }
             return false;
         }
 
-#if CONFIG_HAL_BOARD == HAL_BOARD_APM1 || CONFIG_HAL_BOARD == HAL_BOARD_APM2
-# define COMPASS_MAGFIELD_EXPECTED     330        // pre arm will fail if mag field > 544 or < 115
-#else // PX4, SITL
-#define COMPASS_MAGFIELD_EXPECTED      530        // pre arm will fail if mag field > 874 or < 185
-#endif
-
         // check for unreasonable mag field length
         float mag_field = _compass.get_field_milligauss().length();
-        if (mag_field > COMPASS_MAGFIELD_EXPECTED*1.65f || mag_field < COMPASS_MAGFIELD_EXPECTED*0.35f) {
+        if (mag_field > AP_ARMING_COMPASS_MAGFIELD_MAX || mag_field < AP_ARMING_COMPASS_MAGFIELD_MIN) {
             if (report) {
                 GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, PSTR("PreArm: Check mag field"));
             }
             return false;
         }
-        
+
+        // check all compasses point in roughly same direction
+        if (!_compass.consistent()) {
+            if (report) {
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,PSTR("PreArm: inconsistent compasses"));
+            }
+            return false;
+        }
     }
 
     return true;

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -18,6 +18,9 @@
 #include <AP_Notify/AP_Notify.h>
 #include <GCS_MAVLink/GCS.h>
 
+#define AP_ARMING_BOARD_VOLTAGE_MIN     4.3f
+#define AP_ARMING_BOARD_VOLTAGE_MAX     5.8f
+
 extern const AP_HAL::HAL& hal;
 
 const AP_Param::GroupInfo AP_Arming::var_info[] PROGMEM = {
@@ -348,6 +351,25 @@ bool AP_Arming::manual_transmitter_checks(bool report)
     return true;
 }
 
+bool AP_Arming::board_voltage_checks(bool report)
+{
+#if CONFIG_HAL_BOARD != HAL_BOARD_VRBRAIN
+#ifndef CONFIG_ARCH_BOARD_PX4FMU_V1
+    // check board voltage
+    if ((checks_to_perform & ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_VOLTAGE)) {
+        if((hal.analogin->board_voltage() < AP_ARMING_BOARD_VOLTAGE_MIN) || (hal.analogin->board_voltage() > AP_ARMING_BOARD_VOLTAGE_MAX)) {
+            if (report) {
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,PSTR("PreArm: Check Board Voltage"));
+            }
+            return false;
+        }
+    }
+#endif
+#endif
+
+    return true;
+}
+
 bool AP_Arming::pre_arm_checks(bool report)
 {
     bool ret = true;
@@ -365,6 +387,7 @@ bool AP_Arming::pre_arm_checks(bool report)
     ret &= battery_checks(report);
     ret &= logging_checks(report);
     ret &= manual_transmitter_checks(report);
+    ret &= board_voltage_checks(report);
 
     return ret;
 }

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -61,28 +61,26 @@ public:
 
     void set_logging_available(bool set) { logging_available = set; }
 
-    //for params
     static const struct AP_Param::GroupInfo        var_info[];
 
 protected:
-    bool                                                armed:1;
-    bool                                                logging_available:1;
+    // Parameters
+    AP_Int8                 require;
+    AP_Int8                 rudder_arming_value;
+    AP_Int16                checks_to_perform;      // bitmask for which checks are required
 
-    //Parameters
-    AP_Int8                                           require;
-    AP_Int8                               rudder_arming_value;
-        //bitmask for which checks are required
-    AP_Int16                                checks_to_perform;
+    // references
+    const AP_AHRS           &ahrs;
+    const AP_Baro           &barometer;
+    Compass                 &_compass;
+    const enum HomeState    &home_is_set;
 
-    //how the vehicle was armed
-    uint8_t                                     arming_method;
-
-    const AP_AHRS                                       &ahrs;
-    const AP_Baro                                  &barometer;
-    Compass                                         &_compass;
-    const enum HomeState                         &home_is_set;
-    uint32_t                                  last_accel_pass_ms[INS_MAX_INSTANCES];
-    uint32_t                                  last_gyro_pass_ms[INS_MAX_INSTANCES];
+    // internal members
+    bool                    armed:1;
+    bool                    logging_available:1;
+    uint8_t                 arming_method;          // how the vehicle was armed
+    uint32_t                last_accel_pass_ms[INS_MAX_INSTANCES];
+    uint32_t                last_gyro_pass_ms[INS_MAX_INSTANCES];
 
     void set_enabled_checks(uint16_t);
 

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -100,6 +100,8 @@ protected:
 
     bool hardware_safety_check(bool report);
 
+    bool board_voltage_checks(bool report);
+
     bool manual_transmitter_checks(bool report);
 };
 


### PR DESCRIPTION
I'm sure the most controversial change is the removal of the prearm_failure_reason() if AHRS is unhealthy.  The failure-reason is not directly related to the AHRS health however.

The second most controversial change is probably the removal of the exclamation marks from the text strings sent to the GCS.

Also modified formatting.

