### PR TITLE
AP_HAL_Linux: fix warning due to derived PWM_Sysfs

### DIFF
--- a/libraries/AP_HAL_Linux/PWM_Sysfs.h
+++ b/libraries/AP_HAL_Linux/PWM_Sysfs.h
@@ -7,7 +7,7 @@
 
 class Linux::PWM_Sysfs_Base {
 public:
-    ~PWM_Sysfs_Base();
+    virtual ~PWM_Sysfs_Base();
 
     enum Polarity {
         NORMAL = 0,


### PR DESCRIPTION
PWM_Sysfs derives from PWM_Sysfs_Base which was not update to have a
virtual destructor. Make PWM_Sysfs_Base's constructor virtual.