### PR TITLE
Return more meaningful errors from mission load

### DIFF
--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -471,8 +471,8 @@ void AP_Mission::write_home_to_storage()
 }
 
 // mavlink_to_mission_cmd - converts mavlink message to an AP_Mission::Mission_Command object which can be stored to eeprom
-//  return true on success, false on failure
-bool AP_Mission::mavlink_to_mission_cmd(const mavlink_mission_item_t& packet, AP_Mission::Mission_Command& cmd)
+//  return MAV_MISSION_ACCEPTED on success, MAV_MISSION_RESULT error on failure
+MAV_MISSION_RESULT AP_Mission::mavlink_to_mission_cmd(const mavlink_mission_item_t& packet, AP_Mission::Mission_Command& cmd)
 {
     bool copy_location = false;
     bool copy_alt = false;
@@ -711,7 +711,7 @@ bool AP_Mission::mavlink_to_mission_cmd(const mavlink_mission_item_t& packet, AP
 
     default:
         // unrecognised command
-        return false;
+        return MAV_MISSION_UNSUPPORTED;
     }
 
     // copy location from mavlink to command
@@ -719,12 +719,15 @@ bool AP_Mission::mavlink_to_mission_cmd(const mavlink_mission_item_t& packet, AP
 
         // sanity check location
         if (copy_location) {
-            if (fabsf(packet.x) > 90.0f || fabsf(packet.y) > 180.0f) {
-                return false;
+            if (fabsf(packet.x) > 90.0f) {
+                return MAV_MISSION_INVALID_PARAM5_X;
+            }
+            if (fabsf(packet.y) > 180.0f) {
+                return MAV_MISSION_INVALID_PARAM6_Y;
             }
         }
         if (fabsf(packet.z) >= LOCATION_ALT_MAX_M) {
-            return false;
+            return MAV_MISSION_INVALID_PARAM7;
         }
 
         switch (packet.frame) {
@@ -788,12 +791,12 @@ bool AP_Mission::mavlink_to_mission_cmd(const mavlink_mission_item_t& packet, AP
 #endif
 
         default:
-            return false;
+            return MAV_MISSION_UNSUPPORTED_FRAME;
         }
     }
 
     // if we got this far then it must have been succesful
-    return true;
+    return MAV_MISSION_ACCEPTED;
 }
 
 // mission_cmd_to_mavlink - converts an AP_Mission::Mission_Command object to a mavlink message which can be sent to the GCS

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -365,8 +365,8 @@ public:
     void write_home_to_storage();
 
     // mavlink_to_mission_cmd - converts mavlink message to an AP_Mission::Mission_Command object which can be stored to eeprom
-    //  return true on success, false on failure
-    static bool mavlink_to_mission_cmd(const mavlink_mission_item_t& packet, AP_Mission::Mission_Command& cmd);
+    //  return MAV_MISSION_ACCEPTED on success, MAV_MISSION_RESULT error on failure
+    static MAV_MISSION_RESULT mavlink_to_mission_cmd(const mavlink_mission_item_t& packet, AP_Mission::Mission_Command& cmd);
 
     // mission_cmd_to_mavlink - converts an AP_Mission::Mission_Command object to a mavlink message which can be sent to the GCS
     //  return true on success, false on failure

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -664,8 +664,8 @@ bool GCS_MAVLINK::handle_mission_item(mavlink_message_t *msg, AP_Mission &missio
     mavlink_msg_mission_item_decode(msg, &packet);
 
     // convert mavlink packet to mission command
-    if (!AP_Mission::mavlink_to_mission_cmd(packet, cmd)) {
-        result = MAV_MISSION_INVALID;
+    result = AP_Mission::mavlink_to_mission_cmd(packet, cmd);
+    if (result != MAV_MISSION_ACCEPTED) {
         goto mission_ack;
     }
 


### PR DESCRIPTION
QGroundControl shows these errors to the user. So the more specific the better for debugging user problems.