### PR TITLE
EKF2 - allow multiple instances to use optical flow data

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -823,7 +823,9 @@ bool NavEKF2::use_compass(void) const
 void NavEKF2::writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRates, Vector2f &rawGyroRates, uint32_t &msecFlowMeas)
 {
     if (core) {
-        core[primary].writeOptFlowMeas(rawFlowQuality, rawFlowRates, rawGyroRates, msecFlowMeas);
+        for (uint8_t i=0; i<num_cores; i++) {
+            core[i].writeOptFlowMeas(rawFlowQuality, rawFlowRates, rawGyroRates, msecFlowMeas);
+        }
     }
 }
 


### PR DESCRIPTION
When using more than one IMU with EKF2 and optical flow, the second and subsequent instances were not going into optical flow mode because data was only being passed to the primary instance.