### PR TITLE
GPS Glitch Detector

### DIFF
--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -285,6 +285,8 @@ void Copter::fast_loop()
     // check if we've landed or crashed
     update_land_and_crash_detectors();
 
+    gps_glitch_update();
+
     // log sensor health
     if (should_log(MASK_LOG_ANY)) {
         Log_Sensor_Health();

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -125,7 +125,8 @@ Copter::Copter(void) :
 #endif
     in_mavlink_delay(false),
     gcs_out_of_time(false),
-    param_loader(var_info)
+    param_loader(var_info),
+    gps_glitch_switch_mode_on_resolve(false)
 {
     memset(&current_loc, 0, sizeof(current_loc));
 

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -280,7 +280,7 @@ private:
         uint8_t battery             : 1; // 2   // A status flag for the battery failsafe
         uint8_t gcs                 : 1; // 4   // A status flag for the ground station failsafe
         uint8_t ekf                 : 1; // 5   // true if ekf failsafe has occurred
-
+        uint8_t gps_glitch          : 1; // 6   // true if gps glitch failsafe has occurred
         int8_t radio_counter;            // number of iterations with throttle below throttle_fs_value
 
         uint32_t last_heartbeat_ms;      // the time when the last HEARTBEAT message arrived from a GCS - used for triggering gcs failsafe
@@ -530,6 +530,8 @@ private:
         uint8_t init_targets_on_arming  : 1;    // 1   // true if we have been disarmed, and need to reset rate controller targets when we arm
     } heli_flags;
 #endif
+
+    bool gps_glitch_switch_mode_on_resolve;
 
     static const AP_Scheduler::Task scheduler_tasks[];
     static const AP_Param::Info var_info[];
@@ -937,6 +939,12 @@ private:
     bool start_command(const AP_Mission::Mission_Command& cmd);
     bool verify_command(const AP_Mission::Mission_Command& cmd);
     bool verify_command_callback(const AP_Mission::Mission_Command& cmd);
+
+    void gps_glitch_update(void);
+    void gps_glitch_mode_change_commanded(uint8_t mode_commanded);
+    void gps_glitch_on_event();
+    bool gps_glitch_action_mode(uint8_t mode);
+    void gps_glitch_off_event();
 
     bool do_guided(const AP_Mission::Mission_Command& cmd);
     void do_takeoff(const AP_Mission::Mission_Command& cmd);

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -166,6 +166,14 @@ const AP_Param::Info Copter::var_info[] = {
     // @User: Standard
     GSCALAR(failsafe_gcs, "FS_GCS_ENABLE", FS_GCS_ENABLED_ALWAYS_RTL),
 
+
+    // @Param: FS_GPS_GLITCH
+    // @DisplayName: GPS Glitch Failsafe Type
+    // @Description: Controls whether failsafe will be invoked (and what action to take) when "GPS is inaccurate" is reported by EKF. This will involve switching to ALT_HOLD mode in case of GPS glitch.
+    // @Values: 0:Disabled,1:Enabled for non autonomous gps aided modes,2:Enabled for all gps aided modes
+    // @User: Standard
+    GSCALAR(fs_gps_glitch_type, "FS_GPS_GLITCH", FS_GPS_GLITCH_ENABLED_NON_AUTO),
+
     // @Param: GPS_HDOP_GOOD
     // @DisplayName: GPS Hdop Good
     // @Description: GPS Hdop value at or below this value represent a good position.  Used for pre-arm checks

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -211,7 +211,7 @@ public:
         //
         k_param_rtl_speed_cms = 135,
         k_param_fs_batt_curr_rtl, // 136
-
+        k_param_fs_gps_glitch_type, //137
         //
         // 140: Sensor parameters
         //
@@ -379,6 +379,7 @@ public:
     AP_Float        fs_batt_mah;                // battery capacity (in mah) below which failsafe will be triggered
 
     AP_Int8         failsafe_gcs;               // ground station failsafe behavior
+    AP_Int8         fs_gps_glitch_type;         // gps glitch failsafe behaviour
     AP_Int16        gps_hdop_good;              // GPS Hdop value at or below this value represent a good position
 
     AP_Int8         compass_enabled;

--- a/ArduCopter/control_auto.cpp
+++ b/ArduCopter/control_auto.cpp
@@ -22,6 +22,10 @@
 // auto_init - initialise auto controller
 bool Copter::auto_init(bool ignore_checks)
 {
+    if (!ignore_checks && failsafe.gps_glitch) {
+        return false;
+    }
+
     if ((position_ok() && mission.num_commands() > 1) || ignore_checks) {
         auto_mode = Auto_Loiter;
 

--- a/ArduCopter/control_brake.cpp
+++ b/ArduCopter/control_brake.cpp
@@ -9,6 +9,9 @@
 // brake_init - initialise brake controller
 bool Copter::brake_init(bool ignore_checks)
 {
+    if (!ignore_checks && failsafe.gps_glitch) {
+        return false;
+    }
     if (position_ok() || ignore_checks) {
 
         // set desired acceleration to zero

--- a/ArduCopter/control_circle.cpp
+++ b/ArduCopter/control_circle.cpp
@@ -9,6 +9,9 @@
 // circle_init - initialise circle controller flight mode
 bool Copter::circle_init(bool ignore_checks)
 {
+    if (!ignore_checks && failsafe.gps_glitch) {
+        return false;
+    }
     if (position_ok() || ignore_checks) {
         circle_pilot_yaw_override = false;
 

--- a/ArduCopter/control_guided.cpp
+++ b/ArduCopter/control_guided.cpp
@@ -38,6 +38,10 @@ struct Guided_Limit {
 // guided_init - initialise guided controller
 bool Copter::guided_init(bool ignore_checks)
 {
+    if (!ignore_checks && failsafe.gps_glitch) {
+        return false;
+    }
+
     if (position_ok() || ignore_checks) {
         // initialise yaw
         set_auto_yaw_mode(get_default_auto_yaw_mode(false));

--- a/ArduCopter/control_land.cpp
+++ b/ArduCopter/control_land.cpp
@@ -11,7 +11,7 @@ static bool land_pause;
 bool Copter::land_init(bool ignore_checks)
 {
     // check if we have GPS and decide which LAND we're going to do
-    land_with_gps = position_ok();
+    land_with_gps = position_ok() && !failsafe.gps_glitch;
     if (land_with_gps) {
         // set target to stopping point
         Vector3f stopping_point;

--- a/ArduCopter/control_loiter.cpp
+++ b/ArduCopter/control_loiter.cpp
@@ -9,6 +9,9 @@
 // loiter_init - initialise loiter controller
 bool Copter::loiter_init(bool ignore_checks)
 {
+    if (!ignore_checks && failsafe.gps_glitch) {
+        return false;
+    }
     if (position_ok() || ignore_checks) {
 
         // set target to current position

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -166,6 +166,11 @@ enum tuning_func {
 #define WP_YAW_BEHAVIOR_LOOK_AT_NEXT_WP_EXCEPT_RTL    2   // auto pilot will face next waypoint except when doing RTL at which time it will stay in it's last
 #define WP_YAW_BEHAVIOR_LOOK_AHEAD                    3   // auto pilot will look ahead during missions and rtl (primarily meant for traditional helicotpers)
 
+// GPS Glitch Failsafe behaviour
+#define FS_GPS_GLITCH_DISABLED          0
+#define FS_GPS_GLITCH_ENABLED_NON_AUTO  1
+#define FS_GPS_GLITCH_ENABLED_ALWAYS    2
+
 // Auto modes
 enum AutoMode {
     Auto_TakeOff,

--- a/ArduCopter/flight_mode.cpp
+++ b/ArduCopter/flight_mode.cpp
@@ -16,7 +16,7 @@ bool Copter::set_mode(uint8_t mode)
     // boolean to record if flight mode could be set
     bool success = false;
     bool ignore_checks = !motors.armed();   // allow switching to any mode if disarmed.  We rely on the arming check to perform
-
+    gps_glitch_mode_change_commanded(mode);
     // return immediately if we are already in the desired mode
     if (mode == control_mode) {
         return true;

--- a/ArduCopter/gps_glitch.cpp
+++ b/ArduCopter/gps_glitch.cpp
@@ -1,0 +1,62 @@
+/// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+
+#include "Copter.h"
+
+void Copter::gps_glitch_update() {
+    bool glitch = ahrs.get_NavEKF().getGpsGlitchStatus();
+
+    if (glitch && !failsafe.gps_glitch) {
+        gps_glitch_on_event();
+    } else if (!glitch && failsafe.gps_glitch) {
+        gps_glitch_off_event();
+    }
+
+    if (failsafe.gps_glitch && control_mode != ALT_HOLD) {
+        // if the mode has changed during gps glitch, don't return to LOITER on resolve
+        gps_glitch_switch_mode_on_resolve = false;
+    }
+}
+
+void Copter::gps_glitch_mode_change_commanded(uint8_t mode_commanded)
+{
+    // ensure that commanded mode switches to ALT_HOLD will cancel the switch back to FLY
+    if (mode_commanded == ALT_HOLD) {
+        gps_glitch_switch_mode_on_resolve = false;
+    }
+}
+
+bool Copter::gps_glitch_action_mode(uint8_t mode) {
+    switch(control_mode) {
+        case LAND:
+            return landing_with_GPS();
+        case RTL:
+            return rtl_state == RTL_Land;
+        case GUIDED: // GUIDED for solo because shots modes use GUIDED
+        case LOITER:
+        case DRIFT:
+        case BRAKE:
+        case POSHOLD:
+            return true;
+        default:
+            return false;
+    }
+    return false;
+}
+
+void Copter::gps_glitch_on_event() {
+    failsafe.gps_glitch = true;
+
+    if (motors.armed() && gps_glitch_action_mode(control_mode) && !failsafe.radio) {
+        if(set_mode(ALT_HOLD)) {
+            gps_glitch_switch_mode_on_resolve = true;
+        }
+    }
+}
+
+void Copter::gps_glitch_off_event() {
+    failsafe.gps_glitch = false;
+
+    if (gps_glitch_switch_mode_on_resolve) {
+        set_mode(LOITER);
+    }
+}


### PR DESCRIPTION
This PR solves the issue of erratic behaviour when there is momentary or long term GPS glitch during GPS aided flight modes. The patches included with this PR will make arducopter switch to non-GPS aided mode ALT_HOLD in which the copter will maintain its height with imprecise horizontal position, so user can takeover and take action to save from copter doing damage to itself or surrounding. There is addition of parameter "FS_GPS_GLITCH" which will enable/disable and determine the behaviour of copter in the case of gps glitch as reported by EKF.
Assigned to @rmackay9 for review.