### PR TITLE
Plane,Copter,Rover: Camera options for better camera control

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -381,7 +381,7 @@ void Rover::update_GPS_10Hz(void)
         }
 
 #if CAMERA == ENABLED
-        if (camera.update_location(current_loc) == true) {
+        if (camera.update_location(current_loc, rover.ahrs) == true) {
             do_take_picture();
         }
 #endif

--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -548,7 +548,7 @@ void Copter::update_GPS(void)
         if (gps.status() >= AP_GPS::GPS_OK_FIX_3D) {
 
 #if CAMERA == ENABLED
-            if (camera.update_location(current_loc) == true) {
+            if (camera.update_location(current_loc, copter.ahrs) == true) {
                 do_take_picture();
             }
 #endif

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -456,7 +456,7 @@ void Plane::update_GPS_10Hz(void)
         geofence_check(false);
 
 #if CAMERA == ENABLED
-        if (camera.update_location(current_loc) == true) {
+        if (camera.update_location(current_loc, plane.ahrs ) == true) {
             do_take_picture();
         }
 #endif        

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -60,7 +60,7 @@ public:
     void            set_trigger_distance(uint32_t distance_m) { _trigg_dist.set(distance_m); }
 
     // Update location of vehicle and return true if a picture should be taken
-    bool update_location(const struct Location &loc);
+    bool update_location(const struct Location &loc, const AP_AHRS &ahrs);
 
     static const struct AP_Param::GroupInfo        var_info[];
 
@@ -77,6 +77,9 @@ private:
     void            relay_pic();        // basic relay activation
 
     AP_Float        _trigg_dist;        // distance between trigger points (meters)
+    AP_Int16        _min_interval;      // Minimum time between shots required by camera
+    AP_Int16        _max_roll;          // Maximum acceptable roll angle when trigging camera
+    uint32_t        _last_photo_time;   // last time a photo was taken
     struct Location _last_location;
     uint16_t        _image_index;       // number of pictures taken since boot
 


### PR DESCRIPTION
All on one because they would not pass autotest if split up.
This gives user option to set max roll (to avoid useless photos while turning)  , minimum interval that camera can handle in case of higher than expected GS, esulting in best possible overlap, vs random missing image.  And it can also be used as intervalometer if desired.