### PR TITLE
build: allow -j on top level makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,13 @@ clean: plane copter rover antennatracker
 .PHONY: plane copter rover antennatracker
 
 plane:
-	make -C ArduPlane $(TARGET)
+	$(MAKE) -C ArduPlane $(TARGET)
 
 copter:
-	make -C ArduCopter $(TARGET)
+	$(MAKE) -C ArduCopter $(TARGET)
 
 rover:
-	make -C APMrover2 $(TARGET)
+	$(MAKE) -C APMrover2 $(TARGET)
 
 antennatracker:
-	make -C AntennaTracker $(TARGET)
+	$(MAKE) -C AntennaTracker $(TARGET)


### PR DESCRIPTION
By using $(MAKE) variable we allow to pass down to the called makefile
the number of jobs we want to compile with. The flags are communicated
to the next level via MAKEFLAGS variable.

Reference:
https://www.gnu.org/software/make/manual/html_node/Options_002fRecursion.html#Options_002fRecursion