### PR TITLE
AP_HAL_VRBRAIN: fix typo using comma operator

### DIFF
--- a/libraries/AP_HAL_VRBRAIN/Util.cpp
+++ b/libraries/AP_HAL_VRBRAIN/Util.cpp
@@ -134,7 +134,7 @@ bool VRBRAINUtil::get_system_id(char buf[40])
 */
 uint32_t VRBRAINUtil::available_memory(void)
 {
-    return mallinfo(),fordblks;
+    return mallinfo().fordblks;
 }
 
 #endif // CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN


### PR DESCRIPTION
We want to return mallinfo().fordblks, not the struct using the comma
operator with a non-existing fordblks variable.