### PR TITLE
mk: build the bebop statically

### DIFF
--- a/mk/targets.mk
+++ b/mk/targets.mk
@@ -38,6 +38,7 @@ pxf: all
 
 bebop: HAL_BOARD = HAL_BOARD_LINUX
 bebop: TOOLCHAIN = BBONE
+bebop: LDFLAGS += "-static"
 bebop: all
 
 minlure: HAL_BOARD = HAL_BOARD_LINUX


### PR DESCRIPTION
The toolchains aren't compatible and the size of the binary doesn't get too
big with the static flag so it avoids creating a chroot.