### PR TITLE
Reame printf format attribute

### DIFF
--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -43,7 +43,7 @@
 // sometimes we need to prevent inlining to prevent large stack usage
 #define NOINLINE __attribute__((noinline))
 
-#define FORMAT(a,b) __attribute__((format(printf, a, b)))
+#define FMT_PRINTF(a,b) __attribute__((format(printf, a, b)))
 #define FMT_SCANF(a,b) __attribute__((format(scanf, a, b)))
 
 // Make some dire warnings into errors

--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -51,7 +51,7 @@ public:
      * provided by AP_HAL to ensure consistency between ports to
      * different boards
      */
-    void printf(const char *s, ...) FORMAT(2, 3);
+    void printf(const char *s, ...) FMT_PRINTF(2, 3);
     void vprintf(const char *s, va_list ap);
 };
 

--- a/libraries/AP_HAL/system.h
+++ b/libraries/AP_HAL/system.h
@@ -10,7 +10,7 @@ namespace AP_HAL {
 
 void init();
 
-void panic(const char *errormsg, ...) FORMAT(1, 2) NORETURN;
+void panic(const char *errormsg, ...) FMT_PRINTF(1, 2) NORETURN;
 
 uint32_t micros();
 uint32_t millis();

--- a/libraries/AP_HAL/utility/BetterStream.h
+++ b/libraries/AP_HAL/utility/BetterStream.h
@@ -32,7 +32,7 @@ class AP_HAL::BetterStream : public AP_HAL::Stream {
 public:
     BetterStream(void) {}
 
-    virtual void printf(const char *, ...) FORMAT(2, 3) = 0;
+    virtual void printf(const char *, ...) FMT_PRINTF(2, 3) = 0;
     virtual void vprintf(const char *, va_list) = 0;
 };
 

--- a/libraries/AP_HAL_Linux/Util.h
+++ b/libraries/AP_HAL_Linux/Util.h
@@ -47,7 +47,7 @@ public:
      * should not be used on hot path since it will open, write and close the
      * file for each call.
      */
-    int write_file(const char *path, const char *fmt, ...) FORMAT(3, 4);
+    int write_file(const char *path, const char *fmt, ...) FMT_PRINTF(3, 4);
 
     /*
      * Read a string as specified by @fmt from the file in @path. Note this

--- a/libraries/AP_InertialSensor/AP_InertialSensor_UserInteract.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_UserInteract.h
@@ -8,7 +8,7 @@
 class AP_InertialSensor_UserInteract {
 public:
     virtual bool blocking_read() = 0;
-    virtual void printf(const char *, ...) FORMAT(2, 3) = 0;
+    virtual void printf(const char *, ...) FMT_PRINTF(2, 3) = 0;
 };
 
 #endif // __AP_INERTIAL_SENSOR_USER_INTERACT_H__

--- a/libraries/AP_InertialSensor/AP_InertialSensor_UserInteract_MAVLink.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_UserInteract_MAVLink.h
@@ -19,7 +19,7 @@ public:
     _gcs(gcs) {}
 
     bool blocking_read();
-    void printf(const char *, ...) FORMAT(2, 3);
+    void printf(const char *, ...) FMT_PRINTF(2, 3);
 private:
     GCS_MAVLINK *_gcs;
 };

--- a/libraries/AP_InertialSensor/AP_InertialSensor_UserInteract_Stream.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_UserInteract_Stream.h
@@ -16,7 +16,7 @@ public:
         _s(s) {}
 
     bool blocking_read();
-    void printf(const char*, ...) FORMAT(2, 3);
+    void printf(const char*, ...) FMT_PRINTF(2, 3);
 private:
     AP_HAL::BetterStream *_s;
 };


### PR DESCRIPTION
As commented in 8218140 ("AP_Common: add scanf format macro"), "FORMAT"
was a bad name for this macro since there's also the scanf. Rename to
FMT_PRINTF to follow the scanf name.


As this is a search and replace, it's better done in a single commit rather than spreading it through multiple commits, one per directory.