### PR TITLE
EKF2 Improvements

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -34,7 +34,7 @@
 #define FLOW_MEAS_DELAY         10
 #define FLOW_NOISE_DEFAULT      0.25f
 #define FLOW_GATE_DEFAULT       3
-#define GSCALE_PNOISE_DEFAULT   1.5E-03f
+#define GSCALE_PNOISE_DEFAULT   3.0E-03f
 
 #elif APM_BUILD_TYPE(APM_BUILD_APMrover2)
 // rover defaults
@@ -57,7 +57,7 @@
 #define FLOW_MEAS_DELAY         10
 #define FLOW_NOISE_DEFAULT      0.25f
 #define FLOW_GATE_DEFAULT       3
-#define GSCALE_PNOISE_DEFAULT   1.5E-03f
+#define GSCALE_PNOISE_DEFAULT   3.0E-03f
 
 #else
 // generic defaults (and for plane)
@@ -80,7 +80,7 @@
 #define FLOW_MEAS_DELAY         10
 #define FLOW_NOISE_DEFAULT      0.25f
 #define FLOW_GATE_DEFAULT       3
-#define GSCALE_PNOISE_DEFAULT   1.5E-03f
+#define GSCALE_PNOISE_DEFAULT   3.0E-03f
 
 #endif // APM_BUILD_DIRECTORY
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -18,7 +18,7 @@
 #define VELNE_NOISE_DEFAULT     0.5f
 #define VELD_NOISE_DEFAULT      0.7f
 #define POSNE_NOISE_DEFAULT     1.0f
-#define ALT_NOISE_DEFAULT       1.5f
+#define ALT_NOISE_DEFAULT       2.0f
 #define MAG_NOISE_DEFAULT       0.05f
 #define GYRO_PNOISE_DEFAULT     0.005f
 #define ACC_PNOISE_DEFAULT      0.25f
@@ -41,7 +41,7 @@
 #define VELNE_NOISE_DEFAULT     0.5f
 #define VELD_NOISE_DEFAULT      0.7f
 #define POSNE_NOISE_DEFAULT     1.0f
-#define ALT_NOISE_DEFAULT       1.5f
+#define ALT_NOISE_DEFAULT       2.0f
 #define MAG_NOISE_DEFAULT       0.05f
 #define GYRO_PNOISE_DEFAULT     0.005f
 #define ACC_PNOISE_DEFAULT      0.25f
@@ -64,7 +64,7 @@
 #define VELNE_NOISE_DEFAULT     0.5f
 #define VELD_NOISE_DEFAULT      0.7f
 #define POSNE_NOISE_DEFAULT     1.0f
-#define ALT_NOISE_DEFAULT       1.5f
+#define ALT_NOISE_DEFAULT       2.0f
 #define MAG_NOISE_DEFAULT       0.05f
 #define GYRO_PNOISE_DEFAULT     0.005f
 #define ACC_PNOISE_DEFAULT      0.25f

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -171,7 +171,7 @@ void NavEKF2_core::checkAttitudeAlignmentStatus()
     // Once tilt has converged, align yaw using magnetic field measurements
     if (tiltAlignComplete && !yawAlignComplete) {
         Vector3f eulerAngles;
-        getEulerAngles(eulerAngles);
+        stateStruct.quat.to_euler(eulerAngles.x, eulerAngles.y, eulerAngles.z);
         stateStruct.quat = calcQuatAndFieldStates(eulerAngles.x, eulerAngles.y);
         StoreQuatReset();
         yawAlignComplete = true;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -196,6 +196,7 @@ void NavEKF2_core::InitialiseVariables()
     optFlowFusionDelayed = false;
     airSpdFusionDelayed = false;
     sideSlipFusionDelayed = false;
+    magFuseTiltInhibit = false;
 }
 
 // Initialise the states from accelerometer and magnetometer data (if present)
@@ -1371,6 +1372,18 @@ Quaternion NavEKF2_core::calcQuatAndFieldStates(float roll, float pitch)
 
         // align the NE earth magnetic field states with the published declination
         alignMagStateDeclination();
+
+        // zero the magnetic field state associated covariances
+        zeroRows(P,16,21);
+        zeroCols(P,16,21);
+        // set initial earth magnetic field variances
+        P[16][16] = sq(0.05f);
+        P[17][17] = P[16][16];
+        P[18][18] = P[16][16];
+        // set initial body magnetic field variances
+        P[19][19] = sq(0.05f);
+        P[20][20] = P[19][19];
+        P[21][21] = P[19][19];
 
         // clear bad magnetometer status
         badMag = false;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -765,6 +765,8 @@ private:
     bool optFlowFusionDelayed;      // true when the optical flow fusion has been delayed
     bool airSpdFusionDelayed;       // true when the air speed fusion has been delayed
     bool sideSlipFusionDelayed;     // true when the sideslip fusion has been delayed
+    bool magFuseTiltInhibit;        // true when the 3-axis magnetoemter fusion is prevented from changing tilt angle
+    uint32_t magFuseTiltInhibit_ms; // time in msec that the condition indicated by magFuseTiltInhibit was commenced
 
     // variables used to calulate a vertical velocity that is kinematically consistent with the verical position
     float posDownDerivative;        // Rate of chage of vertical position (dPosD/dt) in m/s. This is the first time derivative of PosD.


### PR DESCRIPTION
The in-air reset of heading and field states at 1.5m and 5m height gain for copters could cause a small kick in roll and/or pitch  that would decay over 5 seconds. This 'twitch' has been reduced to an equivalent level to that produced by EKF1. Further refinements to the output data buffer reset will be required to eliminate it completely.

EKF2 was tending to react more to Baro noise. A minor increase in assumed Baro noise from 1.5 to 2.0m has ben made to improve this.

The EKF2 gyro scale factor learning was too slow to be useful in flight. The scale factor process noise has been doubled and flight testing shows that it is learning faster. It is recommended that we look at options for saving the scale factor in non-voltile memory.

For flight without GPS, the accuracy of angle estimates and recovery time after disturbances due to manoeuvres has been improved with adjustments to assumed accuracy of the synthetic position and velocity measurements used to constrain tilt drift. This is a compromise between sensitivity to IMU errors vs manoeuvre disturbances.