### PR TITLE
waf: make each board a build variant

### DIFF
--- a/Tools/ardupilotwaf/gbenchmark.py
+++ b/Tools/ardupilotwaf/gbenchmark.py
@@ -38,13 +38,14 @@ def configure(cfg):
     if env.GBENCHMARK_CMAKE_GENERATOR:
         env.GBENCHMARK_GENERATOR_OPTION = '-G%s' % env.GBENCHMARK_CMAKE_GENERATOR
 
-    prefix_node = cfg.bldnode.make_node('gbenchmark')
-    my_build_node = cfg.bldnode.make_node('gbenchmark_build')
+    bldnode = cfg.bldnode.make_node(cfg.variant)
+    prefix_node = bldnode.make_node('gbenchmark')
+    my_build_node = bldnode.make_node('gbenchmark_build')
     my_src_node = cfg.srcnode.find_dir('modules/gbenchmark')
 
-    env.GBENCHMARK_PREFIX_REL = prefix_node.path_from(cfg.bldnode)
+    env.GBENCHMARK_PREFIX_REL = prefix_node.path_from(bldnode)
     env.GBENCHMARK_BUILD = my_build_node.abspath()
-    env.GBENCHMARK_BUILD_REL = my_build_node.path_from(cfg.bldnode)
+    env.GBENCHMARK_BUILD_REL = my_build_node.path_from(bldnode)
     env.GBENCHMARK_SRC = my_src_node.abspath()
 
     env.INCLUDES_GBENCHMARK = [prefix_node.make_node('include').abspath()]

--- a/Tools/ardupilotwaf/gbenchmark.py
+++ b/Tools/ardupilotwaf/gbenchmark.py
@@ -7,6 +7,7 @@ gbenchmark is a Waf tool for benchmark builds in Ardupilot
 
 from waflib import Build, Context, Task
 from waflib.TaskGen import feature, before_method, after_method
+from waflib.Errors import WafError
 
 def configure(cfg):
     env = cfg.env
@@ -102,8 +103,11 @@ class gbenchmark_build(Task.Task):
                     quiet=Context.BOTH,
                 )
             return 0
-        except Exception as e:
-            print(e.stdout, e.stderr)
+        except WafError as e:
+            print(e)
+            if hasattr(e, 'stderr'):
+                print('')
+                print(e.stderr)
             return 1
 
     def __str__(self):

--- a/wscript
+++ b/wscript
@@ -9,7 +9,9 @@ sys.path.insert(0, 'Tools/ardupilotwaf/')
 
 import ardupilotwaf
 import boards
-import waflib
+
+from waflib import ConfigSet, Utils
+from waflib.Build import BuildContext, CleanContext, InstallContext, UninstallContext
 
 # TODO: implement a command 'waf help' that shows the basic tasks a
 # developer might want to do: e.g. how to configure a board, compile a
@@ -34,6 +36,20 @@ import waflib
 # contain the board extension so make it less convenient, maybe hook
 # to support automatic filling this extension?
 
+def init(ctx):
+    env = ConfigSet.ConfigSet()
+    try:
+        env.load('build/c4che/_cache.py')
+    except:
+        return
+
+    # define the variant build commands according to the board
+    # this was addapted from the tip to memorize the default variant in waf
+    # variant demo
+    for c in (BuildContext, CleanContext, InstallContext, UninstallContext):
+        class context(c):
+            variant = env.BOARD
+
 def options(opt):
     boards_names = boards.get_boards_names()
 
@@ -50,6 +66,10 @@ def options(opt):
                  help='Output all test programs')
 
 def configure(cfg):
+    cfg.env.BOARD = cfg.options.board
+    # use a different variant for each board
+    cfg.setenv(cfg.env.BOARD)
+
     cfg.load('compiler_cxx compiler_c')
     cfg.load('clang_compilation_database')
     cfg.load('waf_unit_test')
@@ -96,7 +116,7 @@ def configure(cfg):
 
 def collect_dirs_to_recurse(bld, globs, **kw):
     dirs = []
-    globs = waflib.Utils.to_list(globs)
+    globs = Utils.to_list(globs)
     for g in globs:
         for d in bld.srcnode.ant_glob(g + '/wscript', **kw):
             dirs.append(d.parent.relpath())
@@ -156,6 +176,6 @@ def build(bld):
             bld.fatal('check: gtest library is required')
         bld.add_post_fun(ardupilotwaf.test_summary)
 
-class CheckContext(waflib.Build.BuildContext):
+class CheckContext(BuildContext):
     '''executes tests after build'''
     cmd = 'check'


### PR DESCRIPTION
With that, we don't have to recompile unnecessarily when switching between boards. Now, each board has it's own build directory.

Additionally, this does a minor change in the command execution error handling for gbenchmark.

**Question:**
I'm still keeping the board extension for the binaries names. Do you guys think it's worth removing the extension? My personal opinion is that we could keep them.

Best regards,
Gustavo Sousa