### PR TITLE
AP_Motors: allow change to heli rotor speed controls while armed

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -204,6 +204,7 @@ void AP_MotorsHeli::output()
     update_throttle_filter();
 
     if (_flags.armed) {
+        calculate_armed_scalars();
         if (!_flags.interlock) {
             output_armed_zero_throttle();
         } else if (_flags.stabilizing) {

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -136,6 +136,9 @@ public:
     // calculate_scalars - must be implemented by child classes
     virtual void calculate_scalars() = 0;
 
+    // calculate_armed_scalars - must be implemented by child classes
+    virtual void calculate_armed_scalars() = 0;
+    
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo var_info[];
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -219,6 +219,18 @@ void AP_MotorsHeli_Single::set_desired_rotor_speed(int16_t desired_speed)
 }
 
 // calculate_scalars - recalculates various scalers used.
+void AP_MotorsHeli_Single::calculate_armed_scalars()
+{
+    _main_rotor.set_ramp_time(_rsc_ramp_time);
+    _main_rotor.set_runup_time(_rsc_runup_time);
+    _main_rotor.set_critical_speed(_rsc_critical);
+    _main_rotor.set_idle_output(_rsc_idle_output);
+    _main_rotor.set_power_output_range(_rsc_power_low, _rsc_power_high);
+    _main_rotor.recalc_scalers();
+}
+
+
+// calculate_scalars - recalculates various scalers used.
 void AP_MotorsHeli_Single::calculate_scalars()
 {
     // range check collective min, max and mid
@@ -244,13 +256,8 @@ void AP_MotorsHeli_Single::calculate_scalars()
 
     // send setpoints to main rotor controller and trigger recalculation of scalars
     _main_rotor.set_control_mode(static_cast<RotorControlMode>(_rsc_mode.get()));
-    _main_rotor.set_ramp_time(_rsc_ramp_time);
-    _main_rotor.set_runup_time(_rsc_runup_time);
-    _main_rotor.set_critical_speed(_rsc_critical);
-    _main_rotor.set_idle_output(_rsc_idle_output);
-    _main_rotor.set_power_output_range(_rsc_power_low, _rsc_power_high);
-    _main_rotor.recalc_scalers();
-
+    calculate_armed_scalars();
+    
     // send setpoints to tail rotor controller and trigger recalculation of scalars
     if (_tail_type == AP_MOTORS_HELI_SINGLE_TAILTYPE_DIRECTDRIVE_VARPITCH) {
         _tail_rotor.set_control_mode(ROTOR_CONTROL_MODE_SPEED_SETPOINT);

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.h
@@ -95,6 +95,9 @@ public:
     // calculate_scalars - recalculates various scalars used
     void calculate_scalars();
 
+    // calculate_armed_scalars - recalculates scalars that can change while armed
+    void calculate_armed_scalars();
+    
     // get_motor_mask - returns a bitmask of which outputs are being used for motors or servos (1 means being used)
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
     uint16_t get_motor_mask();


### PR DESCRIPTION
this is important for two reasons:
1) the right idle speed changes a lot with the weather. If it idles too fast the clutch engages and the rotors spin while idling. If too slow you can stop the motor. You have to change this while armed
2) if monitoring engine temperature in a long flight and it rises too much you have to be able to lower the maximum throttle or the engine could overheat and seize, destroying the engine and the helicopter.
