### PR TITLE
Plane: flight_stage_takeoff not set correctly

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -829,7 +829,7 @@ void Plane::update_alt()
 void Plane::update_flight_stage(void)
 {
     // Update the speed & height controller states
-    if (auto_throttle_mode && !throttle_suppressed) {        
+    if (auto_throttle_mode) {
         if (control_mode==AUTO) {
             if (auto_state.takeoff_complete == false) {
                 set_flight_stage(AP_SpdHgtControl::FLIGHT_TAKEOFF);


### PR DESCRIPTION
In Plane, when an AUTO mission is set with a takeoff the throttle is immediately suppressed. When in a bungee launch situation the flight stage was actually never being put into _TAKEOFF until the launch occurred because the throttle suppression was inhibiting that set. Whoops! We've been in NORMAL stage all this time on the ground!

This will also fix an issue of the crash detection logic where it thinks we launched then crashed on takeoff all while stationary on the ground so your actual launch will keep the motor off. This can happen if the airspeed sensor is pointing into the wind and it meets the threshold to set is_flying() true (around 7m/s). There was special handling for that scenario while in _TAKEOFF stage but they were bypassed because we were incorrectly not in that stage.

@tridge This is a good candidate to go into a v3.4.1 hotfix release.