### PR TITLE
consolidate INS sensor handling

### DIFF
--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -365,7 +365,7 @@ void Copter::Log_Write_Attitude()
  #endif
     DataFlash.Log_Write_AHRS2(ahrs);
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-    sitl.Log_Write_SIMSTATE(DataFlash);
+    sitl.Log_Write_SIMSTATE(&DataFlash);
 #endif
     DataFlash.Log_Write_POS(ahrs);
 }

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -178,7 +178,7 @@ void Plane::Log_Write_Attitude(void)
     DataFlash.Log_Write_AHRS2(ahrs);
 #endif
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-    sitl.Log_Write_SIMSTATE(DataFlash);
+    sitl.Log_Write_SIMSTATE(&DataFlash);
 #endif
     DataFlash.Log_Write_POS(ahrs);
 }

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -315,6 +315,7 @@ void SITL_State::_fdm_input_local(void)
 
     // get FDM output from the model
     sitl_model->fill_fdm(_sitl->state);
+    _sitl->update_rate_hz = sitl_model->get_rate_hz();
 
     if (gimbal != NULL) {
         gimbal->update();
@@ -418,7 +419,7 @@ void SITL_State::_simulator_servos(Aircraft::sitl_input &input)
             input.servos[2] = ((input.servos[2]-1000) * _sitl->engine_mul) + 1000;
             if (input.servos[2] > 2000) input.servos[2] = 2000;
         }
-        _motors_on = ((input.servos[2]-1000)/1000.0f) > 0;
+        _sitl->motors_on = ((input.servos[2]-1000)/1000.0f) > 0;
     } else if (_vehicle == APMrover2) {
         // add in engine multiplier
         if (input.servos[2] != 1500) {
@@ -426,9 +427,9 @@ void SITL_State::_simulator_servos(Aircraft::sitl_input &input)
             if (input.servos[2] > 2000) input.servos[2] = 2000;
             if (input.servos[2] < 1000) input.servos[2] = 1000;
         }
-        _motors_on = ((input.servos[2]-1500)/500.0f) != 0;
+        _sitl->motors_on = ((input.servos[2]-1500)/500.0f) != 0;
     } else {
-        _motors_on = false;
+        _sitl->motors_on = false;
         // apply engine multiplier to first motor
         input.servos[0] = ((input.servos[0]-1000) * _sitl->engine_mul) + 1000;
         // run checks on each motor
@@ -438,12 +439,12 @@ void SITL_State::_simulator_servos(Aircraft::sitl_input &input)
             if (input.servos[i] < 1000) input.servos[i] = 1000;
             // update motor_on flag
             if ((input.servos[i]-1000)/1000.0f > 0) {
-                _motors_on = true;
+                _sitl->motors_on = true;
             }
         }
     }
 
-    float throttle = _motors_on?(input.servos[2]-1000) / 1000.0f:0;
+    float throttle = _sitl->motors_on?(input.servos[2]-1000) / 1000.0f:0;
     // lose 0.7V at full throttle
     float voltage = _sitl->batt_voltage - 0.7f*throttle;
 

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -130,9 +130,6 @@ private:
 
     void wait_clock(uint64_t wait_time_usec);
 
-    pthread_t _fdm_thread_ctx;
-    void _fdm_thread(void);
-
     // internal state
     enum vehicle_type _vehicle;
     uint16_t _framerate;

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -123,7 +123,6 @@ private:
     void _apply_servo_filter(float deltat);
     uint16_t _airspeed_sensor(float airspeed);
     uint16_t _ground_sonar();
-    float _gyro_drift(void);
     float _rand_float(void);
     Vector3f _rand_vec3f(void);
     void _fdm_input_step(void);
@@ -138,7 +137,6 @@ private:
     struct sockaddr_in _rcout_addr;
     pid_t _parent_pid;
     uint32_t _update_count;
-    bool _motors_on;
 
     AP_Baro *_barometer;
     AP_InertialSensor *_ins;

--- a/libraries/AP_HAL_SITL/sitl_ins.cpp
+++ b/libraries/AP_HAL_SITL/sitl_ins.cpp
@@ -77,21 +77,6 @@ uint16_t SITL_State::_airspeed_sensor(float airspeed)
 }
 
 
-float SITL_State::_gyro_drift(void)
-{
-    if (_sitl->drift_speed == 0.0f ||
-            _sitl->drift_time == 0.0f) {
-        return 0;
-    }
-    double period  = _sitl->drift_time * 2;
-    double minutes = fmod(_scheduler->_micros64() / 60.0e6, period);
-    if (minutes < period/2) {
-        return minutes * ToRad(_sitl->drift_speed);
-    }
-    return (period - minutes) * ToRad(_sitl->drift_speed);
-
-}
-
 /*
   emulate an analog rangefinder
  */
@@ -155,59 +140,6 @@ void SITL_State::_update_ins(float roll, 	float pitch, 	float yaw,		// Relative 
         // no inertial sensor in this sketch
         return;
     }
-
-    // minimum noise levels are 2 bits, but averaged over many
-    // samples, giving around 0.01 m/s/s
-    float accel_noise = 0.01f;
-    float accel2_noise = 0.01f;
-    // minimum gyro noise is also less than 1 bit
-    float gyro_noise = ToRad(0.04f);
-    if (_motors_on) {
-        // add extra noise when the motors are on
-        accel_noise += _sitl->accel_noise;
-        accel2_noise += _sitl->accel2_noise;
-        gyro_noise += ToRad(_sitl->gyro_noise);
-    }
-    // get accel bias (add only to first accelerometer)
-    Vector3f accel_bias = _sitl->accel_bias.get();
-    float xAccel1 = xAccel + accel_noise * _rand_float() + accel_bias.x;
-    float yAccel1 = yAccel + accel_noise * _rand_float() + accel_bias.y;
-    float zAccel1 = zAccel + accel_noise * _rand_float() + accel_bias.z;
-
-    float xAccel2 = xAccel + accel2_noise * _rand_float();
-    float yAccel2 = yAccel + accel2_noise * _rand_float();
-    float zAccel2 = zAccel + accel2_noise * _rand_float();
-
-    if (fabsf(_sitl->accel_fail) > 1.0e-6f) {
-        xAccel1 = _sitl->accel_fail;
-        yAccel1 = _sitl->accel_fail;
-        zAccel1 = _sitl->accel_fail;
-    }
-
-    Vector3f accel0 = Vector3f(xAccel1, yAccel1, zAccel1) + _ins->get_accel_offsets(0);
-    Vector3f accel1 = Vector3f(xAccel2, yAccel2, zAccel2) + _ins->get_accel_offsets(1);
-    _ins->set_accel(0, accel0);
-    _ins->set_accel(1, accel1);
-
-    // check noise
-    _ins->calc_vibration_and_clipping(0, accel0, 0.0025f);
-    _ins->calc_vibration_and_clipping(1, accel1, 0.0025f);
-
-    float p = radians(rollRate) + _gyro_drift();
-    float q = radians(pitchRate) + _gyro_drift();
-    float r = radians(yawRate) + _gyro_drift();
-
-    float p1 = p + gyro_noise * _rand_float();
-    float q1 = q + gyro_noise * _rand_float();
-    float r1 = r + gyro_noise * _rand_float();
-
-    float p2 = p + gyro_noise * _rand_float();
-    float q2 = q + gyro_noise * _rand_float();
-    float r2 = r + gyro_noise * _rand_float();
-
-    _ins->set_gyro(0, Vector3f(p1, q1, r1) + _ins->get_gyro_offsets(0));
-    _ins->set_gyro(1, Vector3f(p2, q2, r2) + _ins->get_gyro_offsets(1));
-
 
     sonar_pin_value    = _ground_sonar();
     float airspeed_simulated = (fabsf(_sitl->aspd_fail) > 1.0e-6f) ? _sitl->aspd_fail : airspeed;

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -368,22 +368,24 @@ AP_InertialSensor *AP_InertialSensor::get_instance()
 /*
   register a new gyro instance
  */
-uint8_t AP_InertialSensor::register_gyro(void)
+uint8_t AP_InertialSensor::register_gyro(uint16_t raw_sample_rate_hz)
 {
     if (_gyro_count == INS_MAX_INSTANCES) {
         hal.scheduler->panic("Too many gyros");
     }
+    _gyro_raw_sample_rates[_gyro_count] = raw_sample_rate_hz;
     return _gyro_count++;
 }
 
 /*
   register a new accel instance
  */
-uint8_t AP_InertialSensor::register_accel(void)
+uint8_t AP_InertialSensor::register_accel(uint16_t raw_sample_rate_hz)
 {
     if (_accel_count == INS_MAX_INSTANCES) {
         hal.scheduler->panic("Too many accels");
     }
+    _accel_raw_sample_rates[_accel_count] = raw_sample_rate_hz;
     return _accel_count++;
 }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1394,8 +1394,11 @@ check_sample:
         bool accel_available = false;
         while (!gyro_available || !accel_available) {
             for (uint8_t i=0; i<_backend_count; i++) {
-                gyro_available |= _backends[i]->gyro_sample_available();
-                accel_available |= _backends[i]->accel_sample_available();
+                _backends[i]->accumulate();
+            }
+            for (uint8_t i=0; i<INS_MAX_INSTANCES; i++) {
+                gyro_available |= _new_gyro_data[i];
+                accel_available |= _new_accel_data[i];
             }
             if (!gyro_available || !accel_available) {
                 hal.scheduler->delay_microseconds(100);

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -499,7 +499,9 @@ AP_InertialSensor::detect_backends(void)
         _add_backend(AP_InertialSensor_HIL::detect(*this));
         return;
     }
-#if HAL_INS_DEFAULT == HAL_INS_HIL
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    _add_backend(AP_InertialSensor_SITL::detect(*this));    
+#elif HAL_INS_DEFAULT == HAL_INS_HIL
     _add_backend(AP_InertialSensor_HIL::detect(*this));
 #elif HAL_INS_DEFAULT == HAL_INS_MPU60XX_SPI
     _add_backend(AP_InertialSensor_MPU6000::detect_spi(*this));

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -23,6 +23,7 @@
 #include <AP_Math/AP_Math.h>
 #include "AP_InertialSensor_UserInteract.h"
 #include <Filter/LowPassFilter.h>
+#include <Filter/LowPassFilter2p.h>
 
 class AP_InertialSensor_Backend;
 class AuxiliaryBus;
@@ -73,8 +74,8 @@ public:
 
     /// Register a new gyro/accel driver, allocating an instance
     /// number
-    uint8_t register_gyro(void);
-    uint8_t register_accel(void);
+    uint8_t register_gyro(uint16_t raw_sample_rate_hz);
+    uint8_t register_accel(uint16_t raw_sample_rate_hz);
 
     // perform accelerometer calibration including providing user instructions
     // and feedback
@@ -283,6 +284,14 @@ private:
     // time accumulator for delta velocity accumulator
     float _delta_velocity_acc_dt[INS_MAX_INSTANCES];
 
+    // Low Pass filters for gyro and accel
+    LowPassFilter2pVector3f _accel_filter[INS_MAX_INSTANCES];
+    LowPassFilter2pVector3f _gyro_filter[INS_MAX_INSTANCES];
+    Vector3f _accel_filtered[INS_MAX_INSTANCES];
+    Vector3f _gyro_filtered[INS_MAX_INSTANCES];
+    bool _new_accel_data[INS_MAX_INSTANCES];
+    bool _new_gyro_data[INS_MAX_INSTANCES];
+    
     // Most recent gyro reading
     Vector3f _gyro[INS_MAX_INSTANCES];
     Vector3f _delta_angle[INS_MAX_INSTANCES];
@@ -303,8 +312,8 @@ private:
     float _accel_max_abs_offsets[INS_MAX_INSTANCES];
 
     // accelerometer and gyro raw sample rate in units of Hz
-    uint32_t _accel_raw_sample_rates[INS_MAX_INSTANCES];
-    uint32_t _gyro_raw_sample_rates[INS_MAX_INSTANCES];
+    uint16_t _accel_raw_sample_rates[INS_MAX_INSTANCES];
+    uint16_t _gyro_raw_sample_rates[INS_MAX_INSTANCES];
 
     // temperatures for an instance if available
     float _temperature[INS_MAX_INSTANCES];

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -398,6 +398,7 @@ private:
 #include "AP_InertialSensor_MPU9150.h"
 #include "AP_InertialSensor_LSM9DS0.h"
 #include "AP_InertialSensor_HIL.h"
+#include "AP_InertialSensor_SITL.h"
 #include "AP_InertialSensor_UserInteract_Stream.h"
 #include "AP_InertialSensor_UserInteract_MAVLink.h"
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -212,9 +212,9 @@ void AP_InertialSensor_Backend::update_gyro(uint8_t instance)
     }
 
     // possibly update filter frequency
-    if (_last_gyro_filter_hz != _gyro_filter_cutoff()) {
+    if (_last_gyro_filter_hz[instance] != _gyro_filter_cutoff()) {
         _imu._gyro_filter[instance].set_cutoff_frequency(_gyro_raw_sample_rate(instance), _gyro_filter_cutoff());
-        _last_gyro_filter_hz = _gyro_filter_cutoff();
+        _last_gyro_filter_hz[instance] = _gyro_filter_cutoff();
     }
 
     hal.scheduler->resume_timer_procs();
@@ -233,9 +233,9 @@ void AP_InertialSensor_Backend::update_accel(uint8_t instance)
     }
     
     // possibly update filter frequency
-    if (_last_accel_filter_hz != _accel_filter_cutoff()) {
+    if (_last_accel_filter_hz[instance] != _accel_filter_cutoff()) {
         _imu._accel_filter[instance].set_cutoff_frequency(_accel_raw_sample_rate(instance), _accel_filter_cutoff());
-        _last_accel_filter_hz = _accel_filter_cutoff();
+        _last_accel_filter_hz[instance] = _accel_filter_cutoff();
     }
 
     hal.scheduler->resume_timer_procs();

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -4,6 +4,8 @@
 #include "AP_InertialSensor.h"
 #include "AP_InertialSensor_Backend.h"
 
+const extern AP_HAL::HAL& hal;
+
 AP_InertialSensor_Backend::AP_InertialSensor_Backend(AP_InertialSensor &imu) :
     _imu(imu),
     _product_id(AP_PRODUCT_ID_NONE)
@@ -87,6 +89,10 @@ void AP_InertialSensor_Backend::_notify_new_gyro_raw_sample(uint8_t instance,
     // save previous delta angle for coning correction
     _imu._last_delta_angle[instance] = delta_angle;
     _imu._last_raw_gyro[instance] = gyro;
+
+    _imu._gyro_filtered[instance] = _imu._gyro_filter[instance].apply(gyro);
+
+    _imu._new_gyro_data[instance] = true;
 }
 
 /*
@@ -123,6 +129,10 @@ void AP_InertialSensor_Backend::_notify_new_accel_raw_sample(uint8_t instance,
     // delta velocity
     _imu._delta_velocity_acc[instance] += accel * dt;
     _imu._delta_velocity_acc_dt[instance] += dt;
+
+    _imu._accel_filtered[instance] = _imu._accel_filter[instance].apply(accel);
+
+    _imu._new_accel_data[instance] = true;
 }
 
 void AP_InertialSensor_Backend::_set_accel_max_abs_offset(uint8_t instance,
@@ -131,22 +141,10 @@ void AP_InertialSensor_Backend::_set_accel_max_abs_offset(uint8_t instance,
     _imu._accel_max_abs_offsets[instance] = max_offset;
 }
 
-void AP_InertialSensor_Backend::_set_accel_raw_sample_rate(uint8_t instance,
-                                                           uint32_t rate)
-{
-    _imu._accel_raw_sample_rates[instance] = rate;
-}
-
 // set accelerometer error_count
 void AP_InertialSensor_Backend::_set_accel_error_count(uint8_t instance, uint32_t error_count)
 {
     _imu._accel_error_count[instance] = error_count;
-}
-
-void AP_InertialSensor_Backend::_set_gyro_raw_sample_rate(uint8_t instance,
-                                                          uint32_t rate)
-{
-    _imu._gyro_raw_sample_rates[instance] = rate;
 }
 
 // set gyro error_count
@@ -168,4 +166,46 @@ uint16_t AP_InertialSensor_Backend::get_sample_rate_hz(void) const
 void AP_InertialSensor_Backend::_publish_temperature(uint8_t instance, float temperature)
 {
     _imu._temperature[instance] = temperature;
+}
+
+/*
+  common gyro update function for all backends
+ */
+void AP_InertialSensor_Backend::update_gyro(uint8_t instance)
+{    
+    hal.scheduler->suspend_timer_procs();
+
+    if (_imu._new_gyro_data[instance]) {
+        _publish_gyro(instance, _imu._gyro_filtered[instance]);
+        _imu._new_gyro_data[instance] = false;
+    }
+
+    // possibly update filter frequency
+    if (_last_gyro_filter_hz != _gyro_filter_cutoff()) {
+        _imu._gyro_filter[instance].set_cutoff_frequency(_gyro_raw_sample_rate(instance), _gyro_filter_cutoff());
+        _last_gyro_filter_hz = _gyro_filter_cutoff();
+    }
+
+    hal.scheduler->resume_timer_procs();
+}
+
+/*
+  common accel update function for all backends
+ */
+void AP_InertialSensor_Backend::update_accel(uint8_t instance)
+{    
+    hal.scheduler->suspend_timer_procs();
+
+    if (_imu._new_accel_data[instance]) {
+        _publish_accel(instance, _imu._accel_filtered[instance]);
+        _imu._new_accel_data[instance] = false;
+    }
+    
+    // possibly update filter frequency
+    if (_last_accel_filter_hz != _accel_filter_cutoff()) {
+        _imu._accel_filter[instance].set_cutoff_frequency(_accel_raw_sample_rate(instance), _accel_filter_cutoff());
+        _last_accel_filter_hz = _accel_filter_cutoff();
+    }
+
+    hal.scheduler->resume_timer_procs();
 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -140,8 +140,8 @@ protected:
     void update_accel(uint8_t instance);
     
     // support for updating filter at runtime
-    int8_t _last_accel_filter_hz;
-    int8_t _last_gyro_filter_hz;
+    int8_t _last_accel_filter_hz[INS_MAX_INSTANCES];
+    int8_t _last_gyro_filter_hz[INS_MAX_INSTANCES];
     
     // note that each backend is also expected to have a static detect()
     // function which instantiates an instance of the backend sensor

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -43,17 +43,10 @@ public:
      */
     virtual bool update() = 0;
 
-    /* 
-     * return true if at least one accel sample is available in the backend
-     * since the last call to update()
+    /*
+     * optional function to accumulate more samples. This is needed for drivers that don't use a timer to gather samples
      */
-    virtual bool accel_sample_available() = 0;
-
-    /* 
-     * return true if at least one gyro sample is available in the backend
-     * since the last call to update()
-     */
-    virtual bool gyro_sample_available() = 0;
+    virtual void accumulate() {}
 
     /*
      * Configure and start all sensors. The empty implementation allows

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -80,7 +80,7 @@ protected:
     // be it published or not
     // the sample is raw in the sense that it's not filtered yet, but it must
     // be rotated and corrected (_rotate_and_correct_gyro)
-    void _notify_new_gyro_raw_sample(uint8_t instance, const Vector3f &accel);
+    void _notify_new_gyro_raw_sample(uint8_t instance, const Vector3f &accel, uint64_t sample_us=0);
 
     // rotate accel vector, scale, offset and publish
     void _publish_accel(uint8_t instance, const Vector3f &accel);
@@ -89,7 +89,7 @@ protected:
     // be it published or not
     // the sample is raw in the sense that it's not filtered yet, but it must
     // be rotated and corrected (_rotate_and_correct_accel)
-    void _notify_new_accel_raw_sample(uint8_t instance, const Vector3f &accel);
+    void _notify_new_accel_raw_sample(uint8_t instance, const Vector3f &accel, uint64_t sample_us=0);
 
     // set accelerometer max absolute offset for calibration
     void _set_accel_max_abs_offset(uint8_t instance, float offset);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -101,14 +101,12 @@ protected:
     // set accelerometer max absolute offset for calibration
     void _set_accel_max_abs_offset(uint8_t instance, float offset);
 
-    // set accelerometer raw sample rate
-    void _set_accel_raw_sample_rate(uint8_t instance, uint32_t rate);
+    // get accelerometer raw sample rate
     uint32_t _accel_raw_sample_rate(uint8_t instance) const {
         return _imu._accel_raw_sample_rates[instance];
     }
 
-    // set gyroscope raw sample rate
-    void _set_gyro_raw_sample_rate(uint8_t instance, uint32_t rate);
+    // get gyroscope raw sample rate
     uint32_t _gyro_raw_sample_rate(uint8_t instance) const {
         return _imu._gyro_raw_sample_rates[instance];
     }
@@ -142,6 +140,16 @@ protected:
         return _imu._log_raw_data? _imu._dataflash : NULL; 
     }
 
+    // common gyro update function for all backends
+    void update_gyro(uint8_t instance);
+
+    // common accel update function for all backends
+    void update_accel(uint8_t instance);
+    
+    // support for updating filter at runtime
+    int8_t _last_accel_filter_hz;
+    int8_t _last_gyro_filter_hz;
+    
     // note that each backend is also expected to have a static detect()
     // function which instantiates an instance of the backend sensor
     // driver if the sensor is available

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Flymaple.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Flymaple.cpp
@@ -65,8 +65,6 @@ const uint32_t  raw_sample_interval_us = (1000000 / raw_sample_rate_hz);
 
 AP_InertialSensor_Flymaple::AP_InertialSensor_Flymaple(AP_InertialSensor &imu) :
     AP_InertialSensor_Backend(imu),
-    _have_gyro_sample(false),
-    _have_accel_sample(false),
     _accel_filter(raw_sample_rate_hz, 10),
     _gyro_filter(raw_sample_rate_hz, 10),
     _last_gyro_timestamp(0),
@@ -166,9 +164,6 @@ void AP_InertialSensor_Flymaple::_set_filter_frequency(uint8_t filter_hz)
 // This takes about 20us to run
 bool AP_InertialSensor_Flymaple::update(void) 
 {
-    _have_gyro_sample = false;
-    _have_accel_sample = false;
-
     update_accel(_accel_instance);
     update_gyro(_gyro_instance);
 
@@ -215,7 +210,6 @@ void AP_InertialSensor_Flymaple::accumulate(void)
         accel *= FLYMAPLE_ACCELEROMETER_SCALE_M_S;
         _rotate_and_correct_accel(_accel_instance, accel);
         _notify_new_accel_raw_sample(_accel_instance, accel);
-        _have_accel_sample = true;
         _last_accel_timestamp = now;
     }
 
@@ -234,8 +228,6 @@ void AP_InertialSensor_Flymaple::accumulate(void)
         gyro *= FLYMAPLE_GYRO_SCALE_R_S;
         _rotate_and_correct_gyro(_gyro_instance, gyro);
         _notify_new_gyro_raw_sample(_gyro_instance, gyro);
-        _have_gyro_sample = true;
-        _last_gyro_timestamp = now;
     }
 
     // give back i2c semaphore

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Flymaple.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Flymaple.cpp
@@ -186,7 +186,7 @@ bool AP_InertialSensor_Flymaple::update(void)
 // operations take too long
 // So we are stuck with a suboptimal solution. The results are not so
 // good in terms of timing. It may be better with the FIFOs enabled
-void AP_InertialSensor_Flymaple::_accumulate(void)
+void AP_InertialSensor_Flymaple::accumulate(void)
 {
     // get pointer to i2c bus semaphore
     AP_HAL::Semaphore* i2c_sem = hal.i2c->get_semaphore();

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Flymaple.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Flymaple.h
@@ -27,18 +27,8 @@ public:
 private:
     bool        _init_sensor(void);
     void        _accumulate(void);
-    Vector3f	_accel_filtered;
-    Vector3f	_gyro_filtered;
     bool        _have_gyro_sample;
     bool        _have_accel_sample;
-
-    // support for updating filter at runtime
-    uint8_t _last_filter_hz;
-
-    void _set_filter_frequency(uint8_t filter_hz);
-    // Low Pass filters for gyro and accel 
-    LowPassFilter2pVector3f _accel_filter;
-    LowPassFilter2pVector3f _gyro_filter;
 
     uint8_t _gyro_instance;
     uint8_t _accel_instance;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Flymaple.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Flymaple.h
@@ -18,15 +18,14 @@ public:
     /* update accel and gyro state */
     bool update();
 
-    bool gyro_sample_available(void) { _accumulate(); return _have_gyro_sample; }
-    bool accel_sample_available(void) { _accumulate(); return _have_accel_sample; }
+    // accumulate samples
+    void accumulate(void) override;
 
     // detect the sensor
     static AP_InertialSensor_Backend *detect(AP_InertialSensor &imu);
 
 private:
     bool        _init_sensor(void);
-    void        _accumulate(void);
     bool        _have_gyro_sample;
     bool        _have_accel_sample;
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Flymaple.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Flymaple.h
@@ -26,14 +26,10 @@ public:
 
 private:
     bool        _init_sensor(void);
-    bool        _have_gyro_sample;
-    bool        _have_accel_sample;
 
     uint8_t _gyro_instance;
     uint8_t _accel_instance;
-
-    uint32_t _last_gyro_timestamp;
-    uint32_t _last_accel_timestamp;
 };
+
 #endif
 #endif // __AP_INERTIAL_SENSOR_FLYMAPLE_H__

--- a/libraries/AP_InertialSensor/AP_InertialSensor_HIL.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_HIL.cpp
@@ -29,8 +29,8 @@ AP_InertialSensor_Backend *AP_InertialSensor_HIL::detect(AP_InertialSensor &_imu
 bool AP_InertialSensor_HIL::_init_sensor(void) 
 {
     // grab the used instances
-    _imu.register_gyro();
-    _imu.register_accel();
+    _imu.register_gyro(1200);
+    _imu.register_accel(1200);
 
     _product_id = AP_PRODUCT_ID_NONE;
     _imu.set_hil_mode();

--- a/libraries/AP_InertialSensor/AP_InertialSensor_HIL.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_HIL.h
@@ -13,9 +13,6 @@ public:
     /* update accel and gyro state */
     bool update();
 
-    bool gyro_sample_available(void) { return true; }
-    bool accel_sample_available(void) { return true; }
-
     // detect the sensor
     static AP_InertialSensor_Backend *detect(AP_InertialSensor &imu);
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.cpp
@@ -113,9 +113,7 @@ const extern AP_HAL::HAL& hal;
 
 // constructor
 AP_InertialSensor_L3G4200D::AP_InertialSensor_L3G4200D(AP_InertialSensor &imu) :
-    AP_InertialSensor_Backend(imu),
-    _have_gyro_sample(false),
-    _have_accel_sample(false)
+    AP_InertialSensor_Backend(imu)
 {
 }
 
@@ -289,7 +287,6 @@ void AP_InertialSensor_L3G4200D::_accumulate(void)
                 gyro *= L3G4200D_GYRO_SCALE_R_S;
                 _rotate_and_correct_gyro(_gyro_instance, gyro);
                 _notify_new_gyro_raw_sample(_gyro_instance, gyro);
-                _have_gyro_sample = true;
             }
         }
     }
@@ -313,18 +310,12 @@ void AP_InertialSensor_L3G4200D::_accumulate(void)
                 accel *= ADXL345_ACCELEROMETER_SCALE_M_S;
                 _rotate_and_correct_accel(_accel_instance, accel);
                 _notify_new_accel_raw_sample(_accel_instance, accel);
-                _have_accel_sample = true;
             }
         }
     }
 
     // give back i2c semaphore
     i2c_sem->give();
-
-    if (_have_accel_sample && _have_gyro_sample) {
-        _have_gyro_sample = false;
-        _have_accel_sample = false;
-    }
 }
 
 #endif // CONFIG_HAL_BOARD

--- a/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.h
@@ -32,9 +32,6 @@ private:
     bool            _init_sensor(void);
     void            _accumulate(void);
 
-    bool _have_gyro_sample;
-    bool _have_accel_sample;
-
     // gyro and accel instances
     uint8_t _gyro_instance;
     uint8_t _accel_instance;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.h
@@ -22,9 +22,6 @@ public:
     /* update accel and gyro state */
     bool update();
 
-    bool gyro_sample_available(void) { return _have_sample; }
-    bool accel_sample_available(void) { return _have_sample; }
-
     // detect the sensor
     static AP_InertialSensor_Backend *detect(AP_InertialSensor &imu);
 
@@ -35,12 +32,8 @@ private:
     bool            _init_sensor(void);
     void            _accumulate(void);
 
-    int _data_idx;
-    pthread_spinlock_t _data_lock;
-
     bool _have_gyro_sample;
     bool _have_accel_sample;
-    volatile bool _have_sample;
 
     // gyro and accel instances
     uint8_t _gyro_instance;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_L3G4200D.h
@@ -35,25 +35,12 @@ private:
     bool            _init_sensor(void);
     void            _accumulate(void);
 
-    struct {
-        Vector3f accel_filtered;
-        Vector3f gyro_filtered;
-    } _data[2];
     int _data_idx;
     pthread_spinlock_t _data_lock;
 
     bool _have_gyro_sample;
     bool _have_accel_sample;
     volatile bool _have_sample;
-
-    // support for updating filter at runtime
-    uint8_t         _last_filter_hz;
-
-    void _set_filter_frequency(uint8_t filter_hz);
-
-    // Low Pass filters for gyro and accel 
-    LowPassFilter2pVector3f _accel_filter;
-    LowPassFilter2pVector3f _gyro_filter;
 
     // gyro and accel instances
     uint8_t _gyro_instance;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
@@ -376,8 +376,6 @@ AP_InertialSensor_LSM9DS0::AP_InertialSensor_LSM9DS0(AP_InertialSensor &imu,
     AP_InertialSensor_Backend(imu),
     _drdy_pin_a(NULL),
     _drdy_pin_g(NULL),
-    _gyro_sample_available(false),
-    _accel_sample_available(false),
     _drdy_pin_num_a(drdy_pin_num_a),
     _drdy_pin_num_g(drdy_pin_num_g)
 {
@@ -736,9 +734,9 @@ void AP_InertialSensor_LSM9DS0::_read_data_transaction_a()
 
     Vector3f accel_data(raw_data.x, -raw_data.y, -raw_data.z);
     accel_data *= _accel_scale;
+
     _rotate_and_correct_accel(_accel_instance, accel_data);
     _notify_new_accel_raw_sample(_accel_instance, accel_data);
-    _accel_sample_available = true;
 }
 
 /*
@@ -751,16 +749,13 @@ void AP_InertialSensor_LSM9DS0::_read_data_transaction_g()
 
     Vector3f gyro_data(raw_data.x, -raw_data.y, -raw_data.z);
     gyro_data *= _gyro_scale;
+
     _rotate_and_correct_gyro(_gyro_instance, gyro_data);
     _notify_new_gyro_raw_sample(_gyro_instance, gyro_data);
-    _gyro_sample_available = true;
 }
 
 bool AP_InertialSensor_LSM9DS0::update()
 {
-    _accel_sample_available = false;
-    _gyro_sample_available = false;
-
     update_gyro(_gyro_instance);
     update_accel(_accel_instance);
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.cpp
@@ -376,10 +376,6 @@ AP_InertialSensor_LSM9DS0::AP_InertialSensor_LSM9DS0(AP_InertialSensor &imu,
     AP_InertialSensor_Backend(imu),
     _drdy_pin_a(NULL),
     _drdy_pin_g(NULL),
-    _last_accel_filter_hz(-1),
-    _last_gyro_filter_hz(-1),
-    _accel_filter(800, 15),
-    _gyro_filter(760, 15),
     _gyro_sample_available(false),
     _accel_sample_available(false),
     _drdy_pin_num_a(drdy_pin_num_a),
@@ -480,8 +476,8 @@ bool AP_InertialSensor_LSM9DS0::_init_sensor()
 
     hal.scheduler->resume_timer_procs();
 
-    _gyro_instance = _imu.register_gyro();
-    _accel_instance = _imu.register_accel();
+    _gyro_instance = _imu.register_gyro(760);
+    _accel_instance = _imu.register_accel(800);
 
     _set_accel_max_abs_offset(_accel_instance, 5.0f);
 
@@ -742,7 +738,6 @@ void AP_InertialSensor_LSM9DS0::_read_data_transaction_a()
     accel_data *= _accel_scale;
     _rotate_and_correct_accel(_accel_instance, accel_data);
     _notify_new_accel_raw_sample(_accel_instance, accel_data);
-    _accel_filtered = _accel_filter.apply(accel_data);
     _accel_sample_available = true;
 }
 
@@ -758,7 +753,6 @@ void AP_InertialSensor_LSM9DS0::_read_data_transaction_g()
     gyro_data *= _gyro_scale;
     _rotate_and_correct_gyro(_gyro_instance, gyro_data);
     _notify_new_gyro_raw_sample(_gyro_instance, gyro_data);
-    _gyro_filtered = _gyro_filter.apply(gyro_data);
     _gyro_sample_available = true;
 }
 
@@ -767,36 +761,10 @@ bool AP_InertialSensor_LSM9DS0::update()
     _accel_sample_available = false;
     _gyro_sample_available = false;
 
-    _publish_gyro(_gyro_instance, _gyro_filtered);
-    _publish_accel(_accel_instance, _accel_filtered);
-
-    if (_last_accel_filter_hz != _accel_filter_cutoff()) {
-        _set_accel_filter(_accel_filter_cutoff());
-        _last_accel_filter_hz = _accel_filter_cutoff();
-    }
-
-    if (_last_gyro_filter_hz != _gyro_filter_cutoff()) {
-        _set_gyro_filter(_gyro_filter_cutoff());
-        _last_gyro_filter_hz = _gyro_filter_cutoff();
-    }
+    update_gyro(_gyro_instance);
+    update_accel(_accel_instance);
 
     return true;
-}
-
-/*
- *  set the accel filter frequency
- */
-void AP_InertialSensor_LSM9DS0::_set_accel_filter(uint8_t filter_hz)
-{
-    _accel_filter.set_cutoff_frequency(800, filter_hz);
-}
-
-/*
- *  set the gyro filter frequency
- */
-void AP_InertialSensor_LSM9DS0::_set_gyro_filter(uint8_t filter_hz)
-{
-    _gyro_filter.set_cutoff_frequency(760, filter_hz);
 }
 
  #if LSM9DS0_DEBUG

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.h
@@ -97,21 +97,6 @@ private:
     void                            _read_data_transaction_a();
     void                            _read_data_transaction_g();
 
-    /* support for updating filter at runtime */
-    int16_t         _last_gyro_filter_hz;
-    int16_t         _last_accel_filter_hz;
-
-    /* change the filter frequency */
-    void            _set_accel_filter(uint8_t filter_hz);
-    void            _set_gyro_filter(uint8_t filter_hz);
-
-    Vector3f        _accel_filtered;
-    Vector3f        _gyro_filtered;
-
-    /* Low Pass filters for gyro and accel */
-    LowPassFilter2pVector3f         _accel_filter;
-    LowPassFilter2pVector3f         _gyro_filter;
-
 #if LSM9DS0_DEBUG
     void        _dump_registers();
 #endif

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM9DS0.h
@@ -32,14 +32,6 @@ public:
 
     bool        update();
 
-    bool        gyro_sample_available() {
-        return _gyro_sample_available;
-    };
-
-    bool        accel_sample_available() {
-        return _accel_sample_available;
-    };
-
     static AP_InertialSensor_Backend *      detect(AP_InertialSensor &imu);
 
 private:
@@ -63,9 +55,6 @@ private:
     AP_HAL::DigitalSource *         _drdy_pin_a;
     int                             _drdy_pin_num_g;
     AP_HAL::DigitalSource *         _drdy_pin_g;
-
-    bool                            _gyro_sample_available;
-    bool                            _accel_sample_available;
 
     bool                            _accel_data_ready();
     bool                            _gyro_data_ready();

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.cpp
@@ -537,8 +537,6 @@ void AP_InertialSensor_MPU6000::start()
     _samples = new uint8_t[max_samples * MPU6000_SAMPLE_SIZE];
     hal.scheduler->delay(1);
 
-    _sample_count = 1;
-
     // disable sensor filtering
     _set_filter_register(256);
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.h
@@ -106,22 +106,13 @@ private:
 
     static const float   _gyro_scale;
 
-    // support for updating filter at runtime
-    int8_t _last_accel_filter_hz;
-    int8_t _last_gyro_filter_hz;
-
     void _set_filter_register(uint16_t filter_hz);
 
     // how many hardware samples before we report a sample to the caller
     uint8_t _sample_count;
 
-    Vector3f _accel_filtered;
-    Vector3f _gyro_filtered;
     float    _temp_filtered;
 
-    // Low Pass filters for gyro and accel
-    LowPassFilter2pVector3f _accel_filter;
-    LowPassFilter2pVector3f _gyro_filter;
     LowPassFilter2pFloat    _temp_filter;
 
     volatile uint16_t _sum_count;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU6000.h
@@ -63,9 +63,6 @@ public:
     /* update accel and gyro state */
     bool update();
 
-    bool gyro_sample_available(void) { return _sum_count >= _sample_count; }
-    bool accel_sample_available(void) { return _sum_count >= _sample_count; }
-
     /*
      * Return an AuxiliaryBus if the bus driver allows it
      */
@@ -88,7 +85,6 @@ private:
 
     AP_HAL::DigitalSource *_drdy_pin;
     bool    _init_sensor(void);
-    bool    _sample_available();
     void    _read_data_transaction();
     bool    _data_ready();
     void    _poll_data(void);
@@ -108,14 +104,10 @@ private:
 
     void _set_filter_register(uint16_t filter_hz);
 
-    // how many hardware samples before we report a sample to the caller
-    uint8_t _sample_count;
-
     float    _temp_filtered;
 
     LowPassFilter2pFloat    _temp_filter;
 
-    volatile uint16_t _sum_count;
     bool _fifo_mode;
     uint8_t *_samples = nullptr;
 };

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9150.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9150.cpp
@@ -325,8 +325,7 @@ static struct gyro_state_s st = {
  *  @brief      Constructor
  */
 AP_InertialSensor_MPU9150::AP_InertialSensor_MPU9150(AP_InertialSensor &imu) :
-    AP_InertialSensor_Backend(imu),
-    _have_sample_available(false)
+    AP_InertialSensor_Backend(imu)
 {
 }
 
@@ -1076,8 +1075,6 @@ void AP_InertialSensor_MPU9150::_accumulate(void)
         gyro *= MPU9150_GYRO_SCALE_2000;
         _rotate_and_correct_gyro(_gyro_instance, gyro);
         _notify_new_gyro_raw_sample(_gyro_instance, gyro);
-
-        _have_sample_available = true;
     }
 
     // give back i2c semaphore
@@ -1086,7 +1083,6 @@ void AP_InertialSensor_MPU9150::_accumulate(void)
 
 bool AP_InertialSensor_MPU9150::update(void) 
 {
-    _have_sample_available = false;
     update_gyro(_gyro_instance);
     update_accel(_accel_instance);
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9150.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9150.cpp
@@ -326,9 +326,7 @@ static struct gyro_state_s st = {
  */
 AP_InertialSensor_MPU9150::AP_InertialSensor_MPU9150(AP_InertialSensor &imu) :
     AP_InertialSensor_Backend(imu),
-    _have_sample_available(false),
-    _accel_filter(800, 10),
-    _gyro_filter(800, 10)
+    _have_sample_available(false)
 {
 }
 
@@ -347,22 +345,6 @@ AP_InertialSensor_Backend *AP_InertialSensor_MPU9150::detect(AP_InertialSensor &
         return NULL;
     }
     return sensor;
-}
-
-/*
-  set the accel filter frequency
- */
-void AP_InertialSensor_MPU9150::_set_accel_filter_frequency(uint8_t filter_hz)
-{
-    _accel_filter.set_cutoff_frequency(800, filter_hz);
-}
-
-/*
-  set the gyro filter frequency
- */
-void AP_InertialSensor_MPU9150::_set_gyro_filter_frequency(uint8_t filter_hz)
-{
-    _gyro_filter.set_cutoff_frequency(800, filter_hz);
 }
 
 /**
@@ -458,15 +440,11 @@ bool AP_InertialSensor_MPU9150::_init_sensor(void)
 
     mpu_set_sensors(sensors);
 
-    // Set the filter frecuency
-    _set_accel_filter_frequency(_accel_filter_cutoff());
-    _set_gyro_filter_frequency(_gyro_filter_cutoff());
-
     // give back i2c semaphore
     i2c_sem->give();
 
-    _gyro_instance = _imu.register_gyro();
-    _accel_instance = _imu.register_accel();
+    _gyro_instance = _imu.register_gyro(800);
+    _accel_instance = _imu.register_accel(800);
 
     // start the timer process to read samples    
     hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&AP_InertialSensor_MPU9150::_accumulate, void));
@@ -1093,13 +1071,11 @@ void AP_InertialSensor_MPU9150::_accumulate(void)
         accel *= MPU9150_ACCEL_SCALE_2G;
         _rotate_and_correct_accel(_accel_instance, accel);
         _notify_new_accel_raw_sample(_accel_instance, accel);
-        _accel_filtered = _accel_filter.apply(accel);
 
         gyro = Vector3f(gyro_x, gyro_y, gyro_z);
         gyro *= MPU9150_GYRO_SCALE_2000;
         _rotate_and_correct_gyro(_gyro_instance, gyro);
         _notify_new_gyro_raw_sample(_gyro_instance, gyro);
-        _gyro_filtered = _gyro_filter.apply(gyro);
 
         _have_sample_available = true;
     }
@@ -1110,26 +1086,9 @@ void AP_InertialSensor_MPU9150::_accumulate(void)
 
 bool AP_InertialSensor_MPU9150::update(void) 
 {
-    Vector3f accel, gyro;
-
-    hal.scheduler->suspend_timer_procs();
-    accel = _accel_filtered;
-    gyro = _gyro_filtered;
     _have_sample_available = false;
-    hal.scheduler->resume_timer_procs();
-
-    _publish_accel(_accel_instance, accel);
-    _publish_gyro(_gyro_instance, gyro);
-
-    if (_last_accel_filter_hz != _accel_filter_cutoff()) {
-        _set_accel_filter_frequency(_accel_filter_cutoff());
-        _last_accel_filter_hz = _accel_filter_cutoff();
-    }
-
-    if (_last_gyro_filter_hz != _gyro_filter_cutoff()) {
-        _set_gyro_filter_frequency(_gyro_filter_cutoff());
-        _last_gyro_filter_hz = _gyro_filter_cutoff();
-    }
+    update_gyro(_gyro_instance);
+    update_accel(_accel_instance);
 
     return true;
 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9150.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9150.h
@@ -19,16 +19,12 @@ public:
     /* update accel and gyro state */
     bool update();
 
-    bool gyro_sample_available(void) { return _have_sample_available; }
-    bool accel_sample_available(void) { return _have_sample_available; }
-
     // detect the sensor
     static AP_InertialSensor_Backend *detect(AP_InertialSensor &imu);
 
 private:
     bool            _init_sensor();
     void             _accumulate(void);
-    bool            _have_sample_available;
 
     int16_t mpu_set_gyro_fsr(uint16_t fsr);
     int16_t mpu_set_accel_fsr(uint8_t fsr);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9150.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9150.h
@@ -28,13 +28,7 @@ public:
 private:
     bool            _init_sensor();
     void             _accumulate(void);
-    Vector3f        _accel_filtered;
-    Vector3f        _gyro_filtered;
     bool            _have_sample_available;
-
-    // // support for updating filter at runtime
-    uint8_t         _last_accel_filter_hz;
-    uint8_t         _last_gyro_filter_hz;
 
     int16_t mpu_set_gyro_fsr(uint16_t fsr);
     int16_t mpu_set_accel_fsr(uint8_t fsr);
@@ -47,13 +41,6 @@ private:
     int16_t mpu_set_sensors(uint8_t sensors);
     int16_t mpu_set_int_latched(uint8_t enable);
     int16_t mpu_read_fifo(int16_t *gyro, int16_t *accel, uint32_t *timestamp, uint8_t *sensors, uint8_t *more);
-
-    void _set_accel_filter_frequency(uint8_t filter_hz);
-    void _set_gyro_filter_frequency(uint8_t filter_hz);
-
-    // Low Pass filters for gyro and accel 
-    LowPassFilter2pVector3f _accel_filter;
-    LowPassFilter2pVector3f _gyro_filter;
 
     uint8_t _gyro_instance;
     uint8_t _accel_instance;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
@@ -362,7 +362,6 @@ bool AP_MPU9250_BusDriver_I2C::has_auxiliary_bus()
 
 AP_InertialSensor_MPU9250::AP_InertialSensor_MPU9250(AP_InertialSensor &imu, AP_MPU9250_BusDriver *bus) :
 	AP_InertialSensor_Backend(imu),
-    _have_sample_available(false),
     _bus(bus),
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_PXF
     _default_rotation(ROTATION_ROLL_180_YAW_270)
@@ -451,8 +450,6 @@ bool AP_InertialSensor_MPU9250::_init_sensor()
  */
 bool AP_InertialSensor_MPU9250::update( void )
 {
-    _have_sample_available = false;
-
     update_gyro(_gyro_instance);
     update_accel(_accel_instance);
 
@@ -508,10 +505,9 @@ void AP_InertialSensor_MPU9250::_read_data_transaction()
                     -int16_val(rx, 6));
     gyro *= GYRO_SCALE;
     gyro.rotate(_default_rotation);
+
     _rotate_and_correct_gyro(_gyro_instance, gyro);
     _notify_new_gyro_raw_sample(_gyro_instance, gyro);
-
-    _have_sample_available = true;
 }
 
 /*

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.h
@@ -44,9 +44,6 @@ public:
     /* update accel and gyro state */
     bool update();
 
-    bool gyro_sample_available(void) { return _have_sample_available; }
-    bool accel_sample_available(void) { return _have_sample_available; }
-
     AuxiliaryBus *get_auxiliary_bus();
 
     static AP_InertialSensor_MPU9250 &from(AP_InertialSensor_Backend &backend) {
@@ -71,14 +68,10 @@ private:
     uint8_t              _register_read( uint8_t reg );
     void                 _register_write( uint8_t reg, uint8_t val );
     bool                 _hardware_init(void);
-    bool                 _sample_available();
 
     AP_MPU9250_BusDriver *_bus;
     AP_HAL::Semaphore *_bus_sem;
     AP_MPU9250_AuxiliaryBus *_auxiliar_bus = nullptr;
-
-    // do we currently have a sample pending?
-    bool _have_sample_available;
 
     // gyro and accel instances
     uint8_t _gyro_instance;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.h
@@ -77,28 +77,6 @@ private:
     AP_HAL::Semaphore *_bus_sem;
     AP_MPU9250_AuxiliaryBus *_auxiliar_bus = nullptr;
 
-    // support for updating filter at runtime
-    int16_t _last_gyro_filter_hz;
-    int16_t _last_accel_filter_hz;
-
-    // change the filter frequency
-    void _set_accel_filter(uint8_t filter_hz);
-    void _set_gyro_filter(uint8_t filter_hz);
-
-    // This structure is used to pass data from the timer which reads
-    // the sensor to the main thread. The _shared_data_idx is used to
-    // prevent race conditions by ensuring the data is fully updated
-    // before being used by the consumer
-    struct {
-        Vector3f _accel_filtered;
-        Vector3f _gyro_filtered;
-    } _shared_data[2];
-    volatile uint8_t _shared_data_idx;
-
-    // Low Pass filters for gyro and accel 
-    LowPassFilter2pVector3f _accel_filter;
-    LowPassFilter2pVector3f _gyro_filter;
-
     // do we currently have a sample pending?
     bool _have_sample_available;
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_PX4.cpp
@@ -23,9 +23,7 @@ const extern AP_HAL::HAL& hal;
 AP_InertialSensor_PX4::AP_InertialSensor_PX4(AP_InertialSensor &imu) :
     AP_InertialSensor_Backend(imu),
     _last_get_sample_timestamp(0),
-    _last_sample_timestamp(0),
-    _last_gyro_filter_hz(-1),
-    _last_accel_filter_hz(-1)
+    _last_sample_timestamp(0)
 {
 }
 
@@ -164,9 +162,6 @@ bool AP_InertialSensor_PX4::_init_sensor(void)
         _accel_sample_time[i] = 1.0f / samplerate;
     }
 
-    _set_accel_filter_frequency(_accel_filter_cutoff());
-    _set_gyro_filter_frequency(_gyro_filter_cutoff());
-
 #if  CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
     _product_id = AP_PRODUCT_ID_VRBRAIN;
 #else
@@ -177,28 +172,6 @@ bool AP_InertialSensor_PX4::_init_sensor(void)
 #endif
 #endif
     return true;
-}
-
-/*
-  set the accel filter frequency
- */
-void AP_InertialSensor_PX4::_set_accel_filter_frequency(uint8_t filter_hz)
-{
-    for (uint8_t i=0; i<_num_accel_instances; i++) {
-        float samplerate = _accel_raw_sample_rate(_accel_instance[i]);
-        _accel_filter[i].set_cutoff_frequency(samplerate, filter_hz);
-    }
-}
-
-/*
-  set the gyro filter frequency
- */
-void AP_InertialSensor_PX4::_set_gyro_filter_frequency(uint8_t filter_hz)
-{
-    for (uint8_t i=0; i<_num_gyro_instances; i++) {
-        float samplerate = _gyro_raw_sample_rate(_gyro_instance[i]);
-        _gyro_filter[i].set_cutoff_frequency(samplerate, filter_hz);
-    }
 }
 
 bool AP_InertialSensor_PX4::update(void) 
@@ -366,28 +339,6 @@ bool AP_InertialSensor_PX4::_get_gyro_sample(uint8_t i, struct gyro_report &gyro
         }
         return true;
     }
-    return false;
-}
-
-bool AP_InertialSensor_PX4::gyro_sample_available(void)
-{
-    _get_sample();
-    for (uint8_t i=0; i<_num_gyro_instances; i++) {
-        if (_last_gyro_timestamp[i] != _last_gyro_update_timestamp[i]) {
-            return true;
-        }
-    }    
-    return false;
-}
-
-bool AP_InertialSensor_PX4::accel_sample_available(void)
-{
-    _get_sample();
-    for (uint8_t i=0; i<_num_accel_instances; i++) {
-        if (_last_accel_timestamp[i] != _last_accel_update_timestamp[i]) {
-            return true;
-        }
-    }    
     return false;
 }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_PX4.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_PX4.h
@@ -35,12 +35,8 @@ private:
     void     _get_sample(void);
     uint64_t _last_accel_timestamp[INS_MAX_INSTANCES];
     uint64_t _last_gyro_timestamp[INS_MAX_INSTANCES];
-    uint64_t _last_accel_update_timestamp[INS_MAX_INSTANCES];
-    uint64_t _last_gyro_update_timestamp[INS_MAX_INSTANCES];
     float    _accel_sample_time[INS_MAX_INSTANCES];
     float    _gyro_sample_time[INS_MAX_INSTANCES];
-    uint64_t _last_get_sample_timestamp;
-    uint64_t _last_sample_timestamp;
 
     void _new_accel_sample(uint8_t i, accel_report &accel_report);
     void _new_gyro_sample(uint8_t i, gyro_report &gyro_report);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_PX4.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_PX4.h
@@ -34,8 +34,6 @@ private:
     bool     _init_sensor(void);
     void     _get_sample(void);
     bool     _sample_available(void);
-    Vector3f _accel_in[INS_MAX_INSTANCES];
-    Vector3f _gyro_in[INS_MAX_INSTANCES];
     uint64_t _last_accel_timestamp[INS_MAX_INSTANCES];
     uint64_t _last_gyro_timestamp[INS_MAX_INSTANCES];
     uint64_t _last_accel_update_timestamp[INS_MAX_INSTANCES];
@@ -54,13 +52,6 @@ private:
     // calculate right queue depth for a sensor
     uint8_t _queue_depth(uint16_t sensor_sample_rate) const;
 
-    // support for updating filter at runtime (-1 means unset)
-    int8_t _last_gyro_filter_hz;
-    int8_t _last_accel_filter_hz;
-
-    void _set_gyro_filter_frequency(uint8_t filter_hz);
-    void _set_accel_filter_frequency(uint8_t filter_hz);
-
     // accelerometer and gyro driver handles
     uint8_t _num_accel_instances;
     uint8_t _num_gyro_instances;
@@ -72,10 +63,6 @@ private:
     // from the backend indexes
     uint8_t _accel_instance[INS_MAX_INSTANCES];
     uint8_t _gyro_instance[INS_MAX_INSTANCES];
-
-    // Low Pass filters for gyro and accel
-    LowPassFilter2pVector3f _accel_filter[INS_MAX_INSTANCES];
-    LowPassFilter2pVector3f _gyro_filter[INS_MAX_INSTANCES];
 
 #ifdef AP_INERTIALSENSOR_PX4_DEBUG
     uint32_t _gyro_meas_count[INS_MAX_INSTANCES];

--- a/libraries/AP_InertialSensor/AP_InertialSensor_PX4.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_PX4.h
@@ -27,13 +27,12 @@ public:
     // detect the sensor
     static AP_InertialSensor_Backend *detect(AP_InertialSensor &imu);
 
-    bool gyro_sample_available(void);
-    bool accel_sample_available(void);
+    // accumulate more samples
+    void accumulate(void) override { _get_sample(); }
 
 private:
     bool     _init_sensor(void);
     void     _get_sample(void);
-    bool     _sample_available(void);
     uint64_t _last_accel_timestamp[INS_MAX_INSTANCES];
     uint64_t _last_gyro_timestamp[INS_MAX_INSTANCES];
     uint64_t _last_accel_update_timestamp[INS_MAX_INSTANCES];

--- a/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
@@ -1,0 +1,139 @@
+/// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+
+#include <AP_HAL/AP_HAL.h>
+#include "AP_InertialSensor_SITL.h"
+#include <SITL/SITL.h>
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+
+const extern AP_HAL::HAL& hal;
+
+AP_InertialSensor_SITL::AP_InertialSensor_SITL(AP_InertialSensor &imu) :
+    AP_InertialSensor_Backend(imu)
+{
+}
+
+/*
+  detect the sensor
+ */
+AP_InertialSensor_Backend *AP_InertialSensor_SITL::detect(AP_InertialSensor &_imu)
+{
+    AP_InertialSensor_SITL *sensor = new AP_InertialSensor_SITL(_imu);
+    if (sensor == NULL) {
+        return NULL;
+    }
+    if (!sensor->init_sensor()) {
+        delete sensor;
+        return NULL;
+    }
+    return sensor;
+}
+
+bool AP_InertialSensor_SITL::init_sensor(void) 
+{
+    sitl = (SITL::SITL *)AP_Param::find_object("SIM_");
+    if (sitl == nullptr) {
+        return false;
+    }
+
+    // grab the used instances
+    for (uint8_t i=0; i<INS_SITL_INSTANCES; i++) {
+        gyro_instance[i] = _imu.register_gyro(sitl->update_rate_hz);
+        accel_instance[i] = _imu.register_accel(sitl->update_rate_hz);
+    }
+
+    hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&AP_InertialSensor_SITL::timer_update, void));
+
+    _product_id = AP_PRODUCT_ID_NONE;
+
+    return true;
+}
+
+void AP_InertialSensor_SITL::timer_update(void)
+{
+    // minimum noise levels are 2 bits, but averaged over many
+    // samples, giving around 0.01 m/s/s
+    float accel_noise = 0.01f;
+    float accel2_noise = 0.01f;
+
+    // minimum gyro noise is also less than 1 bit
+    float gyro_noise = ToRad(0.04f);
+    if (sitl->motors_on) {
+        // add extra noise when the motors are on
+        accel_noise += sitl->accel_noise;
+        accel2_noise += sitl->accel2_noise;
+        gyro_noise += ToRad(sitl->gyro_noise);
+    }
+
+    // get accel bias (add only to first accelerometer)
+    Vector3f accel_bias = sitl->accel_bias.get();
+    float xAccel1 = sitl->state.xAccel + accel_noise * rand_float() + accel_bias.x;
+    float yAccel1 = sitl->state.yAccel + accel_noise * rand_float() + accel_bias.y;
+    float zAccel1 = sitl->state.zAccel + accel_noise * rand_float() + accel_bias.z;
+
+    float xAccel2 = sitl->state.xAccel + accel2_noise * rand_float();
+    float yAccel2 = sitl->state.yAccel + accel2_noise * rand_float();
+    float zAccel2 = sitl->state.zAccel + accel2_noise * rand_float();
+
+    if (fabsf(sitl->accel_fail) > 1.0e-6f) {
+        xAccel1 = sitl->accel_fail;
+        yAccel1 = sitl->accel_fail;
+        zAccel1 = sitl->accel_fail;
+    }
+
+    Vector3f accel0 = Vector3f(xAccel1, yAccel1, zAccel1) + _imu.get_accel_offsets(0);
+    Vector3f accel1 = Vector3f(xAccel2, yAccel2, zAccel2) + _imu.get_accel_offsets(1);
+    _notify_new_accel_raw_sample(accel_instance[0], accel0);
+    _notify_new_accel_raw_sample(accel_instance[1], accel1);
+
+    float p = radians(sitl->state.rollRate) + gyro_drift();
+    float q = radians(sitl->state.pitchRate) + gyro_drift();
+    float r = radians(sitl->state.yawRate) + gyro_drift();
+
+    float p1 = p + gyro_noise * rand_float();
+    float q1 = q + gyro_noise * rand_float();
+    float r1 = r + gyro_noise * rand_float();
+
+    float p2 = p + gyro_noise * rand_float();
+    float q2 = q + gyro_noise * rand_float();
+    float r2 = r + gyro_noise * rand_float();
+
+    Vector3f gyro0 = Vector3f(p1, q1, r1) + _imu.get_gyro_offsets(0);
+    Vector3f gyro1 = Vector3f(p2, q2, r2) + _imu.get_gyro_offsets(1);
+
+    _notify_new_gyro_raw_sample(gyro_instance[0], gyro0);
+    _notify_new_gyro_raw_sample(gyro_instance[1], gyro1);
+}
+
+// generate a random float between -1 and 1
+float AP_InertialSensor_SITL::rand_float(void)
+{
+    return ((((unsigned)random()) % 2000000) - 1.0e6) / 1.0e6;
+}
+
+float AP_InertialSensor_SITL::gyro_drift(void)
+{
+    if (sitl->drift_speed == 0.0f ||
+        sitl->drift_time == 0.0f) {
+        return 0;
+    }
+    double period  = sitl->drift_time * 2;
+    double minutes = fmod(hal.scheduler->micros64() / 60.0e6, period);
+    if (minutes < period/2) {
+        return minutes * ToRad(sitl->drift_speed);
+    }
+    return (period - minutes) * ToRad(sitl->drift_speed);
+
+}
+
+
+bool AP_InertialSensor_SITL::update(void) 
+{
+    for (uint8_t i=0; i<INS_SITL_INSTANCES; i++) {
+        update_accel(accel_instance[i]);
+        update_gyro(gyro_instance[i]);
+    }
+    return true;
+}
+
+#endif // HAL_BOARD_SITL

--- a/libraries/AP_InertialSensor/AP_InertialSensor_SITL.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SITL.h
@@ -1,0 +1,34 @@
+/// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+
+#ifndef __AP_INERTIALSENSOR_SITL_H__
+#define __AP_INERTIALSENSOR_SITL_H__
+
+#include "AP_InertialSensor.h"
+#include <SITL/SITL.h>
+
+#define INS_SITL_INSTANCES 2
+
+class AP_InertialSensor_SITL : public AP_InertialSensor_Backend
+{
+public:
+    AP_InertialSensor_SITL(AP_InertialSensor &imu);
+
+    /* update accel and gyro state */
+    bool update();
+
+    // detect the sensor
+    static AP_InertialSensor_Backend *detect(AP_InertialSensor &imu);
+
+private:
+    bool init_sensor(void);
+    void timer_update();
+    float rand_float(void);
+    float gyro_drift(void);
+    
+    SITL::SITL *sitl;
+
+    uint8_t gyro_instance[INS_SITL_INSTANCES];
+    uint8_t accel_instance[INS_SITL_INSTANCES];
+};
+
+#endif // __AP_INERTIALSENSOR_SITL_H__

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -72,6 +72,9 @@ public:
     /* fill a sitl_fdm structure from the simulator state */
     void fill_fdm(struct sitl_fdm &fdm) const;
 
+    // get frame rate of model in Hz
+    float get_rate_hz(void) const { return rate_hz; }       
+    
 protected:
     Location home;
     Location location;

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -23,6 +23,7 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
+#include <DataFlash/DataFlash.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -104,7 +105,7 @@ void SITL::simstate_send(mavlink_channel_t chan)
 }
 
 /* report SITL state to DataFlash */
-void SITL::Log_Write_SIMSTATE(DataFlash_Class &DataFlash)
+void SITL::Log_Write_SIMSTATE(DataFlash_Class *DataFlash)
 {
     float yaw;
 
@@ -124,7 +125,7 @@ void SITL::Log_Write_SIMSTATE(DataFlash_Class &DataFlash)
         lat     : (int32_t)(state.latitude*1.0e7),
         lng     : (int32_t)(state.longitude*1.0e7)
     };
-    DataFlash.WriteBlock(&pkt, sizeof(pkt));
+    DataFlash->WriteBlock(&pkt, sizeof(pkt));
 }
 
 /*

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -2,8 +2,9 @@
 
 #pragma once
 
-#include <DataFlash/DataFlash.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
+
+class DataFlash_Class;
 
 namespace SITL {
 
@@ -26,7 +27,6 @@ struct PACKED sitl_fdm {
 // number of rc output channels
 #define SITL_NUM_CHANNELS 14
 
-
 class SITL {
 public:
 
@@ -48,6 +48,12 @@ public:
     };
 
     struct sitl_fdm state;
+
+    // loop update rate in Hz
+    uint16_t update_rate_hz;
+
+    // true when motors are active
+    bool motors_on;
 
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -105,7 +111,7 @@ public:
 
     void simstate_send(mavlink_channel_t chan);
 
-    void Log_Write_SIMSTATE(DataFlash_Class &dataflash);
+    void Log_Write_SIMSTATE(DataFlash_Class *dataflash);
 
     // convert a set of roll rates from earth frame to body frame
     static void convert_body_frame(double rollDeg, double pitchDeg,


### PR DESCRIPTION
This adds a SITL specific backend to AP_InertialSensor and moves the filter and update handling into common code, allowing the individual drivers to be much simpler
This also brings raw sensor logging to non-PX4 ports, allowing the Linux and SITL ports to have raw logging
