### PR TITLE
Introduce platform namespace

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -114,7 +114,7 @@ void Rover::loop()
     // wait for an INS sample
     ins.wait_for_sample();
 
-    uint32_t timer = hal.scheduler->micros();
+    uint32_t timer = platform::micros();
 
     delta_us_fast_loop  = timer - fast_loopTimer_us;
     G_Dt                = delta_us_fast_loop * 1.0e-6f;

--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -427,7 +427,7 @@ bool GCS_MAVLINK::try_send_message(enum ap_message id)
     switch (id) {
     case MSG_HEARTBEAT:
         CHECK_PAYLOAD_SIZE(HEARTBEAT);
-        rover.gcs[chan-MAVLINK_COMM_0].last_heartbeat_time = hal.scheduler->millis();        
+        rover.gcs[chan-MAVLINK_COMM_0].last_heartbeat_time = platform::millis();        
         rover.send_heartbeat(chan);
         return true;
 
@@ -1232,7 +1232,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
 
         hal.rcin->set_overrides(v, 8);
 
-        rover.failsafe.rc_override_timer = hal.scheduler->millis();
+        rover.failsafe.rc_override_timer = platform::millis();
         rover.failsafe_trigger(FAILSAFE_EVENT_RC, false);
         break;
     }
@@ -1241,7 +1241,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
         {
             // We keep track of the last time we received a heartbeat from our GCS for failsafe purposes
 			if(msg->sysid != rover.g.sysid_my_gcs) break;
-            rover.last_heartbeat_ms = rover.failsafe.rc_override_timer = hal.scheduler->millis();
+            rover.last_heartbeat_ms = rover.failsafe.rc_override_timer = platform::millis();
             rover.failsafe_trigger(FAILSAFE_EVENT_GCS, false);
             break;
         }

--- a/APMrover2/Log.cpp
+++ b/APMrover2/Log.cpp
@@ -172,7 +172,7 @@ void Rover::Log_Write_Performance()
 {
     struct log_Performance pkt = {
         LOG_PACKET_HEADER_INIT(LOG_PERFORMANCE_MSG),
-        time_us         : hal.scheduler->micros64(),
+        time_us         : platform::micros64(),
         loop_time       : millis()- perf_mon_timer,
         main_loop_count : mainLoop_count,
         g_dt_max        : G_Dt_max,
@@ -197,7 +197,7 @@ void Rover::Log_Write_Steering()
 {
     struct log_Steering pkt = {
         LOG_PACKET_HEADER_INIT(LOG_STEERING_MSG),
-        time_us        : hal.scheduler->micros64(),
+        time_us        : platform::micros64(),
         demanded_accel : lateral_acceleration,
         achieved_accel : gps.ground_speed() * ins.get_gyro().z,
     };
@@ -216,7 +216,7 @@ bool Rover::Log_Write_Startup(uint8_t type)
 {
     struct log_Startup pkt = {
         LOG_PACKET_HEADER_INIT(LOG_STARTUP_MSG),
-        time_us         : hal.scheduler->micros64(),
+        time_us         : platform::micros64(),
         startup_type    : type,
         command_total   : mission.num_commands()
     };
@@ -239,7 +239,7 @@ void Rover::Log_Write_Control_Tuning()
     Vector3f accel = ins.get_accel();
     struct log_Control_Tuning pkt = {
         LOG_PACKET_HEADER_INIT(LOG_CTUN_MSG),
-        time_us         : hal.scheduler->micros64(),
+        time_us         : platform::micros64(),
         steer_out       : (int16_t)channel_steer->servo_out,
         roll            : (int16_t)ahrs.roll_sensor,
         pitch           : (int16_t)ahrs.pitch_sensor,
@@ -264,7 +264,7 @@ void Rover::Log_Write_Nav_Tuning()
 {
     struct log_Nav_Tuning pkt = {
         LOG_PACKET_HEADER_INIT(LOG_NTUN_MSG),
-        time_us             : hal.scheduler->micros64(),
+        time_us             : platform::micros64(),
         yaw                 : (uint16_t)ahrs.yaw_sensor,
         wp_distance         : wp_distance,
         target_bearing_cd   : (uint16_t)nav_controller->target_bearing_cd(),
@@ -312,11 +312,11 @@ void Rover::Log_Write_Sonar()
 {
     uint16_t turn_time = 0;
     if (!is_zero(obstacle.turn_angle)) {
-        turn_time = hal.scheduler->millis() - obstacle.detected_time_ms;
+        turn_time = platform::millis() - obstacle.detected_time_ms;
     }
     struct log_Sonar pkt = {
         LOG_PACKET_HEADER_INIT(LOG_SONAR_MSG),
-        time_us         : hal.scheduler->micros64(),
+        time_us         : platform::micros64(),
         lateral_accel   : lateral_acceleration,
         sonar1_distance : (uint16_t)sonar.distance_cm(0),
         sonar2_distance : (uint16_t)sonar.distance_cm(1),
@@ -347,7 +347,7 @@ struct PACKED log_Arm_Disarm {
 void Rover::Log_Arm_Disarm() {
     struct log_Arm_Disarm pkt = {
         LOG_PACKET_HEADER_INIT(LOG_ARM_DISARM_MSG),
-        time_us                 : hal.scheduler->micros64(),
+        time_us                 : platform::micros64(),
         arm_state               : arming.is_armed(),
         arm_checks              : arming.get_enabled_checks()
     };

--- a/APMrover2/Parameters.cpp
+++ b/APMrover2/Parameters.cpp
@@ -563,7 +563,7 @@ void Rover::load_parameters(void)
 {
     if (!AP_Param::check_var_info()) {
         cliSerial->printf("Bad var table\n");
-        hal.scheduler->panic("Bad var table");
+        platform::panic("Bad var table");
     }
 
 	if (!g.format_version.load() ||

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -457,8 +457,6 @@ private:
     void update_commands(void);
     void delay(uint32_t ms);
     void mavlink_delay(uint32_t ms);
-    uint32_t millis();
-    uint32_t micros();
     void read_control_switch();
     uint8_t readSwitch(void);
     void reset_control_switch();
@@ -565,5 +563,8 @@ public:
 
 extern const AP_HAL::HAL& hal;
 extern Rover rover;
+
+using platform::millis;
+using platform::micros;
 
 #endif // _ROVER_H_

--- a/APMrover2/compat.cpp
+++ b/APMrover2/compat.cpp
@@ -9,14 +9,3 @@ void Rover::mavlink_delay(uint32_t ms)
 {
     hal.scheduler->delay(ms);
 }
-
-uint32_t Rover::millis()
-{
-    return hal.scheduler->millis();
-}
-
-uint32_t Rover::micros()
-{
-    return hal.scheduler->micros();
-}
-

--- a/APMrover2/control_modes.cpp
+++ b/APMrover2/control_modes.cpp
@@ -11,7 +11,7 @@ void Rover::read_control_switch()
 	// If we get this value we do not want to change modes.
 	if(switchPosition == 255) return;
 
-    if (hal.scheduler->millis() - failsafe.last_valid_rc_ms > 100) {
+    if (platform::millis() - failsafe.last_valid_rc_ms > 100) {
         // only use signals that are less than 0.1s old.
         return;
     }

--- a/APMrover2/failsafe.cpp
+++ b/APMrover2/failsafe.cpp
@@ -20,7 +20,7 @@ void Rover::failsafe_check()
     static uint16_t last_mainLoop_count;
     static uint32_t last_timestamp;
     static bool in_failsafe;
-    uint32_t tnow = hal.scheduler->micros();
+    uint32_t tnow = platform::micros();
 
     if (mainLoop_count != last_mainLoop_count) {
         // the main loop is running, all is OK

--- a/APMrover2/radio.cpp
+++ b/APMrover2/radio.cpp
@@ -125,7 +125,7 @@ void Rover::read_radio()
         return;
     }
 
-    failsafe.last_valid_rc_ms = hal.scheduler->millis();
+    failsafe.last_valid_rc_ms = platform::millis();
 
     RC_Channel::set_pwm_all();
 
@@ -190,7 +190,7 @@ void Rover::control_failsafe(uint16_t pwm)
         failsafe_trigger(FAILSAFE_EVENT_RC, (millis() - failsafe.rc_override_timer) > 1500);
 	} else if (g.fs_throttle_enabled) {
         bool failed = pwm < (uint16_t)g.fs_throttle_value;
-        if (hal.scheduler->millis() - failsafe.last_valid_rc_ms > 2000) {
+        if (platform::millis() - failsafe.last_valid_rc_ms > 2000) {
             failed = true;
         }
         failsafe_trigger(FAILSAFE_EVENT_THROTTLE, failed);

--- a/APMrover2/sensors.cpp
+++ b/APMrover2/sensors.cpp
@@ -59,7 +59,7 @@ void Rover::read_sonars(void)
                 gcs_send_text_fmt(MAV_SEVERITY_INFO, "Sonar1 obstacle %u cm",
                                   (unsigned)obstacle.sonar1_distance_cm);
             }
-            obstacle.detected_time_ms = hal.scheduler->millis();
+            obstacle.detected_time_ms = platform::millis();
             obstacle.turn_angle = g.sonar_turn_angle;
         } else if (obstacle.sonar2_distance_cm <= (uint16_t)g.sonar_trigger_cm) {
             // we have an object on the right
@@ -70,7 +70,7 @@ void Rover::read_sonars(void)
                 gcs_send_text_fmt(MAV_SEVERITY_INFO, "Sonar2 obstacle %u cm",
                                   (unsigned)obstacle.sonar2_distance_cm);
             }
-            obstacle.detected_time_ms = hal.scheduler->millis();
+            obstacle.detected_time_ms = platform::millis();
             obstacle.turn_angle = -g.sonar_turn_angle;
         }
     } else {
@@ -86,7 +86,7 @@ void Rover::read_sonars(void)
                 gcs_send_text_fmt(MAV_SEVERITY_NOTICE, "Sonar obstacle %u cm",
                                   (unsigned)obstacle.sonar1_distance_cm);
             }
-            obstacle.detected_time_ms = hal.scheduler->millis();
+            obstacle.detected_time_ms = platform::millis();
             obstacle.turn_angle = g.sonar_turn_angle;
         }
     }
@@ -95,7 +95,7 @@ void Rover::read_sonars(void)
 
     // no object detected - reset after the turn time
     if (obstacle.detected_count >= g.sonar_debounce &&
-        hal.scheduler->millis() > obstacle.detected_time_ms + g.sonar_turn_time*1000) { 
+        platform::millis() > obstacle.detected_time_ms + g.sonar_turn_time*1000) { 
         gcs_send_text_fmt(MAV_SEVERITY_INFO, "Obstacle passed");
         obstacle.detected_count = 0;
         obstacle.turn_angle = 0;

--- a/AntennaTracker/GCS_Mavlink.cpp
+++ b/AntennaTracker/GCS_Mavlink.cpp
@@ -69,7 +69,7 @@ void Tracker::send_attitude(mavlink_channel_t chan)
     Vector3f omega = ahrs.get_gyro();
     mavlink_msg_attitude_send(
         chan,
-        hal.scheduler->millis(),
+        platform::millis(),
         ahrs.roll,
         ahrs.pitch,
         ahrs.yaw,
@@ -85,7 +85,7 @@ void Tracker::send_location(mavlink_channel_t chan)
     if (gps.status() >= AP_GPS::GPS_OK_FIX_2D) {
         fix_time = gps.last_fix_time_ms();
     } else {
-        fix_time = hal.scheduler->millis();
+        fix_time = platform::millis();
     }
     const Vector3f &vel = gps.velocity();
     mavlink_msg_global_position_int_send(
@@ -105,7 +105,7 @@ void Tracker::send_radio_out(mavlink_channel_t chan)
 {
     mavlink_msg_servo_output_raw_send(
         chan,
-        hal.scheduler->micros(),
+        platform::micros(),
         0,     // port
         hal.rcout->read(0),
         hal.rcout->read(1),
@@ -902,7 +902,7 @@ void Tracker::mavlink_delay_cb()
 
     in_mavlink_delay = true;
 
-    uint32_t tnow = hal.scheduler->millis();
+    uint32_t tnow = platform::millis();
     if (tnow - last_1hz > 1000) {
         last_1hz = tnow;
         gcs_send_message(MSG_HEARTBEAT);

--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -291,9 +291,9 @@ void Tracker::load_parameters(void)
         g.format_version.set_and_save(Parameters::k_format_version);
         hal.console->println("done.");
     } else {
-        uint32_t before = hal.scheduler->micros();
+        uint32_t before = platform::micros();
         // Load all auto-loaded EEPROM variables
         AP_Param::load_all();
-        hal.console->printf("load_all took %luus\n", (unsigned long)(hal.scheduler->micros() - before));
+        hal.console->printf("load_all took %luus\n", (unsigned long)(platform::micros() - before));
     }
 }

--- a/AntennaTracker/servos.cpp
+++ b/AntennaTracker/servos.cpp
@@ -232,11 +232,11 @@ void Tracker::update_yaw_position_servo(float yaw)
     if (abs(channel_yaw.servo_out) == 18000 &&
         labs(angle_err) > margin &&
         making_progress &&
-        hal.scheduler->millis() - slew_start_ms > g.min_reverse_time*1000) {
+        platform::millis() - slew_start_ms > g.min_reverse_time*1000) {
         // we are at the limit of the servo and are not moving in the
         // right direction, so slew the other way
         new_slew_dir = -channel_yaw.servo_out / 18000;
-        slew_start_ms = hal.scheduler->millis();
+        slew_start_ms = platform::millis();
     }
 
     /*

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -181,7 +181,7 @@ void Tracker::disarm_servos()
  */
 void Tracker::prepare_servos()
 {
-    start_time_ms = hal.scheduler->millis();
+    start_time_ms = platform::millis();
     channel_yaw.radio_out = channel_yaw.radio_trim;
     channel_pitch.radio_out = channel_pitch.radio_trim;
     channel_yaw.output();

--- a/AntennaTracker/tracking.cpp
+++ b/AntennaTracker/tracking.cpp
@@ -9,7 +9,7 @@
 void Tracker::update_vehicle_pos_estimate()
 {
     // calculate time since last actual position update
-    float dt = (hal.scheduler->micros() - vehicle.last_update_us) * 1.0e-6f;
+    float dt = (platform::micros() - vehicle.last_update_us) * 1.0e-6f;
 
     // if less than 5 seconds since last position update estimate the position
     if (dt < TRACKING_TIMEOUT_SEC) {
@@ -80,7 +80,7 @@ void Tracker::update_tracking(void)
 
     // do not perform any servo updates until startup delay has passed
     if (g.startup_delay > 0 &&
-        hal.scheduler->millis() - start_time_ms < g.startup_delay*1000) {
+        platform::millis() - start_time_ms < g.startup_delay*1000) {
         return;
     }
 
@@ -119,8 +119,8 @@ void Tracker::tracking_update_position(const mavlink_global_position_int_t &msg)
     vehicle.location.alt = msg.alt/10;
     vehicle.heading      = msg.hdg * 0.01f;
     vehicle.ground_speed = pythagorous2(msg.vx, msg.vy) * 0.01f;
-    vehicle.last_update_us = hal.scheduler->micros();    
-    vehicle.last_update_ms = hal.scheduler->millis();
+    vehicle.last_update_us = platform::micros();    
+    vehicle.last_update_ms = platform::millis();
 }
 
 
@@ -165,7 +165,7 @@ void Tracker::tracking_manual_control(const mavlink_manual_control_t &msg)
  */
 void Tracker::update_armed_disarmed()
 {
-    if (vehicle.last_update_ms != 0 && (hal.scheduler->millis() - vehicle.last_update_ms) < TRACKING_TIMEOUT_MS) {
+    if (vehicle.last_update_ms != 0 && (platform::millis() - vehicle.last_update_ms) < TRACKING_TIMEOUT_MS) {
         AP_Notify::flags.armed = true;
     } else {
         AP_Notify::flags.armed = false;

--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -181,7 +181,7 @@ void Copter::setup()
 
     // setup initial performance counters
     perf_info_reset();
-    fast_loopTimer = hal.scheduler->micros();
+    fast_loopTimer = platform::micros();
 }
 
 /*

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -670,8 +670,6 @@ private:
     void log_picture();
     uint8_t mavlink_compassmot(mavlink_channel_t chan);
     void delay(uint32_t ms);
-    uint32_t millis();
-    uint32_t micros();
     bool acro_init(bool ignore_checks);
     void acro_run();
     void get_pilot_desired_angle_rates(int16_t roll_in, int16_t pitch_in, int16_t yaw_in, float &roll_out, float &pitch_out, float &yaw_out);
@@ -1014,5 +1012,8 @@ public:
 
 extern const AP_HAL::HAL& hal;
 extern Copter copter;
+
+using platform::millis;
+using platform::micros;
 
 #endif // _COPTER_H_

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -531,7 +531,7 @@ bool GCS_MAVLINK::try_send_message(enum ap_message id)
     switch(id) {
     case MSG_HEARTBEAT:
         CHECK_PAYLOAD_SIZE(HEARTBEAT);
-        copter.gcs[chan-MAVLINK_COMM_0].last_heartbeat_time = hal.scheduler->millis();
+        copter.gcs[chan-MAVLINK_COMM_0].last_heartbeat_time = platform::millis();
         copter.send_heartbeat(chan);
         break;
 
@@ -1002,7 +1002,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
     {
         // We keep track of the last time we received a heartbeat from our GCS for failsafe purposes
         if(msg->sysid != copter.g.sysid_my_gcs) break;
-        copter.failsafe.last_heartbeat_ms = hal.scheduler->millis();
+        copter.failsafe.last_heartbeat_ms = platform::millis();
         copter.pmTest1++;
         break;
     }
@@ -1124,7 +1124,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
         copter.failsafe.rc_override_active = hal.rcin->set_overrides(v, 8);
 
         // a RC override message is considered to be a 'heartbeat' from the ground station for failsafe purposes
-        copter.failsafe.last_heartbeat_ms = hal.scheduler->millis();
+        copter.failsafe.last_heartbeat_ms = platform::millis();
         break;
     }
 

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -172,7 +172,7 @@ void Copter::Log_Write_AutoTune(uint8_t axis, uint8_t tune_step, float meas_targ
 {
     struct log_AutoTune pkt = {
         LOG_PACKET_HEADER_INIT(LOG_AUTOTUNE_MSG),
-        time_us     : hal.scheduler->micros64(),
+        time_us     : platform::micros64(),
         axis        : axis,
         tune_step   : tune_step,
         meas_target : meas_target,
@@ -198,7 +198,7 @@ void Copter::Log_Write_AutoTuneDetails(float angle_cd, float rate_cds)
 {
     struct log_AutoTuneDetails pkt = {
         LOG_PACKET_HEADER_INIT(LOG_AUTOTUNEDETAILS_MSG),
-        time_us     : hal.scheduler->micros64(),
+        time_us     : platform::micros64(),
         angle_cd    : angle_cd,
         rate_cds    : rate_cds
     };
@@ -237,7 +237,7 @@ void Copter::Log_Write_Optflow()
     const Vector2f &bodyRate = optflow.bodyRate();
     struct log_Optflow pkt = {
         LOG_PACKET_HEADER_INIT(LOG_OPTFLOW_MSG),
-        time_us         : hal.scheduler->micros64(),
+        time_us         : platform::micros64(),
         surface_quality : optflow.quality(),
         flow_x          : flowRate.x,
         flow_y          : flowRate.y,
@@ -274,7 +274,7 @@ void Copter::Log_Write_Nav_Tuning()
 
     struct log_Nav_Tuning pkt = {
         LOG_PACKET_HEADER_INIT(LOG_NAV_TUNING_MSG),
-        time_us         : hal.scheduler->micros64(),
+        time_us         : platform::micros64(),
         desired_pos_x   : pos_target.x,
         desired_pos_y   : pos_target.y,
         pos_x           : position.x,
@@ -309,7 +309,7 @@ void Copter::Log_Write_Control_Tuning()
 {
     struct log_Control_Tuning pkt = {
         LOG_PACKET_HEADER_INIT(LOG_CONTROL_TUNING_MSG),
-        time_us             : hal.scheduler->micros64(),
+        time_us             : platform::micros64(),
         throttle_in         : channel_throttle->control_in,
         angle_boost         : attitude_control.angle_boost(),
         throttle_out        : motors.get_throttle(),
@@ -340,7 +340,7 @@ void Copter::Log_Write_Performance()
 {
     struct log_Performance pkt = {
         LOG_PACKET_HEADER_INIT(LOG_PERFORMANCE_MSG),
-        time_us          : hal.scheduler->micros64(),
+        time_us          : platform::micros64(),
         num_long_running : perf_info_get_num_long_running(),
         num_loops        : perf_info_get_num_loops(),
         max_time         : perf_info_get_max_time(),
@@ -394,7 +394,7 @@ void Copter::Log_Write_Rate()
     const Vector3f &accel_target = pos_control.get_accel_target();
     struct log_Rate pkt_rate = {
         LOG_PACKET_HEADER_INIT(LOG_RATE_MSG),
-        time_us         : hal.scheduler->micros64(),
+        time_us         : platform::micros64(),
         control_roll    : (float)rate_targets.x,
         roll            : (float)(ahrs.get_gyro().x * AC_ATTITUDE_CONTROL_DEGX100),
         roll_out        : motors.get_roll(),
@@ -426,7 +426,7 @@ void Copter::Log_Write_MotBatt()
 #if FRAME_CONFIG != HELI_FRAME
     struct log_MotBatt pkt_mot = {
         LOG_PACKET_HEADER_INIT(LOG_MOTBATT_MSG),
-        time_us         : hal.scheduler->micros64(),
+        time_us         : platform::micros64(),
         lift_max        : (float)(motors.get_lift_max()),
         bat_volt        : (float)(motors.get_batt_voltage_filt()),
         bat_res         : (float)(motors.get_batt_resistance()),
@@ -446,7 +446,7 @@ void Copter::Log_Write_Startup()
 {
     struct log_Startup pkt = {
         LOG_PACKET_HEADER_INIT(LOG_STARTUP_MSG),
-        time_us         : hal.scheduler->micros64()
+        time_us         : platform::micros64()
     };
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
 }
@@ -463,7 +463,7 @@ void Copter::Log_Write_Event(uint8_t id)
     if (should_log(MASK_LOG_ANY)) {
         struct log_Event pkt = {
             LOG_PACKET_HEADER_INIT(LOG_EVENT_MSG),
-            time_us  : hal.scheduler->micros64(),
+            time_us  : platform::micros64(),
             id       : id
         };
         DataFlash.WriteCriticalBlock(&pkt, sizeof(pkt));
@@ -484,7 +484,7 @@ void Copter::Log_Write_Data(uint8_t id, int16_t value)
     if (should_log(MASK_LOG_ANY)) {
         struct log_Data_Int16t pkt = {
             LOG_PACKET_HEADER_INIT(LOG_DATA_INT16_MSG),
-            time_us     : hal.scheduler->micros64(),
+            time_us     : platform::micros64(),
             id          : id,
             data_value  : value
         };
@@ -506,7 +506,7 @@ void Copter::Log_Write_Data(uint8_t id, uint16_t value)
     if (should_log(MASK_LOG_ANY)) {
         struct log_Data_UInt16t pkt = {
             LOG_PACKET_HEADER_INIT(LOG_DATA_UINT16_MSG),
-            time_us     : hal.scheduler->micros64(),
+            time_us     : platform::micros64(),
             id          : id,
             data_value  : value
         };
@@ -527,7 +527,7 @@ void Copter::Log_Write_Data(uint8_t id, int32_t value)
     if (should_log(MASK_LOG_ANY)) {
         struct log_Data_Int32t pkt = {
             LOG_PACKET_HEADER_INIT(LOG_DATA_INT32_MSG),
-            time_us  : hal.scheduler->micros64(),
+            time_us  : platform::micros64(),
             id          : id,
             data_value  : value
         };
@@ -548,7 +548,7 @@ void Copter::Log_Write_Data(uint8_t id, uint32_t value)
     if (should_log(MASK_LOG_ANY)) {
         struct log_Data_UInt32t pkt = {
             LOG_PACKET_HEADER_INIT(LOG_DATA_UINT32_MSG),
-            time_us     : hal.scheduler->micros64(),
+            time_us     : platform::micros64(),
             id          : id,
             data_value  : value
         };
@@ -570,7 +570,7 @@ void Copter::Log_Write_Data(uint8_t id, float value)
     if (should_log(MASK_LOG_ANY)) {
         struct log_Data_Float pkt = {
             LOG_PACKET_HEADER_INIT(LOG_DATA_FLOAT_MSG),
-            time_us     : hal.scheduler->micros64(),
+            time_us     : platform::micros64(),
             id          : id,
             data_value  : value
         };
@@ -590,7 +590,7 @@ void Copter::Log_Write_Error(uint8_t sub_system, uint8_t error_code)
 {
     struct log_Error pkt = {
         LOG_PACKET_HEADER_INIT(LOG_ERROR_MSG),
-        time_us       : hal.scheduler->micros64(),
+        time_us       : platform::micros64(),
         sub_system    : sub_system,
         error_code    : error_code,
     };
@@ -616,7 +616,7 @@ void Copter::Log_Write_Parameter_Tuning(uint8_t param, float tuning_val, int16_t
 {
     struct log_ParameterTuning pkt_tune = {
         LOG_PACKET_HEADER_INIT(LOG_PARAMTUNE_MSG),
-        time_us        : hal.scheduler->micros64(),
+        time_us        : platform::micros64(),
         parameter      : param,
         tuning_value   : tuning_val,
         control_in     : control_in,
@@ -671,7 +671,7 @@ void Copter::Log_Write_Heli()
 {
     struct log_Heli pkt_heli = {
         LOG_PACKET_HEADER_INIT(LOG_HELI_MSG),
-        time_us                 : hal.scheduler->micros64(),
+        time_us                 : platform::micros64(),
         desired_rotor_speed     : motors.get_desired_rotor_speed(),
         main_rotor_speed        : motors.get_main_rotor_speed(),
     };
@@ -706,7 +706,7 @@ void Copter::Log_Write_Precland()
     const Vector3f &target_pos_ofs = precland.last_target_pos_offset();
     struct log_Precland pkt = {
         LOG_PACKET_HEADER_INIT(LOG_PRECLAND_MSG),
-        time_us         : hal.scheduler->micros64(),
+        time_us         : platform::micros64(),
         healthy         : precland.healthy(),
         bf_angle_x      : degrees(bf_angle.x),
         bf_angle_y      : degrees(bf_angle.y),

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1145,7 +1145,7 @@ void Copter::load_parameters(void)
 {
     if (!AP_Param::check_var_info()) {
         cliSerial->printf("Bad var table\n");
-        hal.scheduler->panic("Bad var table");
+        platform::panic("Bad var table");
     }
 
     // disable centrifugal force correction, it will be enabled as part of the arming process

--- a/ArduCopter/compassmot.cpp
+++ b/ArduCopter/compassmot.cpp
@@ -221,8 +221,8 @@ uint8_t Copter::mavlink_compassmot(mavlink_channel_t chan)
             current_amps_max = max(current_amps_max, battery.current_amps());
 
         }
-        if (hal.scheduler->millis() - last_send_time > 500) {
-            last_send_time = hal.scheduler->millis();
+        if (platform::millis() - last_send_time > 500) {
+            last_send_time = platform::millis();
             mavlink_msg_compassmot_status_send(chan, 
                                                channel_throttle->control_in,
                                                battery.current_amps(),

--- a/ArduCopter/compat.cpp
+++ b/ArduCopter/compat.cpp
@@ -4,13 +4,3 @@ void Copter::delay(uint32_t ms)
 {
     hal.scheduler->delay(ms);
 }
-
-uint32_t Copter::millis()
-{
-    return hal.scheduler->millis();
-}
-
-uint32_t Copter::micros()
-{
-    return hal.scheduler->micros();
-}

--- a/ArduCopter/control_guided.cpp
+++ b/ArduCopter/control_guided.cpp
@@ -524,7 +524,7 @@ void Copter::guided_limit_set(uint32_t timeout_ms, float alt_min_cm, float alt_m
 void Copter::guided_limit_init_time_and_pos()
 {
     // initialise start time
-    guided_limit.start_time = hal.scheduler->millis();
+    guided_limit.start_time = platform::millis();
 
     // initialise start position from current position
     guided_limit.start_pos = inertial_nav.get_position();

--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -59,9 +59,9 @@ void Copter::ekf_check()
                 // log an error in the dataflash
                 Log_Write_Error(ERROR_SUBSYSTEM_EKFCHECK, ERROR_CODE_EKFCHECK_BAD_VARIANCE);
                 // send message to gcs
-                if ((hal.scheduler->millis() - ekf_check_state.last_warn_time) > EKF_CHECK_WARNING_TIME) {
+                if ((platform::millis() - ekf_check_state.last_warn_time) > EKF_CHECK_WARNING_TIME) {
                     gcs_send_text(MAV_SEVERITY_CRITICAL,"EKF variance");
-                    ekf_check_state.last_warn_time = hal.scheduler->millis();
+                    ekf_check_state.last_warn_time = platform::millis();
                 }
                 failsafe_ekf_event();
             }

--- a/ArduCopter/failsafe.cpp
+++ b/ArduCopter/failsafe.cpp
@@ -36,7 +36,7 @@ void Copter::failsafe_disable()
 //
 void Copter::failsafe_check()
 {
-    uint32_t tnow = hal.scheduler->micros();
+    uint32_t tnow = platform::micros();
 
     if (mainLoop_count != failsafe_last_mainLoop_count) {
         // the main loop is running, all is OK

--- a/ArduCopter/motor_test.cpp
+++ b/ArduCopter/motor_test.cpp
@@ -27,7 +27,7 @@ void Copter::motor_test_output()
     }
 
     // check for test timeout
-    if ((hal.scheduler->millis() - motor_test_start_ms) >= motor_test_timeout_ms) {
+    if ((platform::millis() - motor_test_start_ms) >= motor_test_timeout_ms) {
         // stop motor test
         motor_test_stop();
     } else {
@@ -128,7 +128,7 @@ uint8_t Copter::mavlink_motor_test_start(mavlink_channel_t chan, uint8_t motor_s
     }
 
     // set timeout
-    motor_test_start_ms = hal.scheduler->millis();
+    motor_test_start_ms = platform::millis();
     motor_test_timeout_ms = min(timeout_sec * 1000, MOTOR_TEST_TIMEOUT_MS_MAX);
 
     // store required output

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -612,7 +612,7 @@ bool GCS_MAVLINK::try_send_message(enum ap_message id)
     switch (id) {
     case MSG_HEARTBEAT:
         CHECK_PAYLOAD_SIZE(HEARTBEAT);
-        plane.gcs[chan-MAVLINK_COMM_0].last_heartbeat_time = plane.millis();
+        plane.gcs[chan-MAVLINK_COMM_0].last_heartbeat_time = platform::millis();
         plane.send_heartbeat(chan);
         return true;
 
@@ -1724,12 +1724,12 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
         v[7] = packet.chan8_raw;
 
         if (hal.rcin->set_overrides(v, 8)) {
-            plane.failsafe.last_valid_rc_ms = plane.millis();
+            plane.failsafe.last_valid_rc_ms = platform::millis();
         }
 
         // a RC override message is consiered to be a 'heartbeat' from
         // the ground station for failsafe purposes
-        plane.failsafe.last_heartbeat_ms = plane.millis();
+        plane.failsafe.last_heartbeat_ms = platform::millis();
         break;
     }
 
@@ -1738,7 +1738,7 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
         // We keep track of the last time we received a heartbeat from
         // our GCS for failsafe purposes
         if (msg->sysid != plane.g.sysid_my_gcs) break;
-        plane.failsafe.last_heartbeat_ms = plane.millis();
+        plane.failsafe.last_heartbeat_ms = platform::millis();
         break;
     }
 

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -202,7 +202,7 @@ void Plane::Log_Write_Performance()
 {
     struct log_Performance pkt = {
         LOG_PACKET_HEADER_INIT(LOG_PERFORMANCE_MSG),
-        time_us         : hal.scheduler->micros64(),
+        time_us         : platform::micros64(),
         loop_time       : millis() - perf_mon_timer,
         main_loop_count : mainLoop_count,
         g_dt_max        : G_Dt_max,
@@ -227,7 +227,7 @@ bool Plane::Log_Write_Startup(uint8_t type)
 {
     struct log_Startup pkt = {
         LOG_PACKET_HEADER_INIT(LOG_STARTUP_MSG),
-        time_us         : hal.scheduler->micros64(),
+        time_us         : platform::micros64(),
         startup_type    : type,
         command_total   : mission.num_commands()
     };
@@ -252,7 +252,7 @@ void Plane::Log_Write_Control_Tuning()
     Vector3f accel = ins.get_accel();
     struct log_Control_Tuning pkt = {
         LOG_PACKET_HEADER_INIT(LOG_CTUN_MSG),
-        time_us         : hal.scheduler->micros64(),
+        time_us         : platform::micros64(),
         nav_roll_cd     : (int16_t)nav_roll_cd,
         roll            : (int16_t)ahrs.roll_sensor,
         nav_pitch_cd    : (int16_t)nav_pitch_cd,
@@ -288,7 +288,7 @@ void Plane::Log_Write_Nav_Tuning()
 {
     struct log_Nav_Tuning pkt = {
         LOG_PACKET_HEADER_INIT(LOG_NTUN_MSG),
-        time_us             : hal.scheduler->micros64(),
+        time_us             : platform::micros64(),
         yaw                 : (uint16_t)ahrs.yaw_sensor,
         wp_distance         : auto_state.wp_distance,
         target_bearing_cd   : (int16_t)nav_controller->target_bearing_cd(),
@@ -317,7 +317,7 @@ void Plane::Log_Write_Status()
 {
     struct log_Status pkt = {
         LOG_PACKET_HEADER_INIT(LOG_STATUS_MSG)
-        ,time_us   : hal.scheduler->micros64()
+        ,time_us   : platform::micros64()
         ,is_flying   : is_flying()
         ,is_flying_probability : isFlyingProbability
         ,armed       : hal.util->get_soft_armed()
@@ -353,7 +353,7 @@ void Plane::Log_Write_Sonar()
 
     struct log_Sonar pkt = {
         LOG_PACKET_HEADER_INIT(LOG_SONAR_MSG),
-        time_us     : hal.scheduler->micros64(),
+        time_us     : platform::micros64(),
         distance    : distance,
         voltage     : rangefinder.voltage_mv()*0.001f,
         baro_alt    : barometer.get_altitude(),
@@ -390,7 +390,7 @@ void Plane::Log_Write_Optflow()
     const Vector2f &bodyRate = optflow.bodyRate();
     struct log_Optflow pkt = {
         LOG_PACKET_HEADER_INIT(LOG_OPTFLOW_MSG),
-        time_us         : hal.scheduler->micros64(),
+        time_us         : platform::micros64(),
         surface_quality : optflow.quality(),
         flow_x           : flowRate.x,
         flow_y           : flowRate.y,
@@ -419,7 +419,7 @@ void Plane::Log_Write_Current()
 void Plane::Log_Arm_Disarm() {
     struct log_Arm_Disarm pkt = {
         LOG_PACKET_HEADER_INIT(LOG_ARM_DISARM_MSG),
-        time_us                 : hal.scheduler->micros64(),
+        time_us                 : platform::micros64(),
         arm_state               : arming.is_armed(),
         arm_checks              : arming.get_enabled_checks()      
     };

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1252,7 +1252,7 @@ void Plane::load_parameters(void)
 {
     if (!AP_Param::check_var_info()) {
         cliSerial->printf("Bad parameter table\n");
-        hal.scheduler->panic("Bad parameter table");
+        platform::panic("Bad parameter table");
     }
     if (!g.format_version.load() ||
         g.format_version != Parameters::k_format_version) {

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -969,8 +969,6 @@ private:
     void run_cli(AP_HAL::UARTDriver *port);
     bool restart_landing_sequence();
     void log_init();
-    uint32_t millis() const;
-    uint32_t micros() const;
     void init_capabilities(void);
     void dataflash_periodic(void);
     uint16_t throttle_min(void) const;
@@ -1016,5 +1014,8 @@ public:
 
 extern const AP_HAL::HAL& hal;
 extern Plane plane;
+
+using platform::millis;
+using platform::micros;
 
 #endif // _PLANE_H_

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -756,9 +756,9 @@ bool Plane::verify_altitude_wait(const AP_Mission::Mission_Command &cmd)
     if (cmd.content.altitude_wait.wiggle_time != 0) {
         static uint32_t last_wiggle_ms;
         if (auto_state.idle_wiggle_stage == 0 &&
-            hal.scheduler->millis() - last_wiggle_ms > cmd.content.altitude_wait.wiggle_time*1000) {
+            platform::millis() - last_wiggle_ms > cmd.content.altitude_wait.wiggle_time*1000) {
             auto_state.idle_wiggle_stage = 1;
-            last_wiggle_ms = hal.scheduler->millis();
+            last_wiggle_ms = platform::millis();
         }
         // idle_wiggle_stage is updated in set_servos_idle()
     }

--- a/ArduPlane/is_flying.cpp
+++ b/ArduPlane/is_flying.cpp
@@ -14,7 +14,7 @@ void Plane::update_is_flying_5Hz(void)
 {
     float aspeed;
     bool is_flying_bool;
-    uint32_t now_ms = hal.scheduler->millis();
+    uint32_t now_ms = platform::millis();
 
     uint32_t ground_speed_thresh_cm = (g.min_gndspeed_cm > 0) ? ((uint32_t)(g.min_gndspeed_cm*0.9f)) : 500;
     bool gps_confirmed_movement = (gps.status() >= AP_GPS::GPS_OK_FIX_3D) &&
@@ -146,7 +146,7 @@ void Plane::crash_detection_update(void)
         return;
     }
 
-    uint32_t now_ms = hal.scheduler->millis();
+    uint32_t now_ms = platform::millis();
     bool auto_launch_detected;
     bool crashed_near_land_waypoint = false;
     bool crashed = false;

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -775,13 +775,3 @@ bool Plane::disarm_motors(void)
 
     return true;
 }
-
-uint32_t Plane::millis(void) const
-{
-    return hal.scheduler->millis();
-}
-
-uint32_t Plane::micros(void) const
-{
-    return hal.scheduler->micros();
-}

--- a/Tools/CPUInfo/CPUInfo.cpp
+++ b/Tools/CPUInfo/CPUInfo.cpp
@@ -36,11 +36,11 @@ static void show_sizes(void)
 
 #define TIMEIT(name, op, count) do { \
 	uint32_t us_end, us_start; \
-	us_start = hal.scheduler->micros(); \
+	us_start = platform::micros(); \
 	for (uint8_t i=0; i<count; i++) { \
 		FIFTYTIMES(op);				\
 	} \
-	us_end = hal.scheduler->micros(); \
+	us_end = platform::micros(); \
 	hal.console->printf("%-10s %7.2f usec/call\n", name, double(us_end-us_start)/(count*50.0)); \
 } while (0)
 
@@ -61,17 +61,17 @@ volatile uint64_t v_out_64 = 1;
 static void show_timings(void)
 {
 
-	v_f = 1+(hal.scheduler->micros() % 5);
-	v_out = 1+(hal.scheduler->micros() % 3);
+	v_f = 1+(platform::micros() % 5);
+	v_out = 1+(platform::micros() % 3);
 
-	v_32 = 1+(hal.scheduler->micros() % 5);
-	v_out_32 = 1+(hal.scheduler->micros() % 3);
+	v_32 = 1+(platform::micros() % 5);
+	v_out_32 = 1+(platform::micros() % 3);
 
-	v_16 = 1+(hal.scheduler->micros() % 5);
-	v_out_16 = 1+(hal.scheduler->micros() % 3);
+	v_16 = 1+(platform::micros() % 5);
+	v_out_16 = 1+(platform::micros() % 3);
 
-	v_8 = 1+(hal.scheduler->micros() % 5);
-	v_out_8 = 1+(hal.scheduler->micros() % 3);
+	v_8 = 1+(platform::micros() % 5);
+	v_out_8 = 1+(platform::micros() % 3);
 
 
 	hal.console->println("Operation timings:");
@@ -79,8 +79,8 @@ static void show_timings(void)
 
 	TIMEIT("nop", asm volatile("nop"::), 255);
 
-	TIMEIT("micros()", hal.scheduler->micros(), 200);
-	TIMEIT("millis()", hal.scheduler->millis(), 200);
+	TIMEIT("micros()", platform::micros(), 200);
+	TIMEIT("millis()", platform::millis(), 200);
 
 	TIMEIT("fadd", v_out += v_f, 100);
 	TIMEIT("fsub", v_out -= v_f, 100);

--- a/Tools/Replay/LR_MsgHandler.cpp
+++ b/Tools/Replay/LR_MsgHandler.cpp
@@ -58,7 +58,7 @@ void LR_MsgHandler_ARM::process_message(uint8_t *msg)
     hal.util->set_soft_armed(ArmState);
     printf("Armed state: %u at %lu\n", 
            (unsigned)ArmState,
-           (unsigned long)hal.scheduler->millis());
+           (unsigned long)platform::millis());
 }
 
 
@@ -86,7 +86,7 @@ void LR_MsgHandler_ATT::process_message(uint8_t *msg)
 void LR_MsgHandler_CHEK::process_message(uint8_t *msg)
 {
     wait_timestamp_from_msg(msg);
-    check_state.time_us = hal.scheduler->micros64();
+    check_state.time_us = platform::micros64();
     attitude_from_msg(msg, check_state.euler, "Roll", "Pitch", "Yaw");
     check_state.euler *= radians(1);
     location_from_msg(msg, check_state.pos, "Lat", "Lng", "Alt");
@@ -114,11 +114,11 @@ void LR_MsgHandler_Event::process_message(uint8_t *msg)
     if (id == DATA_ARMED) {
         hal.util->set_soft_armed(true);
         printf("Armed at %lu\n", 
-               (unsigned long)hal.scheduler->millis());
+               (unsigned long)platform::millis());
     } else if (id == DATA_DISARMED) {
         hal.util->set_soft_armed(false);
         printf("Disarmed at %lu\n", 
-               (unsigned long)hal.scheduler->millis());
+               (unsigned long)platform::millis());
     }
 }
 

--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -146,7 +146,7 @@ const AP_Param::Info ReplayVehicle::var_info[] = {
 void ReplayVehicle::load_parameters(void)
 {
     if (!AP_Param::check_var_info()) {
-        hal.scheduler->panic("Bad parameter table");
+        platform::panic("Bad parameter table");
     }
 }
 
@@ -697,7 +697,7 @@ void Replay::read_sensors(const char *type)
                      loc.lat * 1.0e-7f, 
                      loc.lng * 1.0e-7f,
                      loc.alt * 0.01f,
-                     hal.scheduler->millis()*0.001f);
+                     platform::millis()*0.001f);
             _vehicle.ahrs.set_home(loc);
             _vehicle.compass.set_initial_location(loc.lat, loc.lng);
             done_home_init = true;
@@ -772,7 +772,7 @@ void Replay::read_sensors(const char *type)
             ahrs_healthy = _vehicle.ahrs.healthy();
             printf("AHRS health: %u at %lu\n", 
                    (unsigned)ahrs_healthy,
-                   (unsigned long)hal.scheduler->millis());
+                   (unsigned long)platform::millis());
         }
         if (check_generate) {
             log_check_generate();
@@ -798,7 +798,7 @@ void Replay::log_check_generate(void)
 
     struct log_Chek packet = {
         LOG_PACKET_HEADER_INIT(LOG_CHEK_MSG),
-        time_us : hal.scheduler->micros64(),
+        time_us : platform::micros64(),
         roll    : (int16_t)(100*degrees(euler.x)), // roll angle (centi-deg, displayed as deg due to format string)
         pitch   : (int16_t)(100*degrees(euler.y)), // pitch angle (centi-deg, displayed as deg due to format string)
         yaw     : (uint16_t)wrap_360_cd(100*degrees(euler.z)), // yaw angle (centi-deg, displayed as deg due to format string)
@@ -847,15 +847,15 @@ void Replay::loop()
     while (true) {
         char type[5];
 
-        if (arm_time_ms >= 0 && hal.scheduler->millis() > (uint32_t)arm_time_ms) {
+        if (arm_time_ms >= 0 && platform::millis() > (uint32_t)arm_time_ms) {
             if (!hal.util->get_soft_armed()) {
                 hal.util->set_soft_armed(true);
-                ::printf("Arming at %u ms\n", (unsigned)hal.scheduler->millis());
+                ::printf("Arming at %u ms\n", (unsigned)platform::millis());
             }
         }
 
         if (!logreader.update(type)) {
-            ::printf("End of log at %.1f seconds\n", hal.scheduler->millis()*0.001f);
+            ::printf("End of log at %.1f seconds\n", platform::millis()*0.001f);
             fclose(plotf);
             break;
         }
@@ -906,7 +906,7 @@ void Replay::loop()
 
             if (temp < 0.0f) temp = temp + 360.0f;
             fprintf(plotf, "%.3f %.1f %.1f %.1f %.2f %.1f %.1f %.1f %.2f %.2f %.2f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.2f %.2f %.2f %.2f %.2f %.2f\n",
-                    hal.scheduler->millis() * 0.001f,
+                    platform::millis() * 0.001f,
                     logreader.get_sim_attitude().x,
                     logreader.get_sim_attitude().y,
                     logreader.get_sim_attitude().z,
@@ -933,7 +933,7 @@ void Replay::loop()
                     ekf_relpos.y,
                     -ekf_relpos.z);
             fprintf(plotf2, "%.3f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f %.1f\n",
-                    hal.scheduler->millis() * 0.001f,
+                    platform::millis() * 0.001f,
                     degrees(ekf_euler.x),
                     degrees(ekf_euler.y),
                     temp,
@@ -974,8 +974,8 @@ void Replay::loop()
 
             // print EKF1 data packet
             fprintf(ekf1f, "%.3f %u %d %d %u %.2f %.2f %.2f %.2f %.2f %.2f %.0f %.0f %.0f\n",
-                    hal.scheduler->millis() * 0.001f,
-                    hal.scheduler->millis(),
+                    platform::millis() * 0.001f,
+                    platform::millis(),
                     roll, 
                     pitch, 
                     yaw, 
@@ -1004,8 +1004,8 @@ void Replay::loop()
 
             // print EKF2 data packet
             fprintf(ekf2f, "%.3f %d %d %d %d %d %d %d %d %d %d %d %d\n",
-                    hal.scheduler->millis() * 0.001f,
-                    hal.scheduler->millis(),
+                    platform::millis() * 0.001f,
+                    platform::millis(),
                     accWeight, 
                     acc1, 
                     acc2, 
@@ -1032,8 +1032,8 @@ void Replay::loop()
 
             // print EKF3 data packet
             fprintf(ekf3f, "%.3f %d %d %d %d %d %d %d %d %d %d %d\n",
-                    hal.scheduler->millis() * 0.001f,
-                    hal.scheduler->millis(),
+                    platform::millis() * 0.001f,
+                    platform::millis(),
                     innovVN, 
                     innovVE, 
                     innovVD, 
@@ -1058,8 +1058,8 @@ void Replay::loop()
 
             // print EKF4 data packet
             fprintf(ekf4f, "%.3f %u %d %d %d %d %d %d %d %d %d %d\n",
-                    hal.scheduler->millis() * 0.001f,
-                    (unsigned)hal.scheduler->millis(),
+                    platform::millis() * 0.001f,
+                    (unsigned)platform::millis(),
                     (int)sqrtvarV,
                     (int)sqrtvarP,
                     (int)sqrtvarH,

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -310,14 +310,14 @@ void AC_PosControl::init_takeoff()
 // is_active_z - returns true if the z-axis position controller has been run very recently
 bool AC_PosControl::is_active_z() const
 {
-    return ((hal.scheduler->millis() - _last_update_z_ms) <= POSCONTROL_ACTIVE_TIMEOUT_MS);
+    return ((platform::millis() - _last_update_z_ms) <= POSCONTROL_ACTIVE_TIMEOUT_MS);
 }
 
 /// update_z_controller - fly to altitude in cm above home
 void AC_PosControl::update_z_controller()
 {
     // check time since last cast
-    uint32_t now = hal.scheduler->millis();
+    uint32_t now = platform::millis();
     if (now - _last_update_z_ms > POSCONTROL_ACTIVE_TIMEOUT_MS) {
         _flags.reset_rate_to_accel_z = true;
         _flags.reset_accel_to_throttle = true;
@@ -612,7 +612,7 @@ float AC_PosControl::get_distance_to_target() const
 // is_active_xy - returns true if the xy position controller has been run very recently
 bool AC_PosControl::is_active_xy() const
 {
-    return ((hal.scheduler->millis() - _last_update_xy_ms) <= POSCONTROL_ACTIVE_TIMEOUT_MS);
+    return ((platform::millis() - _last_update_xy_ms) <= POSCONTROL_ACTIVE_TIMEOUT_MS);
 }
 
 /// init_xy_controller - initialise the xy controller
@@ -642,7 +642,7 @@ void AC_PosControl::init_xy_controller(bool reset_I)
 void AC_PosControl::update_xy_controller(xy_mode mode, float ekfNavVelGainScaler, bool use_althold_lean_angle)
 {
     // compute dt
-    uint32_t now = hal.scheduler->millis();
+    uint32_t now = platform::millis();
     float dt = (now - _last_update_xy_ms) / 1000.0f;
     _last_update_xy_ms = now;
 
@@ -669,7 +669,7 @@ void AC_PosControl::update_xy_controller(xy_mode mode, float ekfNavVelGainScaler
 
 float AC_PosControl::time_since_last_xy_update() const
 {
-    uint32_t now = hal.scheduler->millis();
+    uint32_t now = platform::millis();
     return (now - _last_update_xy_ms)*0.001f;
 }
 
@@ -705,7 +705,7 @@ void AC_PosControl::init_vel_controller_xyz()
 void AC_PosControl::update_vel_controller_xyz(float ekfNavVelGainScaler)
 {
     // capture time since last iteration
-    uint32_t now = hal.scheduler->millis();
+    uint32_t now = platform::millis();
     float dt = (now - _last_update_xy_ms) / 1000.0f;
 
     // sanity check dt - expect to be called faster than ~5hz

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -124,7 +124,7 @@ uint8_t AC_Fence::check_fence(float curr_alt)
     // check if pilot is attempting to recover manually
     if (_manual_recovery_start_ms != 0) {
         // we ignore any fence breaches during the manual recovery period which is about 10 seconds
-        if ((hal.scheduler->millis() - _manual_recovery_start_ms) < AC_FENCE_MANUAL_RECOVERY_TIME_MIN) {
+        if ((platform::millis() - _manual_recovery_start_ms) < AC_FENCE_MANUAL_RECOVERY_TIME_MIN) {
             return AC_FENCE_TYPE_NONE;
         } else {
             // recovery period has passed so reset manual recovery time and continue with fence breach checks
@@ -202,7 +202,7 @@ void AC_Fence::record_breach(uint8_t fence_type)
 {
     // if we haven't already breached a limit, update the breach time
     if (_breached_fences == AC_FENCE_TYPE_NONE) {
-        _breach_time = hal.scheduler->millis();
+        _breach_time = platform::millis();
     }
 
     // update breach count
@@ -254,5 +254,5 @@ void AC_Fence::manual_recovery_start()
     }
 
     // record time pilot began manual recovery
-    _manual_recovery_start_ms = hal.scheduler->millis();
+    _manual_recovery_start_ms = platform::millis();
 }

--- a/libraries/AC_Sprayer/AC_Sprayer.cpp
+++ b/libraries/AC_Sprayer/AC_Sprayer.cpp
@@ -116,7 +116,7 @@ AC_Sprayer::update()
     ground_speed = pythagorous2(velocity.x,velocity.y);
 
     // get the current time
-    now = hal.scheduler->millis();
+    now = platform::millis();
 
     // check our speed vs the minimum
     if (ground_speed >= _speed_min) {

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -419,7 +419,7 @@ void AC_WPNav::set_wp_destination(const Vector3f& destination)
 	Vector3f origin;
 
     // if waypoint controller is active use the existing position target as the origin
-    if ((hal.scheduler->millis() - _wp_last_update) < 1000) {
+    if ((platform::millis() - _wp_last_update) < 1000) {
         origin = _pos_control.get_pos_target();
     } else {
         // if waypoint controller is not active, set origin to reasonable stopping point (using curr pos and velocity)
@@ -687,7 +687,7 @@ void AC_WPNav::update_wpnav()
         _pos_control.update_xy_controller(AC_PosControl::XY_MODE_POS_ONLY, 1.0f, false);
         check_wp_leash_length();
 
-        _wp_last_update = hal.scheduler->millis();
+        _wp_last_update = platform::millis();
     }
 }
 
@@ -757,7 +757,7 @@ void AC_WPNav::set_spline_destination(const Vector3f& destination, bool stopped_
     Vector3f origin;
 
     // if waypoint controller is active and copter has reached the previous waypoint use current pos target as the origin
-    if ((hal.scheduler->millis() - _wp_last_update) < 1000) {
+    if ((platform::millis() - _wp_last_update) < 1000) {
         origin = _pos_control.get_pos_target();
     }else{
         // otherwise calculate origin from the current position and velocity
@@ -774,7 +774,7 @@ void AC_WPNav::set_spline_destination(const Vector3f& destination, bool stopped_
 void AC_WPNav::set_spline_origin_and_destination(const Vector3f& origin, const Vector3f& destination, bool stopped_at_start, spline_segment_end_type seg_end_type, const Vector3f& next_destination)
 {
     // mission is "active" if wpnav has been called recently and vehicle reached the previous waypoint
-    bool prev_segment_exists = (_flags.reached_destination && ((hal.scheduler->millis() - _wp_last_update) < 1000));
+    bool prev_segment_exists = (_flags.reached_destination && ((platform::millis() - _wp_last_update) < 1000));
     float dt = _pos_control.get_dt_xy();
 
     // check _wp_accel_cms is reasonable to avoid divide by zero
@@ -901,7 +901,7 @@ void AC_WPNav::update_spline()
         // run horizontal position controller
         _pos_control.update_xy_controller(AC_PosControl::XY_MODE_POS_ONLY, 1.0f, false);
 
-        _wp_last_update = hal.scheduler->millis();
+        _wp_last_update = platform::millis();
     }
 }
 

--- a/libraries/APM_Control/AP_AutoTune.cpp
+++ b/libraries/APM_Control/AP_AutoTune.cpp
@@ -118,7 +118,7 @@ void AP_AutoTune::start(void)
 {
     running = true;
     state = DEMAND_UNSATURATED;
-    uint32_t now = hal.scheduler->millis();
+    uint32_t now = platform::millis();
 
     state_enter_ms = now;
     last_save_ms = now;
@@ -174,7 +174,7 @@ void AP_AutoTune::update(float desired_rate, float achieved_rate, float servo_ou
     // see what state we are in
     ATState new_state;
     float abs_desired_rate = fabsf(desired_rate);
-    uint32_t now = hal.scheduler->millis();
+    uint32_t now = platform::millis();
 
     if (fabsf(servo_out) >= 45) {
         // we have saturated the servo demand (not including
@@ -242,7 +242,7 @@ void AP_AutoTune::check_state_exit(uint32_t state_time_ms)
  */
 void AP_AutoTune::check_save(void)
 {
-    if (hal.scheduler->millis() - last_save_ms < AUTOTUNE_SAVE_PERIOD) {
+    if (platform::millis() - last_save_ms < AUTOTUNE_SAVE_PERIOD) {
         return;
     }
 
@@ -263,7 +263,7 @@ void AP_AutoTune::check_save(void)
 
     // the next values to save will be the ones we are flying now
     next_save = current;
-    last_save_ms = hal.scheduler->millis();
+    last_save_ms = platform::millis();
 }
 
 /*
@@ -337,7 +337,7 @@ void AP_AutoTune::write_log(float servo, float demanded, float achieved)
 
     struct log_ATRP pkt = {
         LOG_PACKET_HEADER_INIT(LOG_ATRP_MSG),
-        time_us    : hal.scheduler->micros64(),
+        time_us    : platform::micros64(),
         type       : type,
     	state      : (uint8_t)state,
         servo      : (int16_t)(servo*100),

--- a/libraries/APM_Control/AP_PitchController.cpp
+++ b/libraries/APM_Control/AP_PitchController.cpp
@@ -114,7 +114,7 @@ const AP_Param::GroupInfo AP_PitchController::var_info[] = {
 */
 int32_t AP_PitchController::_get_rate_out(float desired_rate, float scaler, bool disable_integrator, float aspeed)
 {
-	uint32_t tnow = hal.scheduler->millis();
+	uint32_t tnow = platform::millis();
 	uint32_t dt = tnow - _last_t;
 	
 	if (_last_t == 0 || dt > 1000) {

--- a/libraries/APM_Control/AP_RollController.cpp
+++ b/libraries/APM_Control/AP_RollController.cpp
@@ -92,7 +92,7 @@ const AP_Param::GroupInfo AP_RollController::var_info[] = {
 */
 int32_t AP_RollController::_get_rate_out(float desired_rate, float scaler, bool disable_integrator)
 {
-	uint32_t tnow = hal.scheduler->millis();
+	uint32_t tnow = platform::millis();
 	uint32_t dt = tnow - _last_t;
 	if (_last_t == 0 || dt > 1000) {
 		dt = 0;

--- a/libraries/APM_Control/AP_SteerController.cpp
+++ b/libraries/APM_Control/AP_SteerController.cpp
@@ -94,7 +94,7 @@ const AP_Param::GroupInfo AP_SteerController::var_info[] = {
 */
 int32_t AP_SteerController::get_steering_out_rate(float desired_rate)
 {
-	uint32_t tnow = hal.scheduler->millis();
+	uint32_t tnow = platform::millis();
 	uint32_t dt = tnow - _last_t;
 	if (_last_t == 0 || dt > 1000) {
 		dt = 0;

--- a/libraries/APM_Control/AP_YawController.cpp
+++ b/libraries/APM_Control/AP_YawController.cpp
@@ -72,7 +72,7 @@ const AP_Param::GroupInfo AP_YawController::var_info[] = {
 
 int32_t AP_YawController::get_servo_out(float scaler, bool disable_integrator)
 {
-	uint32_t tnow = hal.scheduler->millis();
+	uint32_t tnow = platform::millis();
 	uint32_t dt = tnow - _last_t;
 	if (_last_t == 0 || dt > 1000) {
 		dt = 0;

--- a/libraries/APM_OBC/APM_OBC.cpp
+++ b/libraries/APM_OBC/APM_OBC.cpp
@@ -140,7 +140,7 @@ APM_OBC::check(APM_OBC::control_mode mode, uint32_t last_heartbeat_ms, bool geof
     if (_state != STATE_PREFLIGHT && 
         (mode == OBC_MANUAL || mode == OBC_FBW) && 
         _rc_fail_time != 0 && 
-        (hal.scheduler->millis() - last_valid_rc_ms) > (unsigned)_rc_fail_time.get()) {
+        (platform::millis() - last_valid_rc_ms) > (unsigned)_rc_fail_time.get()) {
         if (!_terminate) {
             GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "RC failure terminate");
             _terminate.set(1);
@@ -155,7 +155,7 @@ APM_OBC::check(APM_OBC::control_mode mode, uint32_t last_heartbeat_ms, bool geof
         hal.gpio->write(_manual_pin, mode==OBC_MANUAL);
     }
 
-    uint32_t now = hal.scheduler->millis();
+    uint32_t now = platform::millis();
     bool gcs_link_ok = ((now - last_heartbeat_ms) < 10000);
     bool gps_lock_ok = ((now - gps.last_fix_time_ms()) < 3000);
 
@@ -290,7 +290,7 @@ APM_OBC::check_altlimit(void)
     }
 
     // see if the barometer is dead
-    if (hal.scheduler->millis() - baro.get_last_update() > 5000) {
+    if (platform::millis() - baro.get_last_update() > 5000) {
         // the barometer has been unresponsive for 5 seconds. See if we can switch to GPS
         if (_amsl_margin_gps != -1 &&
             gps.status() >= AP_GPS::GPS_OK_FIX_3D &&

--- a/libraries/AP_ADC/AP_ADC_ADS1115.cpp
+++ b/libraries/AP_ADC/AP_ADC_ADS1115.cpp
@@ -188,7 +188,7 @@ float AP_ADC_ADS1115::_convert_register_data_to_mv(int16_t word) const
         default:
             pga = 0.0f;
             hal.console->printf("Wrong gain");
-            hal.scheduler->panic("ADS1115: wrong gain selected");
+            platform::panic("ADS1115: wrong gain selected");
             break;
     }
 
@@ -198,7 +198,7 @@ float AP_ADC_ADS1115::_convert_register_data_to_mv(int16_t word) const
 void AP_ADC_ADS1115::_update() 
 {
     /* TODO: make update rate configurable */
-    if (hal.scheduler->micros() - _last_update_timestamp < 100000) {
+    if (platform::micros() - _last_update_timestamp < 100000) {
         return;
     }
 
@@ -241,5 +241,5 @@ void AP_ADC_ADS1115::_update()
 
     _i2c_sem->give();
 
-    _last_update_timestamp = hal.scheduler->micros();
+    _last_update_timestamp = platform::micros();
 }

--- a/libraries/AP_ADC/AP_ADC_ADS7844.cpp
+++ b/libraries/AP_ADC/AP_ADC_ADS7844.cpp
@@ -90,7 +90,7 @@ void AP_ADC_ADS7844::read(void)
     if (!got) { 
         semfail_ctr++;
         if (semfail_ctr > 100) {
-            hal.scheduler->panic("PANIC: failed to take _spi_sem "
+            platform::panic("PANIC: failed to take _spi_sem "
                         "100 times in AP_ADC_ADS7844::read");
         }
         return;
@@ -124,7 +124,7 @@ void AP_ADC_ADS7844::read(void)
     _spi_sem->give();
 
     // record time of this sample
-    _ch6_last_sample_time_micros = hal.scheduler->micros();
+    _ch6_last_sample_time_micros = platform::micros();
 }
 
 
@@ -137,19 +137,19 @@ void AP_ADC_ADS7844::Init()
     hal.scheduler->suspend_timer_procs();
     _spi = hal.spi->device(AP_HAL::SPIDevice_ADS7844);
     if (_spi == NULL) {
-        hal.scheduler->panic("PANIC: AP_ADC_ADS7844 missing SPI device "
+        platform::panic("PANIC: AP_ADC_ADS7844 missing SPI device "
                     "driver\n");
     }
 
     _spi_sem = _spi->get_semaphore();
 
     if (_spi_sem == NULL) {
-        hal.scheduler->panic("PANIC: AP_ADC_ADS7844 missing SPI device "
+        platform::panic("PANIC: AP_ADC_ADS7844 missing SPI device "
                     "semaphore");
     }
    
     if (!_spi_sem->take(0)) {
-        hal.scheduler->panic("PANIC: failed to take _spi_sem in"
+        platform::panic("PANIC: failed to take _spi_sem in"
                     "AP_ADC_ADS7844::Init");
     }
     
@@ -168,7 +168,7 @@ void AP_ADC_ADS7844::Init()
 
     _spi_sem->give();
 
-    _ch6_last_sample_time_micros = hal.scheduler->micros();
+    _ch6_last_sample_time_micros = platform::micros();
 
     hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&AP_ADC_ADS7844::read, void));
     hal.scheduler->resume_timer_procs();

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -53,7 +53,7 @@ AP_AHRS_DCM::update(void)
     float delta_t;
 
     if (_last_startup_ms == 0) {
-        _last_startup_ms = hal.scheduler->millis();
+        _last_startup_ms = platform::millis();
     }
 
     // tell the IMU to grab some data
@@ -177,7 +177,7 @@ AP_AHRS_DCM::reset(bool recover_eulers)
 
     }
 
-    _last_startup_ms = hal.scheduler->millis();
+    _last_startup_ms = platform::millis();
 }
 
 // reset the current attitude, used by HIL
@@ -292,7 +292,7 @@ AP_AHRS_DCM::normalize(void)
             !renorm(t2, _dcm_matrix.c)) {
         // Our solution is blowing up and we will force back
         // to last euler angles
-        _last_failure_ms = hal.scheduler->millis();
+        _last_failure_ms = platform::millis();
         AP_AHRS_DCM::reset(true);
     }
 }
@@ -382,7 +382,7 @@ bool AP_AHRS_DCM::have_gps(void) const
  */
 bool AP_AHRS_DCM::use_fast_gains(void) const
 {
-    return !hal.util->get_soft_armed() && (hal.scheduler->millis() - _last_startup_ms) < 20000U;
+    return !hal.util->get_soft_armed() && (platform::millis() - _last_startup_ms) < 20000U;
 }
 
 
@@ -408,13 +408,13 @@ bool AP_AHRS_DCM::use_compass(void)
     // prevent flyaways with very bad compass offsets
     int32_t error = abs(wrap_180_cd(yaw_sensor - _gps.ground_course_cd()));
     if (error > 4500 && _wind.length() < _gps.ground_speed()*0.8f) {
-        if (hal.scheduler->millis() - _last_consistent_heading > 2000) {
+        if (platform::millis() - _last_consistent_heading > 2000) {
             // start using the GPS for heading if the compass has been
             // inconsistent with the GPS for 2 seconds
             return false;
         }
     } else {
-        _last_consistent_heading = hal.scheduler->millis();
+        _last_consistent_heading = platform::millis();
     }
 
     // use the compass
@@ -637,7 +637,7 @@ AP_AHRS_DCM::drift_correction(float deltat)
         // add in wind estimate
         velocity += _wind;
 
-        last_correction_time = hal.scheduler->millis();
+        last_correction_time = platform::millis();
         _have_gps_lock = false;
     } else {
         if (_gps.last_fix_time_ms() == _ra_sum_start) {
@@ -703,7 +703,7 @@ AP_AHRS_DCM::drift_correction(float deltat)
         GA_e.normalize();
         if (GA_e.is_inf()) {
             // wait for some non-zero acceleration information
-            _last_failure_ms = hal.scheduler->millis();
+            _last_failure_ms = platform::millis();
             return;
         }
         using_gps_corrections = true;
@@ -762,7 +762,7 @@ AP_AHRS_DCM::drift_correction(float deltat)
 
     if (besti == -1) {
         // no healthy accelerometers!
-        _last_failure_ms = hal.scheduler->millis();
+        _last_failure_ms = platform::millis();
         return;
     }
 
@@ -812,7 +812,7 @@ AP_AHRS_DCM::drift_correction(float deltat)
     if (error[besti].is_nan() || error[besti].is_inf()) {
         // don't allow bad values
         check_matrix();
-        _last_failure_ms = hal.scheduler->millis();
+        _last_failure_ms = platform::millis();
         return;
     }
 
@@ -887,7 +887,7 @@ void AP_AHRS_DCM::estimate_wind(void)
     // See http://gentlenav.googlecode.com/files/WindEstimation.pdf
     Vector3f fuselageDirection = _dcm_matrix.colx();
     Vector3f fuselageDirectionDiff = fuselageDirection - _last_fuse;
-    uint32_t now = hal.scheduler->millis();
+    uint32_t now = platform::millis();
 
     // scrap our data and start over if we're taking too long to get a direction change
     if (now - _last_wind_time > 10000) {
@@ -1011,7 +1011,7 @@ void AP_AHRS_DCM::set_home(const Location &loc)
 bool AP_AHRS_DCM::healthy(void) const
 {
     // consider ourselves healthy if there have been no failures for 5 seconds
-    return (_last_failure_ms == 0 || hal.scheduler->millis() - _last_failure_ms > 5000);
+    return (_last_failure_ms == 0 || platform::millis() - _last_failure_ms > 5000);
 }
 
 /*
@@ -1022,5 +1022,5 @@ uint32_t AP_AHRS_DCM::uptime_ms(void) const
     if (_last_startup_ms == 0) {
         return 0;
     }
-    return hal.scheduler->millis() - _last_startup_ms;
+    return platform::millis() - _last_startup_ms;
 }

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.cpp
@@ -93,9 +93,9 @@ void AP_AHRS_NavEKF::update_EKF1(void)
     if (!ekf1_started) {
         // wait 1 second for DCM to output a valid tilt error estimate
         if (start_time_ms == 0) {
-            start_time_ms = hal.scheduler->millis();
+            start_time_ms = platform::millis();
         }
-        if (hal.scheduler->millis() - start_time_ms > startup_delay_ms) {
+        if (platform::millis() - start_time_ms > startup_delay_ms) {
             ekf1_started = EKF1.InitialiseFilterDynamic();
         }
     }
@@ -163,9 +163,9 @@ void AP_AHRS_NavEKF::update_EKF2(void)
     if (!ekf2_started) {
         // wait 1 second for DCM to output a valid tilt error estimate
         if (start_time_ms == 0) {
-            start_time_ms = hal.scheduler->millis();
+            start_time_ms = platform::millis();
         }
-        if (hal.scheduler->millis() - start_time_ms > startup_delay_ms) {
+        if (platform::millis() - start_time_ms > startup_delay_ms) {
             ekf2_started = EKF2.InitialiseFilter();
         }
     }
@@ -633,11 +633,11 @@ bool AP_AHRS_NavEKF::initialised(void) const
     case 1:
     default:
         // initialisation complete 10sec after ekf has started
-        return (ekf1_started && (hal.scheduler->millis() - start_time_ms > AP_AHRS_NAVEKF_SETTLE_TIME_MS));
+        return (ekf1_started && (platform::millis() - start_time_ms > AP_AHRS_NAVEKF_SETTLE_TIME_MS));
 
     case 2:
         // initialisation complete 10sec after ekf has started
-        return (ekf2_started && (hal.scheduler->millis() - start_time_ms > AP_AHRS_NAVEKF_SETTLE_TIME_MS));
+        return (ekf2_started && (platform::millis() - start_time_ms > AP_AHRS_NAVEKF_SETTLE_TIME_MS));
     }
 };
 

--- a/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.cpp
+++ b/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.cpp
@@ -47,7 +47,7 @@ void loop(void)
 {
     static uint16_t counter;
     static uint32_t last_t, last_print, last_compass;
-    uint32_t now = hal.scheduler->micros();
+    uint32_t now = platform::micros();
     float heading = 0;
 
     if (last_t == 0) {

--- a/libraries/AP_Airspeed/AP_Airspeed.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed.cpp
@@ -236,7 +236,7 @@ void AP_Airspeed::read(void)
     _last_pressure          = airspeed_pressure;
     _raw_airspeed           = sqrtf(airspeed_pressure * _ratio);
     _airspeed               = 0.7f * _airspeed  +  0.3f * _raw_airspeed;
-    _last_update_ms         = hal.scheduler->millis();
+    _last_update_ms         = platform::millis();
 }
 
 void AP_Airspeed::setHIL(float airspeed, float diff_pressure, float temperature)
@@ -244,7 +244,7 @@ void AP_Airspeed::setHIL(float airspeed, float diff_pressure, float temperature)
     _raw_airspeed = airspeed;
     _airspeed = airspeed;
     _last_pressure = diff_pressure;
-    _last_update_ms = hal.scheduler->millis();    
+    _last_update_ms = platform::millis();    
     _hil_pressure = diff_pressure;
     _hil_set = true;
     _healthy = true;

--- a/libraries/AP_Airspeed/AP_Airspeed_I2C.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_I2C.cpp
@@ -54,7 +54,7 @@ void AP_Airspeed_I2C::_measure(void)
 {
     _measurement_started_ms = 0;
     if (hal.i2c->writeRegisters(I2C_ADDRESS_MS4525DO, 0, 0, NULL) == 0) {
-        _measurement_started_ms = hal.scheduler->millis();
+        _measurement_started_ms = platform::millis();
     }
 }
 
@@ -98,7 +98,7 @@ void AP_Airspeed_I2C::_collect(void)
 	_pressure = diff_press_PSI * PSI_to_Pa;
 	_temperature = ((200.0f * dT_raw) / 2047) - 50;
 
-    _last_sample_time_ms = hal.scheduler->millis();
+    _last_sample_time_ms = platform::millis();
 }
 
 // 1kHz timer
@@ -114,7 +114,7 @@ void AP_Airspeed_I2C::_timer(void)
         i2c_sem->give();
         return;
     }
-    if ((hal.scheduler->millis() - _measurement_started_ms) > 10) {
+    if ((platform::millis() - _measurement_started_ms) > 10) {
         _collect();
         // start a new measurement
         _measure();
@@ -125,7 +125,7 @@ void AP_Airspeed_I2C::_timer(void)
 // return the current differential_pressure in Pascal
 bool AP_Airspeed_I2C::get_differential_pressure(float &pressure)
 {
-    if ((hal.scheduler->millis() - _last_sample_time_ms) > 100) {
+    if ((platform::millis() - _last_sample_time_ms) > 100) {
         return false;
     }
     pressure = _pressure;
@@ -135,7 +135,7 @@ bool AP_Airspeed_I2C::get_differential_pressure(float &pressure)
 // return the current temperature in degrees C, if available
 bool AP_Airspeed_I2C::get_temperature(float &temperature)
 {
-    if ((hal.scheduler->millis() - _last_sample_time_ms) > 100) {
+    if ((platform::millis() - _last_sample_time_ms) > 100) {
         return false;
     }
     temperature = _temperature;

--- a/libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp
+++ b/libraries/AP_Airspeed/examples/Airspeed/Airspeed.cpp
@@ -45,8 +45,8 @@ void setup()
 void loop(void)
 {
     static uint32_t timer;
-    if((hal.scheduler->millis() - timer) > 100) {
-        timer = hal.scheduler->millis();
+    if((platform::millis() - timer) > 100) {
+        timer = platform::millis();
         airspeed.read();
         hal.console->printf("airspeed %.2f healthy=%u\n", airspeed.get_airspeed(), airspeed.healthy());
     }

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -175,9 +175,9 @@ bool AP_Arming::ins_checks(bool report)
                     threshold *= 3;
                 }
                 if (vec_diff.length() <= threshold) {
-                    last_accel_pass_ms[i] = hal.scheduler->millis();
+                    last_accel_pass_ms[i] = platform::millis();
                 }
-                if (hal.scheduler->millis() - last_accel_pass_ms[i] > 10000) {
+                if (platform::millis() - last_accel_pass_ms[i] > 10000) {
                     if (report) {
                         GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "PreArm: inconsistent Accelerometers");
                     }
@@ -196,9 +196,9 @@ bool AP_Arming::ins_checks(bool report)
                 // allow for up to 5 degrees/s difference. Pass if its
                 // been OK in last 10 seconds
                 if (vec_diff.length() <= radians(5)) {
-                    last_gyro_pass_ms[i] = hal.scheduler->millis();
+                    last_gyro_pass_ms[i] = platform::millis();
                 }
-                if (hal.scheduler->millis() - last_gyro_pass_ms[i] > 10000) {
+                if (platform::millis() - last_gyro_pass_ms[i] > 10000) {
                     if (report) {
                         GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "PreArm: inconsistent gyros");
                     }

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -100,11 +100,11 @@ void AP_Baro::calibrate()
     // the MS5611 reads quite a long way off for the first second,
     // leading to about 1m of error if we don't wait
     for (uint8_t i = 0; i < 10; i++) {
-        uint32_t tstart = hal.scheduler->millis();
+        uint32_t tstart = platform::millis();
         do {
             update();
-            if (hal.scheduler->millis() - tstart > 500) {
-                hal.scheduler->panic("PANIC: AP_Baro::read unsuccessful "
+            if (platform::millis() - tstart > 500) {
+                platform::panic("PANIC: AP_Baro::read unsuccessful "
                         "for more than 500ms in AP_Baro::calibrate [2]\r\n");
             }
             hal.scheduler->delay(10);
@@ -120,11 +120,11 @@ void AP_Baro::calibrate()
     const uint8_t num_samples = 5;
 
     for (uint8_t c = 0; c < num_samples; c++) {
-        uint32_t tstart = hal.scheduler->millis();
+        uint32_t tstart = platform::millis();
         do {
             update();
-            if (hal.scheduler->millis() - tstart > 500) {
-                hal.scheduler->panic("PANIC: AP_Baro::read unsuccessful "
+            if (platform::millis() - tstart > 500) {
+                platform::panic("PANIC: AP_Baro::read unsuccessful "
                         "for more than 500ms in AP_Baro::calibrate [3]\r\n");
             }
         } while (!healthy());
@@ -152,7 +152,7 @@ void AP_Baro::calibrate()
             return;
         }
     }
-    hal.scheduler->panic("AP_Baro: all sensors uncalibrated");
+    platform::panic("AP_Baro: all sensors uncalibrated");
 }
 
 /*
@@ -170,7 +170,7 @@ void AP_Baro::update_calibration()
         sensors[i].ground_temperature.set(get_calibration_temperature(i));
 
         // don't notify the GCS too rapidly or we flood the link
-        uint32_t now = hal.scheduler->millis();
+        uint32_t now = platform::millis();
         if (now - _last_notify_ms > 10000) {
             sensors[i].ground_pressure.notify();
             sensors[i].ground_temperature.notify();
@@ -245,7 +245,7 @@ float AP_Baro::get_climb_rate(void)
 void AP_Baro::set_external_temperature(float temperature)
 {
     _external_temperature = temperature;
-    _last_external_temperature_ms = hal.scheduler->millis();
+    _last_external_temperature_ms = platform::millis();
 }
 
 /*
@@ -254,7 +254,7 @@ void AP_Baro::set_external_temperature(float temperature)
 float AP_Baro::get_calibration_temperature(uint8_t instance) const
 {
     // if we have a recent external temperature then use it
-    if (_last_external_temperature_ms != 0 && hal.scheduler->millis() - _last_external_temperature_ms < 10000) {
+    if (_last_external_temperature_ms != 0 && platform::millis() - _last_external_temperature_ms < 10000) {
         return _external_temperature;
     }
     // if we don't have an external temperature then use the minimum
@@ -324,7 +324,7 @@ void AP_Baro::init(void)
     }
 #endif
     if (_num_drivers == 0 || _num_sensors == 0 || drivers[0] == NULL) {
-        hal.scheduler->panic("Baro: unable to initialise driver");
+        platform::panic("Baro: unable to initialise driver");
     }
 }
 
@@ -342,7 +342,7 @@ void AP_Baro::update(void)
 
     // consider a sensor as healthy if it has had an update in the
     // last 0.5 seconds
-    uint32_t now = hal.scheduler->millis();
+    uint32_t now = platform::millis();
     for (uint8_t i=0; i<_num_sensors; i++) {
         sensors[i].healthy = (now - sensors[i].last_update_ms < 500) && !is_zero(sensors[i].pressure);
     }
@@ -398,7 +398,7 @@ void AP_Baro::accumulate(void)
 uint8_t AP_Baro::register_sensor(void)
 {
     if (_num_sensors >= BARO_MAX_INSTANCES) {
-        hal.scheduler->panic("Too many barometers");
+        platform::panic("Too many barometers");
     }
     return _num_sensors++;
 }

--- a/libraries/AP_Baro/AP_Baro_BMP085.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP085.cpp
@@ -35,7 +35,7 @@ extern const AP_HAL::HAL& hal;
 // Temp conversion time is 4.5ms
 // Pressure conversion time is 25.5ms (for OVERSAMPLING=3)
 #define BMP085_EOC -1
-#define BMP_DATA_READY() (BMP085_State == 0 ? hal.scheduler->millis() > (_last_temp_read_command_time + 5) : hal.scheduler->millis() > (_last_press_read_command_time + 26))
+#define BMP_DATA_READY() (BMP085_State == 0 ? platform::millis() > (_last_temp_read_command_time + 5) : platform::millis() > (_last_press_read_command_time + 26))
 #else
 #define BMP_DATA_READY() hal.gpio->read(BMP085_EOC)
 #endif
@@ -64,7 +64,7 @@ AP_Baro_BMP085::AP_Baro_BMP085(AP_Baro &baro) :
 
     // take i2c bus sempahore
     if (!i2c_sem->take(HAL_SEMAPHORE_BLOCK_FOREVER)) {
-        hal.scheduler->panic("BMP085: unable to get semaphore");
+        platform::panic("BMP085: unable to get semaphore");
     }
 
     // End Of Conversion (PC7) input
@@ -74,7 +74,7 @@ AP_Baro_BMP085::AP_Baro_BMP085(AP_Baro &baro) :
 
     // We read the calibration data registers
     if (hal.i2c->readRegisters(BMP085_ADDRESS, 0xAA, 22, buff) != 0) {
-        hal.scheduler->panic("BMP085: bad calibration registers");
+        platform::panic("BMP085: bad calibration registers");
     }
 
     ac1 = ((int16_t)buff[0] << 8) | buff[1];
@@ -164,7 +164,7 @@ void AP_Baro_BMP085::Command_ReadPress()
     // Mode 0x34+(OVERSAMPLING << 6) is osrs=3 when OVERSAMPLING=3 => 25.5ms conversion time
     hal.i2c->writeRegister(BMP085_ADDRESS, 0xF4,
                            0x34+(OVERSAMPLING << 6));
-    _last_press_read_command_time = hal.scheduler->millis();
+    _last_press_read_command_time = platform::millis();
 }
 
 // Read Raw Pressure values
@@ -173,7 +173,7 @@ bool AP_Baro_BMP085::ReadPress()
     uint8_t buf[3];
 
     if (hal.i2c->readRegisters(BMP085_ADDRESS, 0xF6, 3, buf) != 0) {
-        _retry_time = hal.scheduler->millis() + 1000;
+        _retry_time = platform::millis() + 1000;
         hal.i2c->setHighSpeed(false);
         return false;
     }
@@ -188,7 +188,7 @@ bool AP_Baro_BMP085::ReadPress()
 void AP_Baro_BMP085::Command_ReadTemp()
 {
     hal.i2c->writeRegister(BMP085_ADDRESS, 0xF4, 0x2E);
-    _last_temp_read_command_time = hal.scheduler->millis();
+    _last_temp_read_command_time = platform::millis();
 }
 
 // Read Raw Temperature values

--- a/libraries/AP_Baro/AP_Baro_Backend.cpp
+++ b/libraries/AP_Baro/AP_Baro_Backend.cpp
@@ -19,5 +19,5 @@ void AP_Baro_Backend::_copy_to_frontend(uint8_t instance, float pressure, float 
     }
     _frontend.sensors[instance].pressure = pressure;
     _frontend.sensors[instance].temperature = temperature;
-    _frontend.sensors[instance].last_update_ms = hal.scheduler->millis();
+    _frontend.sensors[instance].last_update_ms = platform::millis();
 }

--- a/libraries/AP_Baro/AP_Baro_MS5611.cpp
+++ b/libraries/AP_Baro/AP_Baro_MS5611.cpp
@@ -69,11 +69,11 @@ void AP_SerialBus_SPI::init()
 {
     _spi = hal.spi->device(_device);
     if (_spi == NULL) {
-        hal.scheduler->panic("did not get valid SPI device driver!");
+        platform::panic("did not get valid SPI device driver!");
     }
     _spi_sem = _spi->get_semaphore();
     if (_spi_sem == NULL) {
-        hal.scheduler->panic("AP_SerialBus_SPI did not get valid SPI semaphroe!");
+        platform::panic("AP_SerialBus_SPI did not get valid SPI semaphroe!");
     }
     _spi->set_bus_speed(_speed);
 }
@@ -129,7 +129,7 @@ void AP_SerialBus_I2C::init()
 {
     _i2c_sem = _i2c->get_semaphore();
     if (_i2c_sem == NULL) {
-        hal.scheduler->panic("AP_SerialBus_I2C did not get valid I2C semaphore!");
+        platform::panic("AP_SerialBus_I2C did not get valid I2C semaphore!");
     }
 }
 
@@ -192,7 +192,7 @@ AP_Baro_MS56XX::AP_Baro_MS56XX(AP_Baro &baro, AP_SerialBus *serial, bool use_tim
     hal.scheduler->suspend_timer_procs();
 
     if (!_serial->sem_take_blocking()){
-        hal.scheduler->panic("PANIC: AP_Baro_MS56XX: failed to take serial semaphore for init");
+        platform::panic("PANIC: AP_Baro_MS56XX: failed to take serial semaphore for init");
     }
 
     _serial->write(CMD_MS5611_RESET);
@@ -208,12 +208,12 @@ AP_Baro_MS56XX::AP_Baro_MS56XX(AP_Baro &baro, AP_SerialBus *serial, bool use_tim
     _C6 = _serial->read_16bits(CMD_MS5611_PROM_C6);
 
     if (!_check_crc()) {
-        hal.scheduler->panic("Bad CRC on MS5611");
+        platform::panic("Bad CRC on MS5611");
     }
 
     // Send a command to read Temp first
     _serial->write(ADDR_CMD_CONVERT_D2);
-    _last_timer = hal.scheduler->micros();
+    _last_timer = platform::micros();
     _state = 0;
 
     _s_D1 = 0;
@@ -286,7 +286,7 @@ bool AP_Baro_MS56XX::_check_crc(void)
 void AP_Baro_MS56XX::_timer(void)
 {
     // Throttle read rate to 100hz maximum.
-    if (hal.scheduler->micros() - _last_timer < 10000) {
+    if (platform::micros() - _last_timer < 10000) {
         return;
     }
 
@@ -349,7 +349,7 @@ void AP_Baro_MS56XX::_timer(void)
         }
     }
 
-    _last_timer = hal.scheduler->micros();
+    _last_timer = platform::micros();
     _serial->sem_give();
 }
 

--- a/libraries/AP_Baro/examples/BARO_generic/BARO_generic.cpp
+++ b/libraries/AP_Baro/examples/BARO_generic/BARO_generic.cpp
@@ -21,21 +21,21 @@ void setup()
     barometer.init();
     barometer.calibrate();
 
-    timer = hal.scheduler->micros();
+    timer = platform::micros();
 }
 
 void loop()
 {
     // run accumulate() at 50Hz and update() at 10Hz
-    if((hal.scheduler->micros() - timer) > 20*1000UL) {
-        timer = hal.scheduler->micros();
+    if((platform::micros() - timer) > 20*1000UL) {
+        timer = platform::micros();
         barometer.accumulate();
         if (counter++ < 5) {
             return;
         }
         counter = 0;
         barometer.update();
-        uint32_t read_time = hal.scheduler->micros() - timer;
+        uint32_t read_time = platform::micros() - timer;
         float alt = barometer.get_altitude();
         if (!barometer.healthy()) {
             hal.console->println("not healthy");

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -276,7 +276,7 @@ bool AP_BattMonitor::exhausted(uint8_t instance, float low_voltage, float min_ca
     }
 
     // get current time
-    uint32_t tnow = hal.scheduler->millis();
+    uint32_t tnow = platform::millis();
 
     // check voltage
     if ((state[instance].voltage > 0.0f) && (low_voltage > 0) && (state[instance].voltage < low_voltage)) {

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Analog.cpp
@@ -31,7 +31,7 @@ AP_BattMonitor_Analog::read()
     // read current
     if (_mon.has_current(_state.instance)) {
         // calculate time since last current read
-        uint32_t tnow = hal.scheduler->micros();
+        uint32_t tnow = platform::micros();
         float dt = tnow - _state.last_time_micros;
 
         // this copes with changing the pin at runtime

--- a/libraries/AP_BattMonitor/AP_BattMonitor_Bebop.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Bebop.cpp
@@ -144,7 +144,7 @@ void AP_BattMonitor_Bebop::read(void)
     float remaining, vbat, vbat_raw;
 
     auto rcout = Linux::RCOutput_Bebop::from(hal.rcout);
-    tnow = hal.scheduler->micros();
+    tnow = platform::micros();
 
     ret = rcout->read_obs_data(data);
     if (ret < 0) {

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_I2C.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_I2C.cpp
@@ -37,7 +37,7 @@ void AP_BattMonitor_SMBus_I2C::read()
 {
     uint16_t data;
     uint8_t buff[4];
-    uint32_t tnow = hal.scheduler->micros();
+    uint32_t tnow = platform::micros();
 
     // read voltage
     if (read_word(BATTMONITOR_SMBUS_VOLTAGE, data)) {

--- a/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_PX4.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_SMBus_PX4.cpp
@@ -66,7 +66,7 @@ void AP_BattMonitor_SMBus_PX4::read()
         if (OK == orb_copy(ORB_ID(battery_status), _batt_sub, &batt_status)) {
             _state.voltage = batt_status.voltage_v;
             _state.current_amps = batt_status.current_a;
-            _state.last_time_micros = hal.scheduler->micros();
+            _state.last_time_micros = platform::micros();
             _state.current_total_mah = batt_status.discharged_mah;
             _state.healthy = true;
 
@@ -81,7 +81,7 @@ void AP_BattMonitor_SMBus_PX4::read()
         }
     } else if (_state.healthy) {
         // timeout after 5 seconds
-        if ((hal.scheduler->micros() - _state.last_time_micros) > AP_BATTMONITOR_SMBUS_TIMEOUT_MICROS) {
+        if ((platform::micros() - _state.last_time_micros) > AP_BATTMONITOR_SMBUS_TIMEOUT_MICROS) {
             _state.healthy = false;
         }
     }

--- a/libraries/AP_BattMonitor/examples/AP_BattMonitor_test/AP_BattMonitor_test.cpp
+++ b/libraries/AP_BattMonitor/examples/AP_BattMonitor_test/AP_BattMonitor_test.cpp
@@ -21,13 +21,13 @@ void setup() {
     battery_mon.init();
 
     hal.scheduler->delay(1000);
-    timer = hal.scheduler->millis();
+    timer = platform::millis();
 }
 
 void loop()
 {
     static uint8_t counter; // counter to slow output to the user
-    uint32_t now = hal.scheduler->millis();
+    uint32_t now = platform::millis();
 
     // call battery monitor at 10hz
     if((now - timer) > 100) {

--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -115,7 +115,7 @@ void AP_BoardConfig::init()
 
     int fd = open("/dev/px4fmu", 0);
     if (fd == -1) {
-        hal.scheduler->panic("Unable to open /dev/px4fmu");
+        platform::panic("Unable to open /dev/px4fmu");
     }
     if (ioctl(fd, PWM_SERVO_SET_COUNT, _pwm_count.get()) != 0) {
         hal.console->printf("RCOutput: Unable to setup alt PWM to %u channels\n", _pwm_count.get());  

--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -228,10 +228,10 @@ void AP_Compass_AK8963::_update()
     float mag_x, mag_y, mag_z;
     // get raw_field - sensor frame, uncorrected
     Vector3f raw_field;
-    uint32_t time_us = hal.scheduler->micros();
+    uint32_t time_us = platform::micros();
 
 
-    if (hal.scheduler->micros() - _last_update_timestamp < 10000) {
+    if (platform::micros() - _last_update_timestamp < 10000) {
         goto end;
     }
 
@@ -284,7 +284,7 @@ void AP_Compass_AK8963::_update()
         _accum_count = 5;
     }
 
-    _last_update_timestamp = hal.scheduler->micros();
+    _last_update_timestamp = platform::micros();
 fail:
     _sem_give();
 end:
@@ -356,7 +356,7 @@ bool AP_Compass_AK8963::_sem_take_nonblocking()
     if (!hal.scheduler->system_initializing() ) {
         _sem_failure_count++;
         if (_sem_failure_count > 100) {
-            hal.scheduler->panic("PANIC: failed to take _bus->sem "
+            platform::panic("PANIC: failed to take _bus->sem "
                                  "100 times in a row, in "
                                  "AP_Compass_AK8963");
         }
@@ -393,7 +393,7 @@ AP_AK8963_SerialBus_MPU9250::AP_AK8963_SerialBus_MPU9250(AP_InertialSensor &ins,
     // getting the semaphore
     _bus = ins.get_auxiliary_bus(HAL_INS_MPU9250, mpu9250_instance);
     if (!_bus)
-        hal.scheduler->panic("Cannot get MPU9250 auxiliary bus");
+        platform::panic("Cannot get MPU9250 auxiliary bus");
 
     _slave = _bus->request_next_slave(addr);
 }

--- a/libraries/AP_Compass/AP_Compass_Backend.cpp
+++ b/libraries/AP_Compass/AP_Compass_Backend.cpp
@@ -43,7 +43,7 @@ void AP_Compass_Backend::publish_raw_field(const Vector3f &mag, uint32_t time_us
 {
     Compass::mag_state &state = _compass._state[instance];
 
-    state.last_update_ms = hal.scheduler->millis();
+    state.last_update_ms = platform::millis();
 
     // note that we do not set last_update_usec here as otherwise the
     // EKF and DCM would end up consuming compass data at the full
@@ -110,8 +110,8 @@ void AP_Compass_Backend::publish_filtered_field(const Vector3f &mag, uint8_t ins
 
     state.field = mag;
 
-    state.last_update_ms = hal.scheduler->millis();
-    state.last_update_usec = hal.scheduler->micros();
+    state.last_update_ms = platform::millis();
+    state.last_update_usec = platform::micros();
 
     state.has_raw_field = state.updated_raw_field;
     state.updated_raw_field = false;

--- a/libraries/AP_Compass/AP_Compass_HIL.cpp
+++ b/libraries/AP_Compass/AP_Compass_HIL.cpp
@@ -64,7 +64,7 @@ void AP_Compass_HIL::read()
             uint8_t compass_instance = _compass_instance[i];
             Vector3f field = _compass._hil.field[compass_instance];
             rotate_field(field, compass_instance);
-            publish_raw_field(field, hal.scheduler->micros(), compass_instance);
+            publish_raw_field(field, platform::micros(), compass_instance);
             correct_field(field, compass_instance);
             publish_filtered_field(field, compass_instance);
         }

--- a/libraries/AP_Compass/AP_Compass_HMC5843.cpp
+++ b/libraries/AP_Compass/AP_Compass_HMC5843.cpp
@@ -119,7 +119,7 @@ AP_Compass_Backend *AP_Compass_HMC5843::_detect(Compass &compass,
 bool AP_Compass_HMC5843::read_register(uint8_t address, uint8_t *value)
 {
     if (_bus->register_read(address, value) != 0) {
-        _retry_time = hal.scheduler->millis() + 1000;
+        _retry_time = platform::millis() + 1000;
         return false;
     }
     return true;
@@ -129,7 +129,7 @@ bool AP_Compass_HMC5843::read_register(uint8_t address, uint8_t *value)
 bool AP_Compass_HMC5843::write_register(uint8_t address, uint8_t value)
 {
     if (_bus->register_write(address, value) != 0) {
-        _retry_time = hal.scheduler->millis() + 1000;
+        _retry_time = platform::millis() + 1000;
         return false;
     }
     return true;
@@ -142,7 +142,7 @@ bool AP_Compass_HMC5843::read_raw()
 
     if (_bus->read_raw(&rv) != 0) {
         _bus->set_high_speed(false);
-        _retry_time = hal.scheduler->millis() + 1000;
+        _retry_time = platform::millis() + 1000;
         return false;
     }
 
@@ -178,7 +178,7 @@ void AP_Compass_HMC5843::accumulate(void)
         return;
     }
 
-   uint32_t tnow = hal.scheduler->micros();
+   uint32_t tnow = platform::micros();
    if (_accum_count != 0 && (tnow - _last_accum_time) < 13333) {
 	  // the compass gets new data at 75Hz
 	  return;
@@ -439,11 +439,11 @@ void AP_Compass_HMC5843::read()
         return;
     }
     if (_retry_time != 0) {
-        if (hal.scheduler->millis() < _retry_time) {
+        if (platform::millis() < _retry_time) {
             return;
         }
         if (!re_initialise()) {
-            _retry_time = hal.scheduler->millis() + 1000;
+            _retry_time = platform::millis() + 1000;
             _bus->set_high_speed(false);
             return;
         }

--- a/libraries/AP_Compass/AP_Compass_LSM303D.cpp
+++ b/libraries/AP_Compass/AP_Compass_LSM303D.cpp
@@ -302,7 +302,7 @@ AP_Compass_LSM303D::init()
     uint8_t whoami = _register_read(ADDR_WHO_AM_I);
     if (whoami != WHO_I_AM) {
         hal.console->printf("LSM303D: unexpected WHOAMI 0x%x\n", (unsigned)whoami);
-        hal.scheduler->panic("LSM303D: bad WHOAMI");
+        platform::panic("LSM303D: bad WHOAMI");
     }
 
     uint8_t tries = 0;
@@ -312,7 +312,7 @@ AP_Compass_LSM303D::init()
         if (success) {
             hal.scheduler->delay(5+2);
             if (!_spi_sem->take(100)) {
-                hal.scheduler->panic("LSM303D: Unable to get semaphore");
+                platform::panic("LSM303D: Unable to get semaphore");
             }
             if (_data_ready()) {
                 _spi_sem->give();
@@ -324,7 +324,7 @@ AP_Compass_LSM303D::init()
             _spi_sem->give();
         }
         if (tries++ > 5) {
-            hal.scheduler->panic("PANIC: failed to boot LSM303D 5 times");
+            platform::panic("PANIC: failed to boot LSM303D 5 times");
         }
     } while (1);
 
@@ -356,7 +356,7 @@ uint32_t AP_Compass_LSM303D::get_dev_id()
 bool AP_Compass_LSM303D::_hardware_init(void)
 {
     if (!_spi_sem->take(100)) {
-        hal.scheduler->panic("LSM303D: Unable to get semaphore");
+        platform::panic("LSM303D: Unable to get semaphore");
     }
 
     // initially run the bus at low speed
@@ -385,7 +385,7 @@ bool AP_Compass_LSM303D::_hardware_init(void)
 
 void AP_Compass_LSM303D::_update()
 {
-    if (hal.scheduler->micros() - _last_update_timestamp < 10000) {
+    if (platform::micros() - _last_update_timestamp < 10000) {
         return;
     }
 
@@ -395,7 +395,7 @@ void AP_Compass_LSM303D::_update()
 
     _collect_samples();
 
-    _last_update_timestamp = hal.scheduler->micros();
+    _last_update_timestamp = platform::micros();
     _spi_sem->give();
 }
 
@@ -409,7 +409,7 @@ void AP_Compass_LSM303D::_collect_samples()
         error("_read_raw() failed\n");
     } else {
         Vector3f raw_field = Vector3f(_mag_x, _mag_y, _mag_z) * _mag_range_scale;
-        uint32_t time_us = hal.scheduler->micros();
+        uint32_t time_us = platform::micros();
 
         // rotate raw_field from sensor frame to body frame
         rotate_field(raw_field, _compass_instance);

--- a/libraries/AP_Compass/Compass.cpp
+++ b/libraries/AP_Compass/Compass.cpp
@@ -400,7 +400,7 @@ Compass::init()
 uint8_t Compass::register_compass(void)
 {
     if (_compass_count == COMPASS_MAX_INSTANCES) {
-        hal.scheduler->panic("Too many compass instances");
+        platform::panic("Too many compass instances");
     }
     return _compass_count++;
 }
@@ -410,7 +410,7 @@ void Compass::_add_backend(AP_Compass_Backend *backend)
     if (!backend)
         return;
     if (_backend_count == COMPASS_MAX_BACKEND)
-        hal.scheduler->panic("Too many compass backends");
+        platform::panic("Too many compass backends");
     _backends[_backend_count++] = backend;
 }
 
@@ -476,7 +476,7 @@ Compass::read(void)
         _backends[i]->read();
     }    
     for (uint8_t i=0; i < COMPASS_MAX_INSTANCES; i++) {
-        _state[i].healthy = (hal.scheduler->millis() - _state[i].last_update_ms < 500);
+        _state[i].healthy = (platform::millis() - _state[i].last_update_ms < 500);
     }
     return healthy();
 }
@@ -724,7 +724,7 @@ void Compass::setHIL(uint8_t instance, const Vector3f &mag)
 {
     _hil.field[instance] = mag;
     _hil.healthy[instance] = true;
-    _state[instance].last_update_usec = hal.scheduler->micros();
+    _state[instance].last_update_usec = platform::micros();
 }
 
 const Vector3f& Compass::getHIL(uint8_t instance) const 

--- a/libraries/AP_Compass/CompassCalibrator.cpp
+++ b/libraries/AP_Compass/CompassCalibrator.cpp
@@ -86,7 +86,7 @@ void CompassCalibrator::start(bool retry, bool autosave, float delay) {
     _attempt = 1;
     _retry = retry;
     _delay_start_sec = delay;
-    _start_time_ms = hal.scheduler->millis();
+    _start_time_ms = platform::millis();
     set_status(COMPASS_CAL_WAITING_TO_START);
 }
 
@@ -120,7 +120,7 @@ float CompassCalibrator::get_completion_percent() const {
 }
 
 bool CompassCalibrator::check_for_timeout() {
-    uint32_t tnow = hal.scheduler->millis();
+    uint32_t tnow = platform::millis();
     if(running() && tnow - _last_sample_ms > 1000) {
         _retry = false;
         set_status(COMPASS_CAL_FAILED);
@@ -130,7 +130,7 @@ bool CompassCalibrator::check_for_timeout() {
 }
 
 void CompassCalibrator::new_sample(const Vector3f& sample) {
-    _last_sample_ms = hal.scheduler->millis();
+    _last_sample_ms = platform::millis();
 
     if(_status == COMPASS_CAL_WAITING_TO_START) {
         set_status(COMPASS_CAL_RUNNING_STEP_ONE);
@@ -241,7 +241,7 @@ bool CompassCalibrator::set_status(compass_cal_status_t status) {
                 return false;
             }
 
-            if(_attempt == 1 && (hal.scheduler->millis()-_start_time_ms)*1.0e-3f < _delay_start_sec) {
+            if(_attempt == 1 && (platform::millis()-_start_time_ms)*1.0e-3f < _delay_start_sec) {
                 return false;
             }
 

--- a/libraries/AP_Compass/examples/AP_Compass_test/AP_Compass_test.cpp
+++ b/libraries/AP_Compass/examples/AP_Compass_test/AP_Compass_test.cpp
@@ -25,7 +25,7 @@ void setup() {
     compass.set_declination(ToRad(0.0f)); // set local difference between magnetic north and true north
 
     hal.scheduler->delay(1000);
-    timer = hal.scheduler->micros();
+    timer = platform::micros();
 }
 
 void loop()
@@ -34,11 +34,11 @@ void loop()
 
     compass.accumulate();
 
-    if((hal.scheduler->micros()- timer) > 100000L)
+    if((platform::micros()- timer) > 100000L)
     {
-        timer = hal.scheduler->micros();
+        timer = platform::micros();
         compass.read();
-        unsigned long read_time = hal.scheduler->micros() - timer;
+        unsigned long read_time = platform::micros() - timer;
         float heading;
 
         if (!compass.healthy()) {

--- a/libraries/AP_Declination/examples/AP_Declination_test/AP_Declination_test.cpp
+++ b/libraries/AP_Declination/examples/AP_Declination_test/AP_Declination_test.cpp
@@ -90,9 +90,9 @@ void setup(void)
     {
         for(int16_t j = -180; j <= 180; j+=5)
         {
-            uint32_t t1 = hal.scheduler->micros();
+            uint32_t t1 = platform::micros();
             declination = AP_Declination::get_declination(i, j);
-            total_time += hal.scheduler->micros() - t1;
+            total_time += platform::micros() - t1;
             declination_test = get_declination(i, j);
             if(declination == declination_test)
             {

--- a/libraries/AP_EPM/AP_EPM.cpp
+++ b/libraries/AP_EPM/AP_EPM.cpp
@@ -86,7 +86,7 @@ void AP_EPM::grab()
     _flags.active = true;
 
     // capture time
-    _last_grab_or_release = hal.scheduler->millis();
+    _last_grab_or_release = platform::millis();
 
     // move the servo to the release position
     RC_Channel_aux::set_radio(RC_Channel_aux::k_epm, _grab_pwm);
@@ -105,7 +105,7 @@ void AP_EPM::release()
     _flags.active = true;
 
     // capture time
-    _last_grab_or_release = hal.scheduler->millis();
+    _last_grab_or_release = platform::millis();
 
     // move the servo to the release position
     RC_Channel_aux::set_radio(RC_Channel_aux::k_epm, _release_pwm);
@@ -131,12 +131,12 @@ void AP_EPM::neutral()
 void AP_EPM::update()
 {
     // move EPM PWM output back to neutral 2 seconds after the last grab or release
-    if (_flags.active && (hal.scheduler->millis() - _last_grab_or_release > EPM_RETURN_TO_NEUTRAL_MS)) {
+    if (_flags.active && (platform::millis() - _last_grab_or_release > EPM_RETURN_TO_NEUTRAL_MS)) {
         neutral();
     }
 
     // re-grab the cargo intermittently
-    if (_flags.grab && (_regrab_interval > 0) && (hal.scheduler->millis() - _last_grab_or_release > ((uint32_t)_regrab_interval * 1000))) {
+    if (_flags.grab && (_regrab_interval > 0) && (platform::millis() - _last_grab_or_release > ((uint32_t)_regrab_interval * 1000))) {
         grab();
     }
 }

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.cpp
@@ -156,7 +156,7 @@ void AP_Frsky_Telem::init_uart_for_sport()
 */
 void AP_Frsky_Telem::send_hub_frame()
 {
-    uint32_t now = hal.scheduler->millis();
+    uint32_t now = platform::millis();
 
     // send frame1 every 200ms
     if (now - _last_frame1_ms > 200) {

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -184,7 +184,7 @@ AP_GPS::detect_instance(uint8_t instance)
 {
     AP_GPS_Backend *new_gps = NULL;
     struct detect_state *dstate = &detect_state[instance];
-    uint32_t now = hal.scheduler->millis();
+    uint32_t now = platform::millis();
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4
     if (_type[instance] == GPS_TYPE_PX4) {
@@ -347,7 +347,7 @@ AP_GPS::update_instance(uint8_t instance)
 
     // we have an active driver for this instance
     bool result = drivers[instance]->read();
-    uint32_t tnow = hal.scheduler->millis();
+    uint32_t tnow = platform::millis();
 
     // if we did not get a message, and the idle timer of 1.2 seconds
     // has expired, re-initialise the GPS. This will cause GPS
@@ -401,7 +401,7 @@ AP_GPS::update(void)
 
             if (state[i].status == state[primary_instance].status && another_gps_has_1_or_more_sats) {
 
-                uint32_t now = hal.scheduler->millis();
+                uint32_t now = platform::millis();
                 bool another_gps_has_2_or_more_sats = (state[i].num_sats >= state[primary_instance].num_sats + 2);
 
                 if ( (another_gps_has_1_or_more_sats && (now - _last_instance_swap_ms) >= 20000) ||
@@ -435,7 +435,7 @@ AP_GPS::setHIL(uint8_t instance, GPS_Status _status, uint64_t time_epoch_ms,
     if (instance >= GPS_MAX_INSTANCES) {
         return;
     }
-    uint32_t tnow = hal.scheduler->millis();
+    uint32_t tnow = platform::millis();
     GPS_State &istate = state[instance];
     istate.status = _status;
     istate.location = _location;
@@ -507,7 +507,7 @@ AP_GPS::send_mavlink_gps_raw(mavlink_channel_t chan)
         last_send_time_ms[chan] = last_message_time_ms(0);
     } else {
         // when we don't have a GPS then send at 1Hz
-        uint32_t now = hal.scheduler->millis();
+        uint32_t now = platform::millis();
         if (now - last_send_time_ms[chan] < 1000) {
             return;
         }

--- a/libraries/AP_GPS/AP_GPS_GSOF.cpp
+++ b/libraries/AP_GPS/AP_GPS_GSOF.cpp
@@ -47,7 +47,7 @@ AP_GPS_GSOF::AP_GPS_GSOF(AP_GPS &_gps, AP_GPS::GPS_State &_state,
 
     requestBaud();
 
-    uint32_t now = hal.scheduler->millis();
+    uint32_t now = platform::millis();
     gsofmsg_time = now + 110;
 }
 
@@ -56,7 +56,7 @@ AP_GPS_GSOF::AP_GPS_GSOF(AP_GPS &_gps, AP_GPS::GPS_State &_state,
 bool
 AP_GPS_GSOF::read(void)
 {
-    uint32_t now = hal.scheduler->millis();
+    uint32_t now = platform::millis();
 
     if (gsofmsgreq_index < (sizeof(gsofmsgreq))) {
         if (now > gsofmsg_time) {
@@ -345,7 +345,7 @@ AP_GPS_GSOF::inject_data(uint8_t *data, uint8_t len)
 {
 
     if (port->txspace() > len) {
-        last_injected_data_ms = hal.scheduler->millis();
+        last_injected_data_ms = platform::millis();
         port->write(data, len);
     } else {
         Debug("GSOF: Not enough TXSPACE");

--- a/libraries/AP_GPS/AP_GPS_MTK19.cpp
+++ b/libraries/AP_GPS/AP_GPS_MTK19.cpp
@@ -159,7 +159,7 @@ restart:
                                         (unsigned)_mtk_revision);                                        
 #endif
                     make_gps_time(_buffer.msg.utc_date, bcd_time_ms);
-                    state.last_gps_time_ms = hal.scheduler->millis();
+                    state.last_gps_time_ms = platform::millis();
                 }
                 // the _fix_counter is to reduce the cost of the GPS
                 // BCD time conversion by only doing it every 10s

--- a/libraries/AP_GPS/AP_GPS_NMEA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NMEA.cpp
@@ -261,7 +261,7 @@ bool AP_GPS_NMEA::_have_new_message()
         _last_GPGGA_ms == 0) {
         return false;
     }
-    uint32_t now = hal.scheduler->millis();
+    uint32_t now = platform::millis();
     if (now - _last_GPRMC_ms > 150 ||
         now - _last_GPGGA_ms > 150) {
         return false;
@@ -297,7 +297,7 @@ bool AP_GPS_NMEA::_term_complete()
                     state.ground_speed     = _new_speed*0.01f;
                     state.ground_course_cd = wrap_360_cd(_new_course);
                     make_gps_time(_new_date, _new_time * 10);
-                    state.last_gps_time_ms = hal.scheduler->millis();
+                    state.last_gps_time_ms = platform::millis();
                     // To-Do: add support for proper reporting of 2D and 3D fix
                     state.status           = AP_GPS::GPS_OK_FIX_3D;
                     fill_3d_velocity();
@@ -337,15 +337,15 @@ bool AP_GPS_NMEA::_term_complete()
     if (_term_number == 0) {
         if (!strcmp(_term, _gprmc_string)) {
             _sentence_type = _GPS_SENTENCE_GPRMC;
-            _last_GPRMC_ms = hal.scheduler->millis();
+            _last_GPRMC_ms = platform::millis();
         } else if (!strcmp(_term, _gpgga_string)) {
             _sentence_type = _GPS_SENTENCE_GPGGA;
-            _last_GPGGA_ms = hal.scheduler->millis();
+            _last_GPGGA_ms = platform::millis();
         } else if (!strcmp(_term, _gpvtg_string)) {
             _sentence_type = _GPS_SENTENCE_GPVTG;
             // VTG may not contain a data qualifier, presume the solution is good
             // unless it tells us otherwise.
-            _last_GPVTG_ms = hal.scheduler->millis();
+            _last_GPVTG_ms = platform::millis();
             _gps_data_good = true;
         } else {
             _sentence_type = _GPS_SENTENCE_OTHER;

--- a/libraries/AP_GPS/AP_GPS_PX4.cpp
+++ b/libraries/AP_GPS/AP_GPS_PX4.cpp
@@ -52,7 +52,7 @@ AP_GPS_PX4::read(void)
 
     if (updated) {
         if (OK == orb_copy(ORB_ID(vehicle_gps_position), _gps_sub, &_gps_pos)) {
-            state.last_gps_time_ms = hal.scheduler->millis();
+            state.last_gps_time_ms = platform::millis();
             state.status  = (AP_GPS::GPS_Status) (_gps_pos.fix_type | AP_GPS::NO_FIX);
             state.num_sats = _gps_pos.satellites_used;
             state.hdop = uint16_t(_gps_pos.eph*100.0f + .5f);

--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -53,7 +53,7 @@ AP_GPS_SBF::AP_GPS_SBF(AP_GPS &_gps, AP_GPS::GPS_State &_state,
 bool
 AP_GPS_SBF::read(void)
 {
-	uint32_t now = hal.scheduler->millis();
+	uint32_t now = platform::millis();
 	
 	if (_init_blob_index < (sizeof(_initialisation_blob) / sizeof(_initialisation_blob[0]))) {
 		if (now > _init_blob_time) {
@@ -156,7 +156,7 @@ AP_GPS_SBF::log_ExtEventPVTGeodetic(const msg4007 &temp)
         return;
     }
 
-    uint64_t now = hal.scheduler->micros64();
+    uint64_t now = platform::micros64();
 
     struct log_GPS_SBF_EVENT header = {
         LOG_PACKET_HEADER_INIT(LOG_GPS_SBF_EVENT_MSG),
@@ -199,7 +199,7 @@ AP_GPS_SBF::process_message(void)
             state.time_week_ms = (uint32_t)(temp.TOW);
         }
 		
-		state.last_gps_time_ms = hal.scheduler->millis();
+		state.last_gps_time_ms = platform::millis();
 
         state.hdop = last_hdop;
 
@@ -289,7 +289,7 @@ AP_GPS_SBF::inject_data(uint8_t *data, uint8_t len)
 {
 
     if (port->txspace() > len) {
-        last_injected_data_ms = hal.scheduler->millis();
+        last_injected_data_ms = platform::millis();
         port->write(data, len);
     } else {
         Debug("SBF: Not enough TXSPACE");

--- a/libraries/AP_GPS/AP_GPS_SBP.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBP.cpp
@@ -66,7 +66,7 @@ AP_GPS_SBP::AP_GPS_SBP(AP_GPS &_gps, AP_GPS::GPS_State &_state,
     //Externally visible state
     state.status = AP_GPS::NO_FIX;
     state.have_vertical_velocity = true;
-    state.last_gps_time_ms = last_heatbeat_received_ms = hal.scheduler->millis();
+    state.last_gps_time_ms = last_heatbeat_received_ms = platform::millis();
 
 }
 
@@ -92,7 +92,7 @@ AP_GPS_SBP::inject_data(uint8_t *data, uint8_t len)
 {
 
     if (port->txspace() > len) {
-        last_injected_data_ms = hal.scheduler->millis();
+        last_injected_data_ms = platform::millis();
         port->write(data, len);
     } else {
         Debug("PIKSI: Not enough TXSPACE");
@@ -188,7 +188,7 @@ void
 AP_GPS_SBP::_sbp_process_message() {
     switch(parser_state.msg_type) {
         case SBP_HEARTBEAT_MSGTYPE:
-            last_heatbeat_received_ms = hal.scheduler->millis();
+            last_heatbeat_received_ms = platform::millis();
             break;
 
         case SBP_GPS_TIME_MSGTYPE:
@@ -244,7 +244,7 @@ AP_GPS_SBP::_attempt_state_update()
     //
     // If we have a full update available, save it
     //
-    uint32_t now = hal.scheduler->millis();
+    uint32_t now = platform::millis();
     bool ret = false;
 
     if (now - last_heatbeat_received_ms > SBP_TIMEOUT_HEATBEAT) {
@@ -462,7 +462,7 @@ AP_GPS_SBP::logging_log_full_update()
 
     struct log_SbpHealth pkt = {
         LOG_PACKET_HEADER_INIT(LOG_MSG_SBPHEALTH),
-        time_us                    : hal.scheduler->micros64(),
+        time_us                    : platform::micros64(),
         crc_error_counter          : crc_error_counter,
         last_injected_data_ms      : last_injected_data_ms,
         last_iar_num_hypotheses    : last_iar_num_hypotheses,
@@ -488,7 +488,7 @@ AP_GPS_SBP::logging_log_raw_sbp(uint16_t msg_type,
 
     logging_write_headers();
 
-    uint64_t time_us = hal.scheduler->micros64();
+    uint64_t time_us = platform::micros64();
 
     struct log_SbpRAW1 pkt = {
         LOG_PACKET_HEADER_INIT(LOG_MSG_SBPRAW1),

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -156,7 +156,7 @@ AP_GPS_UBLOX::read(void)
     uint8_t data;
     int16_t numc;
     bool parsed = false;
-    uint32_t millis_now = hal.scheduler->millis();
+    uint32_t millis_now = platform::millis();
 
     if (need_rate_update) {
         send_next_rate_update();
@@ -283,7 +283,7 @@ void AP_GPS_UBLOX::log_mon_hw(void)
     }
     struct log_Ubx1 pkt = {
         LOG_PACKET_HEADER_INIT(_ubx_msg_log_index(LOG_GPS_UBX1_MSG)),
-        time_us    : hal.scheduler->micros64(),
+        time_us    : platform::micros64(),
         instance   : state.instance,
         noisePerMS : _buffer.mon_hw_60.noisePerMS,
         jamInd     : _buffer.mon_hw_60.jamInd,
@@ -307,7 +307,7 @@ void AP_GPS_UBLOX::log_mon_hw2(void)
 
     struct log_Ubx2 pkt = {
         LOG_PACKET_HEADER_INIT(_ubx_msg_log_index(LOG_GPS_UBX2_MSG)),
-        time_us   : hal.scheduler->micros64(),
+        time_us   : platform::micros64(),
         instance  : state.instance,
         ofsI      : _buffer.mon_hw2.ofsI,
         magI      : _buffer.mon_hw2.magI,
@@ -325,7 +325,7 @@ void AP_GPS_UBLOX::log_rxm_raw(const struct ubx_rxm_raw &raw)
     if (gps._DataFlash == NULL || !gps._DataFlash->logging_started()) {
         return;
     }
-    uint64_t now = hal.scheduler->micros64();
+    uint64_t now = platform::micros64();
     for (uint8_t i=0; i<raw.numSV; i++) {
         struct log_GPS_RAW pkt = {
             LOG_PACKET_HEADER_INIT(LOG_GPS_RAW_MSG),
@@ -350,7 +350,7 @@ void AP_GPS_UBLOX::log_rxm_rawx(const struct ubx_rxm_rawx &raw)
     if (gps._DataFlash == NULL || !gps._DataFlash->logging_started()) {
         return;
     }
-    uint64_t now = hal.scheduler->micros64();
+    uint64_t now = platform::micros64();
 
     struct log_GPS_RAWH header = {
         LOG_PACKET_HEADER_INIT(LOG_GPS_RAWH_MSG),
@@ -615,7 +615,7 @@ AP_GPS_UBLOX::_parse_gps(void)
         }
         state.num_sats    = _buffer.solution.satellites;
         if (next_fix >= AP_GPS::GPS_OK_FIX_2D) {
-            state.last_gps_time_ms = hal.scheduler->millis();
+            state.last_gps_time_ms = platform::millis();
             if (state.time_week == _buffer.solution.week &&
                 state.time_week_ms + 200 == _buffer.solution.time) {
                 // we got a 5Hz update. This relies on the way
@@ -630,8 +630,8 @@ AP_GPS_UBLOX::_parse_gps(void)
         next_fix = state.status;
         state.num_sats = 10;
         state.time_week = 1721;
-        state.time_week_ms = hal.scheduler->millis() + 3*60*60*1000 + 37000;
-        state.last_gps_time_ms = hal.scheduler->millis();
+        state.time_week_ms = platform::millis() + 3*60*60*1000 + 37000;
+        state.last_gps_time_ms = platform::millis();
         state.hdop = 130;
 #endif
         break;
@@ -690,13 +690,13 @@ AP_GPS_UBLOX::_parse_gps(void)
     if (_new_position && _new_speed && _last_vel_time == _last_pos_time) {
         _new_speed = _new_position = false;
 		_fix_count++;
-        if ((hal.scheduler->millis() - _last_5hz_time) > 15000U && !need_rate_update) {
+        if ((platform::millis() - _last_5hz_time) > 15000U && !need_rate_update) {
             // the GPS is running slow. It possibly browned out and
             // restarted with incorrect parameters. We will slowly
             // send out new parameters to fix it
             need_rate_update = true;
             rate_update_step = 0;
-            _last_5hz_time = hal.scheduler->millis();
+            _last_5hz_time = platform::millis();
         }
 
 		if (_fix_count == 50 && gps._sbas_mode != 2) {
@@ -791,7 +791,7 @@ AP_GPS_UBLOX::_configure_gps(void)
 {
     // start the process of updating the GPS rates
     need_rate_update = true;
-    _last_5hz_time = hal.scheduler->millis();
+    _last_5hz_time = platform::millis();
     rate_update_step = 0;
 
     // ask for the current navigation settings

--- a/libraries/AP_GPS/GPS_Backend.cpp
+++ b/libraries/AP_GPS/GPS_Backend.cpp
@@ -71,7 +71,7 @@ uint64_t AP_GPS::time_epoch_usec(uint8_t instance)
     const uint64_t unix_offset = 17000ULL*86400ULL + 52*10*7000ULL*86400ULL - 15000ULL;
     uint64_t fix_time_ms = unix_offset + istate.time_week*ms_per_week + istate.time_week_ms;
     // add in the milliseconds since the last fix
-    return (fix_time_ms + (hal.scheduler->millis() - istate.last_gps_time_ms)) * 1000ULL;
+    return (fix_time_ms + (platform::millis() - istate.last_gps_time_ms)) * 1000ULL;
 }
 
 

--- a/libraries/AP_HAL/AP_HAL.h
+++ b/libraries/AP_HAL/AP_HAL.h
@@ -30,5 +30,7 @@
 /* HAL Class definition */
 #include "HAL.h"
 
+#include "platform.h"
+
 #endif // __AP_HAL_H__
 

--- a/libraries/AP_HAL/HAL.h
+++ b/libraries/AP_HAL/HAL.h
@@ -11,6 +11,7 @@
 #include "SPIDriver.h"
 #include "Storage.h"
 #include "UARTDriver.h"
+#include "platform.h"
 
 class AP_HAL::HAL {
 public:
@@ -49,7 +50,9 @@ public:
         rcout(_rcout),
         scheduler(_scheduler),
         util(_util)
-    {}
+    {
+        platform::init();
+    }
 
     struct Callbacks {
         virtual void setup() = 0;

--- a/libraries/AP_HAL/Scheduler.h
+++ b/libraries/AP_HAL/Scheduler.h
@@ -15,10 +15,6 @@ public:
     Scheduler() {}
     virtual void     init(void* implspecific) = 0;
     virtual void     delay(uint16_t ms) = 0;
-    virtual uint32_t millis() = 0;
-    virtual uint32_t micros() = 0;
-    virtual uint64_t millis64() = 0;
-    virtual uint64_t micros64() = 0;
 
     /*
       delay for the given number of microseconds. This needs to be as
@@ -56,7 +52,6 @@ public:
     virtual bool     system_initializing() = 0;
     virtual void     system_initialized() = 0;
 
-    virtual void     panic(const char *errormsg, ...) FORMAT(2, 3) NORETURN = 0;
     virtual void     reboot(bool hold_in_bootloader) = 0;
 
     /**

--- a/libraries/AP_HAL/examples/UART_test/UART_test.cpp
+++ b/libraries/AP_HAL/examples/UART_test/UART_test.cpp
@@ -48,7 +48,7 @@ static void test_uart(AP_HAL::UARTDriver *uart, const char *name)
         return;
     }
     uart->printf("Hello on UART %s at %.3f seconds\n",
-                 name, hal.scheduler->millis()*0.001f);
+                 name, platform::millis()*0.001f);
 }
 
 void loop(void) 
@@ -62,7 +62,7 @@ void loop(void)
     // also do a raw printf() on some platforms, which prints to the
     // debug console
 #if HAL_OS_POSIX_IO
-    ::printf("Hello on debug console at %.3f seconds\n", hal.scheduler->millis()*0.001f);
+    ::printf("Hello on debug console at %.3f seconds\n", platform::millis()*0.001f);
 #endif
 
     hal.scheduler->delay(1000);

--- a/libraries/AP_HAL/platform.h
+++ b/libraries/AP_HAL/platform.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <stdint.h>
+
+#include <AP_Common/AP_Common.h>
+
+#include "AP_HAL_Macros.h"
+
+namespace platform {
+
+void init();
+
+void panic(const char *errormsg, ...) FORMAT(1, 2) NORETURN;
+
+uint32_t micros();
+uint32_t millis();
+uint64_t micros64();
+uint64_t millis64();
+
+} // namespace platform

--- a/libraries/AP_HAL_Empty/Scheduler.cpp
+++ b/libraries/AP_HAL_Empty/Scheduler.cpp
@@ -16,22 +16,6 @@ void EmptyScheduler::init(void* machtnichts)
 void EmptyScheduler::delay(uint16_t ms)
 {}
 
-uint64_t EmptyScheduler::millis64() {
-    return 10000;
-}
-
-uint64_t EmptyScheduler::micros64() {
-    return 200000;
-}
-
-uint32_t EmptyScheduler::millis() {
-    return millis64();
-}
-
-uint32_t EmptyScheduler::micros() {
-    return micros64();
-}
-
 void EmptyScheduler::delay_microseconds(uint16_t us)
 {}
 
@@ -70,18 +54,6 @@ bool EmptyScheduler::system_initializing() {
 
 void EmptyScheduler::system_initialized()
 {}
-
-void EmptyScheduler::panic(const char *errormsg, ...)
-{
-    va_list ap;
-
-    va_start(ap, errormsg);
-    hal.console->vprintf(errormsg, ap);
-    va_end(ap);
-    hal.console->printf("\n");
-
-    for(;;);
-}
 
 void EmptyScheduler::reboot(bool hold_in_bootloader) {
     for(;;);

--- a/libraries/AP_HAL_Empty/Scheduler.h
+++ b/libraries/AP_HAL_Empty/Scheduler.h
@@ -9,10 +9,6 @@ public:
     EmptyScheduler();
     void     init(void* machtnichts);
     void     delay(uint16_t ms);
-    uint32_t millis();
-    uint32_t micros();
-    uint64_t millis64();
-    uint64_t micros64();
     void     delay_microseconds(uint16_t us);
     void     register_delay_callback(AP_HAL::Proc,
                 uint16_t min_time_ms);
@@ -32,7 +28,6 @@ public:
     bool     system_initializing();
     void     system_initialized();
 
-    void     panic(const char *errormsg, ...) FORMAT(2, 3) NORETURN;
     void     reboot(bool hold_in_bootloader);
 
 };

--- a/libraries/AP_HAL_FLYMAPLE/AnalogSource.cpp
+++ b/libraries/AP_HAL_FLYMAPLE/AnalogSource.cpp
@@ -134,7 +134,7 @@ void FLYMAPLEAnalogSource::setup_read() {
         hal.gpio->write(digital_pin, 1);
     }
     if (_settle_time_ms != 0) {
-        _read_start_time_ms = hal.scheduler->millis();
+        _read_start_time_ms = platform::millis();
     }
     adc_reg_map *regs = ADC1->regs;
     adc_set_reg_seqlen(ADC1, 1);
@@ -158,7 +158,7 @@ void FLYMAPLEAnalogSource::stop_read() {
 
 bool FLYMAPLEAnalogSource::reading_settled() 
 {
-    if (_settle_time_ms != 0 && (hal.scheduler->millis() - _read_start_time_ms) < _settle_time_ms) {
+    if (_settle_time_ms != 0 && (platform::millis() - _read_start_time_ms) < _settle_time_ms) {
         return false;
     }
     return true;

--- a/libraries/AP_HAL_FLYMAPLE/RCInput.cpp
+++ b/libraries/AP_HAL_FLYMAPLE/RCInput.cpp
@@ -51,7 +51,7 @@ FLYMAPLERCInput::FLYMAPLERCInput()
 // This interrupt triggers on a negative transiution of the PPM-SIM pin
 void FLYMAPLERCInput::_timer_capt_cb(void)
 {
-    _last_input_interrupt_time = hal.scheduler->millis();
+    _last_input_interrupt_time = platform::millis();
 
     static uint16 previous_count;
     static uint8  channel_ctr;
@@ -128,7 +128,7 @@ void FLYMAPLERCInput::init(void* machtnichts)
 }
 
 bool FLYMAPLERCInput::new_input() {
-    if ((hal.scheduler->millis() - _last_input_interrupt_time) > 50)
+    if ((platform::millis() - _last_input_interrupt_time) > 50)
 	_valid_channels = 0; // Lost RC Input?
     return _valid_channels != 0;
 }

--- a/libraries/AP_HAL_FLYMAPLE/Scheduler.cpp
+++ b/libraries/AP_HAL_FLYMAPLE/Scheduler.cpp
@@ -93,22 +93,6 @@ void FLYMAPLEScheduler::delay(uint16_t ms)
     }
 }
 
-uint32_t FLYMAPLEScheduler::millis() {
-    return platform::millis();
-}
-
-uint32_t FLYMAPLEScheduler::micros() {
-    return platform::micros();
-}
-
-uint64_t FLYMAPLEScheduler::millis64() {
-    return platform::millis64();
-}
-
-uint64_t FLYMAPLEScheduler::micros64() {
-    return platform::micros64();
-}
-
 void FLYMAPLEScheduler::delay_microseconds(uint16_t us)
 { 
     delay_us(us);
@@ -220,22 +204,6 @@ void FLYMAPLEScheduler::system_initialized()
                    "more than once");
     }
     _initialized = true;
-}
-
-void FLYMAPLEScheduler::panic(const char *errormsg, ...) {
-    /* Suspend timer processes. We still want the timer event to go off
-     * to run the _failsafe code, however. */
-    // REVISIT: not tested on FLYMAPLE
-    va_list ap;
-
-    _timer_suspended = true;
-
-    va_start(ap, errormsg);
-    hal.console->vprintf(errormsg, ap);
-    va_end(ap);
-    hal.console->printf("\n");
-
-    for(;;);
 }
 
 void FLYMAPLEScheduler::reboot(bool hold_in_bootloader) {

--- a/libraries/AP_HAL_FLYMAPLE/Scheduler.cpp
+++ b/libraries/AP_HAL_FLYMAPLE/Scheduler.cpp
@@ -17,11 +17,7 @@
 
 #include <stdarg.h>
 
-#define millis libmaple_millis
-#define micros libmaple_micros
 #include "FlymapleWirish.h"
-#undef millis
-#undef micros
 
 // Flymaple: Force init to be called *first*, i.e. before static object allocation.
 // Otherwise, statically allocated objects (eg SerialUSB) that need libmaple may fail.
@@ -81,10 +77,10 @@ void FLYMAPLEScheduler::init(void* machtnichts)
 // This function may calls the _delay_cb to use up time
 void FLYMAPLEScheduler::delay(uint16_t ms)
 {    
-    uint32_t start = libmaple_micros();
+    uint32_t start = platform::micros();
     
     while (ms > 0) {
-        while ((libmaple_micros() - start) >= 1000) {
+        while ((platform::micros() - start) >= 1000) {
             ms--;
             if (ms == 0) break;
             start += 1000;
@@ -98,23 +94,19 @@ void FLYMAPLEScheduler::delay(uint16_t ms)
 }
 
 uint32_t FLYMAPLEScheduler::millis() {
-    return libmaple_millis();
+    return platform::millis();
 }
 
 uint32_t FLYMAPLEScheduler::micros() {
-    return libmaple_micros();
+    return platform::micros();
 }
 
 uint64_t FLYMAPLEScheduler::millis64() {
-    return millis();
+    return platform::millis64();
 }
 
 uint64_t FLYMAPLEScheduler::micros64() {
-    // this is slow, but solves the problem with logging uint64_t timestamps
-    uint64_t ret = millis();
-    ret *= 1000ULL;
-    ret += micros() % 1000;
-    return ret;
+    return platform::micros64();
 }
 
 void FLYMAPLEScheduler::delay_microseconds(uint16_t us)
@@ -224,7 +216,7 @@ bool FLYMAPLEScheduler::system_initializing() {
 void FLYMAPLEScheduler::system_initialized()
 {
     if (_initialized) {
-        panic("PANIC: scheduler::system_initialized called"
+        platform::panic("PANIC: scheduler::system_initialized called"
                    "more than once");
     }
     _initialized = true;

--- a/libraries/AP_HAL_FLYMAPLE/Scheduler.h
+++ b/libraries/AP_HAL_FLYMAPLE/Scheduler.h
@@ -28,10 +28,6 @@ public:
     FLYMAPLEScheduler();
     void     init(void* machtnichts);
     void     delay(uint16_t ms);
-    uint32_t millis();
-    uint32_t micros();
-    uint64_t millis64();
-    uint64_t micros64();
     void     delay_microseconds(uint16_t us);
     void     register_delay_callback(AP_HAL::Proc,
                 uint16_t min_time_ms);
@@ -53,7 +49,6 @@ public:
     bool     system_initializing();
     void     system_initialized();
 
-    void     panic(const char *errormsg, ...) FORMAT(2, 3) NORETURN;
     void     reboot(bool hold_in_bootloader);
 
 private:

--- a/libraries/AP_HAL_FLYMAPLE/Semaphores.cpp
+++ b/libraries/AP_HAL_FLYMAPLE/Semaphores.cpp
@@ -44,7 +44,7 @@ bool FLYMAPLESemaphore::give() {
 
 bool FLYMAPLESemaphore::take(uint32_t timeout_ms) {
     if (hal.scheduler->in_timerprocess()) {
-        hal.scheduler->panic("PANIC: FLYMAPLESemaphore::take used from "
+        platform::panic("PANIC: FLYMAPLESemaphore::take used from "
                     "inside timer process");
         return false; /* Never reached - panic does not return */
     }

--- a/libraries/AP_HAL_FLYMAPLE/examples/AP_Baro_BMP085_test/AP_Baro_BMP085_test.cpp
+++ b/libraries/AP_HAL_FLYMAPLE/examples/AP_Baro_BMP085_test/AP_Baro_BMP085_test.cpp
@@ -41,7 +41,7 @@ void setup()
     }
     hal.console->println("initialisation complete.");
     hal.scheduler->delay(1000);
-    timer = hal.scheduler->micros();
+    timer = platform::micros();
 }
 
 void loop()
@@ -50,17 +50,17 @@ void loop()
     static uint32_t last_print;
 
     // accumulate values at 100Hz
-    if ((hal.scheduler->micros()- timer) > 20000L) {
+    if ((platform::micros()- timer) > 20000L) {
 	    bmp085.accumulate();
-	    timer = hal.scheduler->micros();
+	    timer = platform::micros();
     }
 
     // print at 10Hz
-    if ((hal.scheduler->millis()- last_print) >= 100) {
-	uint32_t start = hal.scheduler->micros();
-        last_print = hal.scheduler->millis();
+    if ((platform::millis()- last_print) >= 100) {
+	uint32_t start = platform::micros();
+        last_print = platform::millis();
         bmp085.read();
-        uint32_t read_time = hal.scheduler->micros() - start;
+        uint32_t read_time = platform::micros() - start;
         if (! bmp085.healthy) {
             hal.console->println("not healthy");
             return;

--- a/libraries/AP_HAL_FLYMAPLE/examples/SPIDriver/SPIDriver.cpp
+++ b/libraries/AP_HAL_FLYMAPLE/examples/SPIDriver/SPIDriver.cpp
@@ -19,7 +19,7 @@ void setup (void) {
 
     spidev = hal.spi->device(AP_HAL::SPIDevice_MPU6000); // Not really MPU6000, just a generic SPU driver
     if (!spidev)
-       hal.scheduler->panic("Starting AP_HAL_FLYMAPLE::SPIDriver failed to get spidev\r\n");
+        platform::panic("Starting AP_HAL_FLYMAPLE::SPIDriver failed to get spidev\r\n");
 }
 
 void loop (void) { 

--- a/libraries/AP_HAL_FLYMAPLE/examples/Semaphore/Semaphore.cpp
+++ b/libraries/AP_HAL_FLYMAPLE/examples/Semaphore/Semaphore.cpp
@@ -73,12 +73,12 @@ void setup (void) {
     AP_HAL::SPIDeviceDriver *dataflash = hal.spi->device(AP_HAL::SPIDevice_Dataflash); // not really
 
     if (dataflash == NULL) {
-        hal.scheduler->panic("Error: No SPIDeviceDriver!");
+        platform::panic("Error: No SPIDeviceDriver!");
     }
    
     sem = dataflash->get_semaphore();
     if (sem == NULL) {
-        hal.scheduler->panic("Error: No SPIDeviceDriver semaphore!");
+        platform::panic("Error: No SPIDeviceDriver semaphore!");
     }
 
     hal.scheduler->register_timer_process(async_blinker);

--- a/libraries/AP_HAL_FLYMAPLE/platform.cpp
+++ b/libraries/AP_HAL_FLYMAPLE/platform.cpp
@@ -1,0 +1,9 @@
+#include <AP_HAL/platform.h>
+
+namespace platform {
+
+void init()
+{
+}
+
+} // namespace platform

--- a/libraries/AP_HAL_FLYMAPLE/platform.cpp
+++ b/libraries/AP_HAL_FLYMAPLE/platform.cpp
@@ -1,9 +1,61 @@
+#include <stdarg.h>
+#include <stdio.h>
+
+#include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/platform.h>
+#include <AP_HAL_FLYMAPLE/Scheduler.h>
+
+#include "FlymapleWirish.h"
+
+extern const AP_HAL::HAL& hal;
 
 namespace platform {
 
 void init()
 {
+}
+
+void panic(const char *errormsg, ...)
+{
+    /* Suspend timer processes. We still want the timer event to go off
+     * to run the _failsafe code, however. */
+    // REVISIT: not tested on FLYMAPLE
+    va_list ap;
+
+    hal.scheduler->suspend_timer_procs();
+
+    va_start(ap, errormsg);
+    hal.console->vprintf(errormsg, ap);
+    va_end(ap);
+    hal.console->printf("\n");
+
+    for(;;);
+}
+
+uint32_t micros()
+{
+    // Use function provided by libmaple.
+    return ::micros();
+}
+
+uint32_t millis()
+{
+    // Use function provided by libmaple.
+    return ::millis();
+}
+
+uint64_t millis64()
+{
+    return millis();
+}
+
+uint64_t micros64()
+{
+    // this is slow, but solves the problem with logging uint64_t timestamps
+    uint64_t ret = millis();
+    ret *= 1000ULL;
+    ret += micros() % 1000;
+    return ret;
 }
 
 } // namespace platform

--- a/libraries/AP_HAL_Linux/AnalogIn_ADS1115.cpp
+++ b/libraries/AP_HAL_Linux/AnalogIn_ADS1115.cpp
@@ -84,7 +84,7 @@ void ADS1115AnalogIn::init(void* implspecific)
 
 void ADS1115AnalogIn::_update()
 {
-    if (hal.scheduler->micros() - _last_update_timestamp < 100000) {
+    if (platform::micros() - _last_update_timestamp < 100000) {
         return;
     }
 
@@ -108,7 +108,7 @@ void ADS1115AnalogIn::_update()
         }
     }
 
-    _last_update_timestamp = hal.scheduler->micros();
+    _last_update_timestamp = platform::micros();
 }
 
 #endif

--- a/libraries/AP_HAL_Linux/GPIO_BBB.cpp
+++ b/libraries/AP_HAL_Linux/GPIO_BBB.cpp
@@ -32,7 +32,7 @@ void GPIO_BBB::init()
     uint8_t bank_enable[3] = { 5, 65, 105 };
     int export_fd = open("/sys/class/gpio/export", O_WRONLY);
     if (export_fd == -1) {
-        hal.scheduler->panic("unable to open /sys/class/gpio/export");
+        platform::panic("unable to open /sys/class/gpio/export");
     }
     for (uint8_t i=0; i<3; i++) {
         dprintf(export_fd, "%u\n", (unsigned)bank_enable[i]);
@@ -51,7 +51,7 @@ void GPIO_BBB::init()
     for (uint8_t i=0; i<LINUX_GPIO_NUM_BANKS; i++) {
         gpio_bank[i].base = (volatile unsigned *)mmap(0, GPIO_SIZE, PROT_READ|PROT_WRITE, MAP_SHARED, mem_fd, offsets[i]);
         if ((char *)gpio_bank[i].base == MAP_FAILED) {
-            hal.scheduler->panic("unable to map GPIO bank");
+            platform::panic("unable to map GPIO bank");
         }
         gpio_bank[i].oe = gpio_bank[i].base + GPIO_OE;
         gpio_bank[i].in = gpio_bank[i].base + GPIO_IN;

--- a/libraries/AP_HAL_Linux/GPIO_RPI.cpp
+++ b/libraries/AP_HAL_Linux/GPIO_RPI.cpp
@@ -30,7 +30,7 @@ void GPIO_RPI::init()
     uint32_t clk_address  = rpi_version == 1 ? CLOCK_BASE(BCM2708_PERI_BASE)  : CLOCK_BASE(BCM2709_PERI_BASE);
     // open /dev/mem
     if ((mem_fd = open("/dev/mem", O_RDWR|O_SYNC) ) < 0) {
-        hal.scheduler->panic("Can't open /dev/mem");
+        platform::panic("Can't open /dev/mem");
     }
 
     // mmap GPIO
@@ -64,7 +64,7 @@ void GPIO_RPI::init()
     close(mem_fd); // No need to keep mem_fd open after mmap
 
     if (gpio_map == MAP_FAILED || pwm_map == MAP_FAILED || clk_map == MAP_FAILED) {
-        hal.scheduler->panic("Can't open /dev/mem");
+        platform::panic("Can't open /dev/mem");
     }
 
     gpio = (volatile uint32_t *)gpio_map; // Always use volatile pointer!

--- a/libraries/AP_HAL_Linux/Heat_Pwm.cpp
+++ b/libraries/AP_HAL_Linux/Heat_Pwm.cpp
@@ -52,32 +52,32 @@ HeatPwm::HeatPwm(const char* pwm_sysfs_path, float Kp, float Ki, uint32_t period
     char *run_path;
 
     if (asprintf(&duty_path, "%s/%s", pwm_sysfs_path, HEAT_PWM_DUTY) == -1) {
-        hal.scheduler->panic("HeatPwm not enough memory\n");
+        platform::panic("HeatPwm not enough memory\n");
     }
     _duty_fd = open(duty_path, O_RDWR);
     if (_duty_fd == -1) {
         perror("opening duty");
-        hal.scheduler->panic("Error Initializing Pwm heat\n");
+        platform::panic("Error Initializing Pwm heat\n");
     }
     free(duty_path);
 
     if (asprintf(&period_path, "%s/%s", pwm_sysfs_path, HEAT_PWM_PERIOD) == -1) {
-        hal.scheduler->panic("HeatPwm not enough memory\n");
+        platform::panic("HeatPwm not enough memory\n");
     }
     _period_fd = open(period_path, O_RDWR);
     if (_period_fd == -1) {
         perror("opening period");
-        hal.scheduler->panic("Error Initializing Pwm heat\n");
+        platform::panic("Error Initializing Pwm heat\n");
     }
     free(period_path);
 
     if (asprintf(&run_path, "%s/%s", pwm_sysfs_path, HEAT_PWM_RUN) == -1) {
-        hal.scheduler->panic("HeatPwm not enough memory\n");
+        platform::panic("HeatPwm not enough memory\n");
     }
     _run_fd = open(run_path, O_RDWR);
     if (_run_fd == -1) {
         perror("opening run");
-        hal.scheduler->panic("Error Initializing Pwm heat\n");
+        platform::panic("Error Initializing Pwm heat\n");
     }
     free(run_path);
 
@@ -90,7 +90,7 @@ void HeatPwm::set_imu_temp(float current)
 {
     float error, output;
 
-    if (hal.scheduler->millis() - _last_temp_update < 5) {
+    if (platform::millis() - _last_temp_update < 5) {
         return;
     }
 
@@ -112,7 +112,7 @@ void HeatPwm::set_imu_temp(float current)
     }
 
     _set_duty(output);
-    _last_temp_update = hal.scheduler->millis();
+    _last_temp_update = platform::millis();
 }
 
 void HeatPwm::_set_duty(uint32_t duty)

--- a/libraries/AP_HAL_Linux/I2CDriver.cpp
+++ b/libraries/AP_HAL_Linux/I2CDriver.cpp
@@ -33,7 +33,7 @@ I2CDriver::I2CDriver(AP_HAL::Semaphore* semaphore, const char *device) :
 
 #if CONFIG_HAL_BOARD_SUBTYPE != HAL_BOARD_SUBTYPE_LINUX_NONE
     if (!((Util*)hal.util)->is_chardev_node(_device))
-        hal.scheduler->panic("I2C device is not a chardev node");
+        platform::panic("I2C device is not a chardev node");
 #endif
 }
 
@@ -51,7 +51,7 @@ I2CDriver::I2CDriver(AP_HAL::Semaphore* semaphore,
 
     d = opendir(dirname);
     if (!d)
-        hal.scheduler->panic("Could not get list of I2C buses");
+        platform::panic("Could not get list of I2C buses");
 
     for (de = readdir(d); de; de = readdir(d)) {
         const char *p, * const *t;
@@ -85,7 +85,7 @@ I2CDriver::I2CDriver(AP_HAL::Semaphore* semaphore,
     closedir(d);
 
     if (!((Util*)hal.util)->is_chardev_node(_device))
-        hal.scheduler->panic("I2C device is not a chardev node");
+        platform::panic("I2C device is not a chardev node");
 }
 
 I2CDriver::~I2CDriver()

--- a/libraries/AP_HAL_Linux/PWM_Sysfs.cpp
+++ b/libraries/AP_HAL_Linux/PWM_Sysfs.cpp
@@ -57,7 +57,7 @@ PWM_Sysfs::PWM_Sysfs(uint8_t chip, uint8_t channel)
 
     r = snprintf(path, sizeof(path), PWM_BASE_PATH "%u/export", _chip);
     if (r < 0 || r >= (int)sizeof(path)) {
-        hal.scheduler->panic("LinuxPWM_Sysfs: chip=%u channel=%u "
+        platform::panic("LinuxPWM_Sysfs: chip=%u channel=%u "
                                 "Error formatting pwm export: %s",
                                 _chip, _channel, strerror(errno));
     }
@@ -72,14 +72,14 @@ PWM_Sysfs::PWM_Sysfs(uint8_t chip, uint8_t channel)
     r = snprintf(path, sizeof(path), PWM_BASE_PATH "%u/pwm%u/duty_cycle",
                  _chip, _channel);
     if (r < 0 || r >= (int)sizeof(path)) {
-        hal.scheduler->panic("LinuxPWM_Sysfs: chip=%u channel=%u "
+        platform::panic("LinuxPWM_Sysfs: chip=%u channel=%u "
                              "Error formatting channel duty cycle: %s",
                              _chip, _channel, strerror(errno));
     }
 
     _duty_cycle_fd = ::open(path, O_RDWR | O_CLOEXEC);
     if (_duty_cycle_fd < 0) {
-        hal.scheduler->panic("LinuxPWM_Sysfs: chip=%u channel=%u "
+        platform::panic("LinuxPWM_Sysfs: chip=%u channel=%u "
                              "Unable to open file %s: %s",
                              _chip, _channel, path, strerror(errno));
     }

--- a/libraries/AP_HAL_Linux/RCInput.cpp
+++ b/libraries/AP_HAL_Linux/RCInput.cpp
@@ -285,7 +285,7 @@ void RCInput::_process_dsm_pulse(uint16_t width_s0, uint16_t width_s1)
             }
             uint16_t values[8];
             uint16_t num_values=0;
-            if (dsm_decode(hal.scheduler->micros64(), bytes, values, &num_values, 8) && 
+            if (dsm_decode(platform::micros64(), bytes, values, &num_values, 8) && 
                 num_values >= 5) {
                 for (i=0; i<num_values; i++) {
                     _pwm_values[i] = values[i];

--- a/libraries/AP_HAL_Linux/RCInput_AioPRU.cpp
+++ b/libraries/AP_HAL_Linux/RCInput_AioPRU.cpp
@@ -38,7 +38,7 @@ void RCInput_AioPRU::init(void*)
 {
     int mem_fd = open("/dev/mem", O_RDWR|O_SYNC);
     if (mem_fd == -1) {
-        hal.scheduler->panic("Unable to open /dev/mem");
+        platform::panic("Unable to open /dev/mem");
     }
     ring_buffer = (volatile struct ring_buffer*) mmap(0, 0x1000, PROT_READ|PROT_WRITE, MAP_SHARED, mem_fd, RCIN_PRUSS_RAM_BASE);
     close(mem_fd);

--- a/libraries/AP_HAL_Linux/RCInput_PRU.cpp
+++ b/libraries/AP_HAL_Linux/RCInput_PRU.cpp
@@ -28,7 +28,7 @@ void RCInput_PRU::init(void*)
 {
     int mem_fd = open("/dev/mem", O_RDWR|O_SYNC);
     if (mem_fd == -1) {
-        hal.scheduler->panic("Unable to open /dev/mem");
+        platform::panic("Unable to open /dev/mem");
     }
     ring_buffer = (volatile struct ring_buffer*) mmap(0, 0x1000, PROT_READ|PROT_WRITE, 
                                                       MAP_SHARED, mem_fd, RCIN_PRUSS_SHAREDRAM_BASE);

--- a/libraries/AP_HAL_Linux/RCInput_RPI.cpp
+++ b/libraries/AP_HAL_Linux/RCInput_RPI.cpp
@@ -245,7 +245,7 @@ void RCInput_RPI::stop_dma()
 void RCInput_RPI::termination_handler(int signum)
 {
     stop_dma();
-    hal.scheduler->panic("Interrupted");
+    platform::panic("Interrupted");
 }
 
 

--- a/libraries/AP_HAL_Linux/RCInput_Raspilot.cpp
+++ b/libraries/AP_HAL_Linux/RCInput_Raspilot.cpp
@@ -25,7 +25,7 @@ void RCInput_Raspilot::init(void*)
     _spi_sem = _spi->get_semaphore();
 
     if (_spi_sem == NULL) {
-        hal.scheduler->panic("PANIC: RCIutput_Raspilot did not get "
+        platform::panic("PANIC: RCIutput_Raspilot did not get "
                                   "valid SPI semaphore!");
         return; // never reached
     }
@@ -37,11 +37,11 @@ void RCInput_Raspilot::init(void*)
 void RCInput_Raspilot::_poll_data(void)
 {
     // Throttle read rate to 100hz maximum.
-    if (hal.scheduler->micros() - _last_timer < 10000) {
+    if (platform::micros() - _last_timer < 10000) {
         return;
     }
 
-    _last_timer = hal.scheduler->micros();
+    _last_timer = platform::micros();
 
     if (!_spi_sem->take_nonblocking()) {
         return;

--- a/libraries/AP_HAL_Linux/RCInput_UART.cpp
+++ b/libraries/AP_HAL_Linux/RCInput_UART.cpp
@@ -15,15 +15,13 @@
 
 #define MAGIC 0x55AA
 
-static const AP_HAL::HAL& hal = AP_HAL::get_HAL();
-
 using namespace Linux;
 
 RCInput_UART::RCInput_UART(const char *path)
 {
     _fd = open(path, O_RDONLY|O_NOCTTY|O_NONBLOCK|O_NDELAY);
     if (_fd < 0) {
-        hal.scheduler->panic("RCInput_UART: Error opening '%s': %s",
+        platform::panic("RCInput_UART: Error opening '%s': %s",
                              path, strerror(errno));
     }
 }
@@ -50,7 +48,7 @@ void RCInput_UART::init(void*)
     options.c_oflag &= ~OPOST;
 
     if (tcsetattr(_fd, TCSANOW, &options) != 0) {
-        hal.scheduler->panic("RCInput_UART: error configuring device: %s",
+        platform::panic("RCInput_UART: error configuring device: %s",
                              strerror(errno));
     }
 

--- a/libraries/AP_HAL_Linux/RCInput_ZYNQ.cpp
+++ b/libraries/AP_HAL_Linux/RCInput_ZYNQ.cpp
@@ -25,7 +25,7 @@ void RCInput_ZYNQ::init(void*)
 {
     int mem_fd = open("/dev/mem", O_RDWR|O_SYNC);
     if (mem_fd == -1) {
-        hal.scheduler->panic("Unable to open /dev/mem");
+        platform::panic("Unable to open /dev/mem");
     }
     pulse_input = (volatile uint32_t*) mmap(0, 0x1000, PROT_READ|PROT_WRITE, 
                                                       MAP_SHARED, mem_fd, RCIN_ZYNQ_PULSE_INPUT_BASE);

--- a/libraries/AP_HAL_Linux/RCOutput_AioPRU.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_AioPRU.cpp
@@ -31,7 +31,7 @@ static const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
 static void catch_sigbus(int sig)
 {
-    hal.scheduler->panic("RCOutputAioPRU.cpp:SIGBUS error gernerated\n");
+    platform::panic("RCOutputAioPRU.cpp:SIGBUS error gernerated\n");
 }
 void RCOutput_AioPRU::init(void* machtnicht)
 {

--- a/libraries/AP_HAL_Linux/RCOutput_Bebop.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_Bebop.cpp
@@ -247,7 +247,7 @@ void RCOutput_Bebop::init(void* dummy)
 
     _i2c_sem = hal.i2c1->get_semaphore();
     if (_i2c_sem == NULL) {
-        hal.scheduler->panic("RCOutput_Bebop: can't get i2c sem");
+        platform::panic("RCOutput_Bebop: can't get i2c sem");
         return; /* never reached */
     }
 

--- a/libraries/AP_HAL_Linux/RCOutput_PCA9685.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_PCA9685.cpp
@@ -84,7 +84,7 @@ void RCOutput_PCA9685::init(void* machtnicht)
 {
     _i2c_sem = hal.i2c->get_semaphore();
     if (_i2c_sem == NULL) {
-        hal.scheduler->panic("PANIC: RCOutput_PCA9685 did not get "
+        platform::panic("PANIC: RCOutput_PCA9685 did not get "
                                   "valid I2C semaphore!");
         return; /* never reached */
     }

--- a/libraries/AP_HAL_Linux/RCOutput_PRU.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_PRU.cpp
@@ -24,10 +24,9 @@ using namespace Linux;
 static const uint8_t chan_pru_map[]= {10,8,11,9,7,6,5,4,3,2,1,0};                //chan_pru_map[CHANNEL_NUM] = PRU_REG_R30/31_NUM;
 static const uint8_t pru_chan_map[]= {11,10,9,8,7,6,5,4,1,3,0,2};                //pru_chan_map[PRU_REG_R30/31_NUM] = CHANNEL_NUM;
 
-static const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 static void catch_sigbus(int sig)
 {
-    hal.scheduler->panic("RCOutput.cpp:SIGBUS error gernerated\n");
+    platform::panic("RCOutput.cpp:SIGBUS error gernerated\n");
 }
 void RCOutput_PRU::init(void* machtnicht)
 {

--- a/libraries/AP_HAL_Linux/RCOutput_Raspilot.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_Raspilot.cpp
@@ -28,7 +28,7 @@ void RCOutput_Raspilot::init(void* machtnicht)
     _spi_sem = _spi->get_semaphore();
     
     if (_spi_sem == NULL) {
-        hal.scheduler->panic("PANIC: RCOutput_Raspilot did not get "
+        platform::panic("PANIC: RCOutput_Raspilot did not get "
                                   "valid SPI semaphore!");
         return; // never reached
     }
@@ -100,11 +100,11 @@ void RCOutput_Raspilot::_update(void)
 {
     int i;
     
-    if (hal.scheduler->micros() - _last_update_timestamp < 10000) {
+    if (platform::micros() - _last_update_timestamp < 10000) {
         return;
     }
     
-    _last_update_timestamp = hal.scheduler->micros();
+    _last_update_timestamp = platform::micros();
     
     if (!_spi_sem->take_nonblocking()) {
         return;

--- a/libraries/AP_HAL_Linux/RCOutput_Sysfs.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_Sysfs.cpp
@@ -27,8 +27,6 @@
 
 namespace Linux {
 
-static const AP_HAL::HAL &hal = AP_HAL::get_HAL();
-
 RCOutput_Sysfs::RCOutput_Sysfs(uint8_t chip, uint8_t channel_count)
     : _chip(chip)
     , _channel_count(channel_count)
@@ -50,7 +48,7 @@ void RCOutput_Sysfs::init(void *machtnichts)
     for (uint8_t i = 0; i < _channel_count; i++) {
         _pwm_channels[i] = new PWM_Sysfs(_chip, i);
         if (!_pwm_channels[i]) {
-            hal.scheduler->panic("RCOutput_Sysfs_PWM: Unable to setup PWM pin.");
+            platform::panic("RCOutput_Sysfs_PWM: Unable to setup PWM pin.");
         }
         _pwm_channels[i]->enable(false);
 

--- a/libraries/AP_HAL_Linux/RCOutput_ZYNQ.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_ZYNQ.cpp
@@ -20,10 +20,9 @@ using namespace Linux;
 
 #define PWM_CHAN_COUNT 8	// FIXME
 
-static const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 static void catch_sigbus(int sig)
 {
-    hal.scheduler->panic("RCOutput.cpp:SIGBUS error gernerated\n");
+    platform::panic("RCOutput.cpp:SIGBUS error gernerated\n");
 }
 void RCOutput_ZYNQ::init(void* machtnicht)
 {

--- a/libraries/AP_HAL_Linux/RPIOUARTDriver.cpp
+++ b/libraries/AP_HAL_Linux/RPIOUARTDriver.cpp
@@ -108,13 +108,13 @@ void RPIOUARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
    _spi = hal.spi->device(AP_HAL::SPIDevice_RASPIO);
 
    if (_spi == NULL) {
-       hal.scheduler->panic("Cannot get SPIDevice_RASPIO");
+       platform::panic("Cannot get SPIDevice_RASPIO");
    }
 
    _spi_sem = _spi->get_semaphore();
     
     if (_spi_sem == NULL) {
-        hal.scheduler->panic("PANIC: RASPIOUARTDriver did not get "
+        platform::panic("PANIC: RASPIOUARTDriver did not get "
                                   "valid SPI semaphore!");
         return; // never reached
     }
@@ -191,7 +191,7 @@ void RPIOUARTDriver::_timer_tick(void)
     if (!_initialised) return;
     
     /* lower the update rate */
-    if (hal.scheduler->micros() - _last_update_timestamp < RPIOUART_POLL_TIME_INTERVAL) {
+    if (platform::micros() - _last_update_timestamp < RPIOUART_POLL_TIME_INTERVAL) {
         return;
     }
     
@@ -287,7 +287,7 @@ void RPIOUARTDriver::_timer_tick(void)
     
     _in_timer = false;
     
-    _last_update_timestamp = hal.scheduler->micros();
+    _last_update_timestamp = platform::micros();
 }
 
 #endif

--- a/libraries/AP_HAL_Linux/RaspilotAnalogIn.cpp
+++ b/libraries/AP_HAL_Linux/RaspilotAnalogIn.cpp
@@ -91,7 +91,7 @@ void RaspilotAnalogIn::init(void* implspecific)
     _spi_sem = _spi->get_semaphore();
     
     if (_spi_sem == NULL) {
-        hal.scheduler->panic("PANIC: RCIutput_Raspilot did not get "
+        platform::panic("PANIC: RCIutput_Raspilot did not get "
                                   "valid SPI semaphore!");
         return; // never reached
     }
@@ -103,7 +103,7 @@ void RaspilotAnalogIn::init(void* implspecific)
 
 void RaspilotAnalogIn::_update()
 {
-    if (hal.scheduler->micros() - _last_update_timestamp < 100000) {
+    if (platform::micros() - _last_update_timestamp < 100000) {
         return;
     }
     
@@ -141,7 +141,7 @@ void RaspilotAnalogIn::_update()
 
     }
 
-    _last_update_timestamp = hal.scheduler->micros();
+    _last_update_timestamp = platform::micros();
 }
 
 #endif

--- a/libraries/AP_HAL_Linux/SPIDriver.cpp
+++ b/libraries/AP_HAL_Linux/SPIDriver.cpp
@@ -96,7 +96,7 @@ void SPIDeviceDriver::init()
     if(_cs_pin != SPI_CS_KERNEL) {
         _cs = hal.gpio->channel(_cs_pin);
         if (_cs == NULL) {
-            hal.scheduler->panic("Unable to instantiate cs pin");
+            platform::panic("Unable to instantiate cs pin");
         }
         _cs->mode(HAL_GPIO_OUTPUT);
         _cs->write(1);       // do not hold the SPI bus initially
@@ -150,7 +150,7 @@ void SPIDeviceManager::init(void *)
 {
     for (uint8_t i=0; i<LINUX_SPI_DEVICE_NUM_DEVICES; i++) {
         if (_device[i]._bus >= LINUX_SPI_MAX_BUSES) {
-            hal.scheduler->panic("SPIDriver: invalid bus number");
+            platform::panic("SPIDriver: invalid bus number");
         }
         char path[255];
         snprintf(path, sizeof(path), "/dev/spidev%u.%u",
@@ -158,7 +158,7 @@ void SPIDeviceManager::init(void *)
         _device[i]._fd = open(path, O_RDWR);
         if (_device[i]._fd == -1) {
             printf("Unable to open %s - %s\n", path, strerror(errno));
-            hal.scheduler->panic("SPIDriver: unable to open SPI bus");
+            platform::panic("SPIDriver: unable to open SPI bus");
         }
 #if SPI_DEBUGGING
         printf("Opened %s\n", path);
@@ -178,7 +178,7 @@ void SPIDeviceManager::cs_assert(enum AP_HAL::SPIDevice type)
         }
     }
     if (i == LINUX_SPI_DEVICE_NUM_DEVICES) {
-        hal.scheduler->panic("Bad device type");
+        platform::panic("Bad device type");
     }
 
     // Kernel-mode CS handling
@@ -214,7 +214,7 @@ void SPIDeviceManager::cs_release(enum AP_HAL::SPIDevice type)
         }
     }
     if (i == LINUX_SPI_DEVICE_NUM_DEVICES) {
-        hal.scheduler->panic("Bad device type");
+        platform::panic("Bad device type");
     }
 
     // Kernel-mode CS handling

--- a/libraries/AP_HAL_Linux/SPIUARTDriver.cpp
+++ b/libraries/AP_HAL_Linux/SPIUARTDriver.cpp
@@ -93,14 +93,14 @@ void SPIUARTDriver::begin(uint32_t b, uint16_t rxS, uint16_t txS)
        _buffer = new uint8_t[rxS];
        if (_buffer == NULL) {
            hal.console->printf("Not enough memory\n");
-           hal.scheduler->panic("Not enough memory\n");
+           platform::panic("Not enough memory\n");
        }
    }
 
    _spi = hal.spi->device(AP_HAL::SPIDevice_Ublox);
 
    if (_spi == NULL) {
-       hal.scheduler->panic("Cannot get SPIDevice_Ublox");
+       platform::panic("Cannot get SPIDevice_Ublox");
    }
 
    _spi_sem = _spi->get_semaphore();
@@ -230,13 +230,13 @@ void SPIUARTDriver::_timer_tick(void)
         return;
     }
     /* lower the update rate */
-    if (hal.scheduler->micros() - _last_update_timestamp < 10000) {
+    if (platform::micros() - _last_update_timestamp < 10000) {
         return;
     }
 
     UARTDriver::_timer_tick();
 
-    _last_update_timestamp = hal.scheduler->micros();
+    _last_update_timestamp = platform::micros();
 }
 
 #endif

--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -9,7 +9,6 @@
 #include "Util.h"
 #include "SPIUARTDriver.h"
 #include "RPIOUARTDriver.h"
-#include <sys/time.h>
 #include <poll.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -69,7 +68,7 @@ void Scheduler::_create_realtime_thread(pthread_t *ctx, int rtprio,
     if (r != 0) {
         hal.console->printf("Error creating thread '%s': %s\n",
                             name, strerror(r));
-        panic("Failed to create thread");
+        platform::panic("Failed to create thread");
     }
     pthread_attr_destroy(&attr);
 
@@ -81,8 +80,6 @@ void Scheduler::_create_realtime_thread(pthread_t *ctx, int rtprio,
 void Scheduler::init(void* machtnichts)
 {
     mlockall(MCL_CURRENT|MCL_FUTURE);
-
-    clock_gettime(CLOCK_MONOTONIC, &_sketch_start_time);
 
     struct sched_param param = { .sched_priority = APM_LINUX_MAIN_PRIORITY };
     sched_setscheduler(0, SCHED_FIFO, &param);
@@ -140,12 +137,12 @@ void Scheduler::_microsleep(uint32_t usec)
 
 void Scheduler::delay(uint16_t ms)
 {
-    if (stopped_clock_usec) {
+    if (_stopped_clock_usec) {
         return;
     }
-    uint64_t start = millis64();
+    uint64_t start = platform::millis64();
 
-    while ((millis64() - start) < ms) {
+    while ((platform::millis64() - start) < ms) {
         // this yields the CPU to other apps
         _microsleep(1000);
         if (_min_delay_cb_ms <= ms) {
@@ -158,41 +155,27 @@ void Scheduler::delay(uint16_t ms)
 
 uint64_t Scheduler::millis64()
 {
-    if (stopped_clock_usec) {
-        return stopped_clock_usec/1000;
-    }
-    struct timespec ts;
-    clock_gettime(CLOCK_MONOTONIC, &ts);
-    return 1.0e3*((ts.tv_sec + (ts.tv_nsec*1.0e-9)) -
-                  (_sketch_start_time.tv_sec +
-                   (_sketch_start_time.tv_nsec*1.0e-9)));
+    return platform::millis64();
 }
 
 uint64_t Scheduler::micros64()
 {
-    if (stopped_clock_usec) {
-        return stopped_clock_usec;
-    }
-    struct timespec ts;
-    clock_gettime(CLOCK_MONOTONIC, &ts);
-    return 1.0e6*((ts.tv_sec + (ts.tv_nsec*1.0e-9)) -
-                  (_sketch_start_time.tv_sec +
-                   (_sketch_start_time.tv_nsec*1.0e-9)));
+    return platform::micros64();
 }
 
 uint32_t Scheduler::millis()
 {
-    return millis64() & 0xFFFFFFFF;
+    return platform::millis();
 }
 
 uint32_t Scheduler::micros()
 {
-    return micros64() & 0xFFFFFFFF;
+    return platform::micros();
 }
 
 void Scheduler::delay_microseconds(uint16_t us)
 {
-    if (stopped_clock_usec) {
+    if (_stopped_clock_usec) {
         return;
     }
     _microsleep(us);
@@ -300,12 +283,12 @@ void *Scheduler::_timer_thread(void* arg)
       this aims to run at an average of 1kHz, so that it can be used
       to drive 1kHz processes without drift
      */
-    uint64_t next_run_usec = sched->micros64() + 1000;
+    uint64_t next_run_usec = platform::micros64() + 1000;
     while (true) {
-        uint64_t dt = next_run_usec - sched->micros64();
+        uint64_t dt = next_run_usec - platform::micros64();
         if (dt > 2000) {
             // we've lost sync - restart
-            next_run_usec = sched->micros64();
+            next_run_usec = platform::micros64();
         } else {
             sched->_microsleep(dt);
         }
@@ -439,7 +422,7 @@ bool Scheduler::system_initializing() {
 void Scheduler::system_initialized()
 {
     if (_initialized) {
-        panic("PANIC: scheduler::system_initialized called more than once");
+        platform::panic("PANIC: scheduler::system_initialized called more than once");
     }
     _initialized = true;
 }
@@ -451,8 +434,8 @@ void Scheduler::reboot(bool hold_in_bootloader)
 
 void Scheduler::stop_clock(uint64_t time_usec)
 {
-    if (time_usec >= stopped_clock_usec) {
-        stopped_clock_usec = time_usec;
+    if (time_usec >= _stopped_clock_usec) {
+        _stopped_clock_usec = time_usec;
         _run_io();
     }
 }

--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -153,26 +153,6 @@ void Scheduler::delay(uint16_t ms)
     }
 }
 
-uint64_t Scheduler::millis64()
-{
-    return platform::millis64();
-}
-
-uint64_t Scheduler::micros64()
-{
-    return platform::micros64();
-}
-
-uint32_t Scheduler::millis()
-{
-    return platform::millis();
-}
-
-uint32_t Scheduler::micros()
-{
-    return platform::micros();
-}
-
 void Scheduler::delay_microseconds(uint16_t us)
 {
     if (_stopped_clock_usec) {
@@ -388,20 +368,6 @@ void *Scheduler::_io_thread(void* arg)
         sched->_run_io();
     }
     return NULL;
-}
-
-void Scheduler::panic(const char *errormsg, ...)
-{
-    va_list ap;
-
-    va_start(ap, errormsg);
-    vdprintf(1, errormsg, ap);
-    va_end(ap);
-    write(1, "\n", 1);
-
-    hal.rcin->deinit();
-    hal.scheduler->delay_microseconds(10000);
-    exit(1);
 }
 
 bool Scheduler::in_timerprocess()

--- a/libraries/AP_HAL_Linux/Scheduler.h
+++ b/libraries/AP_HAL_Linux/Scheduler.h
@@ -25,10 +25,6 @@ public:
 
     void     init(void* machtnichts);
     void     delay(uint16_t ms);
-    uint32_t millis();
-    uint32_t micros();
-    uint64_t millis64();
-    uint64_t micros64();
     void     delay_microseconds(uint16_t us);
     void     register_delay_callback(AP_HAL::Proc,
                 uint16_t min_time_ms);
@@ -48,7 +44,6 @@ public:
     bool     system_initializing();
     void     system_initialized();
 
-    void     panic(const char *errormsg, ...) FORMAT(2, 3) NORETURN;
     void     reboot(bool hold_in_bootloader);
 
     void     stop_clock(uint64_t time_usec);

--- a/libraries/AP_HAL_Linux/Scheduler.h
+++ b/libraries/AP_HAL_Linux/Scheduler.h
@@ -18,6 +18,11 @@ typedef void *(*pthread_startroutine_t)(void *);
 
 public:
     Scheduler();
+
+    static Scheduler *from(AP_HAL::Scheduler *scheduler) {
+        return static_cast<Scheduler*>(scheduler);
+    }
+
     void     init(void* machtnichts);
     void     delay(uint16_t ms);
     uint32_t millis();
@@ -48,8 +53,9 @@ public:
 
     void     stop_clock(uint64_t time_usec);
 
+    uint64_t stopped_clock_usec() const { return _stopped_clock_usec; }
+
 private:
-    struct timespec _sketch_start_time;    
     void _timer_handler(int signum);
     void _microsleep(uint32_t usec);
 
@@ -88,7 +94,7 @@ private:
     void _create_realtime_thread(pthread_t *ctx, int rtprio, const char *name,
                                  pthread_startroutine_t start_routine);
 
-    uint64_t stopped_clock_usec;
+    uint64_t _stopped_clock_usec;
 
     Semaphore _timer_semaphore;
     Semaphore _io_semaphore;

--- a/libraries/AP_HAL_Linux/Semaphores.cpp
+++ b/libraries/AP_HAL_Linux/Semaphores.cpp
@@ -21,13 +21,13 @@ bool Semaphore::take(uint32_t timeout_ms)
     if (take_nonblocking()) {
         return true;
     }
-    uint64_t start = hal.scheduler->micros64();
+    uint64_t start = platform::micros64();
     do {
         hal.scheduler->delay_microseconds(200);
         if (take_nonblocking()) {
             return true;
         }
-    } while ((hal.scheduler->micros64() - start) < timeout_ms*1000);
+    } while ((platform::micros64() - start) < timeout_ms*1000);
     return false;
 }
 

--- a/libraries/AP_HAL_Linux/Storage.cpp
+++ b/libraries/AP_HAL_Linux/Storage.cpp
@@ -35,12 +35,12 @@ void Storage::_storage_create(void)
     unlink(STORAGE_FILE);
     int fd = open(STORAGE_FILE, O_RDWR|O_CREAT, 0666);
     if (fd == -1) {
-        hal.scheduler->panic("Failed to create " STORAGE_FILE);
+        platform::panic("Failed to create " STORAGE_FILE);
     }
     for (uint16_t loc=0; loc<sizeof(_buffer); loc += LINUX_STORAGE_MAX_WRITE) {
         if (write(fd, &_buffer[loc], LINUX_STORAGE_MAX_WRITE) != LINUX_STORAGE_MAX_WRITE) {
             perror("write");
-            hal.scheduler->panic("Error filling " STORAGE_FILE);            
+            platform::panic("Error filling " STORAGE_FILE);
         }
     }
     // ensure the directory is updated with the new size
@@ -60,7 +60,7 @@ void Storage::_storage_open(void)
         _storage_create();
         fd = open(STORAGE_FILE, O_RDWR);
         if (fd == -1) {
-            hal.scheduler->panic("Failed to open " STORAGE_FILE);
+            platform::panic("Failed to open " STORAGE_FILE);
         }
     }
     memset(_buffer, 0, sizeof(_buffer));
@@ -71,7 +71,7 @@ void Storage::_storage_open(void)
     ssize_t ret = read(fd, _buffer, sizeof(_buffer));
     if (ret == 4096 && ret != sizeof(_buffer)) {
         if (ftruncate(fd, sizeof(_buffer)) != 0) {
-            hal.scheduler->panic("Failed to expand " STORAGE_FILE);            
+            platform::panic("Failed to expand " STORAGE_FILE);
         }
         ret = sizeof(_buffer);
     }
@@ -80,10 +80,10 @@ void Storage::_storage_open(void)
         _storage_create();
         fd = open(STORAGE_FILE, O_RDONLY);
         if (fd == -1) {
-            hal.scheduler->panic("Failed to open " STORAGE_FILE);
+            platform::panic("Failed to open " STORAGE_FILE);
         }
         if (read(fd, _buffer, sizeof(_buffer)) != sizeof(_buffer)) {
-            hal.scheduler->panic("Failed to read " STORAGE_FILE);
+            platform::panic("Failed to read " STORAGE_FILE);
         }
     }
     close(fd);

--- a/libraries/AP_HAL_Linux/Storage_FRAM.cpp
+++ b/libraries/AP_HAL_Linux/Storage_FRAM.cpp
@@ -34,11 +34,11 @@ void Storage_FRAM::_storage_create(void)
     hal.console->println("Storage: FRAM is getting reset to default values");
     
     if (fd == -1) {
-        hal.scheduler->panic("Failed to load FRAM");
+        platform::panic("Failed to load FRAM");
     }
     for (uint16_t loc=0; loc<sizeof(_buffer); loc += LINUX_STORAGE_MAX_WRITE) {
         if (write(fd, &_buffer[loc], LINUX_STORAGE_MAX_WRITE) != LINUX_STORAGE_MAX_WRITE) {
-            hal.scheduler->panic("Error filling FRAM");            
+            platform::panic("Error filling FRAM");
         }
     }
 
@@ -60,7 +60,7 @@ void Storage_FRAM::_storage_open(void)
         _storage_create();
         fd = open();
         if (fd == -1) {
-            hal.scheduler->panic("Failed to access FRAM");
+            platform::panic("Failed to access FRAM");
         }
     }
     
@@ -68,10 +68,10 @@ void Storage_FRAM::_storage_open(void)
         _storage_create();
         fd = open();
         if (fd == -1) {
-            hal.scheduler->panic("Failed to access FRAM");
+            platform::panic("Failed to access FRAM");
         }
         if (read(fd, _buffer, sizeof(_buffer)) != sizeof(_buffer)) {
-            hal.scheduler->panic("Failed to read FRAM");
+            platform::panic("Failed to read FRAM");
         }
     }
     _initialised = true;
@@ -150,7 +150,7 @@ int8_t Storage_FRAM::open()
             hal.scheduler->delay(1000);
         }
         if(i==4){
-            hal.scheduler->panic("FRAM: Failed to receive Manufacturer ID 5 times");
+            platform::panic("FRAM: Failed to receive Manufacturer ID 5 times");
         }
     }
     

--- a/libraries/AP_HAL_Linux/TCPServerDevice.cpp
+++ b/libraries/AP_HAL_Linux/TCPServerDevice.cpp
@@ -64,23 +64,23 @@ bool TCPServerDevice::open()
     listener.reuseaddress();
 
     if (!listener.bind(_ip, _port)) {
-        if (hal.scheduler->millis() - _last_bind_warning > 5000) {
+        if (platform::millis() - _last_bind_warning > 5000) {
             ::printf("bind failed on %s port %u - %s\n",
                      _ip,
                      _port,
                      strerror(errno));
-            _last_bind_warning = hal.scheduler->millis();
+            _last_bind_warning = platform::millis();
         }
         return false;
     }
 
     if (!listener.listen(1)) {
-        if (hal.scheduler->millis() - _last_bind_warning > 5000) {
+        if (platform::millis() - _last_bind_warning > 5000) {
             ::printf("listen failed on %s port %u - %s\n",
                      _ip,
                      _port,
                      strerror(errno));
-            _last_bind_warning = hal.scheduler->millis();
+            _last_bind_warning = platform::millis();
         }
         return false;
     }

--- a/libraries/AP_HAL_Linux/ToneAlarmDriver.cpp
+++ b/libraries/AP_HAL_Linux/ToneAlarmDriver.cpp
@@ -89,7 +89,7 @@ void ToneAlarm::stop()
 
 bool ToneAlarm::play()
 {
-    uint16_t cur_time = hal.scheduler->millis();
+    uint16_t cur_time = platform::millis();
     if(tune_num != prev_tune_num){
         tune_changed = true;
         return true;

--- a/libraries/AP_HAL_Linux/platform.cpp
+++ b/libraries/AP_HAL_Linux/platform.cpp
@@ -1,9 +1,79 @@
+#include <stdarg.h>
+#include <stdio.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/platform.h>
+#include <AP_HAL_Linux/Scheduler.h>
+
+extern const AP_HAL::HAL& hal;
+
+using Linux::Scheduler;
 
 namespace platform {
 
+static struct {
+    struct timespec start_time;
+} state;
+
 void init()
 {
+    clock_gettime(CLOCK_MONOTONIC, &state.start_time);
+}
+
+void panic(const char *errormsg, ...)
+{
+    va_list ap;
+
+    va_start(ap, errormsg);
+    vdprintf(1, errormsg, ap);
+    va_end(ap);
+    write(1, "\n", 1);
+
+    hal.rcin->deinit();
+    hal.scheduler->delay_microseconds(10000);
+    exit(1);
+}
+
+uint32_t micros()
+{
+    return micros64() & 0xFFFFFFFF;
+}
+
+uint32_t millis()
+{
+    return millis64() & 0xFFFFFFFF;
+}
+
+uint64_t micros64()
+{
+    const Scheduler* scheduler = Scheduler::from(hal.scheduler);
+    uint64_t stopped_usec = scheduler->stopped_clock_usec();
+    if (stopped_usec) {
+        return stopped_usec;
+    }
+
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return 1.0e6*((ts.tv_sec + (ts.tv_nsec*1.0e-9)) -
+                  (state.start_time.tv_sec +
+                   (state.start_time.tv_nsec*1.0e-9)));
+}
+
+uint64_t millis64()
+{
+    const Scheduler* scheduler = Scheduler::from(hal.scheduler);
+    uint64_t stopped_usec = scheduler->stopped_clock_usec();
+    if (stopped_usec) {
+        return stopped_usec / 1000;
+    }
+
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return 1.0e3*((ts.tv_sec + (ts.tv_nsec*1.0e-9)) -
+                  (state.start_time.tv_sec +
+                   (state.start_time.tv_nsec*1.0e-9)));
 }
 
 } // namespace platform

--- a/libraries/AP_HAL_Linux/platform.cpp
+++ b/libraries/AP_HAL_Linux/platform.cpp
@@ -1,0 +1,9 @@
+#include <AP_HAL/platform.h>
+
+namespace platform {
+
+void init()
+{
+}
+
+} // namespace platform

--- a/libraries/AP_HAL_PX4/AnalogIn.cpp
+++ b/libraries/AP_HAL_PX4/AnalogIn.cpp
@@ -202,7 +202,7 @@ void PX4AnalogIn::init(void* machtnichts)
 {
 	_adc_fd = open(ADC0_DEVICE_PATH, O_RDONLY | O_NONBLOCK);
     if (_adc_fd == -1) {
-        hal.scheduler->panic("Unable to open " ADC0_DEVICE_PATH);
+        platform::panic("Unable to open " ADC0_DEVICE_PATH);
 	}
     _battery_handle   = orb_subscribe(ORB_ID(battery_status));
     _servorail_handle = orb_subscribe(ORB_ID(servorail_status));
@@ -223,7 +223,7 @@ void PX4AnalogIn::next_stop_pin(void)
         PX4::PX4AnalogSource *c = _channels[idx];
         if (c && c->_stop_pin != -1) {
             // found another stop pin
-            _stop_pin_change_time = hal.scheduler->millis();
+            _stop_pin_change_time = platform::millis();
             _current_stop_pin_i = idx;
 
             // set that pin high
@@ -249,7 +249,7 @@ void PX4AnalogIn::next_stop_pin(void)
 void PX4AnalogIn::_timer_tick(void)
 {
     // read adc at 100Hz
-    uint32_t now = hal.scheduler->micros();
+    uint32_t now = platform::micros();
     uint32_t delta_t = now - _last_run;
     if (delta_t < 10000) {
         return;
@@ -288,7 +288,7 @@ void PX4AnalogIn::_timer_tick(void)
                     // the stop pin has been settling for enough time
                     if (c->_stop_pin == -1 || 
                         (_current_stop_pin_i == j &&
-                         hal.scheduler->millis() - _stop_pin_change_time > c->_settle_time_ms)) {
+                         platform::millis() - _stop_pin_change_time > c->_settle_time_ms)) {
                         c->_add_value(buf_adc[i].am_data, _board_voltage);
                         if (c->_stop_pin != -1 && _current_stop_pin_i == j) {
                             next_stop_pin();

--- a/libraries/AP_HAL_PX4/GPIO.cpp
+++ b/libraries/AP_HAL_PX4/GPIO.cpp
@@ -34,7 +34,7 @@ void PX4GPIO::init()
 #ifdef CONFIG_ARCH_BOARD_PX4FMU_V1
     _led_fd = open(LED0_DEVICE_PATH, O_RDWR);
     if (_led_fd == -1) {
-        hal.scheduler->panic("Unable to open " LED0_DEVICE_PATH);
+        platform::panic("Unable to open " LED0_DEVICE_PATH);
     }
     if (ioctl(_led_fd, LED_OFF, LED_BLUE) != 0) {
         hal.console->printf("GPIO: Unable to setup GPIO LED BLUE\n");
@@ -45,12 +45,12 @@ void PX4GPIO::init()
 #endif
     _tone_alarm_fd = open(TONEALARM0_DEVICE_PATH, O_WRONLY);
     if (_tone_alarm_fd == -1) {
-        hal.scheduler->panic("Unable to open " TONEALARM0_DEVICE_PATH);
+        platform::panic("Unable to open " TONEALARM0_DEVICE_PATH);
     }
 
     _gpio_fmu_fd = open(PX4FMU_DEVICE_PATH, 0);
     if (_gpio_fmu_fd == -1) {
-        hal.scheduler->panic("Unable to open GPIO");
+        platform::panic("Unable to open GPIO");
     }
 #ifdef CONFIG_ARCH_BOARD_PX4FMU_V1
     if (ioctl(_gpio_fmu_fd, GPIO_CLEAR, GPIO_EXT_1) != 0) {

--- a/libraries/AP_HAL_PX4/I2CDriver.cpp
+++ b/libraries/AP_HAL_PX4/I2CDriver.cpp
@@ -45,7 +45,7 @@ PX4I2CDriver::PX4I2CDriver(void)
 {
     px4_i2c = new PX4_I2C(PX4_I2C_BUS_EXPANSION);
     if (px4_i2c == nullptr) {
-        hal.scheduler->panic("Unable to allocate PX4 I2C driver");
+        platform::panic("Unable to allocate PX4 I2C driver");
     }
 }
 

--- a/libraries/AP_HAL_PX4/RCInput.cpp
+++ b/libraries/AP_HAL_PX4/RCInput.cpp
@@ -17,7 +17,7 @@ void PX4RCInput::init(void* unused)
 	_perf_rcin = perf_alloc(PC_ELAPSED, "APM_rcin");
 	_rc_sub = orb_subscribe(ORB_ID(input_rc));
 	if (_rc_sub == -1) {
-		hal.scheduler->panic("Unable to subscribe to input_rc");		
+		platform::panic("Unable to subscribe to input_rc");
 	}
 	clear_overrides();
         pthread_mutex_init(&rcin_mutex, NULL);

--- a/libraries/AP_HAL_PX4/RCOutput.cpp
+++ b/libraries/AP_HAL_PX4/RCOutput.cpp
@@ -23,7 +23,7 @@ void PX4RCOutput::init(void* unused)
     _perf_rcout = perf_alloc(PC_ELAPSED, "APM_rcout");
     _pwm_fd = open(PWM_OUTPUT0_DEVICE_PATH, O_RDWR);
     if (_pwm_fd == -1) {
-        hal.scheduler->panic("Unable to open " PWM_OUTPUT0_DEVICE_PATH);
+        platform::panic("Unable to open " PWM_OUTPUT0_DEVICE_PATH);
     }
     if (ioctl(_pwm_fd, PWM_SERVO_ARM, 0) != 0) {
         hal.console->printf("RCOutput: Unable to setup IO arming\n");
@@ -330,7 +330,7 @@ void PX4RCOutput::_publish_actuators(void)
 
 void PX4RCOutput::_timer_tick(void)
 {
-    uint32_t now = hal.scheduler->micros();
+    uint32_t now = platform::micros();
 
     if ((_enabled_channels & ((1U<<_servo_count)-1)) == 0) {
         // no channels enabled

--- a/libraries/AP_HAL_PX4/Scheduler.cpp
+++ b/libraries/AP_HAL_PX4/Scheduler.cpp
@@ -85,26 +85,6 @@ void PX4Scheduler::init(void *unused)
     pthread_create(&_storage_thread_ctx, &thread_attr, (pthread_startroutine_t)&PX4::PX4Scheduler::_storage_thread, this);
 }
 
-uint64_t PX4Scheduler::micros64() 
-{
-    return platform::micros64();
-}
-
-uint64_t PX4Scheduler::millis64() 
-{
-    return platform::millis64();
-}
-
-uint32_t PX4Scheduler::micros() 
-{
-    return platform::micros();
-}
-
-uint32_t PX4Scheduler::millis() 
-{
-    return platform::millis();
-}
-
 /**
    delay for a specified number of microseconds using a semaphore wait
  */
@@ -372,20 +352,6 @@ void *PX4Scheduler::_storage_thread(void)
         perf_end(_perf_storage_timer);
     }
     return NULL;
-}
-
-void PX4Scheduler::panic(const char *errormsg, ...)
-{
-    va_list ap;
-
-    va_start(ap, errormsg);
-    vdprintf(1, errormsg, ap);
-    va_end(ap);
-    write(1, "\n", 1);
-
-    hal.scheduler->delay_microseconds(10000);
-    _px4_thread_should_exit = true;
-    exit(1);
 }
 
 bool PX4Scheduler::in_timerprocess() 

--- a/libraries/AP_HAL_PX4/Scheduler.cpp
+++ b/libraries/AP_HAL_PX4/Scheduler.cpp
@@ -87,22 +87,22 @@ void PX4Scheduler::init(void *unused)
 
 uint64_t PX4Scheduler::micros64() 
 {
-    return hrt_absolute_time();
+    return platform::micros64();
 }
 
 uint64_t PX4Scheduler::millis64() 
 {
-    return micros64() / 1000;
+    return platform::millis64();
 }
 
 uint32_t PX4Scheduler::micros() 
 {
-    return micros64() & 0xFFFFFFFF;
+    return platform::micros();
 }
 
 uint32_t PX4Scheduler::millis() 
 {
-    return millis64() & 0xFFFFFFFF;
+    return platform::millis();
 }
 
 /**
@@ -165,9 +165,9 @@ void PX4Scheduler::delay(uint16_t ms)
         return;
     }
     perf_begin(_perf_delay);
-	uint64_t start = micros64();
+	uint64_t start = platform::micros64();
     
-    while ((micros64() - start)/1000 < ms && 
+    while ((platform::micros64() - start)/1000 < ms && 
            !_px4_thread_should_exit) {
         delay_microseconds_semaphore(1000);
         if (_min_delay_cb_ms <= ms) {
@@ -296,8 +296,8 @@ void *PX4Scheduler::_timer_thread(void)
         // process any pending RC input requests
         ((PX4RCInput *)hal.rcin)->_timer_tick();
 
-        if (px4_ran_overtime && millis() - last_ran_overtime > 2000) {
-            last_ran_overtime = millis();
+        if (px4_ran_overtime && platform::millis() - last_ran_overtime > 2000) {
+            last_ran_overtime = platform::millis();
             printf("Overtime in task %d\n", (int)AP_Scheduler::current_task);
             hal.console->printf("Overtime in task %d\n", (int)AP_Scheduler::current_task);
         }
@@ -399,7 +399,7 @@ bool PX4Scheduler::system_initializing() {
 
 void PX4Scheduler::system_initialized() {
     if (_initialized) {
-        panic("PANIC: scheduler::system_initialized called"
+        platform::panic("PANIC: scheduler::system_initialized called"
                    "more than once");
     }
     _initialized = true;

--- a/libraries/AP_HAL_PX4/Scheduler.h
+++ b/libraries/AP_HAL_PX4/Scheduler.h
@@ -47,10 +47,6 @@ public:
 
     void     init(void *unused);
     void     delay(uint16_t ms);
-    uint32_t millis();
-    uint32_t micros();
-    uint64_t millis64();
-    uint64_t micros64();
     void     delay_microseconds(uint16_t us);
     void     delay_microseconds_boost(uint16_t us);
     void     register_delay_callback(AP_HAL::Proc, uint16_t min_time_ms);
@@ -60,7 +56,6 @@ public:
     void     suspend_timer_procs();
     void     resume_timer_procs();
     void     reboot(bool hold_in_bootloader);
-    void     panic(const char *errormsg, ...) FORMAT(2, 3) NORETURN;
 
     bool     in_timerprocess();
     bool     system_initializing();

--- a/libraries/AP_HAL_PX4/Storage.cpp
+++ b/libraries/AP_HAL_PX4/Storage.cpp
@@ -45,14 +45,14 @@ uint32_t PX4Storage::_mtd_signature(void)
 {
     int mtd_fd = open(MTD_PARAMS_FILE, O_RDONLY);
     if (mtd_fd == -1) {
-        hal.scheduler->panic("Failed to open " MTD_PARAMS_FILE);
+        platform::panic("Failed to open " MTD_PARAMS_FILE);
     }
     uint32_t v;
     if (lseek(mtd_fd, MTD_SIGNATURE_OFFSET, SEEK_SET) != MTD_SIGNATURE_OFFSET) {
-        hal.scheduler->panic("Failed to seek in " MTD_PARAMS_FILE);
+        platform::panic("Failed to seek in " MTD_PARAMS_FILE);
     }
     if (read(mtd_fd, &v, sizeof(v)) != sizeof(v)) {
-        hal.scheduler->panic("Failed to read signature from " MTD_PARAMS_FILE);
+        platform::panic("Failed to read signature from " MTD_PARAMS_FILE);
     }
     close(mtd_fd);
     return v;
@@ -65,14 +65,14 @@ void PX4Storage::_mtd_write_signature(void)
 {
     int mtd_fd = open(MTD_PARAMS_FILE, O_WRONLY);
     if (mtd_fd == -1) {
-        hal.scheduler->panic("Failed to open " MTD_PARAMS_FILE);
+        platform::panic("Failed to open " MTD_PARAMS_FILE);
     }
     uint32_t v = MTD_SIGNATURE;
     if (lseek(mtd_fd, MTD_SIGNATURE_OFFSET, SEEK_SET) != MTD_SIGNATURE_OFFSET) {
-        hal.scheduler->panic("Failed to seek in " MTD_PARAMS_FILE);
+        platform::panic("Failed to seek in " MTD_PARAMS_FILE);
     }
     if (write(mtd_fd, &v, sizeof(v)) != sizeof(v)) {
-        hal.scheduler->panic("Failed to write signature in " MTD_PARAMS_FILE);
+        platform::panic("Failed to write signature in " MTD_PARAMS_FILE);
     }
     close(mtd_fd);
 }
@@ -92,7 +92,7 @@ void PX4Storage::_upgrade_to_mtd(void)
 
     int mtd_fd = open(MTD_PARAMS_FILE, O_WRONLY);
     if (mtd_fd == -1) {
-        hal.scheduler->panic("Unable to open MTD for upgrade");
+        platform::panic("Unable to open MTD for upgrade");
     }
 
     if (::read(old_fd, _buffer, sizeof(_buffer)) != sizeof(_buffer)) {
@@ -105,7 +105,7 @@ void PX4Storage::_upgrade_to_mtd(void)
     ssize_t ret;
     if ((ret=::write(mtd_fd, _buffer, sizeof(_buffer))) != sizeof(_buffer)) {
         ::printf("mtd write of %u bytes returned %d errno=%d\n", sizeof(_buffer), ret, errno);
-        hal.scheduler->panic("Unable to write MTD for upgrade");        
+        platform::panic("Unable to write MTD for upgrade");
     }
     close(mtd_fd);
 #if STORAGE_RENAME_OLD_FILE
@@ -126,7 +126,7 @@ void PX4Storage::_storage_open(void)
 
         // PX4 should always have /fs/mtd_params
         if (!_have_mtd) {
-            hal.scheduler->panic("Failed to find " MTD_PARAMS_FILE);
+            platform::panic("Failed to find " MTD_PARAMS_FILE);
         }
 
         /*
@@ -152,7 +152,7 @@ void PX4Storage::_storage_open(void)
 	_dirty_mask = 0;
 	int fd = open(MTD_PARAMS_FILE, O_RDONLY);
 	if (fd == -1) {
-            hal.scheduler->panic("Failed to open " MTD_PARAMS_FILE);
+            platform::panic("Failed to open " MTD_PARAMS_FILE);
 	}
         const uint16_t chunk_size = 128;
         for (uint16_t ofs=0; ofs<sizeof(_buffer); ofs += chunk_size) {
@@ -160,7 +160,7 @@ void PX4Storage::_storage_open(void)
             if (ret != chunk_size) {
                 ::printf("storage read of %u bytes at %u to %p failed - got %d errno=%d\n",
                          (unsigned)sizeof(_buffer), (unsigned)ofs, &_buffer[ofs], (int)ret, (int)errno);
-                hal.scheduler->panic("Failed to read " MTD_PARAMS_FILE);
+                platform::panic("Failed to read " MTD_PARAMS_FILE);
             }
 	}
 	close(fd);

--- a/libraries/AP_HAL_PX4/UARTDriver.cpp
+++ b/libraries/AP_HAL_PX4/UARTDriver.cpp
@@ -185,10 +185,10 @@ void PX4UARTDriver::try_initialise(void)
     if (_initialised) {
         return;
     }
-    if ((hal.scheduler->millis() - _last_initialise_attempt_ms) < 2000) {
+    if ((platform::millis() - _last_initialise_attempt_ms) < 2000) {
         return;
     }
-    _last_initialise_attempt_ms = hal.scheduler->millis();
+    _last_initialise_attempt_ms = platform::millis();
     if (hal.util->safety_switch_state() != AP_HAL::Util::SAFETY_ARMED || !hal.util->get_soft_armed()) {
         begin(0);
     }
@@ -394,7 +394,7 @@ int PX4UARTDriver::_write_fd(const uint8_t *buf, uint16_t n)
                 }
             } else {
                 if (_os_start_auto_space - nwrite + 1 >= _total_written &&
-                    (hal.scheduler->micros64() - _first_write_time) > 500*1000UL) {
+                    (platform::micros64() - _first_write_time) > 500*1000UL) {
                     // it doesn't look like hw flow control is working
                     ::printf("disabling flow control on %s _total_written=%u\n", 
                              _devpath, (unsigned)_total_written);
@@ -412,7 +412,7 @@ int PX4UARTDriver::_write_fd(const uint8_t *buf, uint16_t n)
 
     if (ret > 0) {
         BUF_ADVANCEHEAD(_writebuf, ret);
-        _last_write_time = hal.scheduler->micros64();
+        _last_write_time = platform::micros64();
         _total_written += ret;
         if (! _first_write_time && _total_written > 5) {
             _first_write_time = _last_write_time;
@@ -420,12 +420,12 @@ int PX4UARTDriver::_write_fd(const uint8_t *buf, uint16_t n)
         return ret;
     }
 
-    if (hal.scheduler->micros64() - _last_write_time > 2000 &&
+    if (platform::micros64() - _last_write_time > 2000 &&
         _flow_control == FLOW_CONTROL_DISABLE) {
 #if 0
         // this trick is disabled for now, as it sometimes blocks on
         // re-opening the ttyACM0 port, which would cause a crash
-        if (hal.scheduler->micros64() - _last_write_time > 2000000) {
+        if (platform::micros64() - _last_write_time > 2000000) {
             // we haven't done a successful write for 2 seconds - try
             // reopening the port        
             _initialised = false;
@@ -438,11 +438,11 @@ int PX4UARTDriver::_write_fd(const uint8_t *buf, uint16_t n)
                 return n;
             }
             
-            _last_write_time = hal.scheduler->micros64();
+            _last_write_time = platform::micros64();
             _initialised = true;
         }
 #else
-        _last_write_time = hal.scheduler->micros64();
+        _last_write_time = platform::micros64();
 #endif
         // we haven't done a successful write for 2ms, which means the 
         // port is running at less than 500 bytes/sec. Start

--- a/libraries/AP_HAL_PX4/platform.cpp
+++ b/libraries/AP_HAL_PX4/platform.cpp
@@ -1,0 +1,9 @@
+#include <AP_HAL/platform.h>
+
+namespace platform {
+
+void init()
+{
+}
+
+} // namespace platform

--- a/libraries/AP_HAL_PX4/platform.cpp
+++ b/libraries/AP_HAL_PX4/platform.cpp
@@ -1,9 +1,53 @@
+#include <stdarg.h>
+#include <stdio.h>
+
+#include <drivers/drv_hrt.h>
+
+#include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/platform.h>
+
+extern const AP_HAL::HAL& hal;
+
+extern bool _px4_thread_should_exit;
 
 namespace platform {
 
 void init()
 {
+}
+
+void panic(const char *errormsg, ...)
+{
+    va_list ap;
+
+    va_start(ap, errormsg);
+    vdprintf(1, errormsg, ap);
+    va_end(ap);
+    write(1, "\n", 1);
+
+    hal.scheduler->delay_microseconds(10000);
+    _px4_thread_should_exit = true;
+    exit(1);
+}
+
+uint32_t micros()
+{
+    return micros64() & 0xFFFFFFFF;
+}
+
+uint32_t millis()
+{
+    return millis64() & 0xFFFFFFFF;
+}
+
+uint64_t micros64()
+{
+    return hrt_absolute_time();
+}
+
+uint64_t millis64()
+{
+    return micros64() / 1000;
 }
 
 } // namespace platform

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -177,8 +177,8 @@ void SITL_State::_fdm_input_step(void)
     }
 
     // simulate RC input at 50Hz
-    if (hal.scheduler->millis() - last_pwm_input >= 20 && _sitl->rc_fail == 0) {
-        last_pwm_input = hal.scheduler->millis();
+    if (platform::millis() - last_pwm_input >= 20 && _sitl->rc_fail == 0) {
+        last_pwm_input = platform::millis();
         new_rc_input = true;
     }
 
@@ -214,7 +214,7 @@ void SITL_State::_fdm_input_step(void)
 
 void SITL_State::wait_clock(uint64_t wait_time_usec)
 {
-    while (hal.scheduler->micros64() < wait_time_usec) {
+    while (platform::micros64() < wait_time_usec) {
         _fdm_input_step();
     }
 }
@@ -270,10 +270,10 @@ void SITL_State::_fdm_input(void)
         _update_count++;
 
         count++;
-        if (hal.scheduler->millis() - last_report > 1000) {
+        if (platform::millis() - last_report > 1000) {
             //fprintf(stdout, "SIM %u FPS\n", count);
             count = 0;
-            last_report = hal.scheduler->millis();
+            last_report = platform::millis();
         }
         break;
 
@@ -384,7 +384,7 @@ void SITL_State::_simulator_servos(Aircraft::sitl_input &input)
     }
 
     // output at chosen framerate
-    uint32_t now = hal.scheduler->micros();
+    uint32_t now = platform::micros();
     float deltat = (now - last_update_usec) * 1.0e-6f;
     last_update_usec = now;
 
@@ -493,7 +493,7 @@ void SITL_State::_simulator_output(bool synthetic_clock_mode)
     control.turbulance = _sitl->wind_turbulance * 100;
 
     // zero the wind for the first 15s to allow pitot calibration
-    if (hal.scheduler->millis() < 15000) {
+    if (platform::millis() < 15000) {
         control.speed = 0;
     }
 

--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -86,7 +86,7 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
     float speedup = 1.0f;
 
     if (asprintf(&autotest_dir, SKETCHBOOK "/Tools/autotest") <= 0) {
-        hal.scheduler->panic("out of memory");
+        platform::panic("out of memory");
     }
 
     signal(SIGFPE, _sig_fpe);

--- a/libraries/AP_HAL_SITL/Scheduler.cpp
+++ b/libraries/AP_HAL_SITL/Scheduler.cpp
@@ -37,31 +37,6 @@ void SITLScheduler::init(void *unused)
 {
 }
 
-uint64_t SITLScheduler::_micros64()
-{
-    return platform::micros64();
-}
-
-uint64_t SITLScheduler::micros64()
-{
-    return platform::micros64();
-}
-
-uint32_t SITLScheduler::micros()
-{
-    return platform::micros();
-}
-
-uint64_t SITLScheduler::millis64()
-{
-    return platform::millis64();
-}
-
-uint32_t SITLScheduler::millis()
-{
-    return platform::millis();
-}
-
 void SITLScheduler::delay_microseconds(uint16_t usec)
 {
     uint64_t start = platform::micros64();
@@ -238,18 +213,6 @@ void SITLScheduler::_run_io_procs(bool called_from_isr)
     }
 
     _in_io_proc = false;
-}
-
-void SITLScheduler::panic(const char *errormsg, ...)
-{
-    va_list ap;
-
-    va_start(ap, errormsg);
-    hal.console->vprintf(errormsg, ap);
-    va_end(ap);
-    hal.console->printf("\n");
-
-    for(;;);
 }
 
 /*

--- a/libraries/AP_HAL_SITL/Scheduler.cpp
+++ b/libraries/AP_HAL_SITL/Scheduler.cpp
@@ -27,66 +27,47 @@ AP_HAL::MemberProc SITLScheduler::_io_proc[SITL_SCHEDULER_MAX_TIMER_PROCS] = {NU
 uint8_t SITLScheduler::_num_io_procs = 0;
 bool SITLScheduler::_in_io_proc = false;
 
-struct timeval SITLScheduler::_sketch_start_time;
-
 SITLScheduler::SITLScheduler(SITL_State *sitlState) :
     _sitlState(sitlState),
-    stopped_clock_usec(0)
+    _stopped_clock_usec(0)
 {
 }
 
 void SITLScheduler::init(void *unused)
 {
-    gettimeofday(&_sketch_start_time,NULL);
 }
 
 uint64_t SITLScheduler::_micros64()
 {
-    struct timeval tp;
-    gettimeofday(&tp,NULL);
-    uint64_t ret = 1.0e6*((tp.tv_sec + (tp.tv_usec*1.0e-6)) -
-                          (_sketch_start_time.tv_sec +
-                           (_sketch_start_time.tv_usec*1.0e-6)));
-    return ret;
+    return platform::micros64();
 }
 
 uint64_t SITLScheduler::micros64()
 {
-    if (stopped_clock_usec) {
-        return stopped_clock_usec;
-    }
-    return _micros64();
+    return platform::micros64();
 }
 
 uint32_t SITLScheduler::micros()
 {
-    return micros64() & 0xFFFFFFFF;
+    return platform::micros();
 }
 
 uint64_t SITLScheduler::millis64()
 {
-    if (stopped_clock_usec) {
-        return stopped_clock_usec/1000;
-    }
-    struct timeval tp;
-    gettimeofday(&tp,NULL);
-    uint64_t ret = 1.0e3*((tp.tv_sec + (tp.tv_usec*1.0e-6)) -
-                          (_sketch_start_time.tv_sec +
-                           (_sketch_start_time.tv_usec*1.0e-6)));
-    return ret;
+    return platform::millis64();
 }
 
 uint32_t SITLScheduler::millis()
 {
-    return millis64() & 0xFFFFFFFF;
+    return platform::millis();
 }
 
 void SITLScheduler::delay_microseconds(uint16_t usec)
 {
-    uint64_t start = micros64();
+    uint64_t start = platform::micros64();
     uint64_t dtime;
-    while ((dtime=(micros64() - start) < usec)) {
-        if (stopped_clock_usec) {
+    while ((dtime=(platform::micros64() - start) < usec)) {
+        if (_stopped_clock_usec) {
             _sitlState->wait_clock(start+usec);
         } else {
             usleep(usec - dtime);
@@ -171,7 +152,7 @@ bool SITLScheduler::system_initializing() {
 
 void SITLScheduler::system_initialized() {
     if (_initialized) {
-        panic(
+        platform::panic(
             "PANIC: scheduler system initialized called more than once");
     }
     int exceptions = FE_OVERFLOW | FE_DIVBYZERO;
@@ -276,7 +257,7 @@ void SITLScheduler::panic(const char *errormsg, ...)
  */
 void SITLScheduler::stop_clock(uint64_t time_usec)
 {
-    stopped_clock_usec = time_usec;
+    _stopped_clock_usec = time_usec;
     _run_io_procs(false);
 }
 

--- a/libraries/AP_HAL_SITL/Scheduler.h
+++ b/libraries/AP_HAL_SITL/Scheduler.h
@@ -59,12 +59,13 @@ public:
         _run_io_procs(true);
     }
 
+    uint64_t stopped_clock_usec() const { return _stopped_clock_usec; }
+
 private:
     SITL_State *_sitlState;
     uint8_t _nested_atomic_ctr;
     AP_HAL::Proc _delay_cb;
     uint16_t _min_delay_cb_ms;
-    static struct timeval _sketch_start_time;
     static AP_HAL::Proc _failsafe;
 
     static void _run_timer_procs(bool called_from_isr);
@@ -82,7 +83,7 @@ private:
     void stop_clock(uint64_t time_usec);
 
     bool _initialized;
-    uint64_t stopped_clock_usec;
+    uint64_t _stopped_clock_usec;
 };
 #endif
 #endif // __AP_HAL_SITL_SCHEDULER_H__

--- a/libraries/AP_HAL_SITL/Scheduler.h
+++ b/libraries/AP_HAL_SITL/Scheduler.h
@@ -21,10 +21,6 @@ public:
 
     void     init(void *unused);
     void     delay(uint16_t ms);
-    uint32_t millis();
-    uint32_t micros();
-    uint64_t millis64();
-    uint64_t micros64();
     void     delay_microseconds(uint16_t us);
     void     register_delay_callback(AP_HAL::Proc, uint16_t min_time_ms);
 
@@ -41,7 +37,6 @@ public:
     void     system_initialized();
 
     void     reboot(bool hold_in_bootloader);
-    void     panic(const char *errormsg, ...) FORMAT(2, 3) NORETURN;
 
     bool     interrupts_are_blocked(void) {
         return _nested_atomic_ctr != 0;
@@ -52,8 +47,6 @@ public:
     }
     void     sitl_end_atomic();
 
-    // callable from interrupt handler
-    static uint64_t _micros64();
     static void timer_event() {
         _run_timer_procs(true);
         _run_io_procs(true);

--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -86,7 +86,7 @@ void SITLUARTDriver::begin(uint32_t baud, uint16_t rxSpace, uint16_t txSpace)
             _tcp_start_connection(port, wait);
         } else if (strcmp(devtype, "tcpclient") == 0) {
             if (args2 == NULL) {
-                hal.scheduler->panic("Invalid tcp client path: %s", path);                
+                platform::panic("Invalid tcp client path: %s", path);
             }
             uint16_t port = atoi(args2);
             _tcp_start_client(args1, port);
@@ -95,7 +95,7 @@ void SITLUARTDriver::begin(uint32_t baud, uint16_t rxSpace, uint16_t txSpace)
             ::printf("UART connection %s:%u\n", args1, baudrate);
             _uart_start_connection(args1, baudrate);
         } else {
-            hal.scheduler->panic("Invalid device path: %s", path);
+            platform::panic("Invalid device path: %s", path);
         }
         free(s);
     }
@@ -363,7 +363,7 @@ void SITLUARTDriver::_uart_start_connection(const char *path, uint32_t baudrate)
     }
 
     if (_fd == -1) {
-        hal.scheduler->panic("Unable to open UART %s", path);
+        platform::panic("Unable to open UART %s", path);
     }
 
     // set non-blocking

--- a/libraries/AP_HAL_SITL/platform.cpp
+++ b/libraries/AP_HAL_SITL/platform.cpp
@@ -1,0 +1,9 @@
+#include <AP_HAL/platform.h>
+
+namespace platform {
+
+void init()
+{
+}
+
+} // namespace platform

--- a/libraries/AP_HAL_SITL/platform.cpp
+++ b/libraries/AP_HAL_SITL/platform.cpp
@@ -1,9 +1,78 @@
+#include <stdarg.h>
+#include <stdio.h>
+
+#include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/platform.h>
+
+#include "Scheduler.h"
+
+extern const AP_HAL::HAL& hal;
+
+using HALSITL::SITLScheduler;
 
 namespace platform {
 
+static struct {
+    struct timeval start_time;
+} state;
+
 void init()
 {
+    gettimeofday(&state.start_time, NULL);
+}
+
+void panic(const char *errormsg, ...)
+{
+    va_list ap;
+
+    va_start(ap, errormsg);
+    vprintf(errormsg, ap);
+    va_end(ap);
+    printf("\n");
+
+    for(;;);
+}
+
+uint32_t micros()
+{
+    return micros64() & 0xFFFFFFFF;
+}
+
+uint32_t millis()
+{
+    return millis64() & 0xFFFFFFFF;
+}
+
+uint64_t micros64()
+{
+    const SITLScheduler* scheduler = SITLScheduler::from(hal.scheduler);
+    uint64_t stopped_usec = scheduler->stopped_clock_usec();
+    if (stopped_usec) {
+        return stopped_usec;
+    }
+
+    struct timeval tp;
+    gettimeofday(&tp, NULL);
+    uint64_t ret = 1.0e6 * ((tp.tv_sec + (tp.tv_usec * 1.0e-6)) -
+                            (state.start_time.tv_sec +
+                             (state.start_time.tv_usec * 1.0e-6)));
+    return ret;
+}
+
+uint64_t millis64()
+{
+    const SITLScheduler* scheduler = SITLScheduler::from(hal.scheduler);
+    uint64_t stopped_usec = scheduler->stopped_clock_usec();
+    if (stopped_usec) {
+        return stopped_usec / 1000;
+    }
+
+    struct timeval tp;
+    gettimeofday(&tp, NULL);
+    uint64_t ret = 1.0e3*((tp.tv_sec + (tp.tv_usec*1.0e-6)) -
+                          (state.start_time.tv_sec +
+                           (state.start_time.tv_usec*1.0e-6)));
+    return ret;
 }
 
 } // namespace platform

--- a/libraries/AP_HAL_SITL/sitl_barometer.cpp
+++ b/libraries/AP_HAL_SITL/sitl_barometer.cpp
@@ -44,7 +44,7 @@ void SITL_State::_update_barometer(float altitude)
     }
 
     // 80Hz
-    uint32_t now = hal.scheduler->millis();
+    uint32_t now = platform::millis();
     if ((now - last_update) < 12) {
         return;
     }

--- a/libraries/AP_HAL_SITL/sitl_compass.cpp
+++ b/libraries/AP_HAL_SITL/sitl_compass.cpp
@@ -48,7 +48,7 @@ void SITL_State::_update_compass(float rollDeg, float pitchDeg, float yawDeg)
     Vector3f new_mag_data = _compass->getHIL(0) + noise + motor;
 
     // 100Hz
-    uint32_t now = hal.scheduler->millis();
+    uint32_t now = platform::millis();
     if ((now - last_update) < 10) {
         return;
     }

--- a/libraries/AP_HAL_SITL/sitl_gps.cpp
+++ b/libraries/AP_HAL_SITL/sitl_gps.cpp
@@ -75,7 +75,7 @@ int SITL_State::gps_pipe(void)
     pipe(fd);
     gps_state.gps_fd    = fd[1];
     gps_state.client_fd = fd[0];
-    gps_state.last_update = _scheduler->millis();
+    gps_state.last_update = platform::millis();
     HALSITL::SITLUARTDriver::_set_nonblocking(gps_state.gps_fd);
     HALSITL::SITLUARTDriver::_set_nonblocking(fd[0]);
     return gps_state.client_fd;
@@ -93,7 +93,7 @@ int SITL_State::gps2_pipe(void)
     pipe(fd);
     gps2_state.gps_fd    = fd[1];
     gps2_state.client_fd = fd[0];
-    gps2_state.last_update = _scheduler->millis();
+    gps2_state.last_update = platform::millis();
     HALSITL::SITLUARTDriver::_set_nonblocking(gps2_state.gps_fd);
     HALSITL::SITLUARTDriver::_set_nonblocking(fd[0]);
     return gps2_state.client_fd;
@@ -248,7 +248,7 @@ void SITL_State::_update_gps_ubx(const struct gps_data *d)
     status.differential_status = 0;
     status.res = 0;
     status.time_to_first_fix = 0;
-    status.uptime = hal.scheduler->millis();
+    status.uptime = platform::millis();
 
     velned.time = time_week_ms;
     velned.ned_north = 100.0f * d->speedN;
@@ -752,7 +752,7 @@ void SITL_State::_update_gps(double latitude, double longitude, float altitude,
     }
 
     // run at configured GPS rate (default 5Hz)
-    if ((hal.scheduler->millis() - gps_state.last_update) < (uint32_t)(1000/_sitl->gps_hertz)) {
+    if ((platform::millis() - gps_state.last_update) < (uint32_t)(1000/_sitl->gps_hertz)) {
         return;
     }
 
@@ -764,8 +764,8 @@ void SITL_State::_update_gps(double latitude, double longitude, float altitude,
         read(gps2_state.gps_fd, &c, 1);
     }
 
-    gps_state.last_update = hal.scheduler->millis();
-    gps2_state.last_update = hal.scheduler->millis();
+    gps_state.last_update = platform::millis();
+    gps2_state.last_update = platform::millis();
 
     d.latitude = latitude + glitch_offsets.x;
     d.longitude = longitude + glitch_offsets.y;
@@ -773,7 +773,7 @@ void SITL_State::_update_gps(double latitude, double longitude, float altitude,
 
     if (_sitl->gps_drift_alt > 0) {
         // slow altitude drift
-        d.altitude += _sitl->gps_drift_alt*sinf(hal.scheduler->millis()*0.001f*0.02f);
+        d.altitude += _sitl->gps_drift_alt*sinf(platform::millis()*0.001f*0.02f);
     }
 
     d.speedN = speedN;

--- a/libraries/AP_HAL_SITL/sitl_ins.cpp
+++ b/libraries/AP_HAL_SITL/sitl_ins.cpp
@@ -43,7 +43,7 @@ uint16_t SITL_State::_airspeed_sensor(float airspeed)
         return 0xFFFF;
     }
     // add delay
-    uint32_t now = hal.scheduler->millis();
+    uint32_t now = platform::millis();
     uint32_t best_time_delta_wind = 200; // initialise large time representing buffer entry closest to current time - delay.
     uint8_t best_index_wind = 0; // initialise number representing the index of the entry in buffer closest to delay.
 
@@ -84,7 +84,7 @@ float SITL_State::_gyro_drift(void)
         return 0;
     }
     double period  = _sitl->drift_time * 2;
-    double minutes = fmod(_scheduler->_micros64() / 60.0e6, period);
+    double minutes = fmod(platform::micros64() / 60.0e6, period);
     if (minutes < period/2) {
         return minutes * ToRad(_sitl->drift_speed);
     }

--- a/libraries/AP_HAL_SITL/sitl_optical_flow.cpp
+++ b/libraries/AP_HAL_SITL/sitl_optical_flow.cpp
@@ -42,7 +42,7 @@ void SITL_State::_update_flow(void)
     }
 
     // update at the requested rate
-    uint32_t now = hal.scheduler->millis();
+    uint32_t now = platform::millis();
     if (now - last_flow_ms < 1000*(1.0f/_sitl->flow_rate)) {
         return;
     }

--- a/libraries/AP_HAL_VRBRAIN/AnalogIn.cpp
+++ b/libraries/AP_HAL_VRBRAIN/AnalogIn.cpp
@@ -194,7 +194,7 @@ void VRBRAINAnalogIn::init(void* machtnichts)
 {
 	_adc_fd = open(ADC_DEVICE_PATH, O_RDONLY | O_NONBLOCK);
     if (_adc_fd == -1) {
-        hal.scheduler->panic("Unable to open " ADC_DEVICE_PATH);
+        platform::panic("Unable to open " ADC_DEVICE_PATH);
 	}
     _battery_handle   = orb_subscribe(ORB_ID(battery_status));
     _servorail_handle = orb_subscribe(ORB_ID(servorail_status));
@@ -215,7 +215,7 @@ void VRBRAINAnalogIn::next_stop_pin(void)
         VRBRAIN::VRBRAINAnalogSource *c = _channels[idx];
         if (c && c->_stop_pin != -1) {
             // found another stop pin
-            _stop_pin_change_time = hal.scheduler->millis();
+            _stop_pin_change_time = platform::millis();
             _current_stop_pin_i = idx;
 
             // set that pin high
@@ -241,7 +241,7 @@ void VRBRAINAnalogIn::next_stop_pin(void)
 void VRBRAINAnalogIn::_timer_tick(void)
 {
     // read adc at 100Hz
-    uint32_t now = hal.scheduler->micros();
+    uint32_t now = platform::micros();
     uint32_t delta_t = now - _last_run;
     if (delta_t < 10000) {
         return;
@@ -271,7 +271,7 @@ void VRBRAINAnalogIn::_timer_tick(void)
                     // the stop pin has been settling for enough time
                     if (c->_stop_pin == -1 || 
                         (_current_stop_pin_i == j &&
-                         hal.scheduler->millis() - _stop_pin_change_time > c->_settle_time_ms)) {
+                         platform::millis() - _stop_pin_change_time > c->_settle_time_ms)) {
                         c->_add_value(buf_adc[i].am_data, _board_voltage);
                         if (c->_stop_pin != -1 && _current_stop_pin_i == j) {
                             next_stop_pin();

--- a/libraries/AP_HAL_VRBRAIN/GPIO.cpp
+++ b/libraries/AP_HAL_VRBRAIN/GPIO.cpp
@@ -33,7 +33,7 @@ void VRBRAINGPIO::init()
 {
     _led_fd = open(LED_DEVICE_PATH, O_RDWR);
     if (_led_fd == -1) {
-        hal.scheduler->panic("Unable to open " LED_DEVICE_PATH);
+        platform::panic("Unable to open " LED_DEVICE_PATH);
     }
     if (ioctl(_led_fd, LED_OFF, LED_BLUE) != 0) {
         hal.console->printf("GPIO: Unable to setup GPIO LED BLUE\n");
@@ -63,7 +63,7 @@ void VRBRAINGPIO::init()
 #if defined(BUZZER_EXT)
     _buzzer_fd = open(BUZZER_DEVICE_PATH, O_RDWR);
     if (_buzzer_fd == -1) {
-        hal.scheduler->panic("Unable to open " BUZZER_DEVICE_PATH);
+        platform::panic("Unable to open " BUZZER_DEVICE_PATH);
     }
     if (ioctl(_buzzer_fd, BUZZER_OFF, BUZZER_EXT) != 0) {
         hal.console->printf("GPIO: Unable to setup GPIO BUZZER\n");

--- a/libraries/AP_HAL_VRBRAIN/RCInput.cpp
+++ b/libraries/AP_HAL_VRBRAIN/RCInput.cpp
@@ -14,7 +14,7 @@ void VRBRAINRCInput::init(void* unused)
 	_perf_rcin = perf_alloc(PC_ELAPSED, "APM_rcin");
 	_rc_sub = orb_subscribe(ORB_ID(input_rc));
 	if (_rc_sub == -1) {
-		hal.scheduler->panic("Unable to subscribe to input_rc");		
+		platform::panic("Unable to subscribe to input_rc");
 	}
 	clear_overrides();
         pthread_mutex_init(&rcin_mutex, NULL);

--- a/libraries/AP_HAL_VRBRAIN/RCOutput.cpp
+++ b/libraries/AP_HAL_VRBRAIN/RCOutput.cpp
@@ -21,7 +21,7 @@ void VRBRAINRCOutput::init(void* unused)
     _perf_rcout = perf_alloc(PC_ELAPSED, "APM_rcout");
     _pwm_fd = open(PWM_OUTPUT_DEVICE_PATH, O_RDWR);
     if (_pwm_fd == -1) {
-        hal.scheduler->panic("Unable to open " PWM_OUTPUT_DEVICE_PATH);
+        platform::panic("Unable to open " PWM_OUTPUT_DEVICE_PATH);
     }
     if (ioctl(_pwm_fd, PWM_SERVO_ARM, 0) != 0) {
         hal.console->printf("RCOutput: Unable to setup IO arming\n");
@@ -199,7 +199,7 @@ void VRBRAINRCOutput::read(uint16_t* period_us, uint8_t len)
 
 void VRBRAINRCOutput::_timer_tick(void)
 {
-    uint32_t now = hal.scheduler->micros();
+    uint32_t now = platform::micros();
 
     // always send at least at 20Hz, otherwise the IO board may think
     // we are dead

--- a/libraries/AP_HAL_VRBRAIN/Scheduler.cpp
+++ b/libraries/AP_HAL_VRBRAIN/Scheduler.cpp
@@ -76,22 +76,22 @@ void VRBRAINScheduler::init(void *unused)
 
 uint64_t VRBRAINScheduler::micros64() 
 {
-    return hrt_absolute_time();
+    return platform::micros64();
 }
 
 uint64_t VRBRAINScheduler::millis64() 
 {
-    return micros64() / 1000;
+    return platform::millis64();
 }
 
 uint32_t VRBRAINScheduler::micros() 
 {
-    return micros64() & 0xFFFFFFFF;
+    return platform::micros();
 }
 
 uint32_t VRBRAINScheduler::millis() 
 {
-    return millis64() & 0xFFFFFFFF;
+    return platform::millis();
 }
 
 /**
@@ -114,9 +114,9 @@ void VRBRAINScheduler::delay_microseconds(uint16_t usec)
         perf_end(_perf_delay);
         return;
     }
-	uint64_t start = micros64();
+	uint64_t start = platform::micros64();
     uint64_t dt;
-	while ((dt=(micros64() - start)) < usec) {
+	while ((dt=(platform::micros64() - start)) < usec) {
 		up_udelay(usec - dt);
 	}
     perf_end(_perf_delay);
@@ -129,9 +129,9 @@ void VRBRAINScheduler::delay(uint16_t ms)
         return;
     }
     perf_begin(_perf_delay);
-	uint64_t start = micros64();
+	uint64_t start = platform::micros64();
     
-    while ((micros64() - start)/1000 < ms && 
+    while ((platform::micros64() - start)/1000 < ms && 
            !_vrbrain_thread_should_exit) {
         delay_microseconds_semaphore(1000);
         if (_min_delay_cb_ms <= ms) {
@@ -260,8 +260,8 @@ void *VRBRAINScheduler::_timer_thread(void)
         // process any pending RC input requests
         ((VRBRAINRCInput *)hal.rcin)->_timer_tick();
 
-        if (vrbrain_ran_overtime && millis() - last_ran_overtime > 2000) {
-            last_ran_overtime = millis();
+        if (vrbrain_ran_overtime && platform::millis() - last_ran_overtime > 2000) {
+            last_ran_overtime = platform::millis();
 //            printf("Overtime in task %d\n", (int)AP_Scheduler::current_task);
 //            hal.console->printf("Overtime in task %d\n", (int)AP_Scheduler::current_task);
         }
@@ -350,7 +350,7 @@ bool VRBRAINScheduler::system_initializing() {
 
 void VRBRAINScheduler::system_initialized() {
     if (_initialized) {
-        panic("PANIC: scheduler::system_initialized called"
+        platform::panic("PANIC: scheduler::system_initialized called"
                    "more than once");
     }
     _initialized = true;

--- a/libraries/AP_HAL_VRBRAIN/Scheduler.cpp
+++ b/libraries/AP_HAL_VRBRAIN/Scheduler.cpp
@@ -74,26 +74,6 @@ void VRBRAINScheduler::init(void *unused)
 	pthread_create(&_io_thread_ctx, &thread_attr, (pthread_startroutine_t)&VRBRAIN::VRBRAINScheduler::_io_thread, this);
 }
 
-uint64_t VRBRAINScheduler::micros64() 
-{
-    return platform::micros64();
-}
-
-uint64_t VRBRAINScheduler::millis64() 
-{
-    return platform::millis64();
-}
-
-uint32_t VRBRAINScheduler::micros() 
-{
-    return platform::micros();
-}
-
-uint32_t VRBRAINScheduler::millis() 
-{
-    return platform::millis();
-}
-
 /**
    delay for a specified number of microseconds using a semaphore wait
  */
@@ -323,20 +303,6 @@ void *VRBRAINScheduler::_io_thread(void)
         perf_end(_perf_io_timers);
     }
     return NULL;
-}
-
-void VRBRAINScheduler::panic(const char *errormsg, ...)
-{
-    va_list ap;
-
-    va_start(ap, errormsg);
-    vdprintf(1, errormsg, ap);
-    va_end(ap);
-    write(1, "\n", 1);
-
-    hal.scheduler->delay_microseconds(10000);
-    _vrbrain_thread_should_exit = true;
-    exit(1);
 }
 
 bool VRBRAINScheduler::in_timerprocess()

--- a/libraries/AP_HAL_VRBRAIN/Scheduler.h
+++ b/libraries/AP_HAL_VRBRAIN/Scheduler.h
@@ -27,10 +27,6 @@ public:
 
     void     init(void *unused);
     void     delay(uint16_t ms);
-    uint32_t millis();
-    uint32_t micros();
-    uint64_t millis64();
-    uint64_t micros64();
     void     delay_microseconds(uint16_t us);
     void     register_delay_callback(AP_HAL::Proc, uint16_t min_time_ms);
     void     register_timer_process(AP_HAL::MemberProc);
@@ -39,7 +35,6 @@ public:
     void     suspend_timer_procs();
     void     resume_timer_procs();
     void     reboot(bool hold_in_bootloader);
-    void     panic(const char *errormsg, ...) FORMAT(2, 3) NORETURN;
 
     bool     in_timerprocess();
     bool     system_initializing();

--- a/libraries/AP_HAL_VRBRAIN/Storage.cpp
+++ b/libraries/AP_HAL_VRBRAIN/Storage.cpp
@@ -45,14 +45,14 @@ uint32_t VRBRAINStorage::_mtd_signature(void)
 {
     int mtd_fd = open(MTD_PARAMS_FILE, O_RDONLY);
     if (mtd_fd == -1) {
-        hal.scheduler->panic("Failed to open " MTD_PARAMS_FILE);
+        platform::panic("Failed to open " MTD_PARAMS_FILE);
     }
     uint32_t v;
     if (lseek(mtd_fd, MTD_SIGNATURE_OFFSET, SEEK_SET) != MTD_SIGNATURE_OFFSET) {
-        hal.scheduler->panic("Failed to seek in " MTD_PARAMS_FILE);
+        platform::panic("Failed to seek in " MTD_PARAMS_FILE);
     }
     if (read(mtd_fd, &v, sizeof(v)) != sizeof(v)) {
-        hal.scheduler->panic("Failed to read signature from " MTD_PARAMS_FILE);
+        platform::panic("Failed to read signature from " MTD_PARAMS_FILE);
     }
     close(mtd_fd);
     return v;
@@ -65,14 +65,14 @@ void VRBRAINStorage::_mtd_write_signature(void)
 {
     int mtd_fd = open(MTD_PARAMS_FILE, O_WRONLY);
     if (mtd_fd == -1) {
-        hal.scheduler->panic("Failed to open " MTD_PARAMS_FILE);
+        platform::panic("Failed to open " MTD_PARAMS_FILE);
     }
     uint32_t v = MTD_SIGNATURE;
     if (lseek(mtd_fd, MTD_SIGNATURE_OFFSET, SEEK_SET) != MTD_SIGNATURE_OFFSET) {
-        hal.scheduler->panic("Failed to seek in " MTD_PARAMS_FILE);
+        platform::panic("Failed to seek in " MTD_PARAMS_FILE);
     }
     if (write(mtd_fd, &v, sizeof(v)) != sizeof(v)) {
-        hal.scheduler->panic("Failed to write signature in " MTD_PARAMS_FILE);
+        platform::panic("Failed to write signature in " MTD_PARAMS_FILE);
     }
     close(mtd_fd);
 }
@@ -92,7 +92,7 @@ void VRBRAINStorage::_upgrade_to_mtd(void)
 
     int mtd_fd = open(MTD_PARAMS_FILE, O_WRONLY);
     if (mtd_fd == -1) {
-        hal.scheduler->panic("Unable to open MTD for upgrade");
+        platform::panic("Unable to open MTD for upgrade");
     }
 
     if (::read(old_fd, _buffer, sizeof(_buffer)) != sizeof(_buffer)) {
@@ -105,7 +105,7 @@ void VRBRAINStorage::_upgrade_to_mtd(void)
     ssize_t ret;
     if ((ret=::write(mtd_fd, _buffer, sizeof(_buffer))) != sizeof(_buffer)) {
         ::printf("mtd write of %u bytes returned %d errno=%d\n", sizeof(_buffer), ret, errno);
-        hal.scheduler->panic("Unable to write MTD for upgrade");        
+        platform::panic("Unable to write MTD for upgrade");
     }
     close(mtd_fd);
 #if STORAGE_RENAME_OLD_FILE
@@ -126,7 +126,7 @@ void VRBRAINStorage::_storage_open(void)
 
         // VRBRAIN should always have /fs/mtd_params
         if (!_have_mtd) {
-            hal.scheduler->panic("Failed to find " MTD_PARAMS_FILE);
+            platform::panic("Failed to find " MTD_PARAMS_FILE);
         }
 
         /*
@@ -152,7 +152,7 @@ void VRBRAINStorage::_storage_open(void)
 	_dirty_mask = 0;
 	int fd = open(MTD_PARAMS_FILE, O_RDONLY);
 	if (fd == -1) {
-            hal.scheduler->panic("Failed to open " MTD_PARAMS_FILE);
+            platform::panic("Failed to open " MTD_PARAMS_FILE);
 	}
         const uint16_t chunk_size = 128;
         for (uint16_t ofs=0; ofs<sizeof(_buffer); ofs += chunk_size) {
@@ -160,7 +160,7 @@ void VRBRAINStorage::_storage_open(void)
             if (ret != chunk_size) {
                 ::printf("storage read of %u bytes at %u to %p failed - got %d errno=%d\n",
                          (unsigned)sizeof(_buffer), (unsigned)ofs, &_buffer[ofs], (int)ret, (int)errno);
-                hal.scheduler->panic("Failed to read " MTD_PARAMS_FILE);
+                platform::panic("Failed to read " MTD_PARAMS_FILE);
             }
 	}
 	close(fd);

--- a/libraries/AP_HAL_VRBRAIN/UARTDriver.cpp
+++ b/libraries/AP_HAL_VRBRAIN/UARTDriver.cpp
@@ -179,10 +179,10 @@ void VRBRAINUARTDriver::try_initialise(void)
     if (_initialised) {
         return;
     }
-    if ((hal.scheduler->millis() - _last_initialise_attempt_ms) < 2000) {
+    if ((platform::millis() - _last_initialise_attempt_ms) < 2000) {
         return;
     }
-    _last_initialise_attempt_ms = hal.scheduler->millis();
+    _last_initialise_attempt_ms = platform::millis();
     if (hal.util->safety_switch_state() != AP_HAL::Util::SAFETY_ARMED || !hal.util->get_soft_armed()) {
         begin(0);
     }
@@ -387,7 +387,7 @@ int VRBRAINUARTDriver::_write_fd(const uint8_t *buf, uint16_t n)
                 }
             } else {
                 if (_os_start_auto_space - nwrite + 1 >= _total_written &&
-                    (hal.scheduler->micros64() - _first_write_time) > 500*1000UL) {
+                    (platform::micros64() - _first_write_time) > 500*1000UL) {
                     // it doesn't look like hw flow control is working
                     ::printf("disabling flow control on %s _total_written=%u\n", 
                              _devpath, (unsigned)_total_written);
@@ -405,7 +405,7 @@ int VRBRAINUARTDriver::_write_fd(const uint8_t *buf, uint16_t n)
 
     if (ret > 0) {
         BUF_ADVANCEHEAD(_writebuf, ret);
-        _last_write_time = hal.scheduler->micros64();
+        _last_write_time = platform::micros64();
         _total_written += ret;
         if (! _first_write_time && _total_written > 5) {
             _first_write_time = _last_write_time;
@@ -413,12 +413,12 @@ int VRBRAINUARTDriver::_write_fd(const uint8_t *buf, uint16_t n)
         return ret;
     }
 
-    if (hal.scheduler->micros64() - _last_write_time > 2000 &&
+    if (platform::micros64() - _last_write_time > 2000 &&
         _flow_control == FLOW_CONTROL_DISABLE) {
 #if 0
         // this trick is disabled for now, as it sometimes blocks on
         // re-opening the ttyACM0 port, which would cause a crash
-        if (hal.scheduler->micros64() - _last_write_time > 2000000) {
+        if (platform::micros64() - _last_write_time > 2000000) {
             // we haven't done a successful write for 2 seconds - try
             // reopening the port        
             _initialised = false;
@@ -431,11 +431,11 @@ int VRBRAINUARTDriver::_write_fd(const uint8_t *buf, uint16_t n)
                 return n;
             }
             
-            _last_write_time = hal.scheduler->micros64();
+            _last_write_time = platform::micros64();
             _initialised = true;
         }
 #else
-        _last_write_time = hal.scheduler->micros64();
+        _last_write_time = platform::micros64();
 #endif
         // we haven't done a successful write for 2ms, which means the 
         // port is running at less than 500 bytes/sec. Start

--- a/libraries/AP_HAL_VRBRAIN/platform.cpp
+++ b/libraries/AP_HAL_VRBRAIN/platform.cpp
@@ -1,0 +1,9 @@
+#include <AP_HAL/platform.h>
+
+namespace platform {
+
+void init()
+{
+}
+
+} // namespace platform

--- a/libraries/AP_HAL_VRBRAIN/platform.cpp
+++ b/libraries/AP_HAL_VRBRAIN/platform.cpp
@@ -1,9 +1,53 @@
+#include <stdarg.h>
+#include <stdio.h>
+
+#include <drivers/drv_hrt.h>
+
+#include <AP_HAL/AP_HAL.h>
 #include <AP_HAL/platform.h>
+
+extern const AP_HAL::HAL& hal;
+
+extern bool _vrbrain_thread_should_exit;
 
 namespace platform {
 
 void init()
 {
+}
+
+void panic(const char *errormsg, ...)
+{
+    va_list ap;
+
+    va_start(ap, errormsg);
+    vdprintf(1, errormsg, ap);
+    va_end(ap);
+    write(1, "\n", 1);
+
+    hal.scheduler->delay_microseconds(10000);
+    _vrbrain_thread_should_exit = true;
+    exit(1);
+}
+
+uint32_t micros()
+{
+    return micros64() & 0xFFFFFFFF;
+}
+
+uint32_t millis()
+{
+    return millis64() & 0xFFFFFFFF;
+}
+
+uint64_t micros64()
+{
+    return hrt_absolute_time();
+}
+
+uint64_t millis64()
+{
+    return micros64() / 1000;
 }
 
 } // namespace platform

--- a/libraries/AP_IRLock/AP_IRLock_PX4.cpp
+++ b/libraries/AP_IRLock/AP_IRLock_PX4.cpp
@@ -66,13 +66,13 @@ bool AP_IRLock_PX4::update()
         _target_info[count].size_y = report.size_y;
         count++;
         _last_timestamp = report.timestamp;
-        _last_update = hal.scheduler->millis();
+        _last_update = platform::millis();
     }
 
     // update num_blocks and implement timeout
     if (count > 0) {
         _num_targets = count;
-    } else if ((hal.scheduler->millis() - _last_update) > IRLOCK_TIMEOUT_MS) {
+    } else if ((platform::millis() - _last_update) > IRLOCK_TIMEOUT_MS) {
         _num_targets = 0;
     }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -322,7 +322,7 @@ AP_InertialSensor::AP_InertialSensor() :
     _dataflash(NULL)
 {
     if (_s_instance) {
-        hal.scheduler->panic("Too many inertial sensors");
+        platform::panic("Too many inertial sensors");
     }
     _s_instance = this;
     AP_Param::setup_object_defaults(this, var_info);        
@@ -371,7 +371,7 @@ AP_InertialSensor *AP_InertialSensor::get_instance()
 uint8_t AP_InertialSensor::register_gyro(void)
 {
     if (_gyro_count == INS_MAX_INSTANCES) {
-        hal.scheduler->panic("Too many gyros");
+        platform::panic("Too many gyros");
     }
     return _gyro_count++;
 }
@@ -382,7 +382,7 @@ uint8_t AP_InertialSensor::register_gyro(void)
 uint8_t AP_InertialSensor::register_accel(void)
 {
     if (_accel_count == INS_MAX_INSTANCES) {
-        hal.scheduler->panic("Too many accels");
+        platform::panic("Too many accels");
     }
     return _accel_count++;
 }
@@ -401,7 +401,7 @@ void AP_InertialSensor::_start_backends()
     }
 
     if (_gyro_count == 0 || _accel_count == 0) {
-        hal.scheduler->panic("INS needs at least 1 gyro and 1 accel");
+        platform::panic("INS needs at least 1 gyro and 1 accel");
     }
 }
 
@@ -478,7 +478,7 @@ void AP_InertialSensor::_add_backend(AP_InertialSensor_Backend *backend)
     if (!backend)
         return;
     if (_backend_count == INS_MAX_BACKENDS)
-        hal.scheduler->panic("Too many INS backends");
+        platform::panic("Too many INS backends");
     _backends[_backend_count++] = backend;
 }
 
@@ -526,7 +526,7 @@ AP_InertialSensor::detect_backends(void)
 #endif
 
     if (_backend_count == 0) {
-        hal.scheduler->panic("No INS backends available");
+        platform::panic("No INS backends available");
     }
 
     // set the product ID to the ID of the first backend
@@ -1348,7 +1348,7 @@ void AP_InertialSensor::wait_for_sample(void)
         return;
     }
 
-    uint32_t now = hal.scheduler->micros();
+    uint32_t now = platform::micros();
 
     if (_next_sample_usec == 0 && _delta_time <= 0) {
         // this is the first call to wait_for_sample()
@@ -1362,7 +1362,7 @@ void AP_InertialSensor::wait_for_sample(void)
         // we're ahead on time, schedule next sample at expected period
         uint32_t wait_usec = _next_sample_usec - now;
         hal.scheduler->delay_microseconds_boost(wait_usec);
-        uint32_t now2 = hal.scheduler->micros();
+        uint32_t now2 = platform::micros();
         if (now2+100 < _next_sample_usec) {
             timing_printf("shortsleep %u\n", (unsigned)(_next_sample_usec-now2));
         }
@@ -1401,7 +1401,7 @@ check_sample:
         }
     }
 
-    now = hal.scheduler->micros();
+    now = platform::micros();
     if (_hil_mode && _hil.delta_time > 0) {
         _delta_time = _hil.delta_time;
         _hil.delta_time = 0;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Flymaple.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Flymaple.cpp
@@ -102,7 +102,7 @@ bool AP_InertialSensor_Flymaple::_init_sensor(void)
     uint8_t data;
     hal.i2c->readRegister(FLYMAPLE_ACCELEROMETER_ADDRESS, FLYMAPLE_ACCELEROMETER_ADXLREG_DEVID, &data);
     if (data != FLYMAPLE_ACCELEROMETER_XL345_DEVID)
-        hal.scheduler->panic("AP_InertialSensor_Flymaple: could not find ADXL345 accelerometer sensor");
+        platform::panic("AP_InertialSensor_Flymaple: could not find ADXL345 accelerometer sensor");
     hal.i2c->writeRegister(FLYMAPLE_ACCELEROMETER_ADDRESS, FLYMAPLE_ACCELEROMETER_ADXLREG_POWER_CTL, 0x00);
     hal.scheduler->delay(5);
     hal.i2c->writeRegister(FLYMAPLE_ACCELEROMETER_ADDRESS, FLYMAPLE_ACCELEROMETER_ADXLREG_POWER_CTL, 0xff);
@@ -124,7 +124,7 @@ bool AP_InertialSensor_Flymaple::_init_sensor(void)
     // Expect to read the same as the Gyro I2C adress:
     hal.i2c->readRegister(FLYMAPLE_GYRO_ADDRESS, FLYMAPLE_GYRO_WHO_AM_I, &data);
     if (data != FLYMAPLE_GYRO_ADDRESS)
-        hal.scheduler->panic("AP_InertialSensor_Flymaple: could not find ITG-3200 accelerometer sensor");
+        platform::panic("AP_InertialSensor_Flymaple: could not find ITG-3200 accelerometer sensor");
     hal.i2c->writeRegister(FLYMAPLE_GYRO_ADDRESS, FLYMAPLE_GYRO_PWR_MGM, 0x00);
     hal.scheduler->delay(1);
     // Sample rate divider: with 8kHz internal clock (see FLYMAPLE_GYRO_DLPF_FS), 
@@ -209,7 +209,7 @@ void AP_InertialSensor_Flymaple::_accumulate(void)
     // Read accelerometer
     // ADXL345 is in the default FIFO bypass mode, so the FIFO is not used
     uint8_t buffer[6];
-    uint32_t now = hal.scheduler->micros();
+    uint32_t now = platform::micros();
     // This takes about 250us at 400kHz I2C speed
     if ((now - _last_accel_timestamp) >= raw_sample_interval_us
         && hal.i2c->readRegisters(FLYMAPLE_ACCELEROMETER_ADDRESS, FLYMAPLE_ACCELEROMETER_ADXLREG_DATAX0, 6, buffer) == 0)
@@ -232,7 +232,7 @@ void AP_InertialSensor_Flymaple::_accumulate(void)
     }
 
     // Read gyro
-    now = hal.scheduler->micros();
+    now = platform::micros();
     // This takes about 250us at 400kHz I2C speed
     if ((now - _last_gyro_timestamp) >= raw_sample_interval_us
         && hal.i2c->readRegisters(FLYMAPLE_GYRO_ADDRESS, FLYMAPLE_GYRO_GYROX_H, 6, buffer) == 0)

--- a/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.cpp
@@ -159,7 +159,7 @@ bool AP_InertialSensor_L3G4200D::_init_sensor(void)
     uint8_t data = 0;
     hal.i2c->readRegister(ADXL345_ACCELEROMETER_ADDRESS, ADXL345_ACCELEROMETER_ADXLREG_DEVID, &data);
     if (data != ADXL345_ACCELEROMETER_XL345_DEVID) {
-        hal.scheduler->panic("AP_InertialSensor_L3G4200D: could not find ADXL345 accelerometer sensor");
+        platform::panic("AP_InertialSensor_L3G4200D: could not find ADXL345 accelerometer sensor");
     }
     hal.i2c->writeRegister(ADXL345_ACCELEROMETER_ADDRESS, ADXL345_ACCELEROMETER_ADXLREG_POWER_CTL, 0x00);
     hal.scheduler->delay(5);
@@ -188,7 +188,7 @@ bool AP_InertialSensor_L3G4200D::_init_sensor(void)
     // Expect to read the right 'WHO_AM_I' value
     hal.i2c->readRegister(L3G4200D_I2C_ADDRESS, L3G4200D_REG_WHO_AM_I, &data);
     if (data != L3G4200D_REG_WHO_AM_I_VALUE)
-        hal.scheduler->panic("AP_InertialSensor_L3G4200D: could not find L3G4200D gyro sensor");
+        platform::panic("AP_InertialSensor_L3G4200D: could not find L3G4200D gyro sensor");
 
     // setup for 800Hz sampling with 110Hz filter
     hal.i2c->writeRegister(L3G4200D_I2C_ADDRESS, 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
@@ -416,14 +416,14 @@ bool AP_InertialSensor_LSM9DS0::_init_sensor()
     if (_drdy_pin_num_a >= 0) {
         _drdy_pin_a = hal.gpio->channel(_drdy_pin_num_a);
         if (_drdy_pin_a == NULL) {
-            hal.scheduler->panic("LSM9DS0: null accel data-ready GPIO channel\n");
+            platform::panic("LSM9DS0: null accel data-ready GPIO channel\n");
         }
     }
 
     if (_drdy_pin_num_g >= 0) {
         _drdy_pin_g = hal.gpio->channel(_drdy_pin_num_g);
         if (_drdy_pin_g == NULL) {
-            hal.scheduler->panic("LSM9DS0: null gyro data-ready GPIO channel\n");
+            platform::panic("LSM9DS0: null gyro data-ready GPIO channel\n");
         }
     }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -526,7 +526,7 @@ void AP_InertialSensor_MPU6000::start()
     hal.scheduler->suspend_timer_procs();
 
     if (!_bus_sem->take(100)) {
-        hal.scheduler->panic("MPU6000: Unable to get semaphore");
+        platform::panic("MPU6000: Unable to get semaphore");
     }
 
     // initially run the bus at low speed
@@ -803,7 +803,7 @@ void AP_InertialSensor_MPU6000::_set_filter_register(uint16_t filter_hz)
 bool AP_InertialSensor_MPU6000::_hardware_init(void)
 {
     if (!_bus_sem->take(100)) {
-        hal.scheduler->panic("MPU6000: Unable to get semaphore");
+        platform::panic("MPU6000: Unable to get semaphore");
     }
 
     // initially run the bus at low speed

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9150.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9150.cpp
@@ -414,11 +414,11 @@ bool AP_InertialSensor_MPU9150::_init_sensor(void)
     //         ;
     //     }
     //     else {
-    //         hal.scheduler->panic("AP_InertialSensor_MPU9150: Unsupported software product rev.\n");
+    //         platform::panic("AP_InertialSensor_MPU9150: Unsupported software product rev.\n");
     //         goto failed;
     //     }
     // } else {
-    //         hal.scheduler->panic("Product ID read as 0 indicates device is either incompatible or an MPU3050.\n");
+    //         platform::panic("Product ID read as 0 indicates device is either incompatible or an MPU3050.\n");
     //         goto failed;            
     // }
 
@@ -984,7 +984,7 @@ int16_t AP_InertialSensor_MPU9150::mpu_read_fifo(int16_t *gyro, int16_t *accel, 
         }
     }
 
-    *timestamp = hal.scheduler->millis();    
+    *timestamp = platform::millis();
     // read the data
     hal.i2c->readRegisters(st.hw->addr, st.reg->fifo_r_w, packet_size, data);
     more[0] = fifo_count / packet_size - 1;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
@@ -120,7 +120,7 @@ bool AP_InertialSensor_PX4::_init_sensor(void)
         // calculate gyro sample time
         int samplerate = ioctl(fd,  GYROIOCGSAMPLERATE, 0);
         if (samplerate < 100 || samplerate > 10000) {
-            hal.scheduler->panic("Invalid gyro sample rate");
+            platform::panic("Invalid gyro sample rate");
         }
         _set_gyro_raw_sample_rate(_gyro_instance[i], (uint32_t)samplerate);
         _gyro_sample_time[i] = 1.0f / samplerate;
@@ -160,7 +160,7 @@ bool AP_InertialSensor_PX4::_init_sensor(void)
         // calculate accel sample time
         int samplerate = ioctl(fd,  ACCELIOCGSAMPLERATE, 0);
         if (samplerate < 100 || samplerate > 10000) {
-            hal.scheduler->panic("Invalid accel sample rate");
+            platform::panic("Invalid accel sample rate");
         }
         _set_accel_raw_sample_rate(_accel_instance[i], (uint32_t) samplerate);
         _accel_sample_time[i] = 1.0f / samplerate;
@@ -271,7 +271,7 @@ void AP_InertialSensor_PX4::_new_accel_sample(uint8_t i, accel_report &accel_rep
     _accel_meas_count[i] ++;
 
     if(_accel_meas_count[i] >= 10000) {
-        uint32_t tnow = hal.scheduler->micros();
+        uint32_t tnow = platform::micros();
 
         ::printf("a%d %.2f Hz max %.8f s\n", frontend_instance, 10000.0f/((tnow-_accel_meas_count_start_us[i])*1.0e-6f),_accel_dt_max[i]);
 
@@ -309,7 +309,7 @@ void AP_InertialSensor_PX4::_new_gyro_sample(uint8_t i, gyro_report &gyro_report
     _gyro_meas_count[i] ++;
 
     if(_gyro_meas_count[i] >= 10000) {
-        uint32_t tnow = hal.scheduler->micros();
+        uint32_t tnow = platform::micros();
 
         ::printf("g%d %.2f Hz max %.8f s\n", frontend_instance, 10000.0f/((tnow-_gyro_meas_count_start_us[i])*1.0e-6f), _gyro_dt_max[i]);
 
@@ -350,7 +350,7 @@ void AP_InertialSensor_PX4::_get_sample()
             }
         }
     }
-    _last_get_sample_timestamp = hal.scheduler->micros64();
+    _last_get_sample_timestamp = platform::micros64();
 }
 
 bool AP_InertialSensor_PX4::_get_accel_sample(uint8_t i, struct accel_report &accel_report) 
@@ -363,7 +363,7 @@ bool AP_InertialSensor_PX4::_get_accel_sample(uint8_t i, struct accel_report &ac
         if (dataflash != NULL) {
             struct log_ACCEL pkt = {
                 LOG_PACKET_HEADER_INIT((uint8_t)(LOG_ACC1_MSG+i)),
-                time_us   : hal.scheduler->micros64(),
+                time_us   : platform::micros64(),
                 sample_us : accel_report.timestamp,
                 AccX      : accel_report.x,
                 AccY      : accel_report.y,
@@ -386,7 +386,7 @@ bool AP_InertialSensor_PX4::_get_gyro_sample(uint8_t i, struct gyro_report &gyro
         if (dataflash != NULL) {
             struct log_GYRO pkt = {
                 LOG_PACKET_HEADER_INIT((uint8_t)(LOG_GYR1_MSG+i)),
-                time_us   : hal.scheduler->micros64(),
+                time_us   : platform::micros64(),
                 sample_us : gyro_report.timestamp,
                 GyrX      : gyro_report.x,
                 GyrY      : gyro_report.y,

--- a/libraries/AP_InertialSensor/AP_InertialSensor_UserInteract_MAVLink.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_UserInteract_MAVLink.cpp
@@ -23,11 +23,11 @@ static void _snoop(const mavlink_message_t* msg)
 
 bool AP_InertialSensor_UserInteract_MAVLink::blocking_read(void) 
 {
-    uint32_t start_ms = hal.scheduler->millis();
+    uint32_t start_ms = platform::millis();
     // setup snooping of packets so we can see the COMMAND_ACK
     _gcs->set_snoop(_snoop);
     _got_ack = false;
-    while (hal.scheduler->millis() - start_ms < 30000U) {
+    while (platform::millis() - start_ms < 30000U) {
         hal.scheduler->delay(10);
         if (_got_ack) {
             _gcs->set_snoop(NULL);

--- a/libraries/AP_InertialSensor/examples/VibTest/VibTest.cpp
+++ b/libraries/AP_InertialSensor/examples/VibTest/VibTest.cpp
@@ -73,7 +73,7 @@ void setup(void)
         gyro_fd[i] = open(gyro_path, O_RDONLY);
     }
     if (accel_fd[0] == -1 || gyro_fd[0] == -1) {
-            hal.scheduler->panic("Failed to open accel/gyro 0");
+        platform::panic("Failed to open accel/gyro 0");
     }
 
     ioctl(gyro_fd[0], SENSORIOCSPOLLRATE, 1000);
@@ -130,7 +130,7 @@ void loop(void)
 
                 struct log_ACCEL pkt = {
                     LOG_PACKET_HEADER_INIT((uint8_t)(LOG_ACC1_MSG+i)),
-                    time_us   : hal.scheduler->micros64(),
+                    time_us   : platform::micros64(),
                     sample_us : accel_report.timestamp,
                     AccX      : accel_report.x,
                     AccY      : accel_report.y,
@@ -154,7 +154,7 @@ void loop(void)
 
                 struct log_GYRO pkt = {
                     LOG_PACKET_HEADER_INIT((uint8_t)(LOG_GYR1_MSG+i)),
-                    time_us   : hal.scheduler->micros64(),
+                    time_us   : platform::micros64(),
                     sample_us : gyro_report.timestamp,
                     GyrX      : gyro_report.x,
                     GyrY      : gyro_report.y,
@@ -169,7 +169,7 @@ void loop(void)
             if (total_samples[0] % 2000 == 0 && last_print != total_samples[0]) {
                 last_print = total_samples[0];
                 hal.console->printf("t=%lu total_samples=%lu/%lu/%lu adt=%u:%u/%u:%u/%u:%u gdt=%u:%u/%u:%u/%u:%u\n",
-                                    (unsigned long)hal.scheduler->millis(), 
+                                    (unsigned long)platform::millis(), 
                                     (unsigned long)total_samples[0], 
                                     (unsigned long)total_samples[1],
                                     (unsigned long)total_samples[2],
@@ -183,7 +183,7 @@ void loop(void)
                                     gyro_deltat_min[2], gyro_deltat_max[2]);
 #if 0
                 ::printf("t=%lu total_samples=%lu/%lu/%lu adt=%u:%u/%u:%u/%u:%u gdt=%u:%u/%u:%u/%u:%u\n",
-                         hal.scheduler->millis(), 
+                         platform::millis(), 
                          total_samples[0], total_samples[1],total_samples[2],
                          accel_deltat_min[0], accel_deltat_max[0], 
                          accel_deltat_min[1], accel_deltat_max[1], 

--- a/libraries/AP_Math/examples/location/location.cpp
+++ b/libraries/AP_Math/examples/location/location.cpp
@@ -66,10 +66,10 @@ static void test_one_offset(const struct Location &loc,
     float dist2, bearing2;
 
     loc2 = loc;
-    uint32_t t1 = hal.scheduler->micros();
+    uint32_t t1 = platform::micros();
     location_offset(loc2, ofs_north, ofs_east);
     hal.console->printf("location_offset took %u usec\n",
-                        (unsigned)(hal.scheduler->micros() - t1));
+                        (unsigned)(platform::micros() - t1));
     dist2 = get_distance(loc, loc2);
     bearing2 = get_bearing_cd(loc, loc2) * 0.01f;
     float brg_error = bearing2-bearing;

--- a/libraries/AP_Math/examples/polygon/polygon.cpp
+++ b/libraries/AP_Math/examples/polygon/polygon.cpp
@@ -92,7 +92,7 @@ void setup(void)
     hal.console->println(all_passed ? "TEST PASSED" : "TEST FAILED");
 
     hal.console->println("Speed test:");
-    start_time = hal.scheduler->micros();
+    start_time = platform::micros();
     for (count=0; count<1000; count++) {
         for (i=0; i<ARRAY_SIZE(test_points); i++) {
             bool result;
@@ -103,7 +103,7 @@ void setup(void)
             }
         }
     }
-    hal.console->printf("%u usec/call\n", (unsigned)((hal.scheduler->micros() 
+    hal.console->printf("%u usec/call\n", (unsigned)((platform::micros()
                     - start_time)/(count*ARRAY_SIZE(test_points))));
     hal.console->println(all_passed ? "ALL TESTS PASSED" : "TEST FAILED");
 }

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -43,10 +43,10 @@ void AP_Mission::init()
 
     // prevent an easy programming error, this will be optimised out
     if (sizeof(union Content) != 12) {
-        hal.scheduler->panic("AP_Mission Content must be 12 bytes");
+        platform::panic("AP_Mission Content must be 12 bytes");
     }
 
-    _last_change_time_ms = hal.scheduler->millis();
+    _last_change_time_ms = platform::millis();
 }
 
 /// start - resets current commands to point to the beginning of the mission
@@ -454,7 +454,7 @@ bool AP_Mission::write_cmd_to_storage(uint16_t index, Mission_Command& cmd)
     _storage.write_block(pos_in_storage+3, cmd.content.bytes, 12);
 
     // remember when the mission last changed
-    _last_change_time_ms = hal.scheduler->millis();
+    _last_change_time_ms = platform::millis();
 
     // return success
     return true;

--- a/libraries/AP_Mission/examples/AP_Mission_test/AP_Mission_test.cpp
+++ b/libraries/AP_Mission/examples/AP_Mission_test/AP_Mission_test.cpp
@@ -768,8 +768,8 @@ void MissionTest::run_resume_test()
     mission.stop();
 
     // update the mission for 5 seconds (nothing should happen)
-    uint32_t start_time = hal.scheduler->millis();
-    while(hal.scheduler->millis() - start_time < 5000) {
+    uint32_t start_time = platform::millis();
+    while(platform::millis() - start_time < 5000) {
         mission.update();
     }
 
@@ -991,8 +991,8 @@ void MissionTest::run_set_current_cmd_while_stopped_test()
     mission.set_current_cmd(2);
 
     // update the mission for 2 seconds (nothing should happen)
-    uint32_t start_time = hal.scheduler->millis();
-    while(hal.scheduler->millis() - start_time < 2000) {
+    uint32_t start_time = platform::millis();
+    while(platform::millis() - start_time < 2000) {
         mission.update();
     }
 
@@ -1006,8 +1006,8 @@ void MissionTest::run_set_current_cmd_while_stopped_test()
     }
 
     // pause for two seconds
-    start_time = hal.scheduler->millis();
-    while(hal.scheduler->millis() - start_time < 2000) {
+    start_time = platform::millis();
+    while(platform::millis() - start_time < 2000) {
         mission.update();
     }
 

--- a/libraries/AP_Motors/examples/AP_Motors_Time_test/AP_Motors_Time_test.cpp
+++ b/libraries/AP_Motors/examples/AP_Motors_Time_test/AP_Motors_Time_test.cpp
@@ -96,9 +96,9 @@ void motor_order_test()
     for (int8_t i=1; i <= 4; i++) {
 		hal.console->printf("Motor %d\n",(int)i);
         int elapsed =0,stop;
-		int start = hal.scheduler->micros();                                                   //Time Test
+		int start = platform::micros();                                                   //Time Test
         motors.output_test(i, 1150);
-        stop = hal.scheduler->micros();
+        stop = platform::micros();
         elapsed = stop - start;
         hal.console->printf("  Elapsed Time: %dus\n",elapsed);
         hal.scheduler->delay(300);

--- a/libraries/AP_Mount/AP_Mount_SToRM32.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.cpp
@@ -75,7 +75,7 @@ void AP_Mount_SToRM32::update()
     }
 
     // resend target angles at least once per second
-    if (resend_now || ((hal.scheduler->millis() - _last_send) > AP_MOUNT_STORM32_RESEND_MS)) {
+    if (resend_now || ((platform::millis() - _last_send) > AP_MOUNT_STORM32_RESEND_MS)) {
         send_do_mount_control(ToDeg(_angle_ef_target_rad.y), ToDeg(_angle_ef_target_rad.x), ToDeg(_angle_ef_target_rad.z), MAV_MOUNT_MODE_MAVLINK_TARGETING);
     }
 }
@@ -115,7 +115,7 @@ void AP_Mount_SToRM32::find_gimbal()
     }
 
     // return if search time has has passed
-    if (hal.scheduler->millis() > AP_MOUNT_STORM32_SEARCH_MS) {
+    if (platform::millis() > AP_MOUNT_STORM32_SEARCH_MS) {
         return;
     }
 
@@ -154,5 +154,5 @@ void AP_Mount_SToRM32::send_do_mount_control(float pitch_deg, float roll_deg, fl
                                   mount_mode);
 
     // store time of send
-    _last_send = hal.scheduler->millis();
+    _last_send = platform::millis();
 }

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.cpp
@@ -90,9 +90,9 @@ void AP_Mount_SToRM32_serial::update()
     }
 
     // resend target angles at least once per second
-    resend_now = resend_now || ((hal.scheduler->millis() - _last_send) > AP_MOUNT_STORM32_SERIAL_RESEND_MS);
+    resend_now = resend_now || ((platform::millis() - _last_send) > AP_MOUNT_STORM32_SERIAL_RESEND_MS);
 
-    if ((hal.scheduler->millis() - _last_send) > AP_MOUNT_STORM32_SERIAL_RESEND_MS*2) {
+    if ((platform::millis() - _last_send) > AP_MOUNT_STORM32_SERIAL_RESEND_MS*2) {
         _reply_type = ReplyType_UNKNOWN;
     }
     if (can_send(resend_now)) {
@@ -189,7 +189,7 @@ void AP_Mount_SToRM32_serial::send_target_angles(float pitch_deg, float roll_deg
     }
 
     // store time of send
-    _last_send = hal.scheduler->millis();
+    _last_send = platform::millis();
 }
 
 void AP_Mount_SToRM32_serial::get_angles() {

--- a/libraries/AP_Mount/AP_Mount_Servo.cpp
+++ b/libraries/AP_Mount/AP_Mount_Servo.cpp
@@ -30,7 +30,7 @@ void AP_Mount_Servo::update()
     static bool mount_open = 0;     // 0 is closed
 
     // check servo map every three seconds to allow users to modify parameters
-    uint32_t now = hal.scheduler->millis();
+    uint32_t now = platform::millis();
     if (now - _last_check_servo_map_ms > 3000) {
         check_servo_map();
         _last_check_servo_map_ms = now;

--- a/libraries/AP_NavEKF/AP_NavEKF_core.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_core.cpp
@@ -380,7 +380,7 @@ void NavEKF_core::UpdateFilter()
     hal.util->perf_begin(_perf_UpdateFilter);
 
     //get starting time for update step
-    imuSampleTime_ms = hal.scheduler->millis();
+    imuSampleTime_ms = platform::millis();
 
     // read IMU data and convert to delta angles and velocities
     readIMUData();
@@ -3823,7 +3823,7 @@ void NavEKF_core::readIMUData()
     dtDelAng = max(ins.get_delta_time(),1.0e-4f);
 
     // the imu sample time is used as a common time reference throughout the filter
-    imuSampleTime_ms = hal.scheduler->millis();
+    imuSampleTime_ms = platform::millis();
 
     // dual accel mode - require both IMU's to be able to provide delta velocity outputs
     if (ins.use_accel(0) && ins.use_accel(1) && readDeltaVelocity(0, dVelIMU1, dtDelVel1) && readDeltaVelocity(1, dVelIMU2, dtDelVel2)) {
@@ -4377,7 +4377,7 @@ void NavEKF_core::InitialiseVariables()
     }
 
     // initialise time stamps
-    imuSampleTime_ms = hal.scheduler->millis();
+    imuSampleTime_ms = platform::millis();
     lastHealthyMagTime_ms = imuSampleTime_ms;
     TASmsecPrev = imuSampleTime_ms;
     BETAmsecPrev = imuSampleTime_ms;

--- a/libraries/AP_NavEKF/AP_SmallEKF.cpp
+++ b/libraries/AP_NavEKF/AP_SmallEKF.cpp
@@ -47,7 +47,7 @@ SmallEKF::SmallEKF(const AP_AHRS_NavEKF &ahrs) :
 // run a 9-state EKF used to calculate orientation
 void SmallEKF::RunEKF(float delta_time, const Vector3f &delta_angles, const Vector3f &delta_velocity, const Vector3f &joint_angles)
 {
-    imuSampleTime_ms = hal.scheduler->millis();
+    imuSampleTime_ms = platform::millis();
     dtIMU = delta_time;
 
     // initialise variables and constants
@@ -882,7 +882,7 @@ void SmallEKF::getQuat(Quaternion &quat) const
 // get filter status - true is aligned
 bool SmallEKF::getStatus() const
 {
-    float run_time = hal.scheduler->millis() - StartTime_ms;
+    float run_time = platform::millis() - StartTime_ms;
     return  YawAligned && (run_time > 30000);
 }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -298,7 +298,7 @@ void NavEKF2_core::readIMUData()
     dtIMUavg = 1.0f/ins.get_sample_rate();
 
     // the imu sample time is used as a common time reference throughout the filter
-    imuSampleTime_ms = hal.scheduler->millis();
+    imuSampleTime_ms = platform::millis();
 
     // use the nominated imu or primary if not available
     if (ins.use_accel(imu_index)) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -77,7 +77,7 @@ void NavEKF2_core::InitialiseVariables()
     localFilterTimeStep_ms = max(localFilterTimeStep_ms,10);
 
     // initialise time stamps
-    imuSampleTime_ms = hal.scheduler->millis();
+    imuSampleTime_ms = platform::millis();
     lastHealthyMagTime_ms = imuSampleTime_ms;
     prevTasStep_ms = imuSampleTime_ms;
     prevBetaStep_ms = imuSampleTime_ms;
@@ -372,7 +372,7 @@ void NavEKF2_core::UpdateFilter(bool predict)
     // TODO - in-flight restart method
 
     //get starting time for update step
-    imuSampleTime_ms = hal.scheduler->millis();
+    imuSampleTime_ms = platform::millis();
 
     // Check arm status and perform required checks and mode changes
     controlFilterModes();

--- a/libraries/AP_Notify/Buzzer.cpp
+++ b/libraries/AP_Notify/Buzzer.cpp
@@ -97,11 +97,11 @@ void Buzzer::update()
             case ARMING_BUZZ:
                 // record start time
                 if (_pattern_counter == 1) {
-                    _arming_buzz_start_ms = hal.scheduler->millis();
+                    _arming_buzz_start_ms = platform::millis();
                     on(true);
                 } else {
                     // turn off buzzer after 3 seconds
-                    if (hal.scheduler->millis() - _arming_buzz_start_ms >= BUZZER_ARMING_BUZZ_MS) {
+                    if (platform::millis() - _arming_buzz_start_ms >= BUZZER_ARMING_BUZZ_MS) {
                         _arming_buzz_start_ms = 0;
                         on(false);
                         _pattern = NONE;

--- a/libraries/AP_Notify/ToneAlarm_PX4.cpp
+++ b/libraries/AP_Notify/ToneAlarm_PX4.cpp
@@ -88,7 +88,7 @@ bool ToneAlarm_PX4::init()
 // play_tune - play one of the pre-defined tunes
 void ToneAlarm_PX4::play_tone(const uint8_t tone_index)
 {
-    uint32_t tnow_ms = hal.scheduler->millis();
+    uint32_t tnow_ms = platform::millis();
     const Tone &tone_requested = _tones[tone_index];
 
     if(tone_requested.continuous) {
@@ -114,7 +114,7 @@ void ToneAlarm_PX4::stop_cont_tone() {
 }
 
 void ToneAlarm_PX4::check_cont_tone() {
-    uint32_t tnow_ms = hal.scheduler->millis();
+    uint32_t tnow_ms = platform::millis();
     // if we are supposed to be playing a continuous tone,
     // and it was interrupted, and the interrupting tone has timed out,
     // resume the continuous tone

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Linux.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Linux.cpp
@@ -154,7 +154,7 @@ void AP_OpticalFlow_Linux::update(void)
     }
 
     // throttle reads to no more than 10hz
-    uint32_t now = hal.scheduler->millis();
+    uint32_t now = platform::millis();
     if (now - last_read_ms < 100) {
         return;
     }

--- a/libraries/AP_OpticalFlow/OpticalFlow.cpp
+++ b/libraries/AP_OpticalFlow/OpticalFlow.cpp
@@ -75,7 +75,7 @@ void OpticalFlow::update(void)
         backend->update();
     }
     // only healthy if the data is less than 0.5s old
-    _flags.healthy = (hal.scheduler->millis() - _last_update_ms < 500);
+    _flags.healthy = (platform::millis() - _last_update_ms < 500);
 }
 
 void OpticalFlow::setHIL(const struct OpticalFlow::OpticalFlow_state &state)

--- a/libraries/AP_OpticalFlow/OpticalFlow_backend.cpp
+++ b/libraries/AP_OpticalFlow/OpticalFlow_backend.cpp
@@ -22,5 +22,5 @@ extern const AP_HAL::HAL& hal;
 void OpticalFlow_backend::_update_frontend(const struct OpticalFlow::OpticalFlow_state &state)
 {
     frontend._state = state;
-    frontend._last_update_ms = hal.scheduler->millis();
+    frontend._last_update_ms = platform::millis();
 }

--- a/libraries/AP_Parachute/AP_Parachute.cpp
+++ b/libraries/AP_Parachute/AP_Parachute.cpp
@@ -74,7 +74,7 @@ void AP_Parachute::release()
 
     // set release time to current system time
     if (_release_time == 0) {
-        _release_time = hal.scheduler->millis();
+        _release_time = platform::millis();
     }
 
     // update AP_Notify
@@ -90,7 +90,7 @@ void AP_Parachute::update()
     }
 
     // calc time since release
-    uint32_t time_diff = hal.scheduler->millis() - _release_time;
+    uint32_t time_diff = platform::millis() - _release_time;
 
     // check if we should release parachute
     if ((_release_time != 0) && !_release_in_progress) {

--- a/libraries/AP_PerfMon/AP_PerfMon.cpp
+++ b/libraries/AP_PerfMon/AP_PerfMon.cpp
@@ -23,7 +23,7 @@ AP_PerfMon::AP_PerfMon(uint8_t funcNum) : _funcNum(funcNum), _time_this_iteratio
 
     // check global start time
     if( allStartTime == 0 ) {
-        allStartTime = hal.scheduler->micros();
+        allStartTime = platform::micros();
     }
 
     // stop recording time from parent
@@ -81,13 +81,13 @@ uint8_t AP_PerfMon::recordFunctionName(const char funcName[])
 // stop recording time
 void AP_PerfMon::start()
 {
-    _startTime = hal.scheduler->micros();  // start recording time spent in this function
+    _startTime = platform::micros();  // start recording time spent in this function
 }
 
 // stop recording time
 void AP_PerfMon::stop()
 {
-    uint32_t temp_time = hal.scheduler->micros()-_startTime;
+    uint32_t temp_time = platform::micros()-_startTime;
     _time_this_iteration += temp_time;
     time[_funcNum] += temp_time;
 }
@@ -105,7 +105,7 @@ void AP_PerfMon::ClearAll()
     }
 
     // reset start time to now
-    allStartTime = hal.scheduler->micros();
+    allStartTime = platform::micros();
     allEndTime = 0;
 
     // reset start times of any active counters
@@ -129,7 +129,7 @@ void AP_PerfMon::DisplayResults()
 
     // record end time
     if( allEndTime == 0 ) {
-        allEndTime = hal.scheduler->micros();
+        allEndTime = platform::micros();
     }
 
     // turn off any time recording
@@ -207,7 +207,7 @@ void AP_PerfMon::DisplayResults()
 // DisplayAndClear - will display results after this many milliseconds.  should be called regularly
 void AP_PerfMon::DisplayAndClear(uint32_t display_after_seconds)
 {
-    if( (hal.scheduler->micros() - allStartTime) > (uint32_t)(display_after_seconds * 1000000) ) {
+    if( (platform::micros() - allStartTime) > (uint32_t)(display_after_seconds * 1000000) ) {
         DisplayResults();
         ClearAll();
     }

--- a/libraries/AP_RPM/AP_RPM.cpp
+++ b/libraries/AP_RPM/AP_RPM.cpp
@@ -118,7 +118,7 @@ bool AP_RPM::healthy(uint8_t instance) const
         return false;
     }
     // assume we get readings at at least 1Hz
-    if (hal.scheduler->millis() - state[instance].last_reading_ms > 1000) {
+    if (platform::millis() - state[instance].last_reading_ms > 1000) {
         return false;
     }
     return true;

--- a/libraries/AP_RPM/RPM_PX4_PWM.cpp
+++ b/libraries/AP_RPM/RPM_PX4_PWM.cpp
@@ -92,7 +92,7 @@ void AP_RPM_PX4_PWM::update(void)
 
     if (count != 0) {
         state.rate_rpm = sum / count;
-        state.last_reading_ms = hal.scheduler->millis();
+        state.last_reading_ms = platform::millis();
     }
 }
 

--- a/libraries/AP_Rally/AP_Rally.cpp
+++ b/libraries/AP_Rally/AP_Rally.cpp
@@ -94,7 +94,7 @@ bool AP_Rally::set_rally_point_with_index(uint8_t i, const RallyLocation &rallyL
 
     _storage.write_block(i * sizeof(RallyLocation), &rallyLoc, sizeof(RallyLocation));
 
-    _last_change_time_ms = hal.scheduler->millis();
+    _last_change_time_ms = platform::millis();
 
     return true;
 }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
@@ -91,9 +91,9 @@ void AP_RangeFinder_LightWareSerial::update(void)
 {
     if (get_reading(state.distance_cm)) {
         // update range_valid state based on distance measured
-        last_reading_ms = hal.scheduler->millis();
+        last_reading_ms = platform::millis();
         update_status();
-    } else if (hal.scheduler->millis() - last_reading_ms > 200) {
+    } else if (platform::millis() - last_reading_ms > 200) {
         set_status(RangeFinder::RangeFinder_NoData);
     }
 }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PX4.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PX4.cpp
@@ -132,7 +132,7 @@ void AP_RangeFinder_PX4::update(void)
     }
 
     // if we have not taken a reading in the last 0.2s set status to No Data
-    if (hal.scheduler->micros64() - _last_timestamp >= 200000) {
+    if (platform::micros64() - _last_timestamp >= 200000) {
         set_status(RangeFinder::RangeFinder_NoData);
     }
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PX4_PWM.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PX4_PWM.cpp
@@ -100,7 +100,7 @@ void AP_RangeFinder_PX4_PWM::update(void)
     float sum_cm = 0;
     uint16_t count = 0;
     const float scaling = ranger._scaling[state.instance];
-    uint32_t now = hal.scheduler->millis();
+    uint32_t now = platform::millis();
 
     while (::read(_fd, &pwm, sizeof(pwm)) == sizeof(pwm)) {
         // report the voltage as the pulse width, so we get the raw
@@ -147,7 +147,7 @@ void AP_RangeFinder_PX4_PWM::update(void)
     }
 
     // if we have not taken a reading in the last 0.2s set status to No Data
-    if (hal.scheduler->micros64() - _last_timestamp >= 200000) {
+    if (platform::micros64() - _last_timestamp >= 200000) {
         set_status(RangeFinder::RangeFinder_NoData);
     }
 

--- a/libraries/AP_Scheduler/AP_Scheduler.cpp
+++ b/libraries/AP_Scheduler/AP_Scheduler.cpp
@@ -61,7 +61,7 @@ void AP_Scheduler::tick(void)
  */
 void AP_Scheduler::run(uint16_t time_available)
 {
-    uint32_t run_started_usec = hal.scheduler->micros();
+    uint32_t run_started_usec = platform::micros();
     uint32_t now = run_started_usec;
 
     for (uint8_t i=0; i<_num_tasks; i++) {
@@ -97,7 +97,7 @@ void AP_Scheduler::run(uint16_t time_available)
                 _last_run[i] = _tick_counter;
                 
                 // work out how long the event actually took
-                now = hal.scheduler->micros();
+                now = platform::micros();
                 uint32_t time_taken = now - _task_time_started;
                 
                 if (time_taken > _task_time_allowed) {
@@ -134,7 +134,7 @@ update_spare_ticks:
  */
 uint16_t AP_Scheduler::time_available_usec(void)
 {
-    uint32_t dt = hal.scheduler->micros() - _task_time_started;
+    uint32_t dt = platform::micros() - _task_time_started;
     if (dt > _task_time_allowed) {
         return 0;
     }

--- a/libraries/AP_Scheduler/examples/Scheduler_test/Scheduler_test.cpp
+++ b/libraries/AP_Scheduler/examples/Scheduler_test/Scheduler_test.cpp
@@ -84,7 +84,7 @@ void SchedTest::ins_update(void)
  */
 void SchedTest::one_hz_print(void)
 {
-    hal.console->printf("one_hz: t=%lu\n", (unsigned long)hal.scheduler->millis());
+    hal.console->printf("one_hz: t=%lu\n", (unsigned long)platform::millis());
 }
 
 /*
@@ -92,7 +92,7 @@ void SchedTest::one_hz_print(void)
  */
 void SchedTest::five_second_call(void)
 {
-    hal.console->printf("five_seconds: t=%lu ins_counter=%u\n", (unsigned long)hal.scheduler->millis(), ins_counter);
+    hal.console->printf("five_seconds: t=%lu ins_counter=%u\n", (unsigned long)platform::millis(), ins_counter);
 }
 
 /*

--- a/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.cpp
+++ b/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.cpp
@@ -99,11 +99,11 @@ bool AP_ServoRelayEvents::do_repeat_relay(uint8_t relay_num, int16_t _repeat, ui
 */
 void AP_ServoRelayEvents::update_events(void)
 {
-    if (repeat == 0 || (hal.scheduler->millis() - start_time_ms) < delay_ms) {
+    if (repeat == 0 || (platform::millis() - start_time_ms) < delay_ms) {
         return;
     }
 
-    start_time_ms = hal.scheduler->millis();
+    start_time_ms = platform::millis();
 
     switch (type) {
     case EVENT_TYPE_SERVO:

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -225,7 +225,7 @@ void AP_TECS::update_50hz(float hgt_afe)
     }
 
     // Calculate time in seconds since last update
-    uint32_t now = hal.scheduler->micros();
+    uint32_t now = platform::micros();
     float DT = max((now - _update_50hz_last_usec),0)*1.0e-6f;
     if (DT > 1.0f) {
         _climb_rate = 0.0f;
@@ -283,7 +283,7 @@ void AP_TECS::update_50hz(float hgt_afe)
 void AP_TECS::_update_speed(float load_factor)
 {
     // Calculate time in seconds since last update
-    uint32_t now = hal.scheduler->micros();
+    uint32_t now = platform::micros();
     float DT = max((now - _update_speed_last_usec),0)*1.0e-6f;
     _update_speed_last_usec = now;
 
@@ -793,7 +793,7 @@ void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
                                     float load_factor)
 {
     // Calculate time in seconds since last update
-    uint32_t now = hal.scheduler->micros();
+    uint32_t now = platform::micros();
     _DT = max((now - _update_pitch_throttle_last_usec),0)*1.0e-6f;
     _update_pitch_throttle_last_usec = now;
 
@@ -907,7 +907,7 @@ void AP_TECS::update_pitch_throttle(int32_t hgt_dem_cm,
     log_tuning.thr      = _throttle_dem;
     log_tuning.ptch     = _pitch_dem;
     log_tuning.dspd_dem = _TAS_rate_dem;
-    log_tuning.time_us  = hal.scheduler->micros64();
+    log_tuning.time_us  = platform::micros64();
 }
 
 // log the contents of the log_tuning structure to dataflash

--- a/libraries/AP_Terrain/AP_Terrain.cpp
+++ b/libraries/AP_Terrain/AP_Terrain.cpp
@@ -357,7 +357,7 @@ void AP_Terrain::log_terrain_data(DataFlash_Class &dataflash)
 
     struct log_TERRAIN pkt = {
         LOG_PACKET_HEADER_INIT(LOG_TERRAIN_MSG),
-        time_us        : hal.scheduler->micros64(),
+        time_us        : platform::micros64(),
         status         : (uint8_t)status(),
         lat            : loc.lat,
         lng            : loc.lng,

--- a/libraries/AP_Terrain/TerrainGCS.cpp
+++ b/libraries/AP_Terrain/TerrainGCS.cpp
@@ -64,7 +64,7 @@ bool AP_Terrain::request_missing(mavlink_channel_t chan, struct grid_cache &gcac
       ask the GCS to send a set of 4x4 grids
      */
     mavlink_msg_terrain_request_send(chan, grid.lat, grid.lon, grid_spacing, bitmap_mask & ~grid.bitmap);
-    last_request_time_ms[chan] = hal.scheduler->millis();
+    last_request_time_ms[chan] = platform::millis();
 
     return true;
 }
@@ -102,7 +102,7 @@ void AP_Terrain::send_request(mavlink_channel_t chan)
     send_terrain_report(chan, loc, true);
 
     // did we request recently?
-    if (hal.scheduler->millis() - last_request_time_ms[chan] < 2000) {
+    if (platform::millis() - last_request_time_ms[chan] < 2000) {
         // too soon to request again
         return;
     }

--- a/libraries/AP_Terrain/TerrainIO.cpp
+++ b/libraries/AP_Terrain/TerrainIO.cpp
@@ -97,7 +97,7 @@ void AP_Terrain::schedule_disk_io(void)
                 cache[cache_idx].grid = disk_block.block;
             }
             cache[cache_idx].state = GRID_CACHE_VALID;
-            cache[cache_idx].last_access_ms = hal.scheduler->millis();
+            cache[cache_idx].last_access_ms = platform::millis();
         }
         disk_io_state = DiskIoIdle;
         break;

--- a/libraries/AP_Terrain/TerrainUtil.cpp
+++ b/libraries/AP_Terrain/TerrainUtil.cpp
@@ -124,7 +124,7 @@ AP_Terrain::grid_cache &AP_Terrain::find_grid_cache(const struct grid_info &info
         if (cache[i].grid.lat == info.grid_lat && 
             cache[i].grid.lon == info.grid_lon &&
             cache[i].grid.spacing == grid_spacing) {
-            cache[i].last_access_ms = hal.scheduler->millis();
+            cache[i].last_access_ms = platform::millis();
             return cache[i];
         }
         if (cache[i].last_access_ms < cache[oldest_i].last_access_ms) {
@@ -145,7 +145,7 @@ AP_Terrain::grid_cache &AP_Terrain::find_grid_cache(const struct grid_info &info
     grid.grid.lat_degrees = info.lat_degrees;
     grid.grid.lon_degrees = info.lon_degrees;
     grid.grid.version = TERRAIN_GRID_FORMAT_VERSION;
-    grid.last_access_ms = hal.scheduler->millis();
+    grid.last_access_ms = platform::millis();
 
     // mark as waiting for disk read
     grid.state = GRID_CACHE_DISKWAIT;

--- a/libraries/DataFlash/DataFlash_Backend.cpp
+++ b/libraries/DataFlash/DataFlash_Backend.cpp
@@ -16,7 +16,7 @@ void DataFlash_Backend::periodic_fullrate(const uint32_t now)
 
 void DataFlash_Backend::periodic_tasks()
 {
-    uint32_t now = hal.scheduler->millis();
+    uint32_t now = platform::millis();
     if (now - _last_periodic_1Hz > 1000) {
         periodic_1Hz(now);
         _last_periodic_1Hz = now;

--- a/libraries/DataFlash/DataFlash_File.cpp
+++ b/libraries/DataFlash/DataFlash_File.cpp
@@ -906,7 +906,7 @@ void DataFlash_File::ListAvailableLogs(AP_HAL::BetterStream *port)
 void DataFlash_File::flush(void)
 {
     uint16_t _tail;
-    uint32_t tnow = hal.scheduler->micros();
+    uint32_t tnow = platform::micros();
     hal.scheduler->suspend_timer_procs();
     while (_write_fd != -1 && _initialised && !_open_error &&
            BUF_AVAILABLE(_writebuf)) {
@@ -933,7 +933,7 @@ void DataFlash_File::_io_timer(void)
     if (nbytes == 0) {
         return;
     }
-    uint32_t tnow = hal.scheduler->micros();
+    uint32_t tnow = platform::micros();
     if (nbytes < _writebuf_chunk && 
         tnow - _last_write_time < 2000000UL) {
         // write in _writebuf_chunk-sized chunks, but always write at

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -32,7 +32,7 @@ void DataFlash_Class::Init(const struct LogStructure *structure, uint8_t num_typ
     backend = new DataFlash_Empty(*this);
 #endif
     if (backend == NULL) {
-        hal.scheduler->panic("Unable to open dataflash");
+        platform::panic("Unable to open dataflash");
     }
     backend->Init(structure, num_types);
 }
@@ -661,7 +661,7 @@ bool DataFlash_Class::Log_Write_Parameter(const char *name, float value)
 {
     struct log_Parameter pkt = {
         LOG_PACKET_HEADER_INIT(LOG_PARAMETER_MSG),
-        time_us : hal.scheduler->micros64(),
+        time_us : platform::micros64(),
         name  : {},
         value : value
     };
@@ -707,7 +707,7 @@ void DataFlash_Class::Log_Write_GPS(const AP_GPS &gps, uint8_t i, int32_t relati
     const struct Location &loc = gps.location(i);
     struct log_GPS pkt = {
         LOG_PACKET_HEADER_INIT((uint8_t)(LOG_GPS_MSG+i)),
-        time_us       : hal.scheduler->micros64(),
+        time_us       : platform::micros64(),
         status        : (uint8_t)gps.status(i),
         gps_week_ms   : gps.time_week_ms(i),
         gps_week      : gps.time_week(i),
@@ -731,7 +731,7 @@ void DataFlash_Class::Log_Write_GPS(const AP_GPS &gps, uint8_t i, int32_t relati
     gps.speed_accuracy(i, sacc);
     struct log_GPA pkt2 = {
         LOG_PACKET_HEADER_INIT((uint8_t)(LOG_GPA_MSG+i)),
-        time_us       : hal.scheduler->micros64(),
+        time_us       : platform::micros64(),
         vdop          : gps.get_vdop(i),
         hacc          : (uint16_t)(hacc*100),
         vacc          : (uint16_t)(vacc*100),
@@ -746,7 +746,7 @@ void DataFlash_Class::Log_Write_RFND(const RangeFinder &rangefinder)
 {
     struct log_RFND pkt = {
         LOG_PACKET_HEADER_INIT((uint8_t)(LOG_RFND_MSG)),
-        time_us       : hal.scheduler->micros64(),
+        time_us       : platform::micros64(),
         dist1         : rangefinder.distance_cm(0),
         dist2         : rangefinder.distance_cm(1)
     };
@@ -758,7 +758,7 @@ void DataFlash_Class::Log_Write_RCIN(void)
 {
     struct log_RCIN pkt = {
         LOG_PACKET_HEADER_INIT(LOG_RCIN_MSG),
-        time_us       : hal.scheduler->micros64(),
+        time_us       : platform::micros64(),
         chan1         : hal.rcin->read(0),
         chan2         : hal.rcin->read(1),
         chan3         : hal.rcin->read(2),
@@ -782,7 +782,7 @@ void DataFlash_Class::Log_Write_RCOUT(void)
 {
     struct log_RCOUT pkt = {
         LOG_PACKET_HEADER_INIT(LOG_RCOUT_MSG),
-        time_us       : hal.scheduler->micros64(),
+        time_us       : platform::micros64(),
         chan1         : hal.rcout->read(0),
         chan2         : hal.rcout->read(1),
         chan3         : hal.rcout->read(2),
@@ -805,7 +805,7 @@ void DataFlash_Class::Log_Write_RSSI(AP_RSSI &rssi)
 {
     struct log_RSSI pkt = {
         LOG_PACKET_HEADER_INIT(LOG_RSSI_MSG),
-        time_us       : hal.scheduler->micros64(),
+        time_us       : platform::micros64(),
         RXRSSI        : rssi.read_receiver_rssi()
     };
     WriteBlock(&pkt, sizeof(pkt));
@@ -814,7 +814,7 @@ void DataFlash_Class::Log_Write_RSSI(AP_RSSI &rssi)
 // Write a BARO packet
 void DataFlash_Class::Log_Write_Baro(AP_Baro &baro)
 {
-    uint64_t time_us = hal.scheduler->micros64();
+    uint64_t time_us = platform::micros64();
     struct log_BARO pkt = {
         LOG_PACKET_HEADER_INIT(LOG_BARO_MSG),
         time_us       : time_us,
@@ -853,7 +853,7 @@ void DataFlash_Class::Log_Write_Baro(AP_Baro &baro)
 // Write an raw accel/gyro data packet
 void DataFlash_Class::Log_Write_IMU(const AP_InertialSensor &ins)
 {
-    uint64_t time_us = hal.scheduler->micros64();
+    uint64_t time_us = platform::micros64();
     const Vector3f &gyro = ins.get_gyro(0);
     const Vector3f &accel = ins.get_accel(0);
     struct log_IMU pkt = {
@@ -926,7 +926,7 @@ void DataFlash_Class::Log_Write_IMUDT(const AP_InertialSensor &ins)
     ins.get_delta_angle(0, delta_angle);
     ins.get_delta_velocity(0, delta_velocity);
 
-    uint64_t time_us = hal.scheduler->micros64();
+    uint64_t time_us = platform::micros64();
     struct log_IMUDT pkt = {
         LOG_PACKET_HEADER_INIT(LOG_IMUDT_MSG),
         time_us : time_us,
@@ -992,7 +992,7 @@ void DataFlash_Class::Log_Write_IMUDT(const AP_InertialSensor &ins)
 
 void DataFlash_Class::Log_Write_Vibration(const AP_InertialSensor &ins)
 {
-    uint64_t time_us = hal.scheduler->micros64();
+    uint64_t time_us = platform::micros64();
     Vector3f vibration = ins.get_vibration_levels();
     struct log_Vibe pkt = {
         LOG_PACKET_HEADER_INIT(LOG_VIBE_MSG),
@@ -1046,7 +1046,7 @@ bool DataFlash_Class::Log_Write_Message(const char *message)
 {
     struct log_Message pkt = {
         LOG_PACKET_HEADER_INIT(LOG_MESSAGE_MSG),
-        time_us : hal.scheduler->micros64(),
+        time_us : platform::micros64(),
         msg  : {}
     };
     strncpy(pkt.msg, message, sizeof(pkt.msg));
@@ -1058,7 +1058,7 @@ void DataFlash_Class::Log_Write_Power(void)
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4
     struct log_POWR pkt = {
         LOG_PACKET_HEADER_INIT(LOG_POWR_MSG),
-        time_us : hal.scheduler->micros64(),
+        time_us : platform::micros64(),
         Vcc     : (uint16_t)(hal.analogin->board_voltage() * 100),
         Vservo  : (uint16_t)(hal.analogin->servorail_voltage() * 100),
         flags   : hal.analogin->power_status_flags()
@@ -1077,7 +1077,7 @@ void DataFlash_Class::Log_Write_AHRS2(AP_AHRS &ahrs)
     }
     struct log_AHRS pkt = {
         LOG_PACKET_HEADER_INIT(LOG_AHR2_MSG),
-        time_us : hal.scheduler->micros64(),
+        time_us : platform::micros64(),
         roll  : (int16_t)(degrees(euler.x)*100),
         pitch : (int16_t)(degrees(euler.y)*100),
         yaw   : (uint16_t)(wrap_360_cd(degrees(euler.z)*100)),
@@ -1099,7 +1099,7 @@ void DataFlash_Class::Log_Write_POS(AP_AHRS &ahrs)
     ahrs.get_relative_position_NED(pos);
     struct log_POS pkt = {
         LOG_PACKET_HEADER_INIT(LOG_POS_MSG),
-        time_us : hal.scheduler->micros64(),
+        time_us : platform::micros64(),
         lat     : loc.lat,
         lng     : loc.lng,
         alt     : loc.alt*1.0e-2f,
@@ -1128,7 +1128,7 @@ void DataFlash_Class::Log_Write_EKF(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
         posDownDeriv = ahrs.get_NavEKF().getPosDownDerivative();
         struct log_EKF1 pkt = {
             LOG_PACKET_HEADER_INIT(LOG_EKF1_MSG),
-            time_us : hal.scheduler->micros64(),
+            time_us : platform::micros64(),
             roll    : (int16_t)(100*degrees(euler.x)), // roll angle (centi-deg, displayed as deg due to format string)
             pitch   : (int16_t)(100*degrees(euler.y)), // pitch angle (centi-deg, displayed as deg due to format string)
             yaw     : (uint16_t)wrap_360_cd(100*degrees(euler.z)), // yaw angle (centi-deg, displayed as deg due to format string)
@@ -1158,7 +1158,7 @@ void DataFlash_Class::Log_Write_EKF(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
         ahrs.get_NavEKF().getMagXYZ(magXYZ);
         struct log_EKF2 pkt2 = {
             LOG_PACKET_HEADER_INIT(LOG_EKF2_MSG),
-            time_us : hal.scheduler->micros64(),
+            time_us : platform::micros64(),
             Ratio   : (int8_t)(100*ratio),
             AZ1bias : (int8_t)(100*az1bias),
             AZ2bias : (int8_t)(100*az2bias),
@@ -1181,7 +1181,7 @@ void DataFlash_Class::Log_Write_EKF(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
         ahrs.get_NavEKF().getInnovations(velInnov, posInnov, magInnov, tasInnov);
         struct log_EKF3 pkt3 = {
             LOG_PACKET_HEADER_INIT(LOG_EKF3_MSG),
-            time_us : hal.scheduler->micros64(),
+            time_us : platform::micros64(),
             innovVN : (int16_t)(100*velInnov.x),
             innovVE : (int16_t)(100*velInnov.y),
             innovVD : (int16_t)(100*velInnov.z),
@@ -1212,7 +1212,7 @@ void DataFlash_Class::Log_Write_EKF(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
         ahrs.get_NavEKF().getFilterGpsStatus(gpsStatus);
         struct log_EKF4 pkt4 = {
             LOG_PACKET_HEADER_INIT(LOG_EKF4_MSG),
-            time_us : hal.scheduler->micros64(),
+            time_us : platform::micros64(),
             sqrtvarV : (int16_t)(100*velVar),
             sqrtvarP : (int16_t)(100*posVar),
             sqrtvarH : (int16_t)(100*hgtVar),
@@ -1243,7 +1243,7 @@ void DataFlash_Class::Log_Write_EKF(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
             ahrs.get_NavEKF().getFlowDebug(normInnov, gndOffset, flowInnovX, flowInnovY, auxFlowInnov, HAGL, rngInnov, range, gndOffsetErr);
             struct log_EKF5 pkt5 = {
                 LOG_PACKET_HEADER_INIT(LOG_EKF5_MSG),
-                time_us : hal.scheduler->micros64(),
+                time_us : platform::micros64(),
                 normInnov : (uint8_t)(min(100*normInnov,255)),
                 FIX : (int16_t)(1000*flowInnovX),
                 FIY : (int16_t)(1000*flowInnovY),
@@ -1281,7 +1281,7 @@ void DataFlash_Class::Log_Write_EKF2(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
     posDownDeriv = ahrs.get_NavEKF2().getPosDownDerivative(0);
     struct log_EKF1 pkt = {
         LOG_PACKET_HEADER_INIT(LOG_NKF1_MSG),
-        time_us : hal.scheduler->micros64(),
+        time_us : platform::micros64(),
         roll    : (int16_t)(100*degrees(euler.x)), // roll angle (centi-deg, displayed as deg due to format string)
         pitch   : (int16_t)(100*degrees(euler.y)), // pitch angle (centi-deg, displayed as deg due to format string)
         yaw     : (uint16_t)wrap_360_cd(100*degrees(euler.z)), // yaw angle (centi-deg, displayed as deg due to format string)
@@ -1312,7 +1312,7 @@ void DataFlash_Class::Log_Write_EKF2(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
     ahrs.get_NavEKF2().getGyroScaleErrorPercentage(0,gyroScaleFactor);
     struct log_NKF2 pkt2 = {
         LOG_PACKET_HEADER_INIT(LOG_NKF2_MSG),
-        time_us : hal.scheduler->micros64(),
+        time_us : platform::micros64(),
         AZbias  : (int8_t)(100*azbias),
         scaleX  : (int16_t)(100*gyroScaleFactor.x),
         scaleY  : (int16_t)(100*gyroScaleFactor.y),
@@ -1338,7 +1338,7 @@ void DataFlash_Class::Log_Write_EKF2(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
     ahrs.get_NavEKF2().getInnovations(0,velInnov, posInnov, magInnov, tasInnov, yawInnov);
     struct log_NKF3 pkt3 = {
         LOG_PACKET_HEADER_INIT(LOG_NKF3_MSG),
-        time_us : hal.scheduler->micros64(),
+        time_us : platform::micros64(),
         innovVN : (int16_t)(100*velInnov.x),
         innovVE : (int16_t)(100*velInnov.y),
         innovVD : (int16_t)(100*velInnov.z),
@@ -1374,7 +1374,7 @@ void DataFlash_Class::Log_Write_EKF2(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
     uint8_t primaryIndex = ahrs.get_NavEKF2().getPrimaryCoreIndex();
     struct log_NKF4 pkt4 = {
         LOG_PACKET_HEADER_INIT(LOG_NKF4_MSG),
-        time_us : hal.scheduler->micros64(),
+        time_us : platform::micros64(),
         sqrtvarV : (int16_t)(100*velVar),
         sqrtvarP : (int16_t)(100*posVar),
         sqrtvarH : (int16_t)(100*hgtVar),
@@ -1404,7 +1404,7 @@ void DataFlash_Class::Log_Write_EKF2(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
         ahrs.get_NavEKF2().getFlowDebug(-1,normInnov, gndOffset, flowInnovX, flowInnovY, auxFlowInnov, HAGL, rngInnov, range, gndOffsetErr);
         struct log_EKF5 pkt5 = {
             LOG_PACKET_HEADER_INIT(LOG_NKF5_MSG),
-            time_us : hal.scheduler->micros64(),
+            time_us : platform::micros64(),
             normInnov : (uint8_t)(min(100*normInnov,255)),
             FIX : (int16_t)(1000*flowInnovX),
             FIY : (int16_t)(1000*flowInnovY),
@@ -1428,7 +1428,7 @@ void DataFlash_Class::Log_Write_EKF2(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
         posDownDeriv = ahrs.get_NavEKF2().getPosDownDerivative(1);
         struct log_EKF1 pkt6 = {
             LOG_PACKET_HEADER_INIT(LOG_NKF6_MSG),
-            time_us : hal.scheduler->micros64(),
+            time_us : platform::micros64(),
             roll    : (int16_t)(100*degrees(euler.x)), // roll angle (centi-deg, displayed as deg due to format string)
             pitch   : (int16_t)(100*degrees(euler.y)), // pitch angle (centi-deg, displayed as deg due to format string)
             yaw     : (uint16_t)wrap_360_cd(100*degrees(euler.z)), // yaw angle (centi-deg, displayed as deg due to format string)
@@ -1454,7 +1454,7 @@ void DataFlash_Class::Log_Write_EKF2(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
         magIndex = ahrs.get_NavEKF2().getActiveMag(1);
         struct log_NKF2 pkt7 = {
             LOG_PACKET_HEADER_INIT(LOG_NKF7_MSG),
-            time_us : hal.scheduler->micros64(),
+            time_us : platform::micros64(),
             AZbias  : (int8_t)(100*azbias),
             scaleX  : (int16_t)(100*gyroScaleFactor.x),
             scaleY  : (int16_t)(100*gyroScaleFactor.y),
@@ -1475,7 +1475,7 @@ void DataFlash_Class::Log_Write_EKF2(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
         ahrs.get_NavEKF2().getInnovations(1,velInnov, posInnov, magInnov, tasInnov, yawInnov);
         struct log_NKF3 pkt8 = {
             LOG_PACKET_HEADER_INIT(LOG_NKF8_MSG),
-            time_us : hal.scheduler->micros64(),
+            time_us : platform::micros64(),
             innovVN : (int16_t)(100*velInnov.x),
             innovVE : (int16_t)(100*velInnov.y),
             innovVD : (int16_t)(100*velInnov.z),
@@ -1500,7 +1500,7 @@ void DataFlash_Class::Log_Write_EKF2(AP_AHRS_NavEKF &ahrs, bool optFlowEnabled)
         ahrs.get_NavEKF2().getTiltError(1,tiltError);
         struct log_NKF4 pkt9 = {
             LOG_PACKET_HEADER_INIT(LOG_NKF9_MSG),
-            time_us : hal.scheduler->micros64(),
+            time_us : platform::micros64(),
             sqrtvarV : (int16_t)(100*velVar),
             sqrtvarP : (int16_t)(100*posVar),
             sqrtvarH : (int16_t)(100*hgtVar),
@@ -1525,7 +1525,7 @@ bool DataFlash_Class::Log_Write_MavCmd(uint16_t cmd_total, const mavlink_mission
 {
     struct log_Cmd pkt = {
         LOG_PACKET_HEADER_INIT(LOG_CMD_MSG),
-        time_us         : hal.scheduler->micros64(),
+        time_us         : platform::micros64(),
         command_total   : (uint16_t)cmd_total,
         sequence        : (uint16_t)mav_cmd.seq,
         command         : (uint16_t)mav_cmd.command,
@@ -1544,7 +1544,7 @@ void DataFlash_Class::Log_Write_Radio(const mavlink_radio_t &packet)
 {
     struct log_Radio pkt = {
         LOG_PACKET_HEADER_INIT(LOG_RADIO_MSG),
-        time_us      : hal.scheduler->micros64(),
+        time_us      : platform::micros64(),
         rssi         : packet.rssi,
         remrssi      : packet.remrssi,
         txbuf        : packet.txbuf,
@@ -1570,7 +1570,7 @@ void DataFlash_Class::Log_Write_Camera(const AP_AHRS &ahrs, const AP_GPS &gps, c
 
     struct log_Camera pkt = {
         LOG_PACKET_HEADER_INIT(LOG_CAMERA_MSG),
-        time_us     : hal.scheduler->micros64(),
+        time_us     : platform::micros64(),
         gps_time    : gps.time_week_ms(),
         gps_week    : gps.time_week(),
         latitude    : current_loc.lat,
@@ -1589,7 +1589,7 @@ void DataFlash_Class::Log_Write_Attitude(AP_AHRS &ahrs, const Vector3f &targets)
 {
     struct log_Attitude pkt = {
         LOG_PACKET_HEADER_INIT(LOG_ATTITUDE_MSG),
-        time_us         : hal.scheduler->micros64(),
+        time_us         : platform::micros64(),
         control_roll    : (int16_t)targets.x,
         roll            : (int16_t)ahrs.roll_sensor,
         control_pitch   : (int16_t)targets.y,
@@ -1608,7 +1608,7 @@ void DataFlash_Class::Log_Write_Current(const AP_BattMonitor &battery, int16_t t
     float voltage2 = battery.voltage2();
     struct log_Current pkt = {
         LOG_PACKET_HEADER_INIT(LOG_CURRENT_MSG),
-        time_us             : hal.scheduler->micros64(),
+        time_us             : platform::micros64(),
         throttle        	: throttle,
         battery_voltage     : (int16_t) (battery.voltage() * 100.0f),
         current_amps        : (int16_t) (battery.current_amps() * 100.0f),
@@ -1627,7 +1627,7 @@ void DataFlash_Class::Log_Write_Compass(const Compass &compass)
     const Vector3f &mag_motor_offsets = compass.get_motor_offsets(0);   
     struct log_Compass pkt = {
         LOG_PACKET_HEADER_INIT(LOG_COMPASS_MSG),
-        time_us         : hal.scheduler->micros64(),
+        time_us         : platform::micros64(),
         mag_x           : (int16_t)mag_field.x,
         mag_y           : (int16_t)mag_field.y,
         mag_z           : (int16_t)mag_field.z,
@@ -1647,7 +1647,7 @@ void DataFlash_Class::Log_Write_Compass(const Compass &compass)
         const Vector3f &mag_motor_offsets2 = compass.get_motor_offsets(1);   
         struct log_Compass pkt2 = {
             LOG_PACKET_HEADER_INIT(LOG_COMPASS2_MSG),
-            time_us         : hal.scheduler->micros64(),
+            time_us         : platform::micros64(),
             mag_x           : (int16_t)mag_field2.x,
             mag_y           : (int16_t)mag_field2.y,
             mag_z           : (int16_t)mag_field2.z,
@@ -1668,7 +1668,7 @@ void DataFlash_Class::Log_Write_Compass(const Compass &compass)
         const Vector3f &mag_motor_offsets3 = compass.get_motor_offsets(2);   
         struct log_Compass pkt3 = {
             LOG_PACKET_HEADER_INIT(LOG_COMPASS3_MSG),
-            time_us         : hal.scheduler->micros64(),
+            time_us         : platform::micros64(),
             mag_x           : (int16_t)mag_field3.x,
             mag_y           : (int16_t)mag_field3.y,
             mag_z           : (int16_t)mag_field3.z,
@@ -1689,7 +1689,7 @@ bool DataFlash_Class::Log_Write_Mode(uint8_t mode)
 {
     struct log_Mode pkt = {
         LOG_PACKET_HEADER_INIT(LOG_MODE_MSG),
-        time_us  : hal.scheduler->micros64(),
+        time_us  : platform::micros64(),
         mode     : mode,
         mode_num : mode
     };
@@ -1715,7 +1715,7 @@ void DataFlash_Class::Log_Write_ESC(void)
         if (esc_status.esc_count > 8) {
             esc_status.esc_count = 8;
         }
-        uint64_t time_us = hal.scheduler->micros64();
+        uint64_t time_us = platform::micros64();
         for (uint8_t i = 0; i < esc_status.esc_count; i++) {
             // skip logging ESCs with a esc_address of zero, and this
             // are probably not populated. The Pixhawk itself should
@@ -1746,7 +1746,7 @@ void DataFlash_Class::Log_Write_Airspeed(AP_Airspeed &airspeed)
     }
     struct log_AIRSPEED pkt = {
         LOG_PACKET_HEADER_INIT(LOG_ARSP_MSG),
-        time_us       : hal.scheduler->micros64(),
+        time_us       : platform::micros64(),
         airspeed      : airspeed.get_raw_airspeed(),
         diffpressure  : airspeed.get_differential_pressure(),
         temperature   : (int16_t)(temperature * 100.0f),
@@ -1761,7 +1761,7 @@ void DataFlash_Class::Log_Write_PID(uint8_t msg_type, const PID_Info &info)
 {
     struct log_PID pkt = {
         LOG_PACKET_HEADER_INIT(msg_type),
-        time_us         : hal.scheduler->micros64(),
+        time_us         : platform::micros64(),
         desired         : info.desired,
         P               : info.P,
         I               : info.I,
@@ -1774,7 +1774,7 @@ void DataFlash_Class::Log_Write_PID(uint8_t msg_type, const PID_Info &info)
 
 void DataFlash_Class::Log_Write_Origin(uint8_t origin_type, const Location &loc)
 {
-    uint64_t time_us = hal.scheduler->micros64();
+    uint64_t time_us = platform::micros64();
     struct log_ORGN pkt = {
         LOG_PACKET_HEADER_INIT(LOG_ORGN_MSG),
         time_us     : time_us,
@@ -1790,7 +1790,7 @@ void DataFlash_Class::Log_Write_RPM(const AP_RPM &rpm_sensor)
 {
     struct log_RPM pkt = {
         LOG_PACKET_HEADER_INIT(LOG_RPM_MSG),
-        time_us     : hal.scheduler->micros64(),
+        time_us     : platform::micros64(),
         rpm1        : rpm_sensor.get_rpm(0),
         rpm2        : rpm_sensor.get_rpm(1)
     };

--- a/libraries/DataFlash/examples/DataFlash_test/DataFlash_test.cpp
+++ b/libraries/DataFlash/examples/DataFlash_test/DataFlash_test.cpp
@@ -67,7 +67,7 @@ void DataFlashTest::setup(void)
     uint16_t i;
 
     for (i = 0; i < NUM_PACKETS; i++) {
-        uint32_t start = hal.scheduler->micros();
+        uint32_t start = platform::micros();
         // note that we use g++ style initialisers to make larger
         // structures easier to follow        
         struct log_Test pkt = {
@@ -80,7 +80,7 @@ void DataFlashTest::setup(void)
             l2    : (int32_t)(i * 16268)
         };
         dataflash.WriteBlock(&pkt, sizeof(pkt));
-        total_micros += hal.scheduler->micros() - start;
+        total_micros += platform::micros() - start;
         hal.scheduler->delay(20);
     }
 

--- a/libraries/Filter/examples/Derivative/Derivative.cpp
+++ b/libraries/Filter/examples/Derivative/Derivative.cpp
@@ -22,10 +22,10 @@ static float noise(void)
 void loop()
 {
     hal.scheduler->delay(50);
-    float t = hal.scheduler->millis()*1.0e-3f;
+    float t = platform::millis()*1.0e-3f;
     float s = sinf(t);
     //s += noise();
-    uint32_t t1 = hal.scheduler->micros();
+    uint32_t t1 = platform::micros();
     derivative.update(s, t1);
     float output = derivative.slope() * 1.0e6f;
     hal.console->printf("%f %f %f %f\n", t, output, s, cosf(t));

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -131,7 +131,7 @@ GCS_MAVLINK::queued_param_send()
 
     uint16_t bytes_allowed;
     uint8_t count;
-    uint32_t tnow = hal.scheduler->millis();
+    uint32_t tnow = platform::millis();
 
     // use at most 30% of bandwidth on parameters. The constant 26 is
     // 1/(1000 * 1/8 * 0.001 * 0.3)
@@ -193,7 +193,7 @@ GCS_MAVLINK::queued_waypoint_send()
 }
 
 void GCS_MAVLINK::reset_cli_timeout() {
-      _cli_timeout = hal.scheduler->millis();
+    _cli_timeout = platform::millis();
 }
 
 void GCS_MAVLINK::send_meminfo(void)
@@ -355,7 +355,7 @@ void GCS_MAVLINK::handle_mission_count(AP_Mission &mission, mavlink_message_t *m
     mission.truncate(packet.count);
 
     // set variables to help handle the expected receiving of commands from the GCS
-    waypoint_timelast_receive = hal.scheduler->millis();    // set time we last received commands to now
+    waypoint_timelast_receive = platform::millis();    // set time we last received commands to now
     waypoint_receiving = true;              // record that we expect to receive commands
     waypoint_request_i = 0;                 // reset the next expected command number to zero
     waypoint_request_last = packet.count;   // record how many commands we expect to receive
@@ -398,7 +398,7 @@ void GCS_MAVLINK::handle_mission_write_partial_list(AP_Mission &mission, mavlink
         return;
     }
 
-    waypoint_timelast_receive = hal.scheduler->millis();
+    waypoint_timelast_receive = platform::millis();
     waypoint_timelast_request = 0;
     waypoint_receiving   = true;
     waypoint_request_i   = packet.start_index;
@@ -623,7 +623,7 @@ void GCS_MAVLINK::handle_radio_status(mavlink_message_t *msg, DataFlash_Class &d
     // record if the GCS has been receiving radio messages from
     // the aircraft
     if (packet.remrssi != 0) {
-        last_radio_status_remrssi_ms = hal.scheduler->millis();
+        last_radio_status_remrssi_ms = platform::millis();
     }
 
     // use the state of the transmit buffer in the radio to
@@ -724,7 +724,7 @@ bool GCS_MAVLINK::handle_mission_item(mavlink_message_t *msg, AP_Mission &missio
     }
     
     // update waypoint receiving state machine
-    waypoint_timelast_receive = hal.scheduler->millis();
+    waypoint_timelast_receive = platform::millis();
     waypoint_request_i++;
     
     if (waypoint_request_i >= waypoint_request_last) {
@@ -741,7 +741,7 @@ bool GCS_MAVLINK::handle_mission_item(mavlink_message_t *msg, AP_Mission &missio
         // XXX ignores waypoint radius for individual waypoints, can
         // only set WP_RADIUS parameter
     } else {
-        waypoint_timelast_request = hal.scheduler->millis();
+        waypoint_timelast_request = platform::millis();
         // if we have enough space, then send the next WP immediately
         if (comm_get_txspace(chan) >= 
             MAVLINK_NUM_NON_PAYLOAD_BYTES+MAVLINK_MSG_ID_MISSION_ITEM_LEN) {
@@ -841,7 +841,7 @@ GCS_MAVLINK::update(run_cli_fn run_cli)
         if (run_cli) {
             /* allow CLI to be started by hitting enter 3 times, if no
              *  heartbeat packets have been received */
-            if ((mavlink_active==0) && (hal.scheduler->millis() - _cli_timeout) < 20000 && 
+            if ((mavlink_active==0) && (platform::millis() - _cli_timeout) < 20000 && 
                 comm_is_idle(chan)) {
                 if (c == '\n' || c == '\r') {
                     crlf_count++;
@@ -875,7 +875,7 @@ GCS_MAVLINK::update(run_cli_fn run_cli)
         return;
     }
 
-    uint32_t tnow = hal.scheduler->millis();
+    uint32_t tnow = platform::millis();
     uint32_t wp_recv_time = 1000U + (stream_slowdown*20);
 
     if (waypoint_receiving &&
@@ -940,7 +940,7 @@ void GCS_MAVLINK::send_system_time(AP_GPS &gps)
     mavlink_msg_system_time_send(
         chan,
         gps.time_epoch_usec(),
-        hal.scheduler->millis());
+        platform::millis());
 }
 
 
@@ -949,7 +949,7 @@ void GCS_MAVLINK::send_system_time(AP_GPS &gps)
  */
 void GCS_MAVLINK::send_radio_in(uint8_t receiver_rssi)
 {
-    uint32_t now = hal.scheduler->millis();
+    uint32_t now = platform::millis();
 
     uint16_t values[8];
     memset(values, 0, sizeof(values));
@@ -1010,7 +1010,7 @@ void GCS_MAVLINK::send_raw_imu(const AP_InertialSensor &ins, const Compass &comp
 
     mavlink_msg_raw_imu_send(
         chan,
-        hal.scheduler->micros(),
+        platform::micros(),
         accel.x * 1000.0f / GRAVITY_MSS,
         accel.y * 1000.0f / GRAVITY_MSS,
         accel.z * 1000.0f / GRAVITY_MSS,
@@ -1035,7 +1035,7 @@ void GCS_MAVLINK::send_raw_imu(const AP_InertialSensor &ins, const Compass &comp
     }
     mavlink_msg_scaled_imu2_send(
         chan,
-        hal.scheduler->millis(),
+        platform::millis(),
         accel2.x * 1000.0f / GRAVITY_MSS,
         accel2.y * 1000.0f / GRAVITY_MSS,
         accel2.z * 1000.0f / GRAVITY_MSS,
@@ -1060,7 +1060,7 @@ void GCS_MAVLINK::send_raw_imu(const AP_InertialSensor &ins, const Compass &comp
     }
     mavlink_msg_scaled_imu3_send(
         chan,
-        hal.scheduler->millis(),
+        platform::millis(),
         accel3.x * 1000.0f / GRAVITY_MSS,
         accel3.y * 1000.0f / GRAVITY_MSS,
         accel3.z * 1000.0f / GRAVITY_MSS,
@@ -1074,7 +1074,7 @@ void GCS_MAVLINK::send_raw_imu(const AP_InertialSensor &ins, const Compass &comp
 
 void GCS_MAVLINK::send_scaled_pressure(AP_Baro &barometer)
 {
-    uint32_t now = hal.scheduler->millis();
+    uint32_t now = platform::millis();
     float pressure = barometer.get_pressure(0);
     mavlink_msg_scaled_pressure_send(
         chan,
@@ -1253,7 +1253,7 @@ void GCS_MAVLINK::send_opticalflow(AP_AHRS_NavEKF &ahrs, const OpticalFlow &optf
     // populate and send message
     mavlink_msg_optical_flow_send(
         chan,
-        hal.scheduler->millis(),
+        platform::millis(),
         0, // sensor id is zero
         flowRate.x,
         flowRate.y,
@@ -1334,7 +1334,7 @@ void GCS_MAVLINK::send_local_position(const AP_AHRS &ahrs) const
 
     mavlink_msg_local_position_ned_send(
         chan,
-        hal.scheduler->millis(),
+        platform::millis(),
         local_position.x,
         local_position.y,
         local_position.z,
@@ -1352,7 +1352,7 @@ void GCS_MAVLINK::send_vibration(const AP_InertialSensor &ins) const
 
     mavlink_msg_vibration_send(
         chan,
-        hal.scheduler->micros64(),
+        platform::micros64(),
         vibration.x,
         vibration.y,
         vibration.z,

--- a/libraries/GCS_MAVLink/GCS_Logs.cpp
+++ b/libraries/GCS_MAVLink/GCS_Logs.cpp
@@ -185,7 +185,7 @@ void GCS_MAVLINK::handle_log_send_listing(DataFlash_Class &dataflash)
         // no space
         return;
     }
-    if (hal.scheduler->millis() - last_heartbeat_time > 3000) {
+    if (platform::millis() - last_heartbeat_time > 3000) {
         // give a heartbeat a chance
         return;
     }
@@ -215,7 +215,7 @@ bool GCS_MAVLINK::handle_log_send_data(DataFlash_Class &dataflash)
         // no space
         return false;
     }
-    if (hal.scheduler->millis() - last_heartbeat_time > 3000) {
+    if (platform::millis() - last_heartbeat_time > 3000) {
         // give a heartbeat a chance
         return false;
     }

--- a/libraries/PID/PID.cpp
+++ b/libraries/PID/PID.cpp
@@ -21,7 +21,7 @@ const AP_Param::GroupInfo PID::var_info[] = {
 
 float PID::get_pid(float error, float scaler)
 {
-    uint32_t tnow = hal.scheduler->millis();
+    uint32_t tnow = platform::millis();
     uint32_t dt = tnow - _last_t;
     float output            = 0;
     float delta_time;

--- a/libraries/SITL/SIM_Gimbal.cpp
+++ b/libraries/SITL/SIM_Gimbal.cpp
@@ -50,7 +50,7 @@ Gimbal::Gimbal(const struct sitl_fdm &_fdm) :
 void Gimbal::update(void)
 {
     // calculate delta time in seconds
-    uint32_t now_us = hal.scheduler->micros();
+    uint32_t now_us = platform::micros();
 
     float delta_t = (now_us - last_update_us) * 1.0e-6f;
     last_update_us = now_us;
@@ -230,7 +230,7 @@ void Gimbal::send_report(void)
     if (!seen_heartbeat) {
         return;
     }
-    uint32_t now = hal.scheduler->millis();
+    uint32_t now = platform::millis();
     mavlink_message_t msg;
     uint16_t len;
 
@@ -262,7 +262,7 @@ void Gimbal::send_report(void)
     /*
       send a GIMBAL_REPORT message
      */
-    uint32_t now_us = hal.scheduler->micros();
+    uint32_t now_us = platform::micros();
     if (now_us - last_report_us > reporting_period_ms*1000UL) {
         mavlink_gimbal_report_t gimbal_report;
         float delta_time = (now_us - last_report_us) * 1.0e-6f;

--- a/libraries/SITL/SIM_JSBSim.cpp
+++ b/libraries/SITL/SIM_JSBSim.cpp
@@ -80,7 +80,7 @@ bool JSBSim::create_templates(void)
 
     FILE *f = fopen(jsbsim_script, "w");
     if (f == NULL) {
-        hal.scheduler->panic("Unable to create jsbsim script %s", jsbsim_script);
+        platform::panic("Unable to create jsbsim script %s", jsbsim_script);
     }
     fprintf(f,
 "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
@@ -125,7 +125,7 @@ bool JSBSim::create_templates(void)
 
     f = fopen(jsbsim_fgout, "w");
     if (f == NULL) {
-        hal.scheduler->panic("Unable to create jsbsim fgout script %s", jsbsim_fgout);
+        platform::panic("Unable to create jsbsim fgout script %s", jsbsim_fgout);
     }
     fprintf(f, "<?xml version=\"1.0\"?>\n"
             "<output name=\"127.0.0.1\" type=\"FLIGHTGEAR\" port=\"%u\" protocol=\"udp\" rate=\"1000\"/>\n",
@@ -136,7 +136,7 @@ bool JSBSim::create_templates(void)
     asprintf(&jsbsim_reset, "%s/aircraft/%s/reset.xml", autotest_dir, jsbsim_model);
     f = fopen(jsbsim_reset, "w");
     if (f == NULL) {
-        hal.scheduler->panic("Unable to create jsbsim reset script %s", jsbsim_reset);
+        platform::panic("Unable to create jsbsim reset script %s", jsbsim_reset);
     }
     float r, p, y;
     dcm.to_euler(&r, &p, &y);
@@ -177,7 +177,7 @@ bool JSBSim::start_JSBSim(void)
     int p[2];
     int devnull = open("/dev/null", O_RDWR);
     if (pipe(p) != 0) {
-        hal.scheduler->panic("Unable to create pipe");
+        platform::panic("Unable to create pipe");
     }
     pid_t child_pid = fork();
     if (child_pid == 0) {
@@ -219,14 +219,14 @@ bool JSBSim::start_JSBSim(void)
     // read startup to be sure it is running
     char c;
     if (read(jsbsim_stdout, &c, 1) != 1) {
-        hal.scheduler->panic("Unable to start JSBSim");
+        platform::panic("Unable to start JSBSim");
     }
 
     if (!expect("JSBSim Execution beginning")) {
-        hal.scheduler->panic("Failed to start JSBSim");
+        platform::panic("Failed to start JSBSim");
     }
     if (!open_control_socket()) {
-        hal.scheduler->panic("Failed to open JSBSim control socket");
+        platform::panic("Failed to open JSBSim control socket");
     }
 
     fcntl(jsbsim_stdout, F_SETFL, fcntl(jsbsim_stdout, F_GETFL, 0) | O_NONBLOCK);

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -116,7 +116,7 @@ void SITL::Log_Write_SIMSTATE(DataFlash_Class &DataFlash)
 
     struct log_AHRS pkt = {
         LOG_PACKET_HEADER_INIT(LOG_SIMSTATE_MSG),
-        time_us : hal.scheduler->micros64(),
+        time_us : platform::micros64(),
         roll    : (int16_t)(state.rollDeg*100),
         pitch   : (int16_t)(state.pitchDeg*100),
         yaw     : (uint16_t)(wrap_360_cd(yaw*100)),


### PR DESCRIPTION
Introduce a new namespace 'platform' for functions that are unlikely to change after link time and would have no benefit from explicit indirection. This includes: `panic()`, `millis()`, `micros()`. The idea is that those basic utility functions could be provided as regular functions instead of virtual functions.

Attention: this PR contains multiple commits, each one has it's own detailed explanation.