### PR TITLE
Heli: fixed external tail gyro with no flybar

### DIFF
--- a/ArduCopter/heli_control_acro.cpp
+++ b/ArduCopter/heli_control_acro.cpp
@@ -53,6 +53,14 @@ void Copter::heli_acro_run()
     if (!motors.has_flybar()){
         // convert the input to the desired body frame rate
         get_pilot_desired_angle_rates(channel_roll->control_in, channel_pitch->control_in, channel_yaw->control_in, target_roll, target_pitch, target_yaw);
+
+        if (motors.supports_yaw_passthrough()) {
+            // if the tail on a flybar heli has an external gyro then
+            // also use no deadzone for the yaw control and
+            // pass-through the input direct to output.
+            target_yaw = channel_yaw->pwm_to_angle_dz(0);
+        }
+
         // run attitude controller
         attitude_control.rate_bf_roll_pitch_yaw(target_roll, target_pitch, target_yaw);
     }else{

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -136,7 +136,7 @@ public:
     void rate_ef_roll_pitch_yaw(float roll_rate_ef, float pitch_rate_ef, float yaw_rate_ef);
 
     // rate_bf_roll_pitch_yaw - attempts to maintain a roll, pitch and yaw rate (all body frame)
-    void rate_bf_roll_pitch_yaw(float roll_rate_bf, float pitch_rate_bf, float yaw_rate_bf);
+    virtual void rate_bf_roll_pitch_yaw(float roll_rate_bf, float pitch_rate_bf, float yaw_rate_bf);
 
     //
     // rate_controller_run - run lowest level body-frame rate controller and send outputs to the motors

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
@@ -86,6 +86,14 @@ void AC_AttitudeControl_Heli::passthrough_bf_roll_pitch_rate_yaw(float roll_pass
     _rate_bf_target.z += _rate_bf_desired.z;
 }
 
+// subclass non-passthrough too, for external gyro, no flybar
+void AC_AttitudeControl_Heli::rate_bf_roll_pitch_yaw(float roll_rate_bf, float pitch_rate_bf, float yaw_rate_bf)
+{
+    _passthrough_yaw = yaw_rate_bf;
+
+    AC_AttitudeControl::rate_bf_roll_pitch_yaw(roll_rate_bf, pitch_rate_bf, yaw_rate_bf);
+}
+
 //
 // rate controller (body-frame) methods
 //

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.h
@@ -49,6 +49,9 @@ public:
     // passthrough_bf_roll_pitch_rate_yaw - roll and pitch are passed through directly, body-frame rate target for yaw
     void passthrough_bf_roll_pitch_rate_yaw(float roll_passthrough, float pitch_passthrough, float yaw_rate_bf);
 
+	// subclass non-passthrough too, for external gyro, no flybar
+	void rate_bf_roll_pitch_yaw(float roll_rate_bf, float pitch_rate_bf, float yaw_rate_bf) override;
+
 	// rate_controller_run - run lowest level body-frame rate controller and send outputs to the motors
 	// should be called at 100hz or more
 	virtual void rate_controller_run();


### PR DESCRIPTION
this fixes acro mode for ext gyro with no flybar
without this change you can't move the tail at all in acro mode
