### PR TITLE
AP_HAL_Linux: Improve loading AioPRU firmware

### DIFF
--- a/libraries/AP_HAL_Linux/RCOutput_AioPRU.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_AioPRU.cpp
@@ -51,13 +51,12 @@ void RCOutput_AioPRU::init(void* machtnicht)
 
    // Reset PRU 1
    *ctrl = 0;
-   hal.scheduler->delay(1);
 
    // Load firmware
    memcpy(iram, PRUcode, sizeof(PRUcode));
 
    // Start PRU 1
-   *ctrl = 3;
+   *ctrl |= 2;
 
    // all outputs default to 50Hz, the top level vehicle code
    // overrides this when necessary


### PR DESCRIPTION
If you start ArduPilot, stop ArduPilot (with Ctrl-C) and restart it again, than sometimes the props start spinning for 1 ms. This PR fix this behaviour. 

This only effects the BBB AioPRU firmware used by BBBMINI.