### PR TITLE
Miscellaneous EKF2 updates

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -721,8 +721,7 @@ const char *AP_AHRS_NavEKF::prearm_failure_reason(void) const
     case 1:
         return EKF1.prearm_failure_reason();
     case 2:
-        // not implemented yet
-        return nullptr;
+        return EKF2.prearm_failure_reason();
     }
     return nullptr;
 }

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -59,8 +59,8 @@
 #define FLOW_GATE_DEFAULT       3
 #define GSCALE_PNOISE_DEFAULT   3.0E-03f
 
-#else
-// generic defaults (and for plane)
+#elif APM_BUILD_TYPE(APM_BUILD_ArduPlane)
+// plane defaults
 #define VELNE_NOISE_DEFAULT     0.5f
 #define VELD_NOISE_DEFAULT      0.7f
 #define POSNE_NOISE_DEFAULT     1.0f
@@ -76,6 +76,29 @@
 #define HGT_GATE_DEFAULT        4
 #define MAG_GATE_DEFAULT        3
 #define MAG_CAL_DEFAULT         0
+#define GLITCH_RADIUS_DEFAULT   25
+#define FLOW_MEAS_DELAY         10
+#define FLOW_NOISE_DEFAULT      0.25f
+#define FLOW_GATE_DEFAULT       3
+#define GSCALE_PNOISE_DEFAULT   3.0E-03f
+
+#else
+// build type not specified, use copter defaults
+#define VELNE_NOISE_DEFAULT     0.5f
+#define VELD_NOISE_DEFAULT      0.7f
+#define POSNE_NOISE_DEFAULT     1.0f
+#define ALT_NOISE_DEFAULT       5.0f
+#define MAG_NOISE_DEFAULT       0.05f
+#define GYRO_PNOISE_DEFAULT     0.005f
+#define ACC_PNOISE_DEFAULT      0.25f
+#define GBIAS_PNOISE_DEFAULT    7.0E-05f
+#define ABIAS_PNOISE_DEFAULT    1.0E-04f
+#define MAG_PNOISE_DEFAULT      2.5E-02f
+#define VEL_GATE_DEFAULT        3
+#define POS_GATE_DEFAULT        3
+#define HGT_GATE_DEFAULT        3
+#define MAG_GATE_DEFAULT        3
+#define MAG_CAL_DEFAULT         3
 #define GLITCH_RADIUS_DEFAULT   25
 #define FLOW_MEAS_DELAY         10
 #define FLOW_NOISE_DEFAULT      0.25f

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -837,4 +837,13 @@ uint32_t NavEKF2::getLastVelNorthEastReset(Vector2f &vel) const
     return core->getLastVelNorthEastReset(vel);
 }
 
+// report the reason for why the backend is refusing to initialise
+const char *NavEKF2::prearm_failure_reason(void) const
+{
+    if (!core) {
+        return nullptr;
+    }
+    return core->prearm_failure_reason();
+}
+
 #endif //HAL_CPU_CLASS

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -235,6 +235,9 @@ public:
     // returns the time of the last reset or 0 if no reset has ever occurred
     uint32_t getLastVelNorthEastReset(Vector2f &vel) const;
 
+    // report any reason for why the backend is refusing to initialise
+    const char *prearm_failure_reason(void) const;
+
     // allow the enable flag to be set by Replay
     void set_enable(bool enable) { _enable.set(enable); }
     

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -70,9 +70,9 @@ void NavEKF2_core::setWindMagStateLearningMode()
     // Inhibit the magnetic field calibration if not requested or denied
     inhibitMagStates = (!magCalRequested || magCalDenied);
 
-    // If magnetometer states are inhibited, we clear the flag indicating that the magnetic field in-flight initialisation has been completed
-    // because it will need to be done again
-    if (inhibitMagStates) {
+    // If on ground we clear the flag indicating that the magnetic field in-flight initialisation has been completed
+    // because we want it re-done for each takeoff
+    if (onGround) {
         firstMagYawInit = false;
     }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -505,4 +505,15 @@ void NavEKF2_core::send_status_report(mavlink_channel_t chan)
 
 }
 
+// report the reason for why the backend is refusing to initialise
+const char *NavEKF2_core::prearm_failure_reason(void) const
+{
+    if (imuSampleTime_ms - lastGpsVelFail_ms > 10000) {
+        // we are not failing
+        return nullptr;
+    }
+    return prearm_fail_string;
+}
+
+
 #endif // HAL_CPU_CLASS

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -20,7 +20,7 @@ extern const AP_HAL::HAL& hal;
 #define STARTUP_WIND_SPEED 3.0f
 
 // initial imu bias uncertainty (deg/sec)
-#define INIT_ACCEL_BIAS_UNCERTAINTY 0.3f
+#define INIT_ACCEL_BIAS_UNCERTAINTY 0.5f
 
 // maximum allowed gyro bias (rad/sec)
 #define GYRO_BIAS_LIMIT 0.349066f

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -778,6 +778,7 @@ private:
     Vector2f velResetNE;            // Change in North/East velocity due to last in-flight reset in metres/sec. Returned by getLastVelNorthEastReset
     uint32_t lastVelReset_ms;       // System time at which the last velocity reset occurred. Returned by getLastVelNorthEastReset
     float yawTestRatio;             // square of magnetometer yaw angle innovation divided by fail threshold
+    Quaternion prevQuatMagReset;    // Quaternion from the last time the magnetic field state reset condition test was performed
 
     // variables used to calulate a vertical velocity that is kinematically consistent with the verical position
     float posDownDerivative;        // Rate of chage of vertical position (dPosD/dt) in m/s. This is the first time derivative of PosD.

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -256,6 +256,9 @@ public:
     // returns the time of the last reset or 0 if no reset has ever occurred
     uint32_t getLastVelNorthEastReset(Vector2f &vel) const;
 
+    // report any reason for why the backend is refusing to initialise
+    const char *prearm_failure_reason(void) const;
+
 private:
     // Reference to the global EKF frontend for parameters
     NavEKF2 &frontend;


### PR DESCRIPTION
The EKF2 pre-flight GPs check status text messages are now wired through.
The order of reporting has been adjusted to make the most of the 40 character limit
A minor parameter change that speeds up initial accel bias learning on startup has been made.
The ArduPlane build type case is now explicitly defined when setting parameter defaults and a separate set of parameters for the unknown case is used (set to Copter defaults)
Vibration noise on gyros was preventing the in-flight magnetometer calibration from occurring when EKF_MAG_CAL=3 was set. A delta rotation between magnetometer updates is now used instead of the last IMU delta angle. This is much more noise resistant.

Future work will look at estimating the earth field from multiple samples rather than taking a snapshot to reduce the effect of magnetic interference and other effects.