### PR TITLE
AP_Math: fix bug in Quaternion::operator*=

### DIFF
--- a/libraries/AP_Math/quaternion.cpp
+++ b/libraries/AP_Math/quaternion.cpp
@@ -291,10 +291,10 @@ Quaternion Quaternion::operator*(const Quaternion &v) const {
 }
 
 Quaternion &Quaternion::operator*=(const Quaternion &v) {
-    float &w1 = q1;
-    float &x1 = q2;
-    float &y1 = q3;
-    float &z1 = q4;
+    float w1 = q1;
+    float x1 = q2;
+    float y1 = q3;
+    float z1 = q4;
 
     float w2 = v.q1;
     float x2 = v.q2;


### PR DESCRIPTION
This affects all 3 EKFs, however the error was very small: 0.095% for a 5 degree rotation (2000 deg/s)