### PR TITLE
Fix Build with removed header files

### DIFF
--- a/mk/board_native.mk
+++ b/mk/board_native.mk
@@ -19,7 +19,7 @@ WARNFLAGSCXX    = -Wno-reorder \
 	-Werror=uninitialized \
 	-Werror=init-self \
 	-Wno-missing-field-initializers
-DEPFLAGS        =   -MD -MT $@
+DEPFLAGS        =   -MD -MP -MT $@
 
 CXXOPTS         =   -ffunction-sections -fdata-sections -fno-exceptions -fsigned-char
 COPTS           =   -ffunction-sections -fdata-sections -fsigned-char


### PR DESCRIPTION
Currently when removing header files, a clean build is needed. It is not the case with this patch.