### PR TITLE
EKF2 - Improved use of GPS and range finder data for height

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -196,10 +196,10 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
 
     // @Param: ALT_SOURCE
     // @DisplayName: Primary height source
-    // @Description: This parameter controls which height sensor is used by the EKF during optical flow navigation (when EKF_GPS_TYPE = 3). A value of will 0 cause it to always use baro altitude. A value of 1 will casue it to use range finder if available.
-    // @Values: 0:Use Baro, 1:Use Range Finder
+    // @Description: This parameter controls which height sensor is used by the EKF. If the selected optionn cannot be used, it will default to Baro as the primary height source. Setting 0 will use the baro altitude at all times. Setting 1 uses the range finder and is only available in combination with optical flow navigation (EK2_GPS_TYPE = 3). Setting 2 uses GPS.
+    // @Values: 0:Use Baro, 1:Use Range Finder, 2:Use GPS
     // @User: Advanced
-    AP_GROUPINFO("ALT_SOURCE", 9, NavEKF2, _altSource, 1),
+    AP_GROUPINFO("ALT_SOURCE", 9, NavEKF2, _altSource, 0),
 
     // @Param: ALT_NOISE
     // @DisplayName: Altitude measurement noise (m)

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -450,7 +450,7 @@ NavEKF2::NavEKF2(const AP_AHRS *ahrs, AP_Baro &baro, const RangeFinder &rng) :
     flowIntervalMax_ms(100),        // maximum allowable time between flow fusion events
     gndEffectTimeout_ms(1000),      // time in msec that baro ground effect compensation will timeout after initiation
     gndEffectBaroScaler(4.0f),      // scaler applied to the barometer observation variance when operating in ground effect
-    gndGradientSigma(2),            // RMS terrain gradient percentage assumed by the terrain height estimation
+    gndGradientSigma(50),           // RMS terrain gradient percentage assumed by the terrain height estimation
     fusionTimeStep_ms(10)           // The minimum number of msec between covariance prediction and fusion operations
 {
     AP_Param::setup_object_defaults(this, var_info);

--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -139,16 +139,16 @@ void NavEKF2_core::SelectMagFusion()
     }
 
     // check for availability of magnetometer data to fuse
-    bool newMagDataAvailable = RecallMag();
+    magDataToFuse = RecallMag();
 
-    if (newMagDataAvailable) {
+    if (magDataToFuse) {
         // Control reset of yaw and magnetic field states
         controlMagYawReset();
     }
 
     // determine if conditions are right to start a new fusion cycle
     // wait until the EKF time horizon catches up with the measurement
-    bool dataReady = (newMagDataAvailable && statesInitialised && use_compass() && yawAlignComplete);
+    bool dataReady = (magDataToFuse && statesInitialised && use_compass() && yawAlignComplete);
     if (dataReady) {
         // If we haven't performed the first airborne magnetic field update or have inhibited magnetic field learning, then we use the simple method of declination to maintain heading
         if(inhibitMagStates) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -18,7 +18,7 @@ extern const AP_HAL::HAL& hal;
 ********************************************************/
 
 // Read the range finder and take new measurements if available
-// Read at 20Hz and apply a median filter
+// Apply a median filter
 void NavEKF2_core::readRangeFinder(void)
 {
     uint8_t midIndex;
@@ -26,19 +26,31 @@ void NavEKF2_core::readRangeFinder(void)
     uint8_t minIndex;
     // get theoretical correct range when the vehicle is on the ground
     rngOnGnd = frontend->_rng.ground_clearance_cm() * 0.01f;
-    if (frontend->_rng.status() == RangeFinder::RangeFinder_Good && (imuSampleTime_ms - lastRngMeasTime_ms) > 50) {
-        // store samples and sample time into a ring buffer
-        rngMeasIndex ++;
-        if (rngMeasIndex > 2) {
-            rngMeasIndex = 0;
+
+    // read range finder at 20Hz
+    // TODO better way of knowing if it has new data
+    if ((imuSampleTime_ms - lastRngMeasTime_ms) > 50) {
+
+        // reset the timer used to control the measurement rate
+        lastRngMeasTime_ms =  imuSampleTime_ms;
+
+        // store samples and sample time into a ring buffer if valid
+        if (frontend->_rng.status() == RangeFinder::RangeFinder_Good) {
+            rngMeasIndex ++;
+            if (rngMeasIndex > 2) {
+                rngMeasIndex = 0;
+            }
+            storedRngMeasTime_ms[rngMeasIndex] = imuSampleTime_ms - 25;
+            storedRngMeas[rngMeasIndex] = frontend->_rng.distance_cm() * 0.01f;
         }
-        storedRngMeasTime_ms[rngMeasIndex] = imuSampleTime_ms;
-        storedRngMeas[rngMeasIndex] = frontend->_rng.distance_cm() * 0.01f;
-        // check for three fresh samples and take median
+
+        // check for three fresh samples
         bool sampleFresh[3];
         for (uint8_t index = 0; index <= 2; index++) {
             sampleFresh[index] = (imuSampleTime_ms - storedRngMeasTime_ms[index]) < 500;
         }
+
+        // find the median value if we have three fresh samples
         if (sampleFresh[0] && sampleFresh[1] && sampleFresh[2]) {
             if (storedRngMeas[0] > storedRngMeas[1]) {
                 minIndex = 1;
@@ -54,18 +66,20 @@ void NavEKF2_core::readRangeFinder(void)
             } else {
                 midIndex = 2;
             }
-            rngMea = max(storedRngMeas[midIndex],rngOnGnd);
-            newDataRng = true;
+            rangeDataNew.time_ms = storedRngMeasTime_ms[midIndex];
+            // limit the measured range to be no less than the on-ground range
+            rangeDataNew.rng = max(storedRngMeas[midIndex],rngOnGnd);
             rngValidMeaTime_ms = imuSampleTime_ms;
-        } else if (onGround) {
-            // if on ground and no return, we assume on ground range
-            rngMea = rngOnGnd;
-            newDataRng = true;
+            // write data to buffer with time stamp to be fused when the fusion time horizon catches up with it
+            StoreRange();
+        } else if (!takeOffDetected) {
+            // before takeoff we assume on-ground range value if there is no data
+            rangeDataNew.time_ms = imuSampleTime_ms;
+            rangeDataNew.rng = rngOnGnd;
             rngValidMeaTime_ms = imuSampleTime_ms;
-        } else {
-            newDataRng = false;
+            // write data to buffer with time stamp to be fused when the fusion time horizon catches up with it
+            StoreRange();
         }
-        lastRngMeasTime_ms =  imuSampleTime_ms;
     }
 }
 
@@ -119,7 +133,7 @@ void NavEKF2_core::writeOptFlowMeas(uint8_t &rawFlowQuality, Vector2f &rawFlowRa
         // Save data to buffer
         StoreOF();
         // Check for data at the fusion time horizon
-        newDataFlow = RecallOF();
+        flowDataToFuse = RecallOF();
     }
 }
 
@@ -243,6 +257,7 @@ void NavEKF2_core::readMagData()
         StoreMag();
     }
 }
+
 // store magnetometer data in a history array
 void NavEKF2_core::StoreMag()
 {
@@ -526,6 +541,7 @@ void NavEKF2_core::readGpsData()
             // convert GPS measurements to local NED and save to buffer to be fused later if we have a valid origin
             if (validOrigin) {
                 gpsDataNew.pos = location_diff(EKF_origin, gpsloc);
+                gpsDataNew.hgt = 0.01f * (gpsloc.alt - EKF_origin.alt);
                 StoreGPS();
                 // declare GPS available for use
                 gpsNotAvailable = false;
@@ -652,54 +668,26 @@ bool NavEKF2_core::readDeltaAngle(uint8_t ins_index, Vector3f &dAng) {
 *                  Height Measurements                  *
 ********************************************************/
 
-// check for new altitude measurement data and update stored measurement if available
-void NavEKF2_core::readHgtData()
+// check for new pressure altitude measurement data and update stored measurement if available
+void NavEKF2_core::readBaroData()
 {
     // check to see if baro measurement has changed so we know if a new measurement has arrived
     // do not accept data at a faster rate than 14Hz to avoid overflowing the FIFO buffer
-    if (frontend->_baro.get_last_update() - lastHgtReceived_ms > 70) {
-        // Don't use Baro height if operating in optical flow mode as we use range finder instead
-        if (frontend->_fusionModeGPS == 3 && frontend->_altSource == 1) {
-            if ((imuSampleTime_ms - rngValidMeaTime_ms) < 2000) {
-                // adjust range finder measurement to allow for effect of vehicle tilt and height of sensor
-                baroDataNew.hgt = max(rngMea * Tnb_flow.c.z, rngOnGnd);
-                // calculate offset to baro data that enables baro to be used as a backup
-                // filter offset to reduce effect of baro noise and other transient errors on estimate
-                baroHgtOffset = 0.1f * (frontend->_baro.get_altitude() + stateStruct.position.z) + 0.9f * baroHgtOffset;
-            } else if (isAiding && takeOffDetected) {
-                // we have lost range finder measurements and are in optical flow flight
-                // use baro measurement and correct for baro offset - failsafe use only as baro will drift
-                baroDataNew.hgt = max(frontend->_baro.get_altitude() - baroHgtOffset, rngOnGnd);
-            } else {
-                // If we are on ground and have no range finder reading, assume the nominal on-ground height
-                baroDataNew.hgt = rngOnGnd;
-                // calculate offset to baro data that enables baro to be used as a backup
-                // filter offset to reduce effect of baro noise and other transient errors on estimate
-                baroHgtOffset = 0.1f * (frontend->_baro.get_altitude() + stateStruct.position.z) + 0.9f * baroHgtOffset;
-            }
-        } else {
-            // Normal operation is to use baro measurement
-            baroDataNew.hgt = frontend->_baro.get_altitude();
-        }
+    if (frontend->_baro.get_last_update() - lastBaroReceived_ms > 70) {
 
-        // filtered baro data used to provide a reference for takeoff
-        // it is is reset to last height measurement on disarming in performArmingChecks()
-        if (!getTakeoffExpected()) {
-            const float gndHgtFiltTC = 0.5f;
-            const float dtBaro = frontend->hgtAvg_ms*1.0e-3f;
-            float alpha = constrain_float(dtBaro / (dtBaro+gndHgtFiltTC),0.0f,1.0f);
-            meaHgtAtTakeOff += (baroDataDelayed.hgt-meaHgtAtTakeOff)*alpha;
-        } else if (isAiding && getTakeoffExpected()) {
-            // If we are in takeoff mode, the height measurement is limited to be no less than the measurement at start of takeoff
-            // This prevents negative baro disturbances due to copter downwash corrupting the EKF altitude during initial ascent
+        baroDataNew.hgt = frontend->_baro.get_altitude();
+
+        // If we are in takeoff mode, the height measurement is limited to be no less than the measurement at start of takeoff
+        // This prevents negative baro disturbances due to copter downwash corrupting the EKF altitude during initial ascent
+        if (isAiding && getTakeoffExpected()) {
             baroDataNew.hgt = max(baroDataNew.hgt, meaHgtAtTakeOff);
         }
 
         // time stamp used to check for new measurement
-        lastHgtReceived_ms = frontend->_baro.get_last_update();
+        lastBaroReceived_ms = frontend->_baro.get_last_update();
 
         // estimate of time height measurement was taken, allowing for delays
-        baroDataNew.time_ms = lastHgtReceived_ms - frontend->_hgtDelay_ms;
+        baroDataNew.time_ms = lastBaroReceived_ms - frontend->_hgtDelay_ms;
 
         // Correct for the average intersampling delay due to the filter updaterate
         baroDataNew.time_ms -= localFilterTimeStep_ms/2;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -712,6 +712,15 @@ void NavEKF2_core::readHgtData()
     }
 }
 
+// calculate filtered offset between baro height measurement and EKF height estimate
+// offset should be subtracted from baro measurement to match filter estimate
+// offset is used to enable reversion to baro if alternate height data sources fail
+void NavEKF2_core::calcFiltBaroOffset()
+{
+    // Apply a first order LPF with spike protection
+    baroHgtOffset += 0.1f * constrain_float(baroDataDelayed.hgt + stateStruct.position.z - baroHgtOffset, -5.0f, 5.0f);
+}
+
 // store baro in a history array
 void NavEKF2_core::StoreBaro()
 {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_OptFlowFusion.cpp
@@ -121,9 +121,9 @@ void NavEKF2_core::EstimateTerrainOffset()
         prevPosN = stateStruct.position[0];
         prevPosE = stateStruct.position[1];
 
-        // in addition to a terrain gradient error model, we also have a time based error growth that is scaled using the gradient parameter
+        // in addition to a terrain gradient error model, we also have the growth in uncertainty due to the copters vertical velocity
         float timeLapsed = min(0.001f * (imuSampleTime_ms - timeAtLastAuxEKF_ms), 1.0f);
-        float Pincrement = (distanceTravelledSq * sq(0.01f*float(frontend->gndGradientSigma))) + sq(float(frontend->gndGradientSigma) * timeLapsed);
+        float Pincrement = (distanceTravelledSq * sq(0.01f*float(frontend->gndGradientSigma))) + sq(timeLapsed)*P[5][5];
         Popt += Pincrement;
         timeAtLastAuxEKF_ms = imuSampleTime_ms;
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -544,7 +544,7 @@ void NavEKF2_core::selectHeightForFusion()
     baroDataToFuse = RecallBaro();
 
     // determine if we should be using a height source other than baro
-    bool usingRangeForHgt = (frontend->_altSource == 1 && imuSampleTime_ms - rngValidMeaTime_ms < 500);
+    bool usingRangeForHgt = (frontend->_altSource == 1 && imuSampleTime_ms - rngValidMeaTime_ms < 500 && frontend->_fusionModeGPS == 3);
     bool usingGpsForHgt = (frontend->_altSource == 2 && imuSampleTime_ms - lastTimeGpsReceived_ms < 500);
 
     // if there is new baro data to fuse, calculate filterred baro data required by other processes

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -545,7 +545,7 @@ void NavEKF2_core::selectHeightForFusion()
 
     // determine if we should be using a height source other than baro
     bool usingRangeForHgt = (frontend->_altSource == 1 && imuSampleTime_ms - rngValidMeaTime_ms < 500 && frontend->_fusionModeGPS == 3);
-    bool usingGpsForHgt = (frontend->_altSource == 2 && imuSampleTime_ms - lastTimeGpsReceived_ms < 500);
+    bool usingGpsForHgt = (frontend->_altSource == 2 && imuSampleTime_ms - lastTimeGpsReceived_ms < 500 && validOrigin);
 
     // if there is new baro data to fuse, calculate filterred baro data required by other processes
     if (baroDataToFuse) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -93,6 +93,19 @@ void NavEKF2_core::ResetHeight(void)
     }
     outputDataNew.position.z = stateStruct.position.z;
     outputDataDelayed.position.z = stateStruct.position.z;
+
+    // Reset the vertical velocity state using GPS vertical velocity if we are airborne
+    // Check that GPS vertical velocity data is available and can be used
+    if (inFlight && !gpsNotAvailable && frontend->_fusionModeGPS == 0) {
+        stateStruct.velocity.z =  gpsDataNew.vel.z;
+    } else if (onGround) {
+        stateStruct.velocity.z = 0.0f;
+    }
+    for (uint8_t i=0; i<IMU_BUFFER_LENGTH; i++) {
+        storedOutput[i].velocity.z = stateStruct.velocity.z;
+    }
+    outputDataNew.velocity.z = stateStruct.velocity.z;
+    outputDataDelayed.velocity.z = stateStruct.velocity.z;
 }
 
 // Reset the baro so that it reads zero at the current height

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -298,7 +298,7 @@ void NavEKF2_core::detectFlight()
         }
 
         // trigger if more than 10m away from initial height
-        if (fabsf(baroDataDelayed.hgt) > 10.0f) {
+        if (fabsf(hgtMea) > 10.0f) {
             largeHgtChange = true;
         }
 
@@ -337,7 +337,7 @@ void NavEKF2_core::detectFlight()
         }
 
         // If rangefinder has increased since exiting on-ground, then we definitely are flying
-        if (!onGround && ((rngMea - rngAtStartOfFlight) > 0.5f)) {
+        if (!onGround && ((rangeDataNew.rng - rngAtStartOfFlight) > 0.5f)) {
             inFlight = true;
         }
 
@@ -352,7 +352,7 @@ void NavEKF2_core::detectFlight()
         // store vertical position at start of flight to use as a reference for ground relative checks
         posDownAtTakeoff = stateStruct.position.z;
         // store the range finder measurement which will be used as a reference to detect when we have taken off
-        rngAtStartOfFlight = rngMea;
+        rngAtStartOfFlight = rangeDataNew.rng;
     }
 
 }
@@ -411,7 +411,7 @@ void NavEKF2_core::detectOptFlowTakeoff(void)
             angRateVec = ins.get_gyro() - gyroBias;
         }
 
-        takeOffDetected = (takeOffDetected || (angRateVec.length() > 0.1f) || (rngMea > (rngAtStartOfFlight + 0.1f)));
+        takeOffDetected = (takeOffDetected || (angRateVec.length() > 0.1f) || (rangeDataNew.rng > (rngAtStartOfFlight + 0.1f)));
     } else if (onGround) {
         // we are confidently on the ground so set the takeoff detected status to false
         takeOffDetected = false;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -103,7 +103,7 @@ void NavEKF2_core::InitialiseVariables()
     prevTasStep_ms = imuSampleTime_ms;
     prevBetaStep_ms = imuSampleTime_ms;
     lastMagUpdate_us = 0;
-    lastHgtReceived_ms = imuSampleTime_ms;
+    lastBaroReceived_ms = imuSampleTime_ms;
     lastVelPassTime_ms = imuSampleTime_ms;
     lastPosPassTime_ms = imuSampleTime_ms;
     lastHgtPassTime_ms = imuSampleTime_ms;
@@ -145,13 +145,12 @@ void NavEKF2_core::InitialiseVariables()
     memset(&nextP[0][0], 0, sizeof(nextP));
     memset(&processNoise[0], 0, sizeof(processNoise));
     flowDataValid = false;
-    newDataRng  = false;
+    rangeDataToFuse  = false;
     fuseOptFlowData = false;
     Popt = 0.0f;
     terrainState = 0.0f;
     prevPosN = stateStruct.position.x;
     prevPosE = stateStruct.position.y;
-    fuseRngData = false;
     inhibitGndState = true;
     flowGyroBias.x = 0;
     flowGyroBias.y = 0;
@@ -187,6 +186,7 @@ void NavEKF2_core::InitialiseVariables()
     yawAlignComplete = false;
     stateIndexLim = 23;
     baroStoreIndex = 0;
+    rangeStoreIndex = 0;
     magStoreIndex = 0;
     gpsStoreIndex = 0;
     tasStoreIndex = 0;
@@ -297,7 +297,7 @@ bool NavEKF2_core::InitialiseFilterBootstrap(void)
     ResetPosition();
 
     // read the barometer and set the height state
-    readHgtData();
+    readBaroData();
     ResetHeight();
 
     // define Earth rotation vector in the NED navigation frame
@@ -408,9 +408,6 @@ void NavEKF2_core::UpdateFilter(bool predict)
 
         // Predict the covariance growth
         CovariancePrediction();
-
-        // Read range finder data which is used by both position and optical flow fusion
-        readRangeFinder();
 
         // Update states using  magnetometer data
         SelectMagFusion();

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -367,6 +367,11 @@ private:
         uint32_t    time_ms;     // 1
     };
 
+    struct range_elements {
+        float       rng;         // 0
+        uint32_t    time_ms;     // 1
+    };
+
     struct tas_elements {
         float       tas;         // 0
         uint32_t    time_ms;     // 1
@@ -444,6 +449,13 @@ private:
     // recall altimeter data at the fusion time horizon
     // return true if data found
     bool RecallBaro();
+
+    // store range finder data
+    void StoreRange();
+
+    // recall range finder data at the fusion time horizon
+    // return true if data found
+    bool RecallRange();
 
     // store magnetometer data
     void StoreMag();
@@ -645,6 +657,7 @@ private:
     gps_elements storedGPS[OBS_BUFFER_LENGTH];      // GPS data buffer
     mag_elements storedMag[OBS_BUFFER_LENGTH];      // Magnetometer data buffer
     baro_elements storedBaro[OBS_BUFFER_LENGTH];    // Baro data buffer
+    range_elements storedRange[OBS_BUFFER_LENGTH];  // Rang finder data buffer
     tas_elements storedTAS[OBS_BUFFER_LENGTH];      // TAS data buffer
     output_elements *storedOutput;  // output state buffer [imu_buffer_length]
     Vector3f correctedDelAng;       // delta angles about the xyz body axes corrected for errors (rad)
@@ -737,6 +750,9 @@ private:
     baro_elements baroDataNew;      // Baro data at the current time horizon
     baro_elements baroDataDelayed;  // Baro data at the fusion time horizon
     uint8_t baroStoreIndex;         // Baro data storage index
+    range_elements rangeDataNew;    // Range finder data at the current time horizon
+    range_elements rangeDataDelayed;// Range finder data at the fusion time horizon
+    uint8_t rangeStoreIndex;        // Range finder data storage index
     tas_elements tasDataNew;        // TAS data at the current time horizon
     tas_elements tasDataDelayed;    // TAS data at the fusion time horizon
     uint8_t tasStoreIndex;          // TAS data storage index

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -629,6 +629,9 @@ private:
     // using a simple observer
     void calcOutputStatesFast();
 
+    // calculate a filtered offset between baro height measurement and EKF height estimate
+    void calcFiltBaroOffset();
+
     // Length of FIFO buffers used for non-IMU sensor data.
     // Must be larger than the time period defined by IMU_BUFFER_LENGTH
     static const uint32_t OBS_BUFFER_LENGTH = 5;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -864,6 +864,7 @@ private:
     bool rangeDataToFuse;           // true when valid range finder height data has arrived at the fusion time horizon.
     bool baroDataToFuse;            // true when valid baro height finder data has arrived at the fusion time horizon.
     bool gpsDataToFuse;             // true when valid GPS data has arrived at the fusion time horizon.
+    bool magDataToFuse;             // true when valid magnetometer data has arrived at the fusion time horizon
     Vector2f heldVelNE;             // velocity held when no aiding is available
     enum AidingMode {AID_ABSOLUTE=0,    // GPS aiding is being used (optical flow may also be used) so position estimates are absolute.
                      AID_NONE=1,       // no aiding is being used so only attitude and height estimates are available. Either constVelMode or constPosMode must be used to constrain tilt drift.


### PR DESCRIPTION
Adds the ability to specify use of GPS as the primary altitude source.
Improves timing accuracy of range finder measurements.
Improves protection against spikes when calculating the baro to GPS offset
Moves selection of altitude source into a separate function.
Uses sensor specific noise parameters when fusing height data from different sources.
Baro drift is learned during non-baro operation so reversion to baro can be made without height jumps.

The following combination were tested  in SITL Plane and SIM_BARO_GLITCH was adjusted by 50m to induce a timeout in the Baro to verify normal operation. The value of EK2_ALT_SOURCE was adjusted mid-flight to verify that the EKF could switch safely between Baro and GPS. A Baro offset was introduced during GPS operation and learning of the baro offset and correct application after switch back was confirmed.

EK2_ALT_SOURCE=0 (Baro option - verified switch to GPs and back again )
EK2_ALT_SOUCE = 1 (Range finder height - verified mode was ignored and continued to use Baro)
EK2_ALT_SOUCE = 2 (GPS option - verified switch to Baro and back again)

This following combinations were tested in Copter SITL

EK2_GPS_TYPE=0 and EK2_ALT_SOURCE=0 (GPS aiding, Baro height)
EK2_GPS_TYPE=0 and EK2_ALT_SOURCE=2 (GPS aiding and height)
EK2_GPS_TYPE=3 and EK2_ALT_SOURCE=0 (OF aiding, Baro height)
EK2_GPS_TYPE=3 and EK2_ALT_SOURCE=1 (OF aiding, RangeFinder height)

It has been flight tested in a copter with the following combinations

EK2_GPS_TYPE=0 and EK2_ALT_SOURCE=0 (GPS aiding, Baro height)
EK2_GPS_TYPE=3 and EK2_ALT_SOURCE=0 (OF aiding, Baro height)
EK2_GPS_TYPE=3 and EK2_ALT_SOURCE=1 (OF aiding, RangeFinder height)

Here are the GPS 3D position innovations from a high dynamics flight in a copter (3g peak manoeuvres) with 11 sats, no SBAS and receiver claimed vertical position accuracy of 1.6m. Pilot observations on this flight was that during high speed manoeuvring, the altitude hold was more consistent using GPS rather than Baro. 

![use gps for height innovations](https://cloud.githubusercontent.com/assets/3596952/11138814/4a30f6ca-8a1b-11e5-9929-4180ace08759.png)

A subsequent low speed flight in a multi-path environment with 8 satellites and vertical position accuracy 2.1m of  showed that there was noticeably more height wander using GPS altitude than there was using Baro. 

![gps vs baro height](https://cloud.githubusercontent.com/assets/3596952/11138925/c8bd3818-8a1c-11e5-813c-45544cf93770.png)

This feature will definitely be of interest to users with higher grade GPS receivers operating where there is SBAS coverage.

