### PR TITLE
Enable both EKF1 & EKF2 to do a clean in-flight entry into GPS aiding

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF_core.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_core.cpp
@@ -3973,14 +3973,11 @@ void NavEKF_core::readGpsData()
 
             // Set the EKF origin and magnetic field declination if not previously set  and GPS checks have passed
             if (!validOrigin && gpsGoodToAlign) {
-                // Set the NE origin to the current GPS position if not previously set
-                if (!validOrigin) {
-                    setOrigin();
-                    // Now we know the location we have an estimate for the magnetic field declination and adjust the earth field accordingly
-                    alignMagStateDeclination();
-                    // Set the height of the NED origin to ‘height of baro height datum relative to GPS height datum'
-                    EKF_origin.alt = gpsloc.alt - hgtMea;
-                }
+                setOrigin();
+                // Now we know the location we have an estimate for the magnetic field declination and adjust the earth field accordingly
+                alignMagStateDeclination();
+                // Set the height of the NED origin to ‘height of baro height datum relative to GPS height datum'
+                EKF_origin.alt = gpsloc.alt - hgtMea;
             }
 
             // Commence GPS aiding when able to

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -98,7 +98,7 @@ void NavEKF2_core::setAidingMode()
     // If GPS useage has been prohiited then we use flow aiding provided optical flow data is present
     bool useFlowAiding = (frontend->_fusionModeGPS == 3) && optFlowDataPresent();
     // Start aiding if we have a source of aiding data and the filter attitude algnment is complete
-    // Latch to on. Aiding can be turned off by setting both
+    // Latch to on
     isAiding = ((readyToUseGPS() || useFlowAiding) && filterIsStable) || isAiding;
 
     // check to see if we are starting or stopping aiding and set states and modes as required

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -205,7 +205,7 @@ bool NavEKF2_core::optFlowDataPresent(void) const
 // return true if the filter to be ready to use gps
 bool NavEKF2_core::readyToUseGPS(void) const
 {
-    return validOrigin && tiltAlignComplete && yawAlignComplete && gpsGoodToAlign;
+    return validOrigin && tiltAlignComplete && yawAlignComplete && gpsGoodToAlign && (frontend->_fusionModeGPS != 3);
 }
 
 // return true if we should use the compass

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -437,14 +437,11 @@ void NavEKF2_core::readGpsData()
 
             // Set the EKF origin and magnetic field declination if not previously set  and GPS checks have passed
             if (gpsGoodToAlign && !validOrigin) {
-                // Set the NE origin to the current GPS position if not previously set
-                if (!validOrigin) {
-                    setOrigin();
-                    // Now we know the location we have an estimate for the magnetic field declination and adjust the earth field accordingly
-                    alignMagStateDeclination();
-                    // Set the height of the NED origin to ‘height of baro height datum relative to GPS height datum'
-                    EKF_origin.alt = gpsloc.alt - baroDataNew.hgt;
-                }
+                setOrigin();
+                // Now we know the location we have an estimate for the magnetic field declination and adjust the earth field accordingly
+                alignMagStateDeclination();
+                // Set the height of the NED origin to ‘height of baro height datum relative to GPS height datum'
+                EKF_origin.alt = gpsloc.alt - baroDataNew.hgt;
             }
 
             // convert GPS measurements to local NED and save to buffer to be fused later if we have a valid origin

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -62,8 +62,8 @@ void NavEKF2_core::ResetPosition(void)
         stateStruct.position.y = lastKnownPositionNE.y;
     } else if (!gpsNotAvailable) {
         // write to state vector and compensate for offset  between last GPs measurement and the EKF time horizon
-        stateStruct.position.x = gpsDataNew.pos.x  + 0.001f*gpsDataNew.vel.x*(float(imuDataDelayed.time_ms) - float(lastTimeGpsReceived_ms));
-        stateStruct.position.y = gpsDataNew.pos.y  + 0.001f*gpsDataNew.vel.y*(float(imuDataDelayed.time_ms) - float(lastTimeGpsReceived_ms));
+        stateStruct.position.x = gpsDataNew.pos.x  + 0.001f*gpsDataNew.vel.x*(float(imuDataDelayed.time_ms) - float(gpsDataNew.time_ms));
+        stateStruct.position.y = gpsDataNew.pos.y  + 0.001f*gpsDataNew.vel.y*(float(imuDataDelayed.time_ms) - float(gpsDataNew.time_ms));
     }
     for (uint8_t i=0; i<IMU_BUFFER_LENGTH; i++) {
         storedOutput[i].position.x = stateStruct.position.x;


### PR DESCRIPTION
Timing offsets and other errors were causing the in-flight entry or re-entry into GP aiding to have transients or sometimes take two attempts after a timeout interval to achieve normal operation. This has been tested in Copter SITL by flying an auto mission at 100metres altitude, disabling GPS using SIM_GPS_DISABLE=1 for 20 seconds, then re-enabling it. Both EKF's now do a clean reset with no large innovation transients or rejection of GPS data leading to timeouts.