### PR TITLE
Fix flickering bad AHRS during pre-arm checks

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -455,7 +455,7 @@ bool NavEKF::healthy(void) const
     }
     // barometer and position innovations must be within limits when on-ground
     float horizErrSq = sq(innovVelPos[3]) + sq(innovVelPos[4]);
-    if (!vehicleArmed && (!hgtHealth || fabsf(hgtInnovFiltState) > 1.0f || horizErrSq > 2.0f)) {
+    if (!vehicleArmed && ((fabsf(hgtInnovFiltState) > 1.0f) || (horizErrSq > 2.0f))) {
         return false;
     }
 


### PR DESCRIPTION
Fixes an issue introduced by the merging of a previous commit from that caused the EKF health status to flicker between good and bad on the ground. 