### PR TITLE
Plane: restrict land_approach stage change with tighter criteria

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -852,8 +852,13 @@ void Plane::update_flight_stage(void)
                     set_flight_stage(AP_SpdHgtControl::FLIGHT_LAND_ABORT);
                 } else if (auto_state.land_complete == true) {
                     set_flight_stage(AP_SpdHgtControl::FLIGHT_LAND_FINAL);
-                } else {
-                    set_flight_stage(AP_SpdHgtControl::FLIGHT_LAND_APPROACH);
+                } else if (flight_stage != AP_SpdHgtControl::FLIGHT_LAND_APPROACH) {
+                    float path_progress = location_path_proportion(current_loc, prev_WP_loc, next_WP_loc);
+                    bool lined_up = abs(nav_controller->bearing_error_cd()) < 1000;
+                    bool below_prev_WP = current_loc.alt < prev_WP_loc.alt;
+                    if ((path_progress > 0.3f && lined_up && below_prev_WP) || path_progress > 0.8f) {
+                        set_flight_stage(AP_SpdHgtControl::FLIGHT_LAND_APPROACH);
+                    }
                 }
 
             } else {


### PR DESCRIPTION
- inhibit switching from FLIGHT_NORMAL to FLIGHT_LAND_APPROACH until we meet stricter criteria other than just that LAND is next waypoint. This is because flight behavior for approach assumes somewhat level flight and switching to it when performing a hard turn to acquire the landing approach leg bearing does not behave well.

additional new criteria:
- requires: nav bearing error < 10deg
- have traveled path forward 30% of path
- are below top of approach in case we hit waypoint while still descending
- exceptions: traveled path forward > 80% which basically means we're getting close to the flare point and better get into approach mode ASAP

see discussion here: https://github.com/diydrones/ardupilot/issues/2921