### PR TITLE
Minor compass cal improvements

### DIFF
--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -253,13 +253,11 @@ bool CompassCalibrator::set_status(compass_cal_status_t status) {
                 return false;
             }
 
-            if(_sample_buffer != NULL) {
-                initialize_fit();
-                _status = COMPASS_CAL_RUNNING_STEP_ONE;
-                return true;
+            if (_sample_buffer == NULL) {
+                _sample_buffer =
+                        (CompassSample*) malloc(sizeof(CompassSample) *
+                                                COMPASS_CAL_NUM_SAMPLES);
             }
-
-            _sample_buffer = (CompassSample*)malloc(sizeof(CompassSample)*COMPASS_CAL_NUM_SAMPLES);
 
             if(_sample_buffer != NULL) {
                 initialize_fit();


### PR DESCRIPTION
Hi all, while I was reviewing the code for onboard compass calibration, I did some minor improvements in the code:
 - Calculate *theta* angle for sample acceptance just once as that value doesn't change.
 - Simplify the transition to state COMPASS_CAL_RUNNING_STEP_ONE

Together with this PR, I'm concerned about the formulas used for sample acceptance criteria: I couldn't find theoretical basis for them. If someone could point to the right resources I'd be glad if someone could point me the correct resources :)

Best regards,
Gustavo Sousa