### PR TITLE
Plane: use abort landing logic with mavlink GO_AROUND cmd

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -839,6 +839,7 @@ void Plane::update_flight_stage(void)
             } else if (mission.get_current_nav_cmd().id == MAV_CMD_NAV_LAND) {
 
                 if ((g.land_abort_throttle_enable && channel_throttle->control_in > 95) ||
+                        auto_state.commanded_go_around ||
                         flight_stage == AP_SpdHgtControl::FLIGHT_LAND_ABORT){
                     // abort mode is sticky, it must complete while executing NAV_LAND
                     set_flight_stage(AP_SpdHgtControl::FLIGHT_LAND_ABORT);

--- a/ArduPlane/landing.cpp
+++ b/ArduPlane/landing.cpp
@@ -16,15 +16,6 @@ bool Plane::verify_land()
     // so we don't verify command completion. Instead we use this to
     // adjust final landing parameters
 
-    // If a go around has been commanded, we are done landing.  This will send
-    // the mission to the next mission item, which presumably is a mission
-    // segment with operations to perform when a landing is called off.
-    // If there are no commands after the land waypoint mission item then
-    // the plane will proceed to loiter about its home point.
-    if (auto_state.commanded_go_around) {
-        return true;
-    }
-
     // when aborting a landing, mimic the verify_takeoff with steering hold. Once
     // the altitude has been reached, restart the landing sequence
     if (flight_stage == AP_SpdHgtControl::FLIGHT_LAND_ABORT) {


### PR DESCRIPTION
Right now the MAV_CMD_DO_GO_AROUND command just forces the LAND command to finish and move the mission index to the next mission item. With this change, that mavlink command will initiate the more fully-featured aborted landing which is currently only triggered via mode change or raising throttle to 95%.

I'll also be writing up a wiki on aborted landings.