### PR TITLE
Change panic() to be a variadic function (v2)

### DIFF
--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -47,6 +47,8 @@
 // sometimes we need to prevent inlining to prevent large stack usage
 #define NOINLINE __attribute__((noinline))
 
+#define FORMAT(a,b) __attribute__((format(printf, a, b)))
+
 // Make some dire warnings into errors
 //
 // Some warnings indicate questionable code; rather than let

--- a/libraries/AP_HAL/Scheduler.h
+++ b/libraries/AP_HAL/Scheduler.h
@@ -2,11 +2,13 @@
 #ifndef __AP_HAL_SCHEDULER_H__
 #define __AP_HAL_SCHEDULER_H__
 
-#include "AP_HAL_Namespace.h"
-#include "AP_HAL_Boards.h"
-
 #include <stdint.h>
+
 #include <AP_Progmem/AP_Progmem.h>
+
+#include "AP_HAL_Boards.h"
+#include "AP_HAL_Namespace.h"
+
 
 class AP_HAL::Scheduler {
 public:

--- a/libraries/AP_HAL/Scheduler.h
+++ b/libraries/AP_HAL/Scheduler.h
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 
+#include <AP_Common/AP_Common.h>
 #include <AP_Progmem/AP_Progmem.h>
 
 #include "AP_HAL_Boards.h"
@@ -56,7 +57,7 @@ public:
     virtual bool     system_initializing() = 0;
     virtual void     system_initialized() = 0;
 
-    virtual void     panic(const prog_char_t *errormsg, ...) NORETURN = 0;
+    virtual void     panic(const prog_char_t *errormsg, ...) FORMAT(2, 3) NORETURN = 0;
     virtual void     reboot(bool hold_in_bootloader) = 0;
 
     /**

--- a/libraries/AP_HAL/Scheduler.h
+++ b/libraries/AP_HAL/Scheduler.h
@@ -56,7 +56,7 @@ public:
     virtual bool     system_initializing() = 0;
     virtual void     system_initialized() = 0;
 
-    virtual void     panic(const prog_char_t *errormsg) NORETURN = 0;
+    virtual void     panic(const prog_char_t *errormsg, ...) NORETURN = 0;
     virtual void     reboot(bool hold_in_bootloader) = 0;
 
     /**

--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -4,6 +4,8 @@
 
 #include <stdint.h>
 
+#include <AP_Common/AP_Common.h>
+
 #include "AP_HAL_Namespace.h"
 #include "utility/BetterStream.h"
 
@@ -51,10 +53,8 @@ public:
      */
     void print_P(const prog_char_t *s);
     void println_P(const prog_char_t *s);
-    void printf(const char *s, ...)
-            __attribute__ ((format(__printf__, 2, 3)));
-    void _printf_P(const prog_char *s, ...)
-            __attribute__ ((format(__printf__, 2, 3)));
+    void printf(const char *s, ...) FORMAT(2, 3);
+    void _printf_P(const prog_char *s, ...) FORMAT(2, 3);
 
     void vprintf(const char *s, va_list ap);
     void vprintf_P(const prog_char *s, va_list ap);

--- a/libraries/AP_HAL_AVR/Scheduler.cpp
+++ b/libraries/AP_HAL_AVR/Scheduler.cpp
@@ -225,7 +225,7 @@ void AVRScheduler::system_initialized() {
     _initialized = true;
 }
 
-void AVRScheduler::panic(const prog_char_t* errormsg) {
+void AVRScheduler::panic(const prog_char_t* errormsg, ...) {
     /* Suspend timer processes. We still want the timer event to go off
      * to run the _failsafe code, however. */
     _timer_suspended = true;

--- a/libraries/AP_HAL_AVR/Scheduler.h
+++ b/libraries/AP_HAL_AVR/Scheduler.h
@@ -45,7 +45,7 @@ public:
     bool     system_initializing();
     void     system_initialized();
 
-    void     panic(const prog_char_t *errormsg) NORETURN;
+    void     panic(const prog_char_t *errormsg, ...) NORETURN;
     void     reboot(bool hold_in_bootloader);
 
     void     set_timer_speed(uint16_t timer_hz);

--- a/libraries/AP_HAL_AVR/Scheduler.h
+++ b/libraries/AP_HAL_AVR/Scheduler.h
@@ -45,7 +45,7 @@ public:
     bool     system_initializing();
     void     system_initialized();
 
-    void     panic(const prog_char_t *errormsg, ...) NORETURN;
+    void     panic(const prog_char_t *errormsg, ...) FORMAT(2, 3) NORETURN;
     void     reboot(bool hold_in_bootloader);
 
     void     set_timer_speed(uint16_t timer_hz);

--- a/libraries/AP_HAL_Empty/Scheduler.cpp
+++ b/libraries/AP_HAL_Empty/Scheduler.cpp
@@ -1,6 +1,8 @@
 
 #include "Scheduler.h"
 
+#include <stdarg.h>
+
 using namespace Empty;
 
 extern const AP_HAL::HAL& hal;
@@ -69,8 +71,15 @@ bool EmptyScheduler::system_initializing() {
 void EmptyScheduler::system_initialized()
 {}
 
-void EmptyScheduler::panic(const prog_char_t *errormsg, ...) {
-    hal.console->println_P(errormsg);
+void EmptyScheduler::panic(const prog_char_t *errormsg, ...)
+{
+    va_list ap;
+
+    va_start(ap, errormsg);
+    hal.console->vprintf_P(errormsg, ap);
+    va_end(ap);
+    hal.console->printf_P("\n");
+
     for(;;);
 }
 

--- a/libraries/AP_HAL_Empty/Scheduler.cpp
+++ b/libraries/AP_HAL_Empty/Scheduler.cpp
@@ -69,7 +69,7 @@ bool EmptyScheduler::system_initializing() {
 void EmptyScheduler::system_initialized()
 {}
 
-void EmptyScheduler::panic(const prog_char_t *errormsg) {
+void EmptyScheduler::panic(const prog_char_t *errormsg, ...) {
     hal.console->println_P(errormsg);
     for(;;);
 }

--- a/libraries/AP_HAL_Empty/Scheduler.h
+++ b/libraries/AP_HAL_Empty/Scheduler.h
@@ -32,7 +32,7 @@ public:
     bool     system_initializing();
     void     system_initialized();
 
-    void     panic(const prog_char_t *errormsg, ...) NORETURN;
+    void     panic(const prog_char_t *errormsg, ...) FORMAT(2, 3) NORETURN;
     void     reboot(bool hold_in_bootloader);
 
 };

--- a/libraries/AP_HAL_Empty/Scheduler.h
+++ b/libraries/AP_HAL_Empty/Scheduler.h
@@ -32,7 +32,7 @@ public:
     bool     system_initializing();
     void     system_initialized();
 
-    void     panic(const prog_char_t *errormsg) NORETURN;
+    void     panic(const prog_char_t *errormsg, ...) NORETURN;
     void     reboot(bool hold_in_bootloader);
 
 };

--- a/libraries/AP_HAL_FLYMAPLE/Scheduler.cpp
+++ b/libraries/AP_HAL_FLYMAPLE/Scheduler.cpp
@@ -15,6 +15,8 @@
 
 #include "Scheduler.h"
 
+#include <stdarg.h>
+
 #define millis libmaple_millis
 #define micros libmaple_micros
 #include "FlymapleWirish.h"
@@ -232,8 +234,15 @@ void FLYMAPLEScheduler::panic(const prog_char_t *errormsg, ...) {
     /* Suspend timer processes. We still want the timer event to go off
      * to run the _failsafe code, however. */
     // REVISIT: not tested on FLYMAPLE
+    va_list ap;
+
     _timer_suspended = true;
-    hal.console->println_P(errormsg);
+
+    va_start(ap, errormsg);
+    hal.console->vprintf_P(errormsg, ap);
+    va_end(ap);
+    hal.console->printf_P("\n");
+
     for(;;);
 }
 

--- a/libraries/AP_HAL_FLYMAPLE/Scheduler.cpp
+++ b/libraries/AP_HAL_FLYMAPLE/Scheduler.cpp
@@ -228,7 +228,7 @@ void FLYMAPLEScheduler::system_initialized()
     _initialized = true;
 }
 
-void FLYMAPLEScheduler::panic(const prog_char_t *errormsg) {
+void FLYMAPLEScheduler::panic(const prog_char_t *errormsg, ...) {
     /* Suspend timer processes. We still want the timer event to go off
      * to run the _failsafe code, however. */
     // REVISIT: not tested on FLYMAPLE

--- a/libraries/AP_HAL_FLYMAPLE/Scheduler.h
+++ b/libraries/AP_HAL_FLYMAPLE/Scheduler.h
@@ -53,7 +53,7 @@ public:
     bool     system_initializing();
     void     system_initialized();
 
-    void     panic(const prog_char_t *errormsg) NORETURN;
+    void     panic(const prog_char_t *errormsg, ...) NORETURN;
     void     reboot(bool hold_in_bootloader);
 
 private:

--- a/libraries/AP_HAL_FLYMAPLE/Scheduler.h
+++ b/libraries/AP_HAL_FLYMAPLE/Scheduler.h
@@ -53,7 +53,7 @@ public:
     bool     system_initializing();
     void     system_initialized();
 
-    void     panic(const prog_char_t *errormsg, ...) NORETURN;
+    void     panic(const prog_char_t *errormsg, ...) FORMAT(2, 3) NORETURN;
     void     reboot(bool hold_in_bootloader);
 
 private:

--- a/libraries/AP_HAL_Linux/RCInput_UART.cpp
+++ b/libraries/AP_HAL_Linux/RCInput_UART.cpp
@@ -21,13 +21,10 @@ using namespace Linux;
 
 RCInput_UART::RCInput_UART(const char *path)
 {
-    char s[256];
-
     _fd = open(path, O_RDONLY|O_NOCTTY|O_NONBLOCK|O_NDELAY);
     if (_fd < 0) {
-        snprintf(s, sizeof(s), "Error opening '%s': %s",
-                 path, strerror(errno));
-        hal.scheduler->panic(s);
+        hal.scheduler->panic("RCInput_UART: Error opening '%s': %s",
+                             path, strerror(errno));
     }
 }
 
@@ -38,8 +35,6 @@ RCInput_UART::~RCInput_UART()
 
 void RCInput_UART::init(void*)
 {
-    char s[256];
-
     struct termios options;
 
     tcgetattr(_fd, &options);
@@ -55,9 +50,8 @@ void RCInput_UART::init(void*)
     options.c_oflag &= ~OPOST;
 
     if (tcsetattr(_fd, TCSANOW, &options) != 0) {
-        snprintf(s, sizeof(s), "RCInput_UART: error configuring device: %s",
-                 strerror(errno));
-        hal.scheduler->panic(s);
+        hal.scheduler->panic("RCInput_UART: error configuring device: %s",
+                             strerror(errno));
     }
 
     tcflush(_fd, TCIOFLUSH);

--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -407,7 +407,7 @@ void *Scheduler::_io_thread(void* arg)
     return NULL;
 }
 
-void Scheduler::panic(const prog_char_t *errormsg)
+void Scheduler::panic(const prog_char_t *errormsg, ...)
 {
     write(1, errormsg, strlen(errormsg));
     write(1, "\n", 1);

--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -409,8 +409,13 @@ void *Scheduler::_io_thread(void* arg)
 
 void Scheduler::panic(const prog_char_t *errormsg, ...)
 {
-    write(1, errormsg, strlen(errormsg));
+    va_list ap;
+
+    va_start(ap, errormsg);
+    vdprintf(1, errormsg, ap);
+    va_end(ap);
     write(1, "\n", 1);
+
     hal.rcin->deinit();
     hal.scheduler->delay_microseconds(10000);
     exit(1);

--- a/libraries/AP_HAL_Linux/Scheduler.h
+++ b/libraries/AP_HAL_Linux/Scheduler.h
@@ -43,7 +43,7 @@ public:
     bool     system_initializing();
     void     system_initialized();
 
-    void     panic(const prog_char_t *errormsg) NORETURN;
+    void     panic(const prog_char_t *errormsg, ...) NORETURN;
     void     reboot(bool hold_in_bootloader);
 
     void     stop_clock(uint64_t time_usec);

--- a/libraries/AP_HAL_Linux/Scheduler.h
+++ b/libraries/AP_HAL_Linux/Scheduler.h
@@ -43,7 +43,7 @@ public:
     bool     system_initializing();
     void     system_initialized();
 
-    void     panic(const prog_char_t *errormsg, ...) NORETURN;
+    void     panic(const prog_char_t *errormsg, ...) FORMAT(2, 3) NORETURN;
     void     reboot(bool hold_in_bootloader);
 
     void     stop_clock(uint64_t time_usec);

--- a/libraries/AP_HAL_PX4/Scheduler.cpp
+++ b/libraries/AP_HAL_PX4/Scheduler.cpp
@@ -374,7 +374,7 @@ void *PX4Scheduler::_storage_thread(void)
     return NULL;
 }
 
-void PX4Scheduler::panic(const prog_char_t *errormsg) 
+void PX4Scheduler::panic(const prog_char_t *errormsg, ...)
 {
     write(1, errormsg, strlen(errormsg));
     write(1, "\n", 1);

--- a/libraries/AP_HAL_PX4/Scheduler.cpp
+++ b/libraries/AP_HAL_PX4/Scheduler.cpp
@@ -376,8 +376,13 @@ void *PX4Scheduler::_storage_thread(void)
 
 void PX4Scheduler::panic(const prog_char_t *errormsg, ...)
 {
-    write(1, errormsg, strlen(errormsg));
+    va_list ap;
+
+    va_start(ap, errormsg);
+    vdprintf(1, errormsg, ap);
+    va_end(ap);
     write(1, "\n", 1);
+
     hal.scheduler->delay_microseconds(10000);
     _px4_thread_should_exit = true;
     exit(1);

--- a/libraries/AP_HAL_PX4/Scheduler.h
+++ b/libraries/AP_HAL_PX4/Scheduler.h
@@ -60,7 +60,7 @@ public:
     void     suspend_timer_procs();
     void     resume_timer_procs();
     void     reboot(bool hold_in_bootloader);
-    void     panic(const prog_char_t *errormsg, ...) NORETURN;
+    void     panic(const prog_char_t *errormsg, ...) FORMAT(2, 3) NORETURN;
 
     bool     in_timerprocess();
     bool     system_initializing();

--- a/libraries/AP_HAL_PX4/Scheduler.h
+++ b/libraries/AP_HAL_PX4/Scheduler.h
@@ -60,7 +60,7 @@ public:
     void     suspend_timer_procs();
     void     resume_timer_procs();
     void     reboot(bool hold_in_bootloader);
-    void     panic(const prog_char_t *errormsg) NORETURN;
+    void     panic(const prog_char_t *errormsg, ...) NORETURN;
 
     bool     in_timerprocess();
     bool     system_initializing();

--- a/libraries/AP_HAL_SITL/Scheduler.cpp
+++ b/libraries/AP_HAL_SITL/Scheduler.cpp
@@ -259,8 +259,15 @@ void SITLScheduler::_run_io_procs(bool called_from_isr)
     _in_io_proc = false;
 }
 
-void SITLScheduler::panic(const prog_char_t *errormsg, ...) {
-    hal.console->println_P(errormsg);
+void SITLScheduler::panic(const prog_char_t *errormsg, ...)
+{
+    va_list ap;
+
+    va_start(ap, errormsg);
+    hal.console->vprintf_P(errormsg, ap);
+    va_end(ap);
+    hal.console->printf_P("\n");
+
     for(;;);
 }
 

--- a/libraries/AP_HAL_SITL/Scheduler.cpp
+++ b/libraries/AP_HAL_SITL/Scheduler.cpp
@@ -259,7 +259,7 @@ void SITLScheduler::_run_io_procs(bool called_from_isr)
     _in_io_proc = false;
 }
 
-void SITLScheduler::panic(const prog_char_t *errormsg) {
+void SITLScheduler::panic(const prog_char_t *errormsg, ...) {
     hal.console->println_P(errormsg);
     for(;;);
 }

--- a/libraries/AP_HAL_SITL/Scheduler.h
+++ b/libraries/AP_HAL_SITL/Scheduler.h
@@ -41,7 +41,7 @@ public:
     void     system_initialized();
 
     void     reboot(bool hold_in_bootloader);
-    void     panic(const prog_char_t *errormsg) NORETURN;
+    void     panic(const prog_char_t *errormsg, ...) NORETURN;
 
     bool     interrupts_are_blocked(void) {
         return _nested_atomic_ctr != 0;

--- a/libraries/AP_HAL_SITL/Scheduler.h
+++ b/libraries/AP_HAL_SITL/Scheduler.h
@@ -41,7 +41,7 @@ public:
     void     system_initialized();
 
     void     reboot(bool hold_in_bootloader);
-    void     panic(const prog_char_t *errormsg, ...) NORETURN;
+    void     panic(const prog_char_t *errormsg, ...) FORMAT(2, 3) NORETURN;
 
     bool     interrupts_are_blocked(void) {
         return _nested_atomic_ctr != 0;

--- a/libraries/AP_HAL_VRBRAIN/Scheduler.cpp
+++ b/libraries/AP_HAL_VRBRAIN/Scheduler.cpp
@@ -327,8 +327,13 @@ void *VRBRAINScheduler::_io_thread(void)
 
 void VRBRAINScheduler::panic(const prog_char_t *errormsg, ...)
 {
-    write(1, errormsg, strlen(errormsg));
+    va_list ap;
+
+    va_start(ap, errormsg);
+    vdprintf(1, errormsg, ap);
+    va_end(ap);
     write(1, "\n", 1);
+
     hal.scheduler->delay_microseconds(10000);
     _vrbrain_thread_should_exit = true;
     exit(1);

--- a/libraries/AP_HAL_VRBRAIN/Scheduler.cpp
+++ b/libraries/AP_HAL_VRBRAIN/Scheduler.cpp
@@ -325,7 +325,7 @@ void *VRBRAINScheduler::_io_thread(void)
     return NULL;
 }
 
-void VRBRAINScheduler::panic(const prog_char_t *errormsg)
+void VRBRAINScheduler::panic(const prog_char_t *errormsg, ...)
 {
     write(1, errormsg, strlen(errormsg));
     write(1, "\n", 1);

--- a/libraries/AP_HAL_VRBRAIN/Scheduler.h
+++ b/libraries/AP_HAL_VRBRAIN/Scheduler.h
@@ -39,7 +39,7 @@ public:
     void     suspend_timer_procs();
     void     resume_timer_procs();
     void     reboot(bool hold_in_bootloader);
-    void     panic(const prog_char_t *errormsg) NORETURN;
+    void     panic(const prog_char_t *errormsg, ...) NORETURN;
 
     bool     in_timerprocess();
     bool     system_initializing();

--- a/libraries/AP_HAL_VRBRAIN/Scheduler.h
+++ b/libraries/AP_HAL_VRBRAIN/Scheduler.h
@@ -39,7 +39,7 @@ public:
     void     suspend_timer_procs();
     void     resume_timer_procs();
     void     reboot(bool hold_in_bootloader);
-    void     panic(const prog_char_t *errormsg, ...) NORETURN;
+    void     panic(const prog_char_t *errormsg, ...) FORMAT(2, 3) NORETURN;
 
     bool     in_timerprocess();
     bool     system_initializing();


### PR DESCRIPTION
Changes from v1:
 - use `vdprintf()` rather than buffered API - for "\n" I actually left the call to write() instead of replacing with dprintf().
 - add missing va_end()
 - reorder commits
 - replace char with prog_char_t (this change will be in another PR)
