### PR TITLE
Enabled 8 kHz gyro and 4 kHz acc sampling using FIFO

### DIFF
--- a/libraries/AP_HAL_Linux/SPIDriver.cpp
+++ b/libraries/AP_HAL_Linux/SPIDriver.cpp
@@ -41,7 +41,7 @@ SPIDeviceDriver SPIDeviceManager::_device[] = {
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO
 SPIDeviceDriver SPIDeviceManager::_device[] = {
     /* MPU9250 is restricted to 1MHz for non-data and interrupt registers */
-    SPIDeviceDriver(0, 1, AP_HAL::SPIDevice_MPU9250, SPI_MODE_0, 8, SPI_CS_KERNEL,  1*MHZ, 20*MHZ),
+    SPIDeviceDriver(0, 1, AP_HAL::SPIDevice_MPU9250, SPI_MODE_0, 8, SPI_CS_KERNEL,  1*MHZ, 15*MHZ),
     SPIDeviceDriver(0, 0, AP_HAL::SPIDevice_Ublox, SPI_MODE_0, 8, SPI_CS_KERNEL,  250*KHZ, 5*MHZ),
 };
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_ERLEBRAIN2

--- a/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_MPU9250.cpp
@@ -72,6 +72,8 @@ extern const AP_HAL::HAL& hal;
 #       define BITS_GYRO_YGYRO_SELFTEST                 0x40
 #       define BITS_GYRO_XGYRO_SELFTEST                 0x80
 #define MPUREG_ACCEL_CONFIG                             0x1C
+#define MPUREG_ACCEL_CONFIG_2                           0x1D
+#       define BIT_ACCEL_FCHOICE_B                              0x08    // used to bypass accelerometer DLPF and sets 4kHz rate (BW = 1.13kHz)
 #define MPUREG_MOT_THR                                  0x1F    // detection threshold for Motion interrupt generation.  Motion is detected when the absolute value of any of the accelerometer measurements exceeds this
 #define MPUREG_MOT_DUR                                  0x20    // duration counter threshold for Motion interrupt generation. The duration counter ticks at 1 kHz, therefore MOT_DUR has a unit of 1 LSB = 1 ms
 #define MPUREG_ZRMOT_THR                                0x21    // detection threshold for Zero Motion interrupt generation.
@@ -606,10 +608,9 @@ bool AP_InertialSensor_MPU9250::_hardware_init(void)
     // desired rate
     _register_write(MPUREG_SMPLRT_DIV, DEFAULT_SMPLRT_DIV);
     _register_write(MPUREG_GYRO_CONFIG, BITS_GYRO_FS_2000DPS);  // Gyro scale 2000º/s
-
-    // RM-MPU-9250A-00.pdf, pg. 15, select accel full scale 16g
+    // RM-MPU-9250A-00.pdf, pg. 15, select accel full scale 16g and bypass DLPF
     _register_write(MPUREG_ACCEL_CONFIG,3<<3);
-
+    _register_write(MPUREG_ACCEL_CONFIG_2, BIT_ACCEL_FCHOICE_B);
     // configure interrupt to fire when new data arrives
     _register_write(MPUREG_INT_ENABLE, BIT_RAW_RDY_EN);
 


### PR DESCRIPTION
Hello all,

This is a request for comments for the introduction of FIFO to inertial sensor MPU9250.
The main advantage of using FIFO is an opportunity to set higher sample frequency and get more values. Large number of samples improves control. Although, FIFO allows saving more values, only part of them is used in the current implementation. 

FIFO buffer operates at 8kHz sample rate and read ~1kHz, therefore contains about 8 samples of 
gyroscope data at the time of the transaction. Accelerometer data is updated at 1kHz but can be set 
higher (up to 4 kHz) if necessary. 

Code was tested on Navio+ board by SPI. Received data is corrupted if SPI frequency is higher than 15 MHz.

Some of the missing features are:
- Transfer by I2C wasn't tested.

Best regards,
Alexey Bulatov.