### PR TITLE
Copter: Automatic deploy of Landing Gear on height control

### DIFF
--- a/ArduCopter/landing_gear.cpp
+++ b/ArduCopter/landing_gear.cpp
@@ -14,7 +14,7 @@ void Copter::landinggear_update(){
 
         // if we are doing an automatic landing procedure, force the landing gear to deploy.
         // To-Do: should we pause the auto-land procedure to give time for gear to come down?
-        if (((inertial_nav.get_altitude()-rtl_alt*1.1)/inertial_nav.get_velocity_z())<_lgear_time_seconds) {
+        if (((current_loc.alt-rtl_alt*1.1f)/inertial_nav.get_velocity_z())<landinggear.get_lgear_time()) {
             landinggear.force_deploy(true);
         }
         if (control_mode == LAND ||

--- a/ArduCopter/landing_gear.cpp
+++ b/ArduCopter/landing_gear.cpp
@@ -14,6 +14,9 @@ void Copter::landinggear_update(){
 
         // if we are doing an automatic landing procedure, force the landing gear to deploy.
         // To-Do: should we pause the auto-land procedure to give time for gear to come down?
+        if (((inertial_nav.get_altitude()-rtl_alt*1.1)/inertial_nav.get_velocity_z())<_lgear_time_seconds) {
+            landinggear.force_deploy(true);
+        }
         if (control_mode == LAND ||
            (control_mode==RTL && (rtl_state == RTL_LoiterAtHome || rtl_state == RTL_Land || rtl_state == RTL_FinalDescent)) ||
            (control_mode == AUTO && auto_mode == Auto_Land) ||

--- a/libraries/AP_LandingGear/AP_LandingGear.cpp
+++ b/libraries/AP_LandingGear/AP_LandingGear.cpp
@@ -28,6 +28,15 @@ const AP_Param::GroupInfo AP_LandingGear::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("SERVO_DEPLOY", 1, AP_LandingGear, _servo_deploy_pwm, AP_LANDINGGEAR_SERVO_DEPLOY_PWM_DEFAULT),
 
+    // @Param: SERVO_DEPLOY
+    // @DisplayName: Time the landing gear takes to be fully deployed
+    // @Description: Seconds that the landing gear takes to be fully deployed
+    // @Range: 1 120
+    // @Units: seconds
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("LGEAR_TIME", 1, AP_LandingGear, _lgear_time_seconds, AP_LANDINGGEAR_TIME_TO_DEPLOY_SECONDS_DEFAULT),
+    
     AP_GROUPEND
 };
 
@@ -44,17 +53,17 @@ void AP_LandingGear::deploy()
     RC_Channel_aux::set_radio(RC_Channel_aux::k_landing_gear_control, _servo_deploy_pwm);
 
     // set deployed flag
-    _deployed = true;    
+    _deployed = true;
 }
 
 /// retract - retract landing gear
 void AP_LandingGear::retract()
-{    
+{
     // set servo PWM to retracted position
     RC_Channel_aux::set_radio(RC_Channel_aux::k_landing_gear_control, _servo_retract_pwm);
 
     // reset deployed flag
-    _deployed = false;   
+    _deployed = false;
 }
 
 /// update - should be called at 10hz

--- a/libraries/AP_LandingGear/AP_LandingGear.h
+++ b/libraries/AP_LandingGear/AP_LandingGear.h
@@ -54,6 +54,11 @@ public:
 
     static const struct AP_Param::GroupInfo        var_info[];
 
+    AP_INT16 get_lgear_time() {
+     return _lgear_time_seconds;
+    }
+
+
 private:
 
     bool     _retract_enabled;          // true if landing gear retraction is enabled

--- a/libraries/AP_LandingGear/AP_LandingGear.h
+++ b/libraries/AP_LandingGear/AP_LandingGear.h
@@ -11,6 +11,7 @@
 
 #define AP_LANDINGGEAR_SERVO_RETRACT_PWM_DEFAULT    1250    // default PWM value to move servo to when landing gear is up
 #define AP_LANDINGGEAR_SERVO_DEPLOY_PWM_DEFAULT     1750    // default PWM value to move servo to when landing gear is down
+#define AP_LANDINGGEAR_TIME_TO_DEPLOY_SECONDS_DEFAULT     30    // default time in seconds to deploy landing gear
 
 // Gear command modes
 enum LandingGearCommandMode {
@@ -60,7 +61,8 @@ private:
     // Parameters
     AP_Int16    _servo_retract_pwm;     // PWM value to move servo to when gear is retracted
     AP_Int16    _servo_deploy_pwm;      // PWM value to move servo to when gear is deployed
-
+    AP_Int16    _lgear_time_seconds;    // Time in seconds that the landing takes to deploy completely
+    
     // internal variables
     bool        _deployed;              // true if the landing gear has been deployed, initialized false
     bool        _force_deploy;          // used by main code to force landing gear to deploy, such as in Land mode


### PR DESCRIPTION
Additional user parameter for the user to define how long it takes the
landing gear to be fully deployed. I believe that between 1 second and
2 minutes might be enough for every case. It defaults to 30 seconds.
The automatic deployment is controlled when the copter is moving down
and the result of its vertical speed and current height vs the time it
takes to be fully deployed is above RTL height. I believe there is no
need to define another parameter for the minimum height the landing
gear should be deployed.
This calculation might invalidate part of the next if condition,
because automatic landing gear deployment becomes a function of flight
dynamics vs a specific flight mode.