### PR TITLE
AP_HAL_Linux: fix two warnings

### DIFF
--- a/libraries/AP_HAL/AP_HAL_Main.h
+++ b/libraries/AP_HAL/AP_HAL_Main.h
@@ -18,6 +18,7 @@
 #if CONFIG_MAIN_WITHOUT_ARGC_ARGV
 
 #define AP_HAL_MAIN() extern "C" { \
+    int AP_MAIN(void); \
     int AP_MAIN(void) { \
         AP_HAL::HAL::FunCallbacks callbacks(setup, loop); \
         hal.run(0, NULL, &callbacks); \
@@ -26,6 +27,7 @@
     }
 
 #define AP_HAL_MAIN_CALLBACKS(CALLBACKS) extern "C" { \
+    int AP_MAIN(void); \
     int AP_MAIN(void) { \
         hal.run(0, NULL, CALLBACKS); \
         return 0; \
@@ -35,6 +37,7 @@
 #else
 
 #define AP_HAL_MAIN() extern "C" { \
+    int AP_MAIN(int argc, char* const argv[]); \
     int AP_MAIN(int argc, char* const argv[]) { \
         AP_HAL::HAL::FunCallbacks callbacks(setup, loop); \
         hal.run(argc, argv, &callbacks); \
@@ -43,6 +46,7 @@
     }
 
 #define AP_HAL_MAIN_CALLBACKS(CALLBACKS) extern "C" { \
+    int AP_MAIN(int argc, char* const argv[]); \
     int AP_MAIN(int argc, char* const argv[]) { \
         hal.run(argc, argv, CALLBACKS); \
         return 0; \

--- a/libraries/AP_HAL_Linux/Storage_FRAM.cpp
+++ b/libraries/AP_HAL_Linux/Storage_FRAM.cpp
@@ -5,6 +5,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <unistd.h>
 #include <errno.h>
 #include <stdio.h>
@@ -180,7 +181,7 @@ int32_t Storage_FRAM::read(uint16_t fd, uint8_t *Buff, uint16_t NumBytes){
     for(uint16_t i=fptr;i<(fptr+NumBytes);i++){
         Buff[i-fptr]= _register_read(i,OPCODE_READ);
 
-        if(Buff[i-fptr]==-1){
+        if(Buff[i-fptr]==UINT8_MAX){
             return -1;
         }
     }


### PR DESCRIPTION
Fix 2 warnings: one in Linux and one in PX4.
