### PR TITLE
EKF2 - Prevent return of uninitialised variable

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -689,6 +689,8 @@ uint8_t NavEKF2::getActiveMag(int8_t instance)
     if (instance < 0 || instance >= num_cores) instance = primary;
     if (core) {
         return core[instance].getActiveMag();
+    } else {
+        return 255;
     }
 }
 


### PR DESCRIPTION
Eliminates a compiler warning message