### PR TITLE
Remove unused extern declaration for HALs

### DIFF
--- a/libraries/AP_HAL_Empty/HAL_Empty_Class.h
+++ b/libraries/AP_HAL_Empty/HAL_Empty_Class.h
@@ -1,6 +1,4 @@
-
-#ifndef __AP_HAL_EMPTY_CLASS_H__
-#define __AP_HAL_EMPTY_CLASS_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 
@@ -14,8 +12,3 @@ public:
 private:
     Empty::EmptyPrivateMember *_member;
 };
-
-extern const HAL_Empty AP_HAL_Empty;
-
-#endif // __AP_HAL_EMPTY_CLASS_H__
-

--- a/libraries/AP_HAL_FLYMAPLE/HAL_FLYMAPLE_Class.h
+++ b/libraries/AP_HAL_FLYMAPLE/HAL_FLYMAPLE_Class.h
@@ -16,8 +16,7 @@
   Flymaple port by Mike McCauley
  */
 
-#ifndef __AP_HAL_FLYMAPLE_CLASS_H__
-#define __AP_HAL_FLYMAPLE_CLASS_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 
@@ -28,8 +27,3 @@ public:
     HAL_FLYMAPLE();
     void run(int argc, char* const* argv, Callbacks* callbacks) const override;
 };
-
-extern const HAL_FLYMAPLE AP_HAL_FLYMAPLE;
-
-#endif // __AP_HAL_FLYMAPLE_CLASS_H__
-

--- a/libraries/AP_HAL_Linux/HAL_Linux_Class.h
+++ b/libraries/AP_HAL_Linux/HAL_Linux_Class.h
@@ -1,6 +1,4 @@
-
-#ifndef __AP_HAL_LINUX_CLASS_H__
-#define __AP_HAL_LINUX_CLASS_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 
@@ -11,8 +9,3 @@ public:
     HAL_Linux();
     void run(int argc, char* const* argv, Callbacks* callbacks) const override;
 };
-
-extern const HAL_Linux AP_HAL_Linux;
-
-#endif // __AP_HAL_LINUX_CLASS_H__
-

--- a/libraries/AP_HAL_PX4/HAL_PX4_Class.h
+++ b/libraries/AP_HAL_PX4/HAL_PX4_Class.h
@@ -1,6 +1,4 @@
-
-#ifndef __AP_HAL_PX4_CLASS_H__
-#define __AP_HAL_PX4_CLASS_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 
@@ -13,13 +11,10 @@
 
 class HAL_PX4 : public AP_HAL::HAL {
 public:
-    HAL_PX4();    
+    HAL_PX4();
     void run(int argc, char* const argv[], Callbacks* callbacks) const override;
 };
 
 void hal_px4_set_priority(uint8_t priority);
 
-extern const HAL_PX4 AP_HAL_PX4;
-
 #endif // CONFIG_HAL_BOARD == HAL_BOARD_PX4
-#endif // __AP_HAL_PX4_CLASS_H__

--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.h
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.h
@@ -1,6 +1,4 @@
-
-#ifndef __AP_HAL_SITL_CLASS_H__
-#define __AP_HAL_SITL_CLASS_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 
@@ -19,8 +17,4 @@ private:
     HALSITL::SITL_State *_sitl_state;
 };
 
-extern const HAL_SITL AP_HAL_SITL;
-
 #endif // CONFIG_HAL_BOARD == HAL_BOARD_SITL
-#endif // __AP_HAL_SITL_CLASS_H__
-

--- a/libraries/AP_HAL_VRBRAIN/HAL_VRBRAIN_Class.h
+++ b/libraries/AP_HAL_VRBRAIN/HAL_VRBRAIN_Class.h
@@ -1,6 +1,4 @@
-
-#ifndef __AP_HAL_VRBRAIN_CLASS_H__
-#define __AP_HAL_VRBRAIN_CLASS_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 
@@ -17,7 +15,4 @@ public:
     void run(int argc, char* const argv[], Callbacks* callbacks) const override;
 };
 
-extern const HAL_VRBRAIN AP_HAL_VRBRAIN;
-
 #endif // CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
-#endif // __AP_HAL_VRBRAIN_CLASS_H__


### PR DESCRIPTION
These are "left-overs" from how things worked before commit
"AP_HAL: make code not depend on concrete HAL
implementations" (2e464a53c25f709d6a9a50885708979b206a6f6f). The real
declaration now lives inside get_HAL() function.

Use the opportunitiy to change the files to use "#pragma once".