### PR TITLE
Validate @Range parameter meta data

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -433,7 +433,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: FBWB_CLIMB_RATE
     // @DisplayName: Fly By Wire B altitude change rate
     // @Description: This sets the rate in m/s at which FBWB and CRUISE modes will change its target altitude for full elevator deflection. Note that the actual climb rate of the aircraft can be lower than this, depending on your airspeed and throttle control settings. If you have this parameter set to the default value of 2.0, then holding the elevator at maximum deflection for 10 seconds would change the target altitude by 20 meters.
-    // @Range: 1-10
+    // @Range: 1 10
 	// @Increment: 0.1
     // @User: Standard
     GSCALAR(flybywire_climb_rate, "FBWB_CLIMB_RATE",  2.0f),

--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -143,6 +143,41 @@ for library in libraries:
 
     debug("Processed %u documented parameters" % len(library.params))
 
+    def is_number(numberString):
+        try:
+            float(numberString)
+            return True
+        except ValueError:
+            return False
+
+    def validate(param):
+        """
+        Validates the parameter meta data.
+        """
+        # Validate values
+        if (hasattr(param, "Range")):
+            rangeValues = param.__dict__["Range"].split(" ")
+            if (len(rangeValues) != 2):
+                error("Invalid Range values for %s" % (param.name))
+                return
+            min = rangeValues[0]
+            max = rangeValues[1]
+            if not is_number(min):
+                error("Min value not number: %s %s" % (param.name, min))
+                return
+            if not is_number(max):
+                error("Max value not number: %s %s" % (param.name, max))
+                return
+
+    for vehicle in vehicles:
+        for param in vehicle.params:
+            validate(param)
+
+
+    for library in libraries:
+        for param in library.params:
+            validate(param)
+    
     def do_emit(emit):
         for vehicle in vehicles:
             emit.emit(vehicle, f)

--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -82,7 +82,7 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
     // @Param: SERIAL_NUM
     // @DisplayName: User-defined serial number
     // @Description: User-defined serial number of this vehicle, it can be any arbitrary number you want and has no effect on the autopilot
-    // @Range: -32767 to 32768 (any 16bit signed number)
+    // @Range: -32767 32768
     // @User: Standard
     AP_GROUPINFO("SERIAL_NUM", 5, AP_BoardConfig, vehicleSerialNumber, 0),
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -285,7 +285,7 @@ const AP_Param::GroupInfo AP_InertialSensor::var_info[] = {
     // @Param: STILL_THRESH
     // @DisplayName: Stillness threshold for detecting if we are moving
     // @Description: Threshold to tolerate vibration to determine if vehicle is motionless. This depends on the frame type and if there is a constant vibration due to motors before launch or after landing. Total motionless is about 0.05. Suggested values: Planes/rover use 0.1, multirotors use 1, tradHeli uses 5
-    // @Range: 0.05 to 50
+    // @Range: 0.05 50
     // @User: Advanced
     AP_GROUPINFO("STILL_THRESH", 23, AP_InertialSensor, _still_threshold,  DEFAULT_STILL_THRESH),
 

--- a/libraries/AP_L1_Control/AP_L1_Control.cpp
+++ b/libraries/AP_L1_Control/AP_L1_Control.cpp
@@ -11,21 +11,21 @@ const AP_Param::GroupInfo AP_L1_Control::var_info[] = {
     // @DisplayName: L1 control period
     // @Description: Period in seconds of L1 tracking loop. This parameter is the primary control for agressiveness of turns in auto mode. This needs to be larger for less responsive airframes. The default of 20 is quite conservative, but for most RC aircraft will lead to reasonable flight. For smaller more agile aircraft a value closer to 15 is appropriate, or even as low as 10 for some very agile aircraft. When tuning, change this value in small increments, as a value that is much too small (say 5 or 10 below the right value) can lead to very radical turns, and a risk of stalling.
 	// @Units: seconds
-	// @Range: 1-60
+	// @Range: 1 60
 	// @Increment: 1
     AP_GROUPINFO("PERIOD",    0, AP_L1_Control, _L1_period, 20),
 	
     // @Param: DAMPING
     // @DisplayName: L1 control damping ratio
     // @Description: Damping ratio for L1 control. Increase this in increments of 0.05 if you are getting overshoot in path tracking. You should not need a value below 0.7 or above 0.85.
-	// @Range: 0.6-1.0
+	// @Range: 0.6 1.0
 	// @Increment: 0.05
     AP_GROUPINFO("DAMPING",   1, AP_L1_Control, _L1_damping, 0.75f),
 
     // @Param: XTRACK_I
     // @DisplayName: L1 control crosstrack integrator gain
     // @Description: Crosstrack error integrator gain. This gain is applied to the crosstrack error to ensure it converges to zero. Set to zero to disable. Smaller values converge slower, higher values will cause crosstrack error oscillation.
-    // @Range: 0 to 0.1
+    // @Range: 0 0.1
     // @Increment: 0.01
     AP_GROUPINFO("XTRACK_I",   2, AP_L1_Control, _L1_xtrack_i_gain, 0.02),
 

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -94,7 +94,7 @@ const AP_Param::GroupInfo AP_MotorsHeli_Single::var_info[] = {
     // @Param: FLYBAR_MODE
     // @DisplayName: Flybar Mode Selector
     // @Description: Flybar present or not.  Affects attitude controller used during ACRO flight mode
-    // @Range: 0:NoFlybar 1:Flybar
+    // @Values: 0:NoFlybar 1:Flybar
     // @User: Standard
     AP_GROUPINFO("FLYBAR_MODE", 9, AP_MotorsHeli_Single, _flybar_mode, AP_MOTORS_HELI_NOFLYBAR),
   

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -328,7 +328,7 @@ const AP_Param::GroupInfo NavEKF::var_info[] = {
     // @Param: GND_GRADIENT
     // @DisplayName: Terrain Gradient % RMS
     // @Description: This parameter sets the RMS terrain gradient percentage assumed by the terrain height estimation. Terrain height can be estimated using optical flow and/or range finder sensor data if fitted. Smaller values cause the terrain height estimate to be slower to respond to changes in measurement. Larger values casue the terrain height estimate to be faster to respond, but also more noisy. Generally this value can be reduced if operating over very flat terrain and increased if operating over uneven terrain.
-    // @Range: 1 - 50
+    // @Range: 1 50
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("GND_GRADIENT",    25, NavEKF, _gndGradientSigma, 2),
@@ -336,7 +336,7 @@ const AP_Param::GroupInfo NavEKF::var_info[] = {
     // @Param: FLOW_NOISE
     // @DisplayName: Optical flow measurement noise (rad/s)
     // @Description: This is the RMS value of noise and errors in optical flow measurements. Increasing it reduces the weighting on these measurements.
-    // @Range: 0.05 - 1.0
+    // @Range: 0.05 1.0
     // @Increment: 0.05
     // @User: Advanced
     // @Units: rad/s
@@ -345,7 +345,7 @@ const AP_Param::GroupInfo NavEKF::var_info[] = {
     // @Param: FLOW_GATE
     // @DisplayName: Optical Flow measurement gate size
     // @Description: This parameter sets the number of standard deviations applied to the optical flow innovation consistency check. Decreasing it makes it more likely that good measurements will be rejected. Increasing it makes it more likely that bad measurements will be accepted.
-    // @Range: 1 - 100
+    // @Range: 1 100
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("FLOW_GATE",    27, NavEKF, _flowInnovGate, FLOW_GATE_DEFAULT),
@@ -353,7 +353,7 @@ const AP_Param::GroupInfo NavEKF::var_info[] = {
     // @Param: FLOW_DELAY
     // @DisplayName: Optical Flow measurement delay (msec)
     // @Description: This is the number of msec that the optical flow measurements lag behind the inertial measurements. It is the time from the end of the optical flow averaging period and does not include the time delay due to the 100msec of averaging within the flow sensor.
-    // @Range: 0 - 500
+    // @Range: 0 500
     // @Increment: 10
     // @User: Advanced
     // @Units: milliseconds
@@ -362,7 +362,7 @@ const AP_Param::GroupInfo NavEKF::var_info[] = {
     // @Param: RNG_GATE
     // @DisplayName: Range finder measurement gate size
     // @Description: This parameter sets the number of standard deviations applied to the range finder innovation consistency check. Decreasing it makes it more likely that good measurements will be rejected. Increasing it makes it more likely that bad measurements will be accepted.
-    // @Range: 1 - 100
+    // @Range: 1 100
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("RNG_GATE",    29, NavEKF, _rngInnovGate, 5),
@@ -370,7 +370,7 @@ const AP_Param::GroupInfo NavEKF::var_info[] = {
     // @Param: MAX_FLOW
     // @DisplayName: Maximum valid optical flow rate
     // @Description: This parameter sets the magnitude maximum optical flow rate in rad/sec that will be accepted by the filter
-    // @Range: 1.0 - 4.0
+    // @Range: 1.0 4.0
     // @Increment: 0.1
     // @User: Advanced
     AP_GROUPINFO("MAX_FLOW",    30, NavEKF, _maxFlowRate, 2.5f),

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -286,7 +286,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Param: RNG_GATE
     // @DisplayName: Range finder measurement gate size
     // @Description: This sets the percentage number of standard deviations applied to the range finder innovation consistency check. Decreasing it makes it more likely that good measurements will be rejected. Increasing it makes it more likely that bad measurements will be accepted.
-    // @Range: 100 - 1000
+    // @Range: 100 1000
     // @Increment: 25
     // @User: Advanced
     AP_GROUPINFO("RNG_GATE", 19, NavEKF2, _rngInnovGate, 500),
@@ -296,7 +296,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Param: MAX_FLOW
     // @DisplayName: Maximum valid optical flow rate
     // @Description: This sets the magnitude maximum optical flow rate in rad/sec that will be accepted by the filter
-    // @Range: 1.0 - 4.0
+    // @Range: 1.0 4.0
     // @Increment: 0.1
     // @User: Advanced
     // @Units: rad/s
@@ -305,7 +305,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Param: FLOW_NOISE
     // @DisplayName: Optical flow measurement noise (rad/s)
     // @Description: This is the RMS value of noise and errors in optical flow measurements. Increasing it reduces the weighting on these measurements.
-    // @Range: 0.05 - 1.0
+    // @Range: 0.05 1.0
     // @Increment: 0.05
     // @User: Advanced
     // @Units: rad/s
@@ -314,7 +314,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Param: FLOW_GATE
     // @DisplayName: Optical Flow measurement gate size
     // @Description: This sets the percentage number of standard deviations applied to the optical flow innovation consistency check. Decreasing it makes it more likely that good measurements will be rejected. Increasing it makes it more likely that bad measurements will be accepted.
-    // @Range: 100 - 1000
+    // @Range: 100 1000
     // @Increment: 25
     // @User: Advanced
     AP_GROUPINFO("FLOW_GATE", 22, NavEKF2, _flowInnovGate, FLOW_GATE_DEFAULT),
@@ -322,7 +322,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Param: FLOW_DELAY
     // @DisplayName: Optical Flow measurement delay (msec)
     // @Description: This is the number of msec that the optical flow measurements lag behind the inertial measurements. It is the time from the end of the optical flow averaging period and does not include the time delay due to the 100msec of averaging within the flow sensor.
-    // @Range: 0 - 250
+    // @Range: 0 250
     // @Increment: 10
     // @User: Advanced
     // @Units: msec

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -123,7 +123,7 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
     // @Param: LAND_THR
     // @DisplayName: Cruise throttle during landing approach (percentage)
     // @Description: Use this parameter instead of LAND_ASPD if your platform does not have an airspeed sensor.  It is the cruise throttle during landing approach.  If it is negative if TECS_LAND_ASPD is in use then this value is not used during landing.
-    // @Range: -1 to 100
+    // @Range: -1 100
     // @Increment: 0.1
     // @User: User
     AP_GROUPINFO("LAND_THR", 13, AP_TECS, _landThrottle, -1),


### PR DESCRIPTION
Two changes:
- Update parameter source parser to output errors for parameter @Range meta data which does not strictly follow the format: @Range minNumber maxNumber. Both min/max are also validate to be numbers.
- Fix @Range meta data which the new parser found to be in error

The reason for this is to provide clean meta data to the ground station for use during parameter editing.

I'm putting this through as a first small pull to get approval for the concept of clean meta data. Next I would like to:
- Validate @Values meta data for correctness
- Validate @Units to be something short for use in text edit fields. Some of them have lengthy descriptions in there. That should be kept in Description.
- Possibly controversial: Include parameter parsing as a step for all builds. Fail the build if the parser detects an error. This is the only real way to stay on top of keeping the meta data clean.