### PR TITLE
EKF2 - Reduce memory required by 6KB when running at 400Hz

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -337,7 +337,7 @@ private:
     const uint16_t gndEffectTimeout_ms; // time in msec that ground effect mode is active after being activated
     const float gndEffectBaroScaler;    // scaler applied to the barometer observation variance when ground effect mode is active
     const uint8_t gndGradientSigma;     // RMS terrain gradient percentage assumed by the terrain height estimation
-    const uint8_t fusionTimeStep_ms;    // The nominal time interval between covariance predictions and measurement fusions in msec
+    const uint8_t fusionTimeStep_ms;    // The minimum time interval between covariance predictions and measurement fusions in msec
 };
 
 #endif //AP_NavEKF2

--- a/libraries/AP_NavEKF2/AP_NavEKF2_AirDataFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_AirDataFusion.cpp
@@ -215,8 +215,6 @@ void NavEKF2_core::SelectTasFusion()
     tasDataWaiting = (statesInitialised && !inhibitWindStates && newDataTas);
     if (tasDataWaiting)
     {
-        // ensure that the covariance prediction is up to date before fusing data
-        if (!covPredStep) CovariancePrediction();
         FuseAirspeed();
         prevTasStep_ms = imuSampleTime_ms;
         tasDataWaiting = false;
@@ -285,8 +283,6 @@ void NavEKF2_core::SelectBetaFusion()
     bool f_feasible = (assume_zero_sideslip() && !inhibitWindStates);
     // use synthetic sideslip fusion if feasible, required and enough time has lapsed since the last fusion
     if (f_feasible && f_required && f_timeTrigger) {
-        // ensure that the covariance prediction is up to date before fusing data
-        if (!covPredStep) CovariancePrediction();
         FuseSideslip();
         prevBetaStep_ms = imuSampleTime_ms;
     }

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -164,7 +164,7 @@ void NavEKF2_core::setAidingMode()
 void NavEKF2_core::checkAttitudeAlignmentStatus()
 {
     // Check for tilt convergence - used during initial alignment
-    float alpha = 1.0f*dtIMUavg;
+    float alpha = 1.0f*imuDataDelayed.delAngDT;
     float temp=tiltErrVec.length();
     tiltErrFilt = alpha*temp + (1.0f-alpha)*tiltErrFilt;
     if (tiltErrFilt < 0.005f && !tiltAlignComplete) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -152,8 +152,6 @@ void NavEKF2_core::SelectMagFusion()
     // wait until the EKF time horizon catches up with the measurement
     bool dataReady = (newMagDataAvailable && statesInitialised && use_compass() && yawAlignComplete);
     if (dataReady) {
-        // ensure that the covariance prediction is up to date before fusing data
-        if (!covPredStep) CovariancePrediction();
         // If we haven't performed the first airborne magnetic field update or have inhibited magnetic field learning, then we use the simple method of declination to maintain heading
         if(inhibitMagStates) {
             fuseCompass();
@@ -261,7 +259,7 @@ void NavEKF2_core::FuseMagnetometer()
         }
 
         // scale magnetometer observation error with total angular rate to allow for timing errors
-        R_MAG = sq(constrain_float(frontend->_magNoise, 0.01f, 0.5f)) + sq(frontend->magVarRateScale*imuDataDelayed.delAng.length() / dtIMUavg);
+        R_MAG = sq(constrain_float(frontend->_magNoise, 0.01f, 0.5f)) + sq(frontend->magVarRateScale*imuDataDelayed.delAng.length() / imuDataDelayed.delAngDT);
 
         // calculate common expressions used to calculate observation jacobians an innovation variance for each component
         SH_MAG[0] = sq(q0) - sq(q1) + sq(q2) - sq(q3);

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -112,9 +112,8 @@ void NavEKF2_core::writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRa
         flowValidMeaTime_ms = imuSampleTime_ms;
         // estimate sample time of the measurement
         ofDataNew.time_ms = imuSampleTime_ms - frontend->_flowDelay_ms - frontend->flowTimeDeltaAvg_ms/2;
-        // Assign measurement to nearest fusion interval so that multiple measurements can be fused on the same frame
-        // This allows us to perform the covariance prediction over longer time steps which reduces numerical precision errors
-        ofDataNew.time_ms = roundToNearest(ofDataNew.time_ms, frontend->fusionTimeStep_ms);
+        // Correct for the average intersampling delay due to the filter updaterate
+        ofDataNew.time_ms -= localFilterTimeStep_ms/2;
         // Prevent time delay exceeding age of oldest IMU data in the buffer
         ofDataNew.time_ms = max(ofDataNew.time_ms,imuDataDelayed.time_ms);
         // Save data to buffer
@@ -224,9 +223,8 @@ void NavEKF2_core::readMagData()
         // estimate of time magnetometer measurement was taken, allowing for delays
         magDataNew.time_ms = imuSampleTime_ms - frontend->magDelay_ms;
 
-        // Assign measurement to nearest fusion interval so that multiple measurements can be fused on the same frame
-        // This allows us to perform the covariance prediction over longer time steps which reduces numerical precision errors
-        magDataNew.time_ms = roundToNearest(magDataNew.time_ms, frontend->fusionTimeStep_ms);
+        // Correct for the average intersampling delay due to the filter updaterate
+        magDataNew.time_ms -= localFilterTimeStep_ms/2;
 
         // read compass data and scale to improve numerical conditioning
         magDataNew.mag = _ahrs->get_compass()->get_field(magSelectIndex) * 0.001f;
@@ -285,7 +283,13 @@ bool NavEKF2_core::RecallMag()
 *                Inertial Measurements                  *
 ********************************************************/
 
-// update IMU delta angle and delta velocity measurements
+/*
+ *  Read IMU delta angle and delta velocity measurements and downsample to 100Hz
+ *  for storage in the data buffers used by the EKF. If the IMU data arrives at
+ *  lower rate than 100Hz, then no downsampling or upsampling will be performed.
+ *  Downsampling is done using a method that does not introduce coning or sculling
+ *  errors.
+ */
 void NavEKF2_core::readIMUData()
 {
     const AP_InertialSensor &ins = _ahrs->get_ins();
@@ -311,11 +315,65 @@ void NavEKF2_core::readIMUData()
     }
     imuDataNew.delAngDT = max(ins.get_delta_time(),1.0e-4f);
 
-    // get current time stamp
+    // Get current time stamp
     imuDataNew.time_ms = imuSampleTime_ms;
 
-    // save data in the FIFO buffer
-    StoreIMU();
+    // remove gyro scale factor errors
+    imuDataNew.delAng.x = imuDataNew.delAng.x * stateStruct.gyro_scale.x;
+    imuDataNew.delAng.y = imuDataNew.delAng.y * stateStruct.gyro_scale.y;
+    imuDataNew.delAng.z = imuDataNew.delAng.z * stateStruct.gyro_scale.z;
+
+    // remove sensor bias errors
+    imuDataNew.delAng -= stateStruct.gyro_bias;
+    imuDataNew.delVel.z -= stateStruct.accel_zbias;
+
+    // Accumulate the measurement time interval for the delta velocity and angle data
+    imuDataDownSampledNew.delAngDT += imuDataNew.delAngDT;
+    imuDataDownSampledNew.delVelDT += imuDataNew.delVelDT;
+
+    // Rotate quaternon atitude from previous to new and normalise.
+    // Accumulation using quaternions prevents introduction of coning errors due to downsampling
+    Quaternion deltaQuat;
+    deltaQuat.rotate(imuDataNew.delAng);
+    imuQuatDownSampleNew = imuQuatDownSampleNew*deltaQuat;
+    imuQuatDownSampleNew.normalize();
+
+    // Rotate the accumulated delta velocity into the new frame of reference created by the latest delta angle
+    // This prevents introduction of sculling errors due to downsampling
+    Matrix3f deltaRotMat;
+    deltaQuat.inverse().rotation_matrix(deltaRotMat);
+    imuDataDownSampledNew.delVel = deltaRotMat*imuDataDownSampledNew.delVel;
+
+    // accumulate the latest delta velocity
+    imuDataDownSampledNew.delVel += imuDataNew.delVel;
+
+    // Keep track of the number of IMU frames since the last state prediction
+    framesSincePredict++;
+
+    // If 10msec has elapsed, and the frontend has allowed us to start a new predict cycle, then store the accumulated IMU data
+    // to be used by the state prediction, ignoring the frontend permission if more than 20msec has lapsed
+    if ((dtIMUavg*(float)framesSincePredict >= 0.01f && startPredictEnabled) || (dtIMUavg*(float)framesSincePredict >= 0.02f)) {
+        // convert the accumulated quaternion to an equivalent delta angle
+        imuQuatDownSampleNew.to_axis_angle(imuDataDownSampledNew.delAng);
+        // Time stamp the data
+        imuDataDownSampledNew.time_ms = imuSampleTime_ms;
+        // Write data to the FIFO IMU buffer
+        StoreIMU();
+        // zero the accumulated IMU data and quaternion
+        imuDataDownSampledNew.delAng.zero();
+        imuDataDownSampledNew.delVel.zero();
+        imuDataDownSampledNew.delAngDT = 0.0f;
+        imuDataDownSampledNew.delVelDT = 0.0f;
+        imuQuatDownSampleNew[0] = 1.0f;
+        imuQuatDownSampleNew[3] = imuQuatDownSampleNew[2] = imuQuatDownSampleNew[1] = 0.0f;
+        // reset the counter used to let the frontend know how many frames have elapsed since we started a new update cycle
+        framesSincePredict = 0;
+        // set the flag to let the filter know it has new IMU data nad needs to run
+        runUpdates = true;
+    } else {
+        // we don't have new IMU data in the buffer so don't run filter updates on this time step
+        runUpdates = false;
+    }
 
     // extract the oldest available data from the FIFO buffer
     imuDataDelayed = storedIMU[fifoIndexDelayed];
@@ -330,10 +388,10 @@ void NavEKF2_core::StoreIMU()
     if (fifoIndexNow >= IMU_BUFFER_LENGTH) {
         fifoIndexNow = 0;
     }
-    storedIMU[fifoIndexNow] = imuDataNew;
+    storedIMU[fifoIndexNow] = imuDataDownSampledNew;
     // set the index required to access the oldest data, applying an offset to the fusion time horizon that is used to
     // prevent the same fusion operation being performed on the same frame across multiple EKF's
-    fifoIndexDelayed = fifoIndexNow + 1 + fusionHorizonOffset;
+    fifoIndexDelayed = fifoIndexNow + 1;
     if (fifoIndexDelayed >= IMU_BUFFER_LENGTH) {
         fifoIndexDelayed = 0;
     }
@@ -359,7 +417,7 @@ void NavEKF2_core::RecallIMU()
     imuDataDelayed = storedIMU[fifoIndexDelayed];
     // make sure that the delta time used for the delta angles and velocities are is no less than 10% of dtIMUavg to prevent
     // divide by zero problems when converting to rates or acceleration
-    float minDT = 0.1f*dtIMUavg;
+    float minDT = 0.1f*dtEkfAvg;
     imuDataDelayed.delAngDT = max(imuDataDelayed.delAngDT,minDT);
     imuDataDelayed.delVelDT = max(imuDataDelayed.delVelDT,minDT);
 }
@@ -401,9 +459,8 @@ void NavEKF2_core::readGpsData()
             // ideally we should be using a timing signal from the GPS receiver to set this time
             gpsDataNew.time_ms = lastTimeGpsReceived_ms - frontend->_gpsDelay_ms;
 
-            // Assign measurement to nearest fusion interval so that multiple measurements can be fused on the same frame
-            // This allows us to perform the covariance prediction over longer time steps which reduces numerical precision errors
-            gpsDataNew.time_ms = roundToNearest(gpsDataNew.time_ms, frontend->fusionTimeStep_ms);
+            // Correct for the average intersampling delay due to the filter updaterate
+            gpsDataNew.time_ms -= localFilterTimeStep_ms/2;
 
             // Prevent time delay exceeding age of oldest IMU data in the buffer
             gpsDataNew.time_ms = max(gpsDataNew.time_ms,imuDataDelayed.time_ms);
@@ -637,9 +694,8 @@ void NavEKF2_core::readHgtData()
         // estimate of time height measurement was taken, allowing for delays
         baroDataNew.time_ms = lastHgtReceived_ms - frontend->_hgtDelay_ms;
 
-        // Assign measurement to nearest fusion interval so that multiple measurements can be fused on the same frame
-        // This allows us to perform the covariance prediction over longer time steps which reduces numerical precision errors
-        baroDataNew.time_ms = roundToNearest(baroDataNew.time_ms, frontend->fusionTimeStep_ms);
+        // Correct for the average intersampling delay due to the filter updaterate
+        baroDataNew.time_ms -= localFilterTimeStep_ms/2;
 
         // Prevent time delay exceeding age of oldest IMU data in the buffer
         baroDataNew.time_ms = max(baroDataNew.time_ms,imuDataDelayed.time_ms);
@@ -708,21 +764,14 @@ void NavEKF2_core::readAirSpdData()
         tasDataNew.tas = aspeed->get_airspeed() * aspeed->get_EAS2TAS();
         timeTasReceived_ms = aspeed->last_update_ms();
         tasDataNew.time_ms = timeTasReceived_ms - frontend->tasDelay_ms;
-        // Assign measurement to nearest fusion interval so that multiple measurements can be fused on the same frame
-        // This allows us to perform the covariance prediction over longer time steps which reduces numerical precision errors
-        tasDataNew.time_ms = roundToNearest(tasDataNew.time_ms, frontend->fusionTimeStep_ms);
+        // Correct for the average intersampling delay due to the filter update rate
+        tasDataNew.time_ms -= localFilterTimeStep_ms/2;
         newDataTas = true;
         StoreTAS();
         RecallTAS();
     } else {
         newDataTas = false;
     }
-}
-
-// Round to the nearest multiple of a integer
-uint32_t NavEKF2_core::roundToNearest(uint32_t dividend, uint32_t divisor )
-{
-  return ((uint32_t)round((float)dividend/float(divisor)))*divisor;
 }
 
 #endif // HAL_CPU_CLASS

--- a/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
@@ -84,8 +84,6 @@ void NavEKF2_core::SelectFlowFusion()
     {
         // Set the flow noise used by the fusion processes
         R_LOS = sq(max(frontend->_flowNoise, 0.05f));
-        // ensure that the covariance prediction is up to date before fusing data
-        if (!covPredStep) CovariancePrediction();
         // Fuse the optical flow X and Y axis data into the main filter sequentially
         FuseOptFlow();
         // reset flag to indicate that no new flow data is available for fusion

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -104,11 +104,11 @@ void NavEKF2_core::getEulerAngles(Vector3f &euler) const
 // return body axis gyro bias estimates in rad/sec
 void NavEKF2_core::getGyroBias(Vector3f &gyroBias) const
 {
-    if (dtIMUavg < 1e-6f) {
+    if (dtEkfAvg < 1e-6f) {
         gyroBias.zero();
         return;
     }
-    gyroBias = stateStruct.gyro_bias / dtIMUavg;
+    gyroBias = stateStruct.gyro_bias / dtEkfAvg;
 }
 
 // return body axis gyro scale factor error as a percentage
@@ -198,8 +198,8 @@ void NavEKF2_core::getAccelNED(Vector3f &accelNED) const {
 
 // return the Z-accel bias estimate in m/s^2
 void NavEKF2_core::getAccelZBias(float &zbias) const {
-    if (dtIMUavg > 0) {
-        zbias = stateStruct.accel_zbias / dtIMUavg;
+    if (dtEkfAvg > 0) {
+        zbias = stateStruct.accel_zbias / dtEkfAvg;
     } else {
         zbias = 0;
     }
@@ -543,5 +543,12 @@ const char *NavEKF2_core::prearm_failure_reason(void) const
     return prearm_fail_string;
 }
 
+
+// report the number of frames lapsed since the last state prediction
+// this is used by other instances to level load
+uint8_t NavEKF2_core::getFramesSincePredict(void) const
+{
+    return framesSincePredict;
+}
 
 #endif // HAL_CPU_CLASS

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -190,8 +190,6 @@ void NavEKF2_core::SelectVelPosFusion()
 
     // perform fusion
     if (fuseVelData || fusePosData || fuseHgtData) {
-        // ensure that the covariance prediction is up to date before fusing data
-        if (!covPredStep) CovariancePrediction();
         FuseVelPosNED();
         // clear the flags to prevent repeated fusion of the same data
         fuseVelData = false;
@@ -233,7 +231,6 @@ void NavEKF2_core::FuseVelPosNED()
     // so we might as well take advantage of the computational efficiencies
     // associated with sequential fusion
     if (fuseVelData || fusePosData || fuseHgtData) {
-
         // set the GPS data timeout depending on whether airspeed data is present
         uint32_t gpsRetryTime;
         if (useAirspeed()) gpsRetryTime = frontend->gpsRetryTimeUseTAS_ms;
@@ -401,7 +398,6 @@ void NavEKF2_core::FuseVelPosNED()
         if (fuseHgtData) {
             // calculate height innovations
             innovVelPos[5] = stateStruct.position.z - observation[5];
-
             varInnovVelPos[5] = P[8][8] + R_OBS_DATA_CHECKS[5];
             // calculate the innovation consistency test ratio
             hgtTestRatio = sq(innovVelPos[5]) / (sq(frontend->_hgtInnovGate) * varInnovVelPos[5]);
@@ -516,7 +512,6 @@ void NavEKF2_core::FuseVelPosNED()
                 stateStruct.angErr.zero();
 
                 // calculate state corrections and re-normalise the quaternions for states predicted using the blended IMU data
-                // Don't apply corrections to Z bias state as this has been done already as part of the single IMU calculations
                 for (uint8_t i = 0; i<=stateIndexLim; i++) {
                     statesArray[i] = statesArray[i] - Kfusion[i] * innovVelPos[obsIndex];
                 }


### PR DESCRIPTION
Down-sample the IMU and output observer state data to 100Hz for storage in the buffer.
This reduces storage requirements for Copter by 75% or 6KB.
It does not reduce memory required by plane which already uses short buffers due to its 50Hz execution rate.
This means that the EKF filter operations operate at a maximum rate of 100Hz.
The output observer continues to operate at 400Hz and coning and sculling corrections are applied during the down-sampling so there is no loss of accuracy.
A frame offset is applied between instances to reduce peak loading.
It has been tested on SITL for plane and coper and flight tested on copter running two instances.
The performance monitor results from the flight test are shown. Loading with dual EKF's is good.
![dual ekf2 loading](https://cloud.githubusercontent.com/assets/3596952/11051566/6bdc9668-87a4-11e5-99d2-401cd790aadf.png)
