### PR TITLE
Fix EKF2 measurement fusion timing errors

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -599,23 +599,6 @@ void NavEKF2_core::readGpsData()
             }
         }
     }
-
-    // If not aiding we synthesise the GPS measurements at the last known position
-    if (PV_AidingMode == AID_NONE) {
-        if (imuSampleTime_ms - gpsDataNew.time_ms > 200) {
-            gpsDataNew.pos.x = lastKnownPositionNE.x;
-            gpsDataNew.pos.y = lastKnownPositionNE.y;
-            gpsDataNew.time_ms = imuSampleTime_ms-frontend._gpsDelay_ms;
-            // Assign measurement to nearest fusion interval so that multiple measurements can be fused on the same frame
-            // This allows us to perform the covariance prediction over longer time steps which reduces numerical precision errors
-            gpsDataNew.time_ms = roundToNearest(gpsDataNew.time_ms, frontend.fusionTimeStep_ms);
-            // Prevent time delay exceeding age of oldest IMU data in the buffer
-            gpsDataNew.time_ms = max(gpsDataNew.time_ms,imuDataDelayed.time_ms);
-            // save measurement to buffer to be fused later
-            StoreGPS();
-        }
-    }
-
 }
 
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -142,20 +142,22 @@ bool NavEKF2_core::RecallOF()
     of_elements dataTempZero;
     dataTempZero.time_ms = 0;
     uint32_t temp_ms = 0;
+    uint8_t bestIndex = 0;
     for (uint8_t i=0; i<OBS_BUFFER_LENGTH; i++) {
         dataTemp = storedOF[i];
         // find a measurement older than the fusion time horizon that we haven't checked before
         if (dataTemp.time_ms != 0 && dataTemp.time_ms <= imuDataDelayed.time_ms) {
-            // zero the time stamp so we won't use it again
-            storedOF[i]=dataTempZero;
             // Find the most recent non-stale measurement that meets the time horizon criteria
             if (((imuDataDelayed.time_ms - dataTemp.time_ms) < 500) && dataTemp.time_ms > temp_ms) {
                 ofDataDelayed = dataTemp;
                 temp_ms = dataTemp.time_ms;
+                bestIndex = i;
             }
         }
     }
     if (temp_ms != 0) {
+        // zero the time stamp for that piece of data so we won't use it again
+        storedOF[bestIndex]=dataTempZero;
         return true;
     } else {
         return false;
@@ -237,20 +239,22 @@ bool NavEKF2_core::RecallMag()
     mag_elements dataTempZero;
     dataTempZero.time_ms = 0;
     uint32_t temp_ms = 0;
+    uint8_t bestIndex = 0;
     for (uint8_t i=0; i<OBS_BUFFER_LENGTH; i++) {
         dataTemp = storedMag[i];
         // find a measurement older than the fusion time horizon that we haven't checked before
         if (dataTemp.time_ms != 0 && dataTemp.time_ms <= imuDataDelayed.time_ms) {
-            // zero the time stamp so we won't use it again
-            storedMag[i]=dataTempZero;
             // Find the most recent non-stale measurement that meets the time horizon criteria
             if (((imuDataDelayed.time_ms - dataTemp.time_ms) < 500) && dataTemp.time_ms > temp_ms) {
                 magDataDelayed = dataTemp;
                 temp_ms = dataTemp.time_ms;
+                bestIndex = i;
             }
         }
     }
     if (temp_ms != 0) {
+        // zero the time stamp for that piece of data so we won't use it again
+        storedMag[bestIndex]=dataTempZero;
         return true;
     } else {
         return false;
@@ -630,20 +634,22 @@ bool NavEKF2_core::RecallGPS()
     gps_elements dataTempZero;
     dataTempZero.time_ms = 0;
     uint32_t temp_ms = 0;
+    uint8_t bestIndex;
     for (uint8_t i=0; i<OBS_BUFFER_LENGTH; i++) {
         dataTemp = storedGPS[i];
         // find a measurement older than the fusion time horizon that we haven't checked before
         if (dataTemp.time_ms != 0 && dataTemp.time_ms <= imuDataDelayed.time_ms) {
-            // zero the time stamp so we won't use it again
-            storedGPS[i]=dataTempZero;
             // Find the most recent non-stale measurement that meets the time horizon criteria
             if (((imuDataDelayed.time_ms - dataTemp.time_ms) < 500) && dataTemp.time_ms > temp_ms) {
                 gpsDataDelayed = dataTemp;
                 temp_ms = dataTemp.time_ms;
+                bestIndex = i;
             }
         }
     }
     if (temp_ms != 0) {
+        // zero the time stamp for that piece of data so we won't use it again
+        storedGPS[bestIndex]=dataTempZero;
         return true;
     } else {
         return false;
@@ -772,20 +778,22 @@ bool NavEKF2_core::RecallBaro()
     baro_elements dataTempZero;
     dataTempZero.time_ms = 0;
     uint32_t temp_ms = 0;
+    uint8_t bestIndex = 0;
     for (uint8_t i=0; i<OBS_BUFFER_LENGTH; i++) {
         dataTemp = storedBaro[i];
         // find a measurement older than the fusion time horizon that we haven't checked before
         if (dataTemp.time_ms != 0 && dataTemp.time_ms <= imuDataDelayed.time_ms) {
-            // zero the time stamp so we won't use it again
-            storedBaro[i]=dataTempZero;
             // Find the most recent non-stale measurement that meets the time horizon criteria
             if (((imuDataDelayed.time_ms - dataTemp.time_ms) < 500) && dataTemp.time_ms > temp_ms) {
                 baroDataDelayed = dataTemp;
                 temp_ms = dataTemp.time_ms;
+                bestIndex = i;
             }
         }
     }
     if (temp_ms != 0) {
+        // zero the time stamp for that piece of data so we won't use it again
+        storedBaro[bestIndex]=dataTempZero;
         return true;
     } else {
         return false;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -185,9 +185,9 @@ bool NavEKF2_core::getMagOffsets(Vector3f &magOffsets) const
 // check for new magnetometer data and update store measurements if available
 void NavEKF2_core::readMagData()
 {
-    if (use_compass() && _ahrs->get_compass()->last_update_usec() != lastMagUpdate_ms) {
+    if (use_compass() && _ahrs->get_compass()->last_update_usec() != lastMagUpdate_us) {
         // store time of last measurement update
-        lastMagUpdate_ms = _ahrs->get_compass()->last_update_usec();
+        lastMagUpdate_us = _ahrs->get_compass()->last_update_usec();
 
         // estimate of time magnetometer measurement was taken, allowing for delays
         magDataNew.time_ms = imuSampleTime_ms - frontend.magDelay_ms;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -386,12 +386,17 @@ void NavEKF2_core::readIMUData()
 // store imu in the FIFO
 void NavEKF2_core::StoreIMU()
 {
-    fifoIndexDelayed = fifoIndexNow;
+    // increment the index and write new data
     fifoIndexNow = fifoIndexNow + 1;
     if (fifoIndexNow >= IMU_BUFFER_LENGTH) {
         fifoIndexNow = 0;
     }
     storedIMU[fifoIndexNow] = imuDataNew;
+    // set the index required to access the oldest data
+    fifoIndexDelayed = fifoIndexNow + 1;
+    if (fifoIndexDelayed >= IMU_BUFFER_LENGTH) {
+        fifoIndexDelayed = 0;
+    }
 }
 
 // reset the stored imu history and store the current value

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -70,7 +70,7 @@ void NavEKF2_core::InitialiseVariables()
     lastHealthyMagTime_ms = imuSampleTime_ms;
     prevTasStep_ms = imuSampleTime_ms;
     prevBetaStep_ms = imuSampleTime_ms;
-    lastMagUpdate_ms = 0;
+    lastMagUpdate_us = 0;
     lastHgtReceived_ms = imuSampleTime_ms;
     lastVelPassTime_ms = imuSampleTime_ms;
     lastPosPassTime_ms = imuSampleTime_ms;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -50,8 +50,10 @@
 #define IMU_BUFFER_LENGTH       104 // maximum 260 msec delay at 400 Hz
 #elif APM_BUILD_TYPE(APM_BUILD_APMrover2)
 #define IMU_BUFFER_LENGTH       13 // maximum 260 msec delay at 50 Hz
-#else
+#elif APM_BUILD_TYPE(APM_BUILD_ArduPlane)
 #define IMU_BUFFER_LENGTH       13 // maximum 260 msec delay at 50 Hz
+#else
+#define IMU_BUFFER_LENGTH       104 // unknown so use max buffer length
 #endif
 
 class AP_AHRS;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -674,7 +674,7 @@ private:
     bool magFuseRequired;           // boolean set to true when magnetometer fusion will be perfomred in the next time step
     uint32_t prevTasStep_ms;        // time stamp of last TAS fusion step
     uint32_t prevBetaStep_ms;       // time stamp of last synthetic sideslip fusion step
-    uint32_t lastMagUpdate_ms;      // last time compass was updated
+    uint32_t lastMagUpdate_us;      // last time compass was updated in usec
     Vector3f velDotNED;             // rate of change of velocity in NED frame
     Vector3f velDotNEDfilt;         // low pass filtered velDotNED
     uint32_t imuSampleTime_ms;      // time that the last IMU value was taken


### PR DESCRIPTION
This has been flown on two quads, one using GPS and one using optical flow. it has also been flown on SITL. Flight conditions were windy so it was hard to tell how the navigation precision compared to previous flights.

These patches reduce innovations during rapid motion as the previous code was not lining up the IMU and other measurements correctly.