### PR TITLE
EKF2 bug fixes

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_AirDataFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_AirDataFusion.cpp
@@ -195,8 +195,12 @@ void NavEKF2_core::SelectTasFusion()
 {
     // Check if the magnetometer has been fused on that time step and the filter is running at faster than 200 Hz
     // If so, don't fuse measurements on this time step to reduce frame over-runs
-    if (magFusePerformed && dtIMUavg < 0.005f) {
+    // Only allow one time slip to prevent high rate magnetometer data preventing fusion of other measurements
+    if (magFusePerformed && dtIMUavg < 0.005f && !airSpdFusionDelayed) {
+        airSpdFusionDelayed = true;
         return;
+    } else {
+        airSpdFusionDelayed = false;
     }
 
     // get true airspeed measurement
@@ -265,8 +269,12 @@ void NavEKF2_core::SelectBetaFusion()
 {
     // Check if the magnetometer has been fused on that time step and the filter is running at faster than 200 Hz
     // If so, don't fuse measurements on this time step to reduce frame over-runs
-    if (magFusePerformed && dtIMUavg < 0.005f) {
+    // Only allow one time slip to prevent high rate magnetometer data preventing fusion of other measurements
+    if (magFusePerformed && dtIMUavg < 0.005f && !sideSlipFusionDelayed) {
+        sideSlipFusionDelayed = true;
         return;
+    } else {
+        sideSlipFusionDelayed = false;
     }
 
     // set true when the fusion time interval has triggered

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -201,7 +201,7 @@ bool NavEKF2_core::optFlowDataPresent(void) const
 // return true if the filter to be ready to use gps
 bool NavEKF2_core::readyToUseGPS(void) const
 {
-    return validOrigin && tiltAlignComplete && yawAlignComplete && gpsQualGood;
+    return validOrigin && tiltAlignComplete && yawAlignComplete && gpsGoodToAlign;
 }
 
 // return true if we should use the compass

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -490,7 +490,7 @@ void NavEKF2_core::readGpsData()
             // Monitor quality of the GPS velocity data before and after alignment using separate checks
             if (PV_AidingMode != AID_ABSOLUTE) {
                 // Pre-alignment checks
-                gpsQualGood = calcGpsGoodToAlign();
+                gpsGoodToAlign = calcGpsGoodToAlign();
             } else {
                 // Post-alignment checks
                 calcGpsGoodForFlight();
@@ -501,7 +501,7 @@ void NavEKF2_core::readGpsData()
             const struct Location &gpsloc = _ahrs->get_gps().location();
             if (validOrigin) {
                 gpsDataNew.pos = location_diff(EKF_origin, gpsloc);
-            } else if (gpsQualGood) {
+            } else if (gpsGoodToAlign) {
                 // Set the NE origin to the current GPS position
                 setOrigin();
                 // Now we know the location we have an estimate for the magnetic field declination and adjust the earth field accordingly

--- a/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
@@ -26,8 +26,12 @@ void NavEKF2_core::SelectFlowFusion()
 {
     // Check if the magnetometer has been fused on that time step and the filter is running at faster than 200 Hz
     // If so, don't fuse measurements on this time step to reduce frame over-runs
-    if (magFusePerformed && dtIMUavg < 0.005f) {
+    // Only allow one time slip to prevent high rate magnetometer data preventing fusion of other measurements
+    if (magFusePerformed && dtIMUavg < 0.005f && !optFlowFusionDelayed) {
+        optFlowFusionDelayed = true;
         return;
+    } else {
+        optFlowFusionDelayed = false;
     }
 
     // start performance timer

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -396,7 +396,7 @@ void  NavEKF2_core::getFilterStatus(nav_filter_status &status) const
     bool someVertRefData = (!velTimeout && useGpsVertVel) || !hgtTimeout;
     bool someHorizRefData = !(velTimeout && posTimeout && tasTimeout) || doingFlowNav;
     bool optFlowNavPossible = flowDataValid && (frontend._fusionModeGPS == 3);
-    bool gpsNavPossible = !gpsNotAvailable && (frontend._fusionModeGPS <= 2);
+    bool gpsNavPossible = !gpsNotAvailable && (PV_AidingMode == AID_ABSOLUTE) && gpsGoodToAlign;
     bool filterHealthy = healthy() && tiltAlignComplete && yawAlignComplete;
 
     // set individual flags

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -107,8 +107,12 @@ void NavEKF2_core::SelectVelPosFusion()
 {
     // Check if the magnetometer has been fused on that time step and the filter is running at faster than 200 Hz
     // If so, don't fuse measurements on this time step to reduce frame over-runs
-    if (magFusePerformed && dtIMUavg < 0.005f) {
+    // Only allow one time slip to prevent high rate magnetometer data preventing fusion of other measurements
+    if (magFusePerformed && dtIMUavg < 0.005f && !posVelFusionDelayed) {
+        posVelFusionDelayed = true;
         return;
+    } else {
+        posVelFusionDelayed = false;
     }
 
     // check for and read new GPS data

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -192,6 +192,10 @@ void NavEKF2_core::InitialiseVariables()
     imuNoiseFiltState0 = 0.0f;
     imuNoiseFiltState1 = 0.0f;
     lastImuSwitchState = IMUSWITCH_MIXED;
+    posVelFusionDelayed = false;
+    optFlowFusionDelayed = false;
+    airSpdFusionDelayed = false;
+    sideSlipFusionDelayed = false;
 }
 
 // Initialise the states from accelerometer and magnetometer data (if present)

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -167,7 +167,7 @@ void NavEKF2_core::InitialiseVariables()
     delAngCorrection.zero();
     delVelCorrection.zero();
     velCorrection.zero();
-    gpsQualGood = false;
+    gpsGoodToAlign = false;
     gpsNotAvailable = true;
     motorsArmed = false;
     prevMotorsArmed = false;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -759,6 +759,10 @@ private:
     bool consistentMagData;         // true when the magnetometers are passing consistency checks
     bool motorsArmed;               // true when the motors have been armed
     bool prevMotorsArmed;           // value of motorsArmed from previous frame
+    bool posVelFusionDelayed;       // true when the position and velocity fusion has been delayed
+    bool optFlowFusionDelayed;      // true when the optical flow fusion has been delayed
+    bool airSpdFusionDelayed;       // true when the air speed fusion has been delayed
+    bool sideSlipFusionDelayed;     // true when the sideslip fusion has been delayed
 
     // variables used to calulate a vertical velocity that is kinematically consistent with the verical position
     float posDownDerivative;        // Rate of chage of vertical position (dPosD/dt) in m/s. This is the first time derivative of PosD.

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -753,8 +753,8 @@ private:
     Vector3f delVelCorrection;      // correction applied to earth frame delta velocities used by output observer to track the EKF
     Vector3f velCorrection;         // correction applied to velocities used by the output observer to track the EKF
     float innovYaw;                 // compass yaw angle innovation (rad)
-    uint32_t timeTasReceived_ms;    // tie last TAS data was received (msec)
-    bool gpsQualGood;               // true when the GPS quality can be used to initialise the navigation system
+    uint32_t timeTasReceived_ms;    // time last TAS data was received (msec)
+    bool gpsGoodToAlign;            // true when the GPS quality can be used to initialise the navigation system
     uint32_t magYawResetTimer_ms;   // timer in msec used to track how long good magnetometer data is failing innovation consistency checks
     bool consistentMagData;         // true when the magnetometers are passing consistency checks
     bool motorsArmed;               // true when the motors have been armed


### PR DESCRIPTION
Closes the following vulnerabilities:

High rate mag data (e.g. SITL) can block the fusion of other measurements due to load levelling
It is possible in Copter to arm whilst in a flight mode requiring GPS before EKF2 has started using GPS