### PR TITLE
SITL: encourage bash to create a subshell when spawning ardupilot

### DIFF
--- a/Tools/autotest/run_in_terminal_window.sh
+++ b/Tools/autotest/run_in_terminal_window.sh
@@ -21,6 +21,9 @@ else
   echo "Window access not found, logging to $filename"
   cmd="$1"
   shift
-  ( $cmd $* &>$filename < /dev/null ) &
+# the following "true" is to avoid bash optimising the following call
+# to avoid creating a subshell.  We need that subshell, or
+# _fdm_input_step sees ArduPilot has no parent and kills ArduPilot!
+  ( : ; $cmd $* &>$filename < /dev/null ) &
 fi
 exit 0


### PR DESCRIPTION
This issue is evident in Vagrant if you don't forward X.

_fdm_input_step determined there was no parent and killed ArduPilot.