### PR TITLE
Improve EKF2  handling of GPS loss and glitching

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -25,9 +25,9 @@
 #define GBIAS_PNOISE_DEFAULT    7.0E-05f
 #define ABIAS_PNOISE_DEFAULT    1.0E-04f
 #define MAG_PNOISE_DEFAULT      2.5E-02f
-#define VEL_GATE_DEFAULT        5
-#define POS_GATE_DEFAULT        5
-#define HGT_GATE_DEFAULT        5
+#define VEL_GATE_DEFAULT        3
+#define POS_GATE_DEFAULT        3
+#define HGT_GATE_DEFAULT        3
 #define MAG_GATE_DEFAULT        3
 #define MAG_CAL_DEFAULT         3
 #define GLITCH_RADIUS_DEFAULT   25
@@ -48,9 +48,9 @@
 #define GBIAS_PNOISE_DEFAULT    7.0E-05f
 #define ABIAS_PNOISE_DEFAULT    1.0E-04f
 #define MAG_PNOISE_DEFAULT      2.5E-02f
-#define VEL_GATE_DEFAULT        5
-#define POS_GATE_DEFAULT        5
-#define HGT_GATE_DEFAULT        5
+#define VEL_GATE_DEFAULT        3
+#define POS_GATE_DEFAULT        3
+#define HGT_GATE_DEFAULT        3
 #define MAG_GATE_DEFAULT        3
 #define MAG_CAL_DEFAULT         2
 #define GLITCH_RADIUS_DEFAULT   25
@@ -64,7 +64,7 @@
 #define VELNE_NOISE_DEFAULT     0.5f
 #define VELD_NOISE_DEFAULT      0.7f
 #define POSNE_NOISE_DEFAULT     1.0f
-#define ALT_NOISE_DEFAULT       2.0f
+#define ALT_NOISE_DEFAULT       5.0f
 #define MAG_NOISE_DEFAULT       0.05f
 #define GYRO_PNOISE_DEFAULT     0.005f
 #define ACC_PNOISE_DEFAULT      0.25f
@@ -73,7 +73,7 @@
 #define MAG_PNOISE_DEFAULT      2.5E-02f
 #define VEL_GATE_DEFAULT        5
 #define POS_GATE_DEFAULT        5
-#define HGT_GATE_DEFAULT        10
+#define HGT_GATE_DEFAULT        4
 #define MAG_GATE_DEFAULT        3
 #define MAG_CAL_DEFAULT         0
 #define GLITCH_RADIUS_DEFAULT   25

--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -151,7 +151,7 @@ void NavEKF2_core::SelectMagFusion()
         } else {
             // if we are not doing aiding with earth relative observations (eg GPS) then the declination is
             // maintained by fusing declination as a synthesised observation
-            if (PV_AidingMode != AID_ABSOLUTE) {
+            if (PV_AidingMode != AID_ABSOLUTE || (imuSampleTime_ms - lastPosPassTime_ms) > 4000) {
                 FuseDeclination();
             }
             // fuse the three magnetometer componenents sequentially

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -305,7 +305,7 @@ void NavEKF2_core::FuseVelPosNED()
                 if (PV_AidingMode == AID_ABSOLUTE) {
                     lastPosPassTime_ms = imuSampleTime_ms;
                     // if timed out or outside the specified uncertainty radius, increment the offset applied to GPS data to compensate for large GPS position jumps
-                    if (posTimeout || ((varInnovVelPos[3] + varInnovVelPos[4]) > sq(float(frontend._gpsGlitchRadiusMax)))) {
+                    if (posTimeout || ((P[6][6] + P[7][7]) > sq(float(frontend._gpsGlitchRadiusMax)))) {
                         gpsPosGlitchOffsetNE.x += innovVelPos[3];
                         gpsPosGlitchOffsetNE.y += innovVelPos[4];
                         // limit the radius of the offset and decay the offset to zero radially
@@ -316,6 +316,11 @@ void NavEKF2_core::FuseVelPosNED()
                         ResetVelocity();
                         // don't fuse data on this time step
                         fusePosData = false;
+                        // Reset the position variances and corresponding covariances to a value that will pass the checks
+                        zeroRows(P,6,7);
+                        zeroCols(P,6,7);
+                        P[6][6] = sq(float(0.5f*frontend._gpsGlitchRadiusMax));
+                        P[7][7] = P[6][6];
                         // Reset the normalised innovation to avoid false failing the bad position fusion test
                         posTestRatio = 0.0f;
                         velTestRatio = 0.0f;


### PR DESCRIPTION
EKF2 is generating smaller normalised innovation variances so the check thresholds have been reduced in to provide better protection against GPS glitching for Copter and Rover. The Plane GPS thresholds have been left the same.

The Plane Baro threshold and noise have been adjusted to keep the same ~20m max baro error limit before baro measurements are rejected, but to allow for more baro noise due to flow disturbances.

Testing in SITL showed that the new EKF was not handling prolonged loss of GPs well because in the  absence of an absolute reference, the magnetic field learning was rotating the earth field states and allowing yaw angle error to build up. When GPS is lost, the declination angle is now constrained.

Position covariances were not being reset when position was reset after loss of GPS, which caused repeated position resets due to the glitch radius logic being activated. The position covariance is now reset when the position is reset after recovering from large GPS glitch or loss of GPS.