### PR TITLE
AP_HAL_Linux: don't log on failed semaphore

### DIFF
--- a/libraries/AP_HAL_Linux/RCOutput_PCA9685.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_PCA9685.cpp
@@ -225,7 +225,6 @@ void RCOutput_PCA9685::push()
     }
 
     if (!_i2c_sem->take_nonblocking()) {
-        hal.console->printf("RCOutput: Unable to get bus semaphore");
         return;
     }
 


### PR DESCRIPTION
With commit 24f4153 ("AP_HAL_Linux: RCOutput_PCA9685: group writes") a
log was introduced when we can't get the bus semaphore. However since we
are calling the non blocking method, failing there is not that unlikely
if the bus is shared. Return back to the previous behavior of not
logging.