### PR TITLE
Move compensation for position and velocity reset deltas from the EKF to control loops

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -532,6 +532,19 @@ void AC_PosControl::set_xy_target(float x, float y)
     _pos_target.y = y;
 }
 
+/// shift position target target in x, y axis
+void AC_PosControl::shift_pos_xy_target(float x_cm, float y_cm)
+{
+    // move pos controller target
+    _pos_target.x += x_cm;
+    _pos_target.y += y_cm;
+
+    // disable feed forward
+    if (!is_zero(x_cm) || !is_zero(y_cm)) {
+        freeze_ff_xy();
+    }
+}
+
 /// set_target_to_stopping_point_xy - sets horizontal target to reasonable stopping position in cm from home
 void AC_PosControl::set_target_to_stopping_point_xy()
 {

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -255,9 +255,6 @@ public:
     /// init_vel_controller_xyz - initialise the velocity controller - should be called once before the caller attempts to use the controller
     void init_vel_controller_xyz();
 
-    /// set_vel_target - sets target velocity in cm/s in north, east and up directions
-    void set_vel_target(const Vector3f& vel_target);
-
     /// update_velocity_controller_xyz - run the velocity controller - should be called at 100hz or higher
     ///     velocity targets should we set using set_desired_velocity_xyz() method
     ///     callers should use get_roll() and get_pitch() methods and sent to the attitude controller

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -209,6 +209,9 @@ public:
     /// set_xy_target in cm from home
     void set_xy_target(float x, float y);
 
+    /// shift position target target in x, y axis
+    void shift_pos_xy_target(float x_cm, float y_cm);
+
     /// get_desired_velocity - returns xy desired velocity (i.e. feed forward) in cm/s in lat and lon direction
     const Vector3f& get_desired_velocity() { return _vel_desired; }
 

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -171,15 +171,8 @@ void AC_WPNav::init_loiter_target(const Vector3f& position, bool reset_I)
 ///     used by precision landing to adjust horizontal position target
 void AC_WPNav::shift_loiter_target(const Vector3f &pos_adjustment)
 {
-    Vector3f new_target = _pos_control.get_pos_target() + pos_adjustment;
-
     // move pos controller target
-    _pos_control.set_xy_target(new_target.x, new_target.y);
-
-    // disable feed forward
-    if (fabsf(pos_adjustment.x) > 0.0f || fabsf(pos_adjustment.y) > 0.0f) {
-        _pos_control.freeze_ff_xy();
-    }
+    _pos_control.shift_pos_xy_target(pos_adjustment.x, pos_adjustment.y);
 }
 
 /// init_loiter_target - initialize's loiter position and feed-forward velocity from current pos and velocity

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -112,6 +112,7 @@ AC_WPNav::AC_WPNav(const AP_InertialNav& inav, const AP_AHRS& ahrs, AC_PosContro
     _loiter_step(0),
     _pilot_accel_fwd_cms(0),
     _pilot_accel_rgt_cms(0),
+    _loiter_ekf_pos_reset_ms(0),
     _wp_last_update(0),
     _wp_step(0),
     _track_length(0.0f),
@@ -180,6 +181,9 @@ void AC_WPNav::init_loiter_target()
 {
     const Vector3f& curr_pos = _inav.get_position();
     const Vector3f& curr_vel = _inav.get_velocity();
+
+    // initialise ekf position reset check
+    init_ekf_position_reset();
 
     // initialise position controller
     _pos_control.init_xy_controller();
@@ -323,6 +327,9 @@ void AC_WPNav::update_loiter(float ekfGndSpdLimit, float ekfNavVelGainScaler)
         if (dt >= 0.2f) {
             dt = 0.0f;
         }
+        // initialise ekf position reset check
+        check_for_ekf_position_reset();
+
         calc_loiter_desired_velocity(dt,ekfGndSpdLimit);
         _pos_control.update_xy_controller(AC_PosControl::XY_MODE_POS_LIMITED_AND_VEL_FF, ekfNavVelGainScaler, true);
     }
@@ -333,6 +340,9 @@ void AC_WPNav::init_brake_target(float accel_cmss)
 {
     const Vector3f& curr_vel = _inav.get_velocity();
     Vector3f stopping_point;
+
+    // initialise ekf position reset check
+    init_ekf_position_reset();
 
     // initialise position controller
     _pos_control.init_xy_controller();
@@ -1045,5 +1055,24 @@ float AC_WPNav::get_slow_down_speed(float dist_from_dest_cm, float accel_cmss)
         return WPNAV_WP_TRACK_SPEED_MIN;
     } else {
         return target_speed;
+    }
+}
+
+/// initialise ekf position reset check
+void AC_WPNav::init_ekf_position_reset()
+{
+    Vector2f pos_shift;
+    _loiter_ekf_pos_reset_ms = _ahrs.getLastPosNorthEastReset(pos_shift);
+}
+
+/// check for ekf position reset and adjust loiter or brake target position
+void AC_WPNav::check_for_ekf_position_reset()
+{
+    // check for position shift
+    Vector2f pos_shift;
+    uint32_t reset_ms = _ahrs.getLastPosNorthEastReset(pos_shift);
+    if (reset_ms != _loiter_ekf_pos_reset_ms) {
+        _pos_control.shift_pos_xy_target(pos_shift.x * 100.0f, pos_shift.y * 100.0f);
+        _loiter_ekf_pos_reset_ms = reset_ms;
     }
 }

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -257,6 +257,10 @@ protected:
     /// get_slow_down_speed - returns target speed of target point based on distance from the destination (in cm)
     float get_slow_down_speed(float dist_from_dest_cm, float accel_cmss);
 
+    /// initialise and check for ekf position reset and adjust loiter or brake target position
+    void init_ekf_position_reset();
+    void check_for_ekf_position_reset();
+
     /// spline protected functions
 
     /// update_spline_solution - recalculates hermite_spline_solution grid
@@ -292,6 +296,7 @@ protected:
     int16_t     _pilot_accel_fwd_cms; 	// pilot's desired acceleration forward (body-frame)
     int16_t     _pilot_accel_rgt_cms;   // pilot's desired acceleration right (body-frame)
     Vector2f    _loiter_desired_accel;  // slewed pilot's desired acceleration in lat/lon frame
+    uint32_t    _loiter_ekf_pos_reset_ms;   // system time of last recorded ekf position reset
 
     // waypoint controller internal variables
     uint32_t    _wp_last_update;        // time of last update_wpnav call

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -394,13 +394,13 @@ public:
 
     // return the amount of NE position change in metres due to the last reset
     // returns the time of the last reset or 0 if no reset has ever occurred
-    virtual uint32_t getLastPosNorthEastReset(Vector2f &pos) {
+    virtual uint32_t getLastPosNorthEastReset(Vector2f &pos) const {
         return 0;
     };
 
     // return the amount of NE velocity change in metres/sec due to the last reset
     // returns the time of the last reset or 0 if no reset has ever occurred
-    virtual uint32_t getLastVelNorthEastReset(Vector2f &vel) {
+    virtual uint32_t getLastVelNorthEastReset(Vector2f &vel) const {
         return 0;
     };
 

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -388,8 +388,8 @@ public:
 
     // return the amount of yaw angle change due to the last yaw angle reset in radians
     // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
-    virtual uint32_t getLastYawResetAngle(float &yawAng) {
-        return false;
+    virtual uint32_t getLastYawResetAngle(float &yawAng) const {
+        return 0;
     };
 
     // return the amount of NE position change in metres due to the last reset

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -392,6 +392,18 @@ public:
         return false;
     };
 
+    // return the amount of NE position change in metres due to the last reset
+    // returns the time of the last reset or 0 if no reset has ever occurred
+    virtual uint32_t getLastPosNorthEastReset(Vector2f &pos) {
+        return 0;
+    };
+
+    // return the amount of NE velocity change in metres/sec due to the last reset
+    // returns the time of the last reset or 0 if no reset has ever occurred
+    virtual uint32_t getLastVelNorthEastReset(Vector2f &vel) {
+        return 0;
+    };
+
     // Resets the baro so that it reads zero at the current height
     // Resets the EKF height to zero
     // Adjusts the EKf origin height so that the EKF height + origin height is the same as before

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -729,7 +729,7 @@ const char *AP_AHRS_NavEKF::prearm_failure_reason(void) const
 
 // return the amount of yaw angle change due to the last yaw angle reset in radians
 // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
-uint32_t AP_AHRS_NavEKF::getLastYawResetAngle(float &yawAng)
+uint32_t AP_AHRS_NavEKF::getLastYawResetAngle(float &yawAng) const
 {
     switch (ekf_type()) {
     case 1:
@@ -737,7 +737,7 @@ uint32_t AP_AHRS_NavEKF::getLastYawResetAngle(float &yawAng)
     case 2:
         return EKF2.getLastYawResetAngle(yawAng);
     }
-    return false;
+    return 0;
 }
 
 // return the amount of NE position change in metres due to the last reset

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -742,7 +742,7 @@ uint32_t AP_AHRS_NavEKF::getLastYawResetAngle(float &yawAng) const
 
 // return the amount of NE position change in metres due to the last reset
 // returns the time of the last reset or 0 if no reset has ever occurred
-uint32_t AP_AHRS_NavEKF::getLastPosNorthEastReset(Vector2f &pos)
+uint32_t AP_AHRS_NavEKF::getLastPosNorthEastReset(Vector2f &pos) const
 {
     switch (ekf_type()) {
     case 1:
@@ -755,7 +755,7 @@ uint32_t AP_AHRS_NavEKF::getLastPosNorthEastReset(Vector2f &pos)
 
 // return the amount of NE velocity change in metres/sec due to the last reset
 // returns the time of the last reset or 0 if no reset has ever occurred
-uint32_t AP_AHRS_NavEKF::getLastVelNorthEastReset(Vector2f &vel)
+uint32_t AP_AHRS_NavEKF::getLastVelNorthEastReset(Vector2f &vel) const
 {
     switch (ekf_type()) {
     case 1:

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -740,6 +740,32 @@ uint32_t AP_AHRS_NavEKF::getLastYawResetAngle(float &yawAng)
     return false;
 }
 
+// return the amount of NE position change in metres due to the last reset
+// returns the time of the last reset or 0 if no reset has ever occurred
+uint32_t AP_AHRS_NavEKF::getLastPosNorthEastReset(Vector2f &pos)
+{
+    switch (ekf_type()) {
+    case 1:
+        return EKF1.getLastPosNorthEastReset(pos);
+    case 2:
+        return EKF2.getLastPosNorthEastReset(pos);
+    }
+    return 0;
+}
+
+// return the amount of NE velocity change in metres/sec due to the last reset
+// returns the time of the last reset or 0 if no reset has ever occurred
+uint32_t AP_AHRS_NavEKF::getLastVelNorthEastReset(Vector2f &vel)
+{
+    switch (ekf_type()) {
+    case 1:
+        return EKF1.getLastVelNorthEastReset(vel);
+    case 2:
+        return EKF2.getLastVelNorthEastReset(vel);
+    }
+    return 0;
+}
+
 // Resets the baro so that it reads zero at the current height
 // Resets the EKF height to zero
 // Adjusts the EKf origin height so that the EKF height + origin height is the same as before

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -167,6 +167,14 @@ public:
     // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
     uint32_t getLastYawResetAngle(float &yawAng);
 
+    // return the amount of NE position change in metres due to the last reset
+    // returns the time of the last reset or 0 if no reset has ever occurred
+    uint32_t getLastPosNorthEastReset(Vector2f &pos);
+
+    // return the amount of NE velocity change in metres/sec due to the last reset
+    // returns the time of the last reset or 0 if no reset has ever occurred
+    uint32_t getLastVelNorthEastReset(Vector2f &vel);
+
     // Resets the baro so that it reads zero at the current height
     // Resets the EKF height to zero
     // Adjusts the EKf origin height so that the EKF height + origin height is the same as before

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -165,7 +165,7 @@ public:
 
     // return the amount of yaw angle change due to the last yaw angle reset in radians
     // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
-    uint32_t getLastYawResetAngle(float &yawAng);
+    uint32_t getLastYawResetAngle(float &yawAng) const;
 
     // return the amount of NE position change in metres due to the last reset
     // returns the time of the last reset or 0 if no reset has ever occurred

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -169,11 +169,11 @@ public:
 
     // return the amount of NE position change in metres due to the last reset
     // returns the time of the last reset or 0 if no reset has ever occurred
-    uint32_t getLastPosNorthEastReset(Vector2f &pos);
+    uint32_t getLastPosNorthEastReset(Vector2f &pos) const;
 
     // return the amount of NE velocity change in metres/sec due to the last reset
     // returns the time of the last reset or 0 if no reset has ever occurred
-    uint32_t getLastVelNorthEastReset(Vector2f &vel);
+    uint32_t getLastVelNorthEastReset(Vector2f &vel) const;
 
     // Resets the baro so that it reads zero at the current height
     // Resets the EKF height to zero

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -5616,6 +5616,22 @@ uint32_t NavEKF::getLastYawResetAngle(float &yawAng)
     return lastYawReset_ms;
 }
 
+// return the amount of NE position change due to the last position reset in metres
+// returns the time of the last reset or 0 if no reset has ever occurred
+uint32_t NavEKF::getLastPosNorthEastReset(Vector2f &pos)
+{
+    pos = posResetNE;
+    return lastPosReset_ms;
+}
+
+// return the amount of NE velocity change due to the last velocity reset in metres/sec
+// returns the time of the last reset or 0 if no reset has ever occurred
+uint32_t NavEKF::getLastVelNorthEastReset(Vector2f &vel)
+{
+    vel = velResetNE;
+    return lastVelReset_ms;
+}
+
 // Check for signs of bad gyro health before flight
 bool NavEKF::checkGyroHealthPreFlight(void) const
 {

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -5592,7 +5592,7 @@ uint32_t NavEKF::getLastYawResetAngle(float &yawAng) const
 
 // return the amount of NE position change due to the last position reset in metres
 // returns the time of the last reset or 0 if no reset has ever occurred
-uint32_t NavEKF::getLastPosNorthEastReset(Vector2f &pos)
+uint32_t NavEKF::getLastPosNorthEastReset(Vector2f &pos) const
 {
     pos = posResetNE;
     return lastPosReset_ms;
@@ -5600,7 +5600,7 @@ uint32_t NavEKF::getLastPosNorthEastReset(Vector2f &pos)
 
 // return the amount of NE velocity change due to the last velocity reset in metres/sec
 // returns the time of the last reset or 0 if no reset has ever occurred
-uint32_t NavEKF::getLastVelNorthEastReset(Vector2f &vel)
+uint32_t NavEKF::getLastVelNorthEastReset(Vector2f &vel) const
 {
     vel = velResetNE;
     return lastVelReset_ms;

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -5584,7 +5584,7 @@ void NavEKF::alignMagStateDeclination()
 
 // return the amount of yaw angle change due to the last yaw angle reset in radians
 // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
-uint32_t NavEKF::getLastYawResetAngle(float &yawAng)
+uint32_t NavEKF::getLastYawResetAngle(float &yawAng) const
 {
     yawAng = yawResetAngle;
     return lastYawReset_ms;

--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -282,11 +282,11 @@ public:
 
     // return the amount of NE position change due to the last position reset in metres
     // returns the time of the last reset or 0 if no reset has ever occurred
-    uint32_t getLastPosNorthEastReset(Vector2f &pos);
+    uint32_t getLastPosNorthEastReset(Vector2f &pos) const;
 
     // return the amount of NE velocity change due to the last velocity reset in metres/sec
     // returns the time of the last reset or 0 if no reset has ever occurred
-    uint32_t getLastVelNorthEastReset(Vector2f &vel);
+    uint32_t getLastVelNorthEastReset(Vector2f &vel) const;
 
     // report any reason for why the backend is refusing to initialise
     const char *prearm_failure_reason(void) const;

--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -278,7 +278,7 @@ public:
 
     // return the amount of yaw angle change due to the last yaw angle reset in radians
     // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
-    uint32_t getLastYawResetAngle(float &yawAng);
+    uint32_t getLastYawResetAngle(float &yawAng) const;
 
     // return the amount of NE position change due to the last position reset in metres
     // returns the time of the last reset or 0 if no reset has ever occurred

--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -280,7 +280,15 @@ public:
     // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
     uint32_t getLastYawResetAngle(float &yawAng);
 
-    // report any reason for why the backend is refusing to initialise    
+    // return the amount of NE position change due to the last position reset in metres
+    // returns the time of the last reset or 0 if no reset has ever occurred
+    uint32_t getLastPosNorthEastReset(Vector2f &pos);
+
+    // return the amount of NE velocity change due to the last velocity reset in metres/sec
+    // returns the time of the last reset or 0 if no reset has ever occurred
+    uint32_t getLastVelNorthEastReset(Vector2f &vel);
+
+    // report any reason for why the backend is refusing to initialise
     const char *prearm_failure_reason(void) const;
 
     static const struct AP_Param::GroupInfo var_info[];
@@ -721,6 +729,11 @@ private:
     float posDownDerivative;        // Rate of chage of vertical position (dPosD/dt) in m/s. This is the first time derivative of PosD.
     float posDown;                  // Down position state used in calculation of posDownRate
     Vector3f delAngBiasAtArming;      // value of the gyro delta angle bias at arming
+    Vector2f posResetNE;            // Change in North/East position due to last in-flight reset in metres. Returned by getLastPosNorthEastReset
+    uint32_t lastPosReset_ms;       // System time at which the last position reset occurred. Returned by getLastPosNorthEastReset
+    Vector2f velResetNE;            // Change in North/East velocity due to last in-flight reset in metres/sec. Returned by getLastVelNorthEastReset
+    uint32_t lastVelReset_ms;       // System time at which the last velocity reset occurred. Returned by getLastVelNorthEastReset
+
 
     // Used by smoothing of state corrections
     Vector10 gpsIncrStateDelta;    // vector of corrections to attitude, velocity and position to be applied over the period between the current and next GPS measurement

--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -438,10 +438,6 @@ private:
     // return true if the vehicle code has requested the filter to be ready for flight
     bool getVehicleArmStatus(void) const;
 
-    // decay GPS horizontal position offset to close to zero at a rate of 1 m/s
-    // this allows large GPS position jumps to be accomodated gradually
-    void decayGpsOffset(void);
-
     // Check for filter divergence
     void checkDivergence(void);
 
@@ -686,7 +682,6 @@ private:
     Vector8 SPP;                    // intermediate variables used to calculate predicted covariance matrix
     float IMU1_weighting;           // Weighting applied to use of IMU1. Varies between 0 and 1.
     bool yawAligned;                // true when the yaw angle has been aligned
-    Vector2f gpsPosGlitchOffsetNE;  // offset applied to GPS data in the NE direction to compensate for rapid changes in GPS solution
     Vector2f lastKnownPositionNE;   // last known position
     uint32_t lastDecayTime_ms;      // time of last decay of GPS position offset
     float velTestRatio;             // sum of squares of GPS velocity innovation divided by fail threshold
@@ -700,7 +695,6 @@ private:
     bool firstMagYawInit;           // true when the first post takeoff initialisation of earth field and yaw angle has been performed
     bool secondMagYawInit;          // true when the second post takeoff initialisation of earth field and yaw angle has been performed
     bool flowTimeout;               // true when optical flow measurements have time out
-    Vector2f gpsVelGlitchOffset;    // Offset applied to the GPS velocity when the gltch radius is being  decayed back to zero
     bool gpsNotAvailable;           // bool true when valid GPS data is not available
     bool vehicleArmed;              // true when the vehicle is disarmed
     bool prevVehicleArmed;          // vehicleArmed from previous frame

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -819,20 +819,20 @@ uint32_t NavEKF2::getLastYawResetAngle(float &yawAng) const
 
 // return the amount of NE position change due to the last position reset in metres
 // returns the time of the last reset or 0 if no reset has ever occurred
-uint32_t NavEKF2::getLastPosNorthEastReset(Vector2f &pos)
+uint32_t NavEKF2::getLastPosNorthEastReset(Vector2f &pos) const
 {
     if (!core) {
-        return false;
+        return 0;
     }
     return core->getLastPosNorthEastReset(pos);
 }
 
 // return the amount of NE velocity change due to the last velocity reset in metres/sec
 // returns the time of the last reset or 0 if no reset has ever occurred
-uint32_t NavEKF2::getLastVelNorthEastReset(Vector2f &vel)
+uint32_t NavEKF2::getLastVelNorthEastReset(Vector2f &vel) const
 {
     if (!core) {
-        return false;
+        return 0;
     }
     return core->getLastVelNorthEastReset(vel);
 }

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -809,10 +809,10 @@ bool NavEKF2::getHeightControlLimit(float &height) const
 
 // return the amount of yaw angle change due to the last yaw angle reset in radians
 // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
-uint32_t NavEKF2::getLastYawResetAngle(float &yawAng)
+uint32_t NavEKF2::getLastYawResetAngle(float &yawAng) const
 {
     if (!core) {
-        return false;
+        return 0;
     }
     return core->getLastYawResetAngle(yawAng);
 }

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -817,4 +817,24 @@ uint32_t NavEKF2::getLastYawResetAngle(float &yawAng)
     return core->getLastYawResetAngle(yawAng);
 }
 
+// return the amount of NE position change due to the last position reset in metres
+// returns the time of the last reset or 0 if no reset has ever occurred
+uint32_t NavEKF2::getLastPosNorthEastReset(Vector2f &pos)
+{
+    if (!core) {
+        return false;
+    }
+    return core->getLastPosNorthEastReset(pos);
+}
+
+// return the amount of NE velocity change due to the last velocity reset in metres/sec
+// returns the time of the last reset or 0 if no reset has ever occurred
+uint32_t NavEKF2::getLastVelNorthEastReset(Vector2f &vel)
+{
+    if (!core) {
+        return false;
+    }
+    return core->getLastVelNorthEastReset(vel);
+}
+
 #endif //HAL_CPU_CLASS

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -227,6 +227,14 @@ public:
     // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
     uint32_t getLastYawResetAngle(float &yawAng);
 
+    // return the amount of NE position change due to the last position reset in metres
+    // returns the time of the last reset or 0 if no reset has ever occurred
+    uint32_t getLastPosNorthEastReset(Vector2f &pos);
+
+    // return the amount of NE velocity change due to the last velocity reset in metres/sec
+    // returns the time of the last reset or 0 if no reset has ever occurred
+    uint32_t getLastVelNorthEastReset(Vector2f &vel);
+
     // allow the enable flag to be set by Replay
     void set_enable(bool enable) { _enable.set(enable); }
     

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -225,7 +225,7 @@ public:
 
     // return the amount of yaw angle change due to the last yaw angle reset in radians
     // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
-    uint32_t getLastYawResetAngle(float &yawAng);
+    uint32_t getLastYawResetAngle(float &yawAng) const;
 
     // return the amount of NE position change due to the last position reset in metres
     // returns the time of the last reset or 0 if no reset has ever occurred

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -229,11 +229,11 @@ public:
 
     // return the amount of NE position change due to the last position reset in metres
     // returns the time of the last reset or 0 if no reset has ever occurred
-    uint32_t getLastPosNorthEastReset(Vector2f &pos);
+    uint32_t getLastPosNorthEastReset(Vector2f &pos) const;
 
     // return the amount of NE velocity change due to the last velocity reset in metres/sec
     // returns the time of the last reset or 0 if no reset has ever occurred
-    uint32_t getLastVelNorthEastReset(Vector2f &vel);
+    uint32_t getLastVelNorthEastReset(Vector2f &vel) const;
 
     // allow the enable flag to be set by Replay
     void set_enable(bool enable) { _enable.set(enable); }

--- a/libraries/AP_NavEKF2/AP_NavEKF2_AirDataFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_AirDataFusion.cpp
@@ -54,8 +54,8 @@ void NavEKF2_core::FuseAirspeed()
     vwn = stateStruct.wind_vel.x;
     vwe = stateStruct.wind_vel.y;
 
-    // calculate the predicted airspeed, compensating for bias in GPS velocity when we are pulling a glitch offset back in
-    VtasPred = pythagorous3((ve - gpsVelGlitchOffset.y - vwe) , (vn - gpsVelGlitchOffset.x - vwn) , vd);
+    // calculate the predicted airspeed
+    VtasPred = pythagorous3((ve - vwe) , (vn - vwn) , vd);
     // perform fusion of True Airspeed measurement
     if (VtasPred > 1.0f)
     {
@@ -330,9 +330,9 @@ void NavEKF2_core::FuseSideslip()
     vwn = stateStruct.wind_vel.x;
     vwe = stateStruct.wind_vel.y;
 
-    // calculate predicted wind relative velocity in NED, compensating for offset in velcity when we are pulling a GPS glitch offset back in
-    vel_rel_wind.x = vn - vwn - gpsVelGlitchOffset.x;
-    vel_rel_wind.y = ve - vwe - gpsVelGlitchOffset.y;
+    // calculate predicted wind relative velocity in NED
+    vel_rel_wind.x = vn - vwn;
+    vel_rel_wind.y = ve - vwe;
     vel_rel_wind.z = vd;
 
     // rotate into body axes

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -583,7 +583,7 @@ void NavEKF2_core::readGpsData()
                 ResetVelocity();
                 ResetPosition();
 
-                // Reset the normalised innovation to avoid false failing the bad position fusion test
+                // Reset the normalised innovation to avoid false failing bad fusion tests
                 velTestRatio = 0.0f;
                 posTestRatio = 0.0f;
             }

--- a/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
@@ -183,7 +183,6 @@ void NavEKF2_core::EstimateTerrainOffset()
 
         if (fuseOptFlowData) {
 
-            Vector3f vel; // velocity of sensor relative to ground in NED axes
             Vector3f relVelSensor; // velocity of sensor relative to ground in sensor axes
             float losPred; // predicted optical flow angular rate measurement
             float q0 = stateStruct.quat[0]; // quaternion at optical flow measurement time
@@ -193,11 +192,6 @@ void NavEKF2_core::EstimateTerrainOffset()
             float K_OPT;
             float H_OPT;
 
-            // Correct velocities for GPS glitch recovery offset
-            vel.x          = stateStruct.velocity[0] - gpsVelGlitchOffset.x;
-            vel.y          = stateStruct.velocity[1] - gpsVelGlitchOffset.y;
-            vel.z          = stateStruct.velocity[2];
-
             // predict range to centre of image
             float flowRngPred = max((terrainState - stateStruct.position[2]),rngOnGnd) / Tnb_flow.c.z;
 
@@ -205,7 +199,7 @@ void NavEKF2_core::EstimateTerrainOffset()
             terrainState = max(terrainState, stateStruct.position[2] + rngOnGnd);
 
             // calculate relative velocity in sensor frame
-            relVelSensor = Tnb_flow*vel;
+            relVelSensor = Tnb_flow*stateStruct.velocity;
 
             // divide velocity by range, subtract body rates and apply scale factor to
             // get predicted sensed angular optical rates relative to X and Y sensor axes
@@ -222,25 +216,25 @@ void NavEKF2_core::EstimateTerrainOffset()
             float t10 = q0*q3*2.0f;
             float t11 = q1*q2*2.0f;
             float t14 = t3+t4-t5-t6;
-            float t15 = t14*vel.x;
+            float t15 = t14*stateStruct.velocity.x;
             float t16 = t10+t11;
-            float t17 = t16*vel.y;
+            float t17 = t16*stateStruct.velocity.y;
             float t18 = q0*q2*2.0f;
             float t19 = q1*q3*2.0f;
             float t20 = t18-t19;
-            float t21 = t20*vel.z;
+            float t21 = t20*stateStruct.velocity.z;
             float t2 = t15+t17-t21;
             float t7 = t3-t4-t5+t6;
             float t8 = stateStruct.position[2]-terrainState;
             float t9 = 1.0f/sq(t8);
             float t24 = t3-t4+t5-t6;
-            float t25 = t24*vel.y;
+            float t25 = t24*stateStruct.velocity.y;
             float t26 = t10-t11;
-            float t27 = t26*vel.x;
+            float t27 = t26*stateStruct.velocity.x;
             float t28 = q0*q1*2.0f;
             float t29 = q2*q3*2.0f;
             float t30 = t28+t29;
-            float t31 = t30*vel.z;
+            float t31 = t30*stateStruct.velocity.z;
             float t12 = t25-t27+t31;
             float t13 = sq(t7);
             float t22 = sq(t2);
@@ -288,7 +282,6 @@ void NavEKF2_core::EstimateTerrainOffset()
 void NavEKF2_core::FuseOptFlow()
 {
     Vector24 H_LOS;
-    Vector3f velNED_local;
     Vector3f relVelSensor;
     Vector14 SH_LOS;
     Vector2 losPred;
@@ -302,11 +295,6 @@ void NavEKF2_core::FuseOptFlow()
     float ve = stateStruct.velocity.y;
     float vd = stateStruct.velocity.z;
     float pd = stateStruct.position.z;
-
-    // Correct velocities for GPS glitch recovery offset
-    velNED_local.x = vn - gpsVelGlitchOffset.x;
-    velNED_local.y = ve - gpsVelGlitchOffset.y;
-    velNED_local.z = vd;
 
     // constrain height above ground to be above range measured on ground
     float heightAboveGndEst = max((terrainState - pd), rngOnGnd);
@@ -334,7 +322,7 @@ void NavEKF2_core::FuseOptFlow()
         float range = constrain_float((heightAboveGndEst/Tnb_flow.c.z),rngOnGnd,1000.0f);
 
         // calculate relative velocity in sensor frame
-        relVelSensor = Tnb_flow*velNED_local;
+        relVelSensor = Tnb_flow*stateStruct.velocity;
 
         // divide velocity by range  to get predicted angular LOS rates relative to X and Y axes
         losPred[0] =  relVelSensor.y/range;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -128,6 +128,22 @@ uint32_t NavEKF2_core::getLastYawResetAngle(float &yawAng)
     return lastYawReset_ms;
 }
 
+// return the amount of NE position change due to the last position reset in metres
+// returns the time of the last reset or 0 if no reset has ever occurred
+uint32_t NavEKF2_core::getLastPosNorthEastReset(Vector2f &pos)
+{
+    pos = posResetNE;
+    return lastPosReset_ms;
+}
+
+// return the amount of NE velocity change due to the last velocity reset in metres/sec
+// returns the time of the last reset or 0 if no reset has ever occurred
+uint32_t NavEKF2_core::getLastVelNorthEastReset(Vector2f &vel)
+{
+    vel = velResetNE;
+    return lastVelReset_ms;
+}
+
 // return the NED wind speed estimates in m/s (positive is air moving in the direction of the axis)
 void NavEKF2_core::getWind(Vector3f &wind) const
 {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -130,7 +130,7 @@ uint32_t NavEKF2_core::getLastYawResetAngle(float &yawAng) const
 
 // return the amount of NE position change due to the last position reset in metres
 // returns the time of the last reset or 0 if no reset has ever occurred
-uint32_t NavEKF2_core::getLastPosNorthEastReset(Vector2f &pos)
+uint32_t NavEKF2_core::getLastPosNorthEastReset(Vector2f &pos) const
 {
     pos = posResetNE;
     return lastPosReset_ms;
@@ -138,7 +138,7 @@ uint32_t NavEKF2_core::getLastPosNorthEastReset(Vector2f &pos)
 
 // return the amount of NE velocity change due to the last velocity reset in metres/sec
 // returns the time of the last reset or 0 if no reset has ever occurred
-uint32_t NavEKF2_core::getLastVelNorthEastReset(Vector2f &vel)
+uint32_t NavEKF2_core::getLastVelNorthEastReset(Vector2f &vel) const
 {
     vel = velResetNE;
     return lastVelReset_ms;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -122,7 +122,7 @@ void NavEKF2_core::getQuaternion(Quaternion& ret) const
 
 // return the amount of yaw angle change due to the last yaw angle reset in radians
 // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
-uint32_t NavEKF2_core::getLastYawResetAngle(float &yawAng)
+uint32_t NavEKF2_core::getLastYawResetAngle(float &yawAng) const
 {
     yawAng = yawResetAngle;
     return lastYawReset_ms;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -337,7 +337,7 @@ void  NavEKF2_core::getInnovations(Vector3f &velInnov, Vector3f &posInnov, Vecto
 
 // return the innovation consistency test ratios for the velocity, position, magnetometer and true airspeed measurements
 // this indicates the amount of margin available when tuning the various error traps
-// also return the current offsets applied to the GPS position measurements
+// also return the delta in position due to the last position reset
 void  NavEKF2_core::getVariances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar, Vector2f &offset) const
 {
     velVar   = sqrtf(velTestRatio);
@@ -347,7 +347,7 @@ void  NavEKF2_core::getVariances(float &velVar, float &posVar, float &hgtVar, Ve
     magVar.y = sqrtf(magTestRatio.y);
     magVar.z = sqrtf(magTestRatio.z);
     tasVar   = sqrtf(tasTestRatio);
-    offset   = gpsPosGlitchOffsetNE;
+    offset   = posResetNE;
 }
 
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -21,12 +21,16 @@ extern const AP_HAL::HAL& hal;
 // Do not reset vertical velocity using GPS as there is baro alt available to constrain drift
 void NavEKF2_core::ResetVelocity(void)
 {
+    // Store the position before the reset so that we can record the reset delta
+    velResetNE.x = stateStruct.velocity.x;
+    velResetNE.y = stateStruct.velocity.y;
+
     if (PV_AidingMode != AID_ABSOLUTE) {
         stateStruct.velocity.zero();
     } else if (!gpsNotAvailable) {
-        // reset horizontal velocity states, applying an offset to the GPS velocity to prevent the GPS position being rejected when the GPS position offset is being decayed to zero.
-        stateStruct.velocity.x  = gpsDataNew.vel.x + gpsVelGlitchOffset.x; // north velocity from blended accel data
-        stateStruct.velocity.y  = gpsDataNew.vel.y + gpsVelGlitchOffset.y; // east velocity from blended accel data
+        // reset horizontal velocity states to the GPS velocity
+        stateStruct.velocity.x  = gpsDataNew.vel.x; // north velocity from blended accel data
+        stateStruct.velocity.y  = gpsDataNew.vel.y; // east velocity from blended accel data
     }
     for (uint8_t i=0; i<IMU_BUFFER_LENGTH; i++) {
         storedOutput[i].velocity.x = stateStruct.velocity.x;
@@ -36,19 +40,30 @@ void NavEKF2_core::ResetVelocity(void)
     outputDataNew.velocity.y = stateStruct.velocity.y;
     outputDataDelayed.velocity.x = stateStruct.velocity.x;
     outputDataDelayed.velocity.y = stateStruct.velocity.y;
+
+    // Calculate the position jump due to the reset
+    velResetNE.x = stateStruct.velocity.x - velResetNE.x;
+    velResetNE.y = stateStruct.velocity.y - velResetNE.y;
+
+    // store the time of the reset
+    lastVelReset_ms = imuSampleTime_ms;
 }
 
 // resets position states to last GPS measurement or to zero if in constant position mode
 void NavEKF2_core::ResetPosition(void)
 {
+    // Store the position before the reset so that we can record the reset delta
+    posResetNE.x = stateStruct.position.x;
+    posResetNE.y = stateStruct.position.y;
+
     if (PV_AidingMode != AID_ABSOLUTE) {
         // reset all position state history to the last known position
         stateStruct.position.x = lastKnownPositionNE.x;
         stateStruct.position.y = lastKnownPositionNE.y;
     } else if (!gpsNotAvailable) {
         // write to state vector and compensate for offset  between last GPs measurement and the EKF time horizon
-        stateStruct.position.x = gpsDataNew.pos.x + gpsPosGlitchOffsetNE.x + 0.001f*gpsDataNew.vel.x*(float(imuDataDelayed.time_ms) - float(lastTimeGpsReceived_ms));
-        stateStruct.position.y = gpsDataNew.pos.y + gpsPosGlitchOffsetNE.y + 0.001f*gpsDataNew.vel.y*(float(imuDataDelayed.time_ms) - float(lastTimeGpsReceived_ms));
+        stateStruct.position.x = gpsDataNew.pos.x  + 0.001f*gpsDataNew.vel.x*(float(imuDataDelayed.time_ms) - float(lastTimeGpsReceived_ms));
+        stateStruct.position.y = gpsDataNew.pos.y  + 0.001f*gpsDataNew.vel.y*(float(imuDataDelayed.time_ms) - float(lastTimeGpsReceived_ms));
     }
     for (uint8_t i=0; i<IMU_BUFFER_LENGTH; i++) {
         storedOutput[i].position.x = stateStruct.position.x;
@@ -58,6 +73,13 @@ void NavEKF2_core::ResetPosition(void)
     outputDataNew.position.y = stateStruct.position.y;
     outputDataDelayed.position.x = stateStruct.position.x;
     outputDataDelayed.position.y = stateStruct.position.y;
+
+    // Calculate the position jump due to the reset
+    posResetNE.x = stateStruct.position.x - posResetNE.x;
+    posResetNE.y = stateStruct.position.y - posResetNE.y;
+
+    // store the time of the reset
+    lastPosReset_ms = imuSampleTime_ms;
 }
 
 // reset the vertical position state using the last height measurement
@@ -218,11 +240,11 @@ void NavEKF2_core::FuseVelPosNED()
         else gpsRetryTime = frontend.gpsRetryTimeNoTAS_ms;
 
         // form the observation vector
-        observation[0] = gpsDataDelayed.vel.x + gpsVelGlitchOffset.x;
-        observation[1] = gpsDataDelayed.vel.y + gpsVelGlitchOffset.y;
+        observation[0] = gpsDataDelayed.vel.x;
+        observation[1] = gpsDataDelayed.vel.y;
         observation[2] = gpsDataDelayed.vel.z;
-        observation[3] = gpsDataDelayed.pos.x + gpsPosGlitchOffsetNE.x;
-        observation[4] = gpsDataDelayed.pos.y + gpsPosGlitchOffsetNE.y;
+        observation[3] = gpsDataDelayed.pos.x;
+        observation[4] = gpsDataDelayed.pos.y;
         observation[5] = -baroDataDelayed.hgt;
 
         // calculate additional error in GPS position caused by manoeuvring
@@ -304,13 +326,9 @@ void NavEKF2_core::FuseVelPosNED()
                 // only reset the failed time and do glitch timeout checks if we are doing full aiding
                 if (PV_AidingMode == AID_ABSOLUTE) {
                     lastPosPassTime_ms = imuSampleTime_ms;
-                    // if timed out or outside the specified uncertainty radius, increment the offset applied to GPS data to compensate for large GPS position jumps
+                    // if timed out or outside the specified uncertainty radius, reset to the GPS
                     if (posTimeout || ((P[6][6] + P[7][7]) > sq(float(frontend._gpsGlitchRadiusMax)))) {
-                        gpsPosGlitchOffsetNE.x += innovVelPos[3];
-                        gpsPosGlitchOffsetNE.y += innovVelPos[4];
-                        // limit the radius of the offset and decay the offset to zero radially
-                        decayGpsOffset();
-                        // reset the position to the current GPS position which will include the glitch correction offset
+                        // reset the position to the current GPS position
                         ResetPosition();
                         // reset the velocity to the GPS velocity
                         ResetVelocity();

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -378,8 +378,8 @@ void NavEKF2_core::FuseVelPosNED()
             velHealth = ((velTestRatio < 1.0f)  || badIMUdata);
             // declare a timeout if we have not fused velocity data for too long or not aiding
             velTimeout = (((imuSampleTime_ms - lastVelPassTime_ms) > gpsRetryTime) || PV_AidingMode == AID_NONE);
-            // use velocity data if healthy, timed out, or in constant position mode
-            if (velHealth || velTimeout || (PV_AidingMode == AID_NONE)) {
+            // use velocity data if healthy or timed out
+            if (velHealth || velTimeout) {
                 velHealth = true;
                 // restart the timeout count
                 lastVelPassTime_ms = imuSampleTime_ms;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -91,6 +91,8 @@ void NavEKF2_core::InitialiseVariables()
     timeTasReceived_ms = 0;
     magYawResetTimer_ms = imuSampleTime_ms;
     lastPreAlignGpsCheckTime_ms = imuSampleTime_ms;
+    lastPosReset_ms = 0;
+    lastVelReset_ms = 0;
 
     // initialise other variables
     gpsNoiseScaler = 1.0f;
@@ -106,7 +108,6 @@ void NavEKF2_core::InitialiseVariables()
     velDotNEDfilt.zero();
     summedDelAng.zero();
     summedDelVel.zero();
-    gpsPosGlitchOffsetNE.zero();
     lastKnownPositionNE.zero();
     prevTnb.zero();
     memset(&P[0][0], 0, sizeof(P));
@@ -127,7 +128,6 @@ void NavEKF2_core::InitialiseVariables()
     PV_AidingMode = AID_NONE;
     posTimeout = true;
     velTimeout = true;
-    gpsVelGlitchOffset.zero();
     isAiding = false;
     prevIsAiding = false;
     memset(&faultStatus, 0, sizeof(faultStatus));
@@ -195,6 +195,8 @@ void NavEKF2_core::InitialiseVariables()
     airSpdFusionDelayed = false;
     sideSlipFusionDelayed = false;
     magFuseTiltInhibit = false;
+    posResetNE.zero();
+    velResetNE.zero();
 }
 
 // Initialise the states from accelerometer and magnetometer data (if present)

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -250,11 +250,11 @@ public:
 
     // return the amount of NE position change due to the last position reset in metres
     // returns the time of the last reset or 0 if no reset has ever occurred
-    uint32_t getLastPosNorthEastReset(Vector2f &pos);
+    uint32_t getLastPosNorthEastReset(Vector2f &pos) const;
 
     // return the amount of NE velocity change due to the last velocity reset in metres/sec
     // returns the time of the last reset or 0 if no reset has ever occurred
-    uint32_t getLastVelNorthEastReset(Vector2f &vel);
+    uint32_t getLastVelNorthEastReset(Vector2f &vel) const;
 
 private:
     // Reference to the global EKF frontend for parameters

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -246,7 +246,7 @@ public:
 
     // return the amount of yaw angle change due to the last yaw angle reset in radians
     // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
-    uint32_t getLastYawResetAngle(float &yawAng);
+    uint32_t getLastYawResetAngle(float &yawAng) const;
 
     // return the amount of NE position change due to the last position reset in metres
     // returns the time of the last reset or 0 if no reset has ever occurred

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -248,6 +248,14 @@ public:
     // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
     uint32_t getLastYawResetAngle(float &yawAng);
 
+    // return the amount of NE position change due to the last position reset in metres
+    // returns the time of the last reset or 0 if no reset has ever occurred
+    uint32_t getLastPosNorthEastReset(Vector2f &pos);
+
+    // return the amount of NE velocity change due to the last velocity reset in metres/sec
+    // returns the time of the last reset or 0 if no reset has ever occurred
+    uint32_t getLastVelNorthEastReset(Vector2f &vel);
+
 private:
     // Reference to the global EKF frontend for parameters
     NavEKF2 &frontend;
@@ -765,6 +773,10 @@ private:
     bool sideSlipFusionDelayed;     // true when the sideslip fusion has been delayed
     bool magFuseTiltInhibit;        // true when the 3-axis magnetoemter fusion is prevented from changing tilt angle
     uint32_t magFuseTiltInhibit_ms; // time in msec that the condition indicated by magFuseTiltInhibit was commenced
+    Vector2f posResetNE;            // Change in North/East position due to last in-flight reset in metres. Returned by getLastPosNorthEastReset
+    uint32_t lastPosReset_ms;       // System time at which the last position reset occurred. Returned by getLastPosNorthEastReset
+    Vector2f velResetNE;            // Change in North/East velocity due to last in-flight reset in metres/sec. Returned by getLastVelNorthEastReset
+    uint32_t lastVelReset_ms;       // System time at which the last velocity reset occurred. Returned by getLastVelNorthEastReset
 
     // variables used to calulate a vertical velocity that is kinematically consistent with the verical position
     float posDownDerivative;        // Rate of chage of vertical position (dPosD/dt) in m/s. This is the first time derivative of PosD.

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -531,10 +531,6 @@ private:
     // return true if the vehicle code has requested the filter to be ready for flight
     bool readyToUseGPS(void) const;
 
-    // decay GPS horizontal position offset to close to zero at a rate of 1 m/s
-    // this allows large GPS position jumps to be accomodated gradually
-    void decayGpsOffset(void);
-
     // Check for filter divergence
     void checkDivergence(void);
 
@@ -708,7 +704,6 @@ private:
     Vector8 SQ;                     // intermediate variables used to calculate predicted covariance matrix
     Vector23 SPP;                   // intermediate variables used to calculate predicted covariance matrix
     bool yawAligned;                // true when the yaw angle has been aligned
-    Vector2f gpsPosGlitchOffsetNE;  // offset applied to GPS data in the NE direction to compensate for rapid changes in GPS solution
     Vector2f lastKnownPositionNE;   // last known position
     uint32_t lastDecayTime_ms;      // time of last decay of GPS position offset
     float velTestRatio;             // sum of squares of GPS velocity innovation divided by fail threshold
@@ -720,7 +715,6 @@ private:
     bool inhibitMagStates;          // true when magnetic field states and covariances are to remain constant
     bool firstMagYawInit;           // true when the first post takeoff initialisation of earth field and yaw angle has been performed
     bool secondMagYawInit;          // true when the second post takeoff initialisation of earth field and yaw angle has been performed
-    Vector2f gpsVelGlitchOffset;    // Offset applied to the GPS velocity when the gltch radius is being  decayed back to zero
     bool gpsNotAvailable;           // bool true when valid GPS data is not available
     bool isAiding;                  // true when the filter is fusing position, velocity or flow measurements
     bool prevIsAiding;              // isAiding from previous frame

--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -824,7 +824,7 @@ Format characters in the format string for binary log messages
     { LOG_EKF3_MSG, sizeof(log_EKF3), \
       "EKF3","Qcccccchhhc","TimeUS,IVN,IVE,IVD,IPN,IPE,IPD,IMX,IMY,IMZ,IVT" }, \
     { LOG_EKF4_MSG, sizeof(log_EKF4), \
-      "EKF4","QcccccccbbBBHH","TimeUS,SV,SP,SH,SMX,SMY,SMZ,SVT,OFN,EFE,FS,TS,SS,GPS" }, \
+      "EKF4","QcccccccbbBBHH","TimeUS,SV,SP,SH,SMX,SMY,SMZ,SVT,OFN,OFE,FS,TS,SS,GPS" }, \
     { LOG_EKF5_MSG, sizeof(log_EKF5), \
       "EKF5","QBhhhcccCC","TimeUS,normInnov,FIX,FIY,AFI,HAGL,offset,RI,meaRng,errHAGL" }, \
     { LOG_NKF1_MSG, sizeof(log_EKF1), \
@@ -834,7 +834,7 @@ Format characters in the format string for binary log messages
     { LOG_NKF3_MSG, sizeof(log_NKF3), \
       "NKF3","Qcccccchhhcc","TimeUS,IVN,IVE,IVD,IPN,IPE,IPD,IMX,IMY,IMZ,IYAW,IVT" }, \
     { LOG_NKF4_MSG, sizeof(log_NKF4), \
-      "NKF4","QcccccfbbBBHH","TimeUS,SV,SP,SH,SM,SVT,errRP,OFN,EFE,FS,TS,SS,GPS" }, \
+      "NKF4","QcccccfbbBBHH","TimeUS,SV,SP,SH,SM,SVT,errRP,OFN,OFE,FS,TS,SS,GPS" }, \
     { LOG_NKF5_MSG, sizeof(log_EKF5), \
       "NKF5","QBhhhcccCC","TimeUS,normInnov,FIX,FIY,AFI,HAGL,offset,RI,meaRng,errHAGL" }, \
     { LOG_TERRAIN_MSG, sizeof(log_TERRAIN), \


### PR DESCRIPTION
Previously when the EKF's reset to the GPS following a large glitch or prolonged loss of data, an offset was applied to the GPS measurements to match them to the EKF states and the offsets were then decayed to zero in a radial direction at a constant rate of 1 m/s for copters and 5 m/s for planes.

Now the EKF publishes the position and velocity reset deltas so that the control loops can compensate if required. This reduces the logic complexity in the EKF and enables the different consumers of EKF sta to deal with the offsets on a case by case basis.

These changes have been tested in SITL for plane and copter to test the handling of GPS glitches and outages and have have had a flight test on Copter to verify normal operation.

Rover may wish to use the published reset deltas for some control modes.