### PR TITLE
Plane: allow rangefinder power-save without terrain data

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -361,13 +361,6 @@ void Plane::terrain_update(void)
 {
 #if AP_TERRAIN_AVAILABLE
     terrain.update();
-
-    // tell the rangefinder our height, so it can go into power saving
-    // mode if available
-    float height;
-    if (terrain.height_above_terrain(height, true)) {
-        rangefinder.set_estimated_terrain_height(height);
-    }
 #endif
 }
 

--- a/ArduPlane/sensors.cpp
+++ b/ArduPlane/sensors.cpp
@@ -24,6 +24,29 @@ void Plane::init_rangefinder(void)
 void Plane::read_rangefinder(void)
 {
 #if RANGEFINDER_ENABLED == ENABLED
+
+    // notify the rangefinder of our approximate altitude above ground to allow it to power on
+    // during low-altitude flight when configured to power down during higher-altitude flight
+    float height;
+#if AP_TERRAIN_AVAILABLE
+    if (terrain.status() == AP_Terrain::TerrainStatusOK && terrain.height_above_terrain(height, true)) {
+        rangefinder.set_estimated_terrain_height(height);
+    } else
+#endif
+    {
+        // use the best available alt estimate via baro above home
+        if (flight_stage == AP_SpdHgtControl::FLIGHT_LAND_APPROACH ||
+            flight_stage == AP_SpdHgtControl::FLIGHT_LAND_FINAL) {
+            // ensure the rangefinder is powered-on when land alt is higher than home altitude.
+            // This is done using the target alt which we know is below us and we are sinking to it
+            height = height_above_target();
+        } else {
+            // otherwise just use the best available baro estimate above home.
+            height = relative_altitude();
+        }
+        rangefinder.set_estimated_terrain_height(height);
+    }
+
     rangefinder.update();
 
     if (should_log(MASK_LOG_SONAR))

--- a/libraries/AP_Terrain/AP_Terrain.h
+++ b/libraries/AP_Terrain/AP_Terrain.h
@@ -94,7 +94,7 @@ public:
     void update(void);
 
     // return status enum for health reporting
-    enum TerrainStatus status(void);
+    enum TerrainStatus status(void) const { return system_status; }
 
     // send any pending terrain request message
     void send_request(mavlink_channel_t chan);
@@ -405,6 +405,9 @@ private:
     uint16_t last_rally_spacing;
 
     char *file_path = NULL;    
+
+    // status
+    enum TerrainStatus system_status = TerrainStatusDisabled;
 };
 #endif // AP_TERRAIN_AVAILABLE
 #endif // __AP_TERRAIN_H__


### PR DESCRIPTION
Allow the rangefinder to power off via RNGFND_PWRRNG using baro if terrain data if not available. I also optimized the terrain status so it is cached instead of calculated each time from whatever task checks it.

There's a special case for landing where it uses height above target instead of relative height above home because the land point could be above the home alt and so it would never turn on.