### PR TITLE
OpticalFlow: minor fixes

### DIFF
--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Linux.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Linux.cpp
@@ -115,6 +115,13 @@ bool AP_OpticalFlow_Linux::read(optical_flow_s* report)
         memcpy(&f_integral, val, I2C_INTEGRAL_FRAME_SIZE);
     }
 
+    i2c_sem->give();
+
+    // reduce error count
+    if (num_errors > 0) {
+        num_errors--;
+    }
+
     report->pixel_flow_x_integral = static_cast<float>(f_integral.pixel_flow_x_integral) / 10000.0f;    //convert to radians
     report->pixel_flow_y_integral = static_cast<float>(f_integral.pixel_flow_y_integral) / 10000.0f;    //convert to radians
     report->frame_count_since_last_readout = f_integral.frame_count_since_last_readout;
@@ -127,13 +134,6 @@ bool AP_OpticalFlow_Linux::read(optical_flow_s* report)
     report->time_since_last_sonar_update = f_integral.sonar_timestamp;  // microseconds
     report->gyro_temperature = f_integral.gyro_temperature;             // Temperature * 100 in centi-degrees Celsius
     report->sensor_id = 0;
-
-    i2c_sem->give();
-
-    // reduce error count
-    if (num_errors > 0) {
-        num_errors--;
-    }
 
     return true;
 

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Linux.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Linux.cpp
@@ -103,18 +103,14 @@ bool AP_OpticalFlow_Linux::read(optical_flow_s* report)
     // Perform the writing and reading in a single command
     if (PX4FLOW_REG == 0x00) {
         if (hal.i2c->readRegisters(PX4FLOW_I2C_ADDRESS, 0, I2C_FRAME_SIZE + I2C_INTEGRAL_FRAME_SIZE, val) != 0) {
-            num_errors++;
-            i2c_sem->give();
-            return false;
+            goto fail_transfer;
         }
         memcpy(&f_integral, &(val[I2C_FRAME_SIZE]), I2C_INTEGRAL_FRAME_SIZE);
     }
 
     if (PX4FLOW_REG == 0x16) {
         if (hal.i2c->readRegisters(PX4FLOW_I2C_ADDRESS, 0, I2C_INTEGRAL_FRAME_SIZE, val) != 0) {
-            num_errors++;
-            i2c_sem->give();
-            return false;
+            goto fail_transfer;
         }
         memcpy(&f_integral, val, I2C_INTEGRAL_FRAME_SIZE);
     }
@@ -140,6 +136,11 @@ bool AP_OpticalFlow_Linux::read(optical_flow_s* report)
     }
 
     return true;
+
+fail_transfer:
+    num_errors++;
+    i2c_sem->give();
+    return false;
 }
 
 // update - read latest values from sensor and fill in x,y and totals.

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Linux.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Linux.cpp
@@ -86,13 +86,11 @@ bool AP_OpticalFlow_Linux::read(optical_flow_s* report)
     // get pointer to i2c bus semaphore
     AP_HAL::Semaphore *i2c_sem = hal.i2c->get_semaphore();
     if (i2c_sem == NULL) {
-        num_errors++;
         return false;
     }
 
     // take i2c bus sempahore (non blocking)
     if (!i2c_sem->take_nonblocking()) {
-        num_errors++;
         return false;
     }
 

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Linux.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Linux.h
@@ -9,6 +9,8 @@
 #define AP_OpticalFlow_Linux_H
 
 #include "OpticalFlow.h"
+
+#include <AP_Common/AP_Common.h>
 #include <AP_Math/AP_Math.h>
 
 class AP_OpticalFlow_Linux : public OpticalFlow_backend
@@ -25,7 +27,7 @@ public:
 
 private:
 
-    typedef struct {
+    typedef struct PACKED {
         uint16_t frame_count;
         int16_t pixel_flow_x_sum;
         int16_t pixel_flow_y_sum;
@@ -40,7 +42,7 @@ private:
         int16_t ground_distance;
     } i2c_frame;
 
-    typedef struct {
+    typedef struct PACKED {
         uint16_t frame_count_since_last_readout;
         int16_t pixel_flow_x_integral;
         int16_t pixel_flow_y_integral;


### PR DESCRIPTION
This addresses my comments on https://github.com/diydrones/ardupilot/pull/2667

I still don't get why we do this https://github.com/diydrones/ardupilot/blob/master/libraries/AP_OpticalFlow/AP_OpticalFlow_Linux.cpp#L106 if the value is hardcoded to 0x16. And reading the value on I2C and then discarding it should be avoided nonetheless.  Comment on that line also looks misplaced, we don't read and write with the same command. Instead we call `request_measurement()` earlier.

I have not tested this on real hardware, it's only compile-tested. @rmackay9 could you take a look?