### PR TITLE
Plane: Don't disable compass checks for HIL mode unless actually in hil mode

### DIFF
--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -168,7 +168,9 @@ void Plane::init_ardupilot()
     if (g.compass_enabled==true) {
         bool compass_ok = compass.init() && compass.read();
 #if HIL_SUPPORT
+    if (!is_zero(g.hil_mode)) {
         compass_ok = true;
+    }
 #endif
         if (!compass_ok) {
             cliSerial->println("Compass initialisation failed!");


### PR DESCRIPTION
Detected by coverity 113979. HIL_SUPPORT is always true in the build system, which means we never ran the checks if the compass wasn't okay after init.