### PR TITLE
fix issue #3074 No vehicle state after starting Vagrant SITL instance

### DIFF
--- a/Tools/autotest/run_cmd.sh
+++ b/Tools/autotest/run_cmd.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# This is a helper script for run_in_terminal_window.sh.  I'm not sure why Ardupilot.elf exits if not run from inside of a script
+echo running $*
+( $* )
+echo cmd exited

--- a/Tools/autotest/run_in_terminal_window.sh
+++ b/Tools/autotest/run_in_terminal_window.sh
@@ -21,6 +21,6 @@ else
   echo "Window access not found, logging to $filename"
   cmd="$1"
   shift
-  ( $cmd $* &>$filename < /dev/null ) &
+  ( $AUTOTEST/run_cmd.sh $cmd $* &>$filename < /dev/null ) &
 fi
 exit 0


### PR DESCRIPTION
Fix issue issue #3074. For some reason I have to do this to make SITL work in vagrant and my linux box. This fix undoes commit 596cac58d04749c7e5575342e08055cfdd30e26b made by @tridge. 