### PR TITLE
Increase max RPM on bebop 2 and fix comment

### DIFF
--- a/libraries/AP_HAL_Linux/GPIO_Bebop.cpp
+++ b/libraries/AP_HAL_Linux/GPIO_Bebop.cpp
@@ -11,6 +11,6 @@ const unsigned Linux::GPIO_Sysfs::pin_table[] = {
 const uint8_t Linux::GPIO_Sysfs::n_pins = _BEBOP_GPIO_MAX;
 
 static_assert(ARRAY_SIZE(Linux::GPIO_Sysfs::pin_table) == _BEBOP_GPIO_MAX,
-              "GPIO pin_table must have the same size of entries in enum gpio_minnow");
+              "GPIO pin_table must have the same size of entries in enum gpio_bebop");
 
 #endif

--- a/libraries/AP_HAL_Linux/RCOutput_Bebop.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_Bebop.cpp
@@ -374,7 +374,7 @@ void RCOutput_Bebop::_run_rcout()
     memset(current_period_us, 0, sizeof(current_period_us));
 
     if (!_get_info(&info)) {
-        AP_HAL::panic("failed to get BLDC info\n");
+        AP_HAL::panic("failed to get BLDC info");
     }
 
     /* Set motor order depending on BLDC version.On bebop 1 with version 1

--- a/libraries/AP_HAL_Linux/RCOutput_Bebop.cpp
+++ b/libraries/AP_HAL_Linux/RCOutput_Bebop.cpp
@@ -11,6 +11,7 @@
 #include <sys/mman.h>
 #include <pthread.h>
 #include "RCOutput_Bebop.h"
+#include "Util.h"
 
 /* BEBOP BLDC motor controller address and registers description */
 #define BEBOP_BLDC_I2C_ADDR 0x08
@@ -51,7 +52,9 @@ struct bldc_obs_data {
 #define BEBOP_BLDC_MIN_PERIOD_US 1100
 #define BEBOP_BLDC_MAX_PERIOD_US 1900
 #define BEBOP_BLDC_MIN_RPM 3000
-#define BEBOP_BLDC_MAX_RPM 11000
+/* the max rpm speed is different on Bebop 2 */
+#define BEBOP_BLDC_MAX_RPM_1 11000
+#define BEBOP_BLDC_MAX_RPM_2 12200
 
 /* Priority of the thread controlling the BLDC via i2c
  * set to 14, which is the same as the UART 
@@ -226,7 +229,7 @@ uint16_t RCOutput_Bebop::_period_us_to_rpm(uint16_t period_us)
     float period_us_fl = period_us;
 
     float rpm_fl = (period_us_fl - _min_pwm)/(_max_pwm - _min_pwm) *
-                    (BEBOP_BLDC_MAX_RPM - BEBOP_BLDC_MIN_RPM) + BEBOP_BLDC_MIN_RPM;
+                    (_max_rpm - BEBOP_BLDC_MIN_RPM) + BEBOP_BLDC_MIN_RPM;
 
     return (uint16_t)rpm_fl;
 }
@@ -370,6 +373,7 @@ void RCOutput_Bebop::_run_rcout()
     uint8_t bebop_bldc_channels[BEBOP_BLDC_MOTORS_NUM];
     uint8_t bebop_bldc_right_front, bebop_bldc_left_front,
             bebop_bldc_left_back, bebop_bldc_right_back;
+    int hw_version;
 
     memset(current_period_us, 0, sizeof(current_period_us));
 
@@ -397,6 +401,17 @@ void RCOutput_Bebop::_run_rcout()
     bebop_bldc_channels[1] = bebop_bldc_left_back;
     bebop_bldc_channels[2] = bebop_bldc_left_front;
     bebop_bldc_channels[3] = bebop_bldc_right_back;
+
+    hw_version = Util::from(hal.util)->get_hw_arm32();
+    if (hw_version == UTIL_HARDWARE_BEBOP) {
+        _max_rpm = BEBOP_BLDC_MAX_RPM_1;
+    } else if (hw_version == UTIL_HARDWARE_BEBOP2) {
+        _max_rpm = BEBOP_BLDC_MAX_RPM_2;
+    } else if (hw_version < 0) {
+        AP_HAL::panic("failed to get hw version %s", strerror(hw_version));
+    } else {
+        AP_HAL::panic("unsupported hw version %d", hw_version);
+    }
 
     while (true) {
         pthread_mutex_lock(&_mutex);

--- a/libraries/AP_HAL_Linux/RCOutput_Bebop.h
+++ b/libraries/AP_HAL_Linux/RCOutput_Bebop.h
@@ -89,6 +89,7 @@ private:
     uint16_t _max_pwm;
     uint8_t  _state;
     bool     _corking = false;
+    uint16_t _max_rpm;
 
     uint8_t _checksum(uint8_t *data, unsigned int len);
     void _start_prop();

--- a/libraries/AP_HAL_Linux/Util.cpp
+++ b/libraries/AP_HAL_Linux/Util.cpp
@@ -160,4 +160,45 @@ int Util::read_file(const char *path, const char *fmt, ...)
     return ret;
 }
 
+const char *Linux::Util::_hw_names[UTIL_NUM_HARDWARES] = {
+    [UTIL_HARDWARE_RPI1]   = "BCM2708",
+    [UTIL_HARDWARE_RPI2]   = "BCM2709",
+    [UTIL_HARDWARE_BEBOP]  = "Mykonos3 board",
+    [UTIL_HARDWARE_BEBOP2] = "Milos board",
+};
+
+#define MAX_SIZE_LINE 50
+int Util::get_hw_arm32()
+{
+    int ret = -ENOENT;
+    char buffer[MAX_SIZE_LINE];
+    const char* hardware_description_entry = "Hardware";
+    char* flag;
+    FILE* f;
+
+    f = fopen("/proc/cpuinfo", "r");
+
+    if (f == NULL) {
+        ret = -errno;
+        goto end;
+    }
+
+    while (fgets(buffer, MAX_SIZE_LINE, f) != NULL) {
+        flag = strstr(buffer, hardware_description_entry);
+        if (flag != NULL) {
+            for (uint8_t i = 0; i < UTIL_NUM_HARDWARES; i++) {
+                if (strstr(buffer, _hw_names[i]) != 0) {
+                     ret = i;
+                     goto close_end;
+                }
+            }
+        }
+    }
+
+close_end:
+    fclose(f);
+end:
+    return ret;
+}
+
 #endif // CONFIG_HAL_BOARD == HAL_BOARD_LINUX

--- a/libraries/AP_HAL_Linux/Util.h
+++ b/libraries/AP_HAL_Linux/Util.h
@@ -9,6 +9,14 @@
 #include "ToneAlarmDriver.h"
 #include "Semaphores.h"
 
+enum hw_type {
+    UTIL_HARDWARE_RPI1 = 0,
+    UTIL_HARDWARE_RPI2,
+    UTIL_HARDWARE_BEBOP,
+    UTIL_HARDWARE_BEBOP2,
+    UTIL_NUM_HARDWARES,
+};
+
 class Linux::Util : public AP_HAL::Util {
 public:
     static Util *from(AP_HAL::Util *util) {
@@ -25,7 +33,7 @@ public:
 
     bool toneAlarm_init();
     void toneAlarm_set_tune(uint8_t tune);
-    
+
     void _toneAlarm_timer_tick();
 
     /*
@@ -64,14 +72,17 @@ public:
 
     // create a new semaphore
     AP_HAL::Semaphore *new_semaphore(void) override { return new Linux::Semaphore; }
-    
+
+    int get_hw_arm32();
+
 private:
     static Linux::ToneAlarm _toneAlarm;
     Linux::Heat *_heat;
     int saved_argc;
     char* const *saved_argv;
     const char* custom_log_directory = NULL;
-    const char* custom_terrain_directory = NULL;	
+    const char* custom_terrain_directory = NULL;
+    static const char *_hw_names[UTIL_NUM_HARDWARES];
 };
 
 

--- a/libraries/AP_HAL_Linux/Util_RPI.cpp
+++ b/libraries/AP_HAL_Linux/Util_RPI.cpp
@@ -14,6 +14,7 @@
 #include <time.h>
 
 #include "Util_RPI.h"
+#include "Util.h"
 
 extern const AP_HAL::HAL& hal;
 
@@ -24,43 +25,22 @@ UtilRPI::UtilRPI()
     _check_rpi_version();
 }
 
-#define MAX_SIZE_LINE 50
 int UtilRPI::_check_rpi_version()
 {
-    char buffer[MAX_SIZE_LINE];
-    const char* hardware_description_entry = "Hardware";
-    const char* v1 = "BCM2708";
-    const char* v2 = "BCM2709";
-    char* flag;
-    FILE* fd;
+    int hw;
+    hw = Util::from(hal.util)->get_hw_arm32();
 
-    fd = fopen("/proc/cpuinfo", "r");
-
-    while (fgets(buffer, MAX_SIZE_LINE, fd) != NULL) {
-        flag = strstr(buffer, hardware_description_entry);
-        if (flag != NULL) {
-            if (strstr(buffer, v2) != NULL) {
-                printf("Raspberry Pi 2 with BCM2709!\n");
-                fclose(fd);
-
-                _rpi_version = 2;
-                return _rpi_version;
-            }
-            else if (strstr(buffer, v1) != NULL) {
-                printf("Raspberry Pi 1 with BCM2708!\n");
-                fclose(fd);
-
-                _rpi_version = 1;
-                return _rpi_version;
-            }
-        }
+    if (hw == UTIL_HARDWARE_RPI2) {
+        printf("Raspberry Pi 2 with BCM2709!\n");
+        _rpi_version = 2;
+    } else if (hw == UTIL_HARDWARE_RPI1) {
+        printf("Raspberry Pi 1 with BCM2708!\n");
+        _rpi_version = 1;
+    } else {
+        /* defaults to 1 */
+        fprintf(stderr, "Could not detect RPi version, defaulting to 1\n");
+        _rpi_version = 1;
     }
-
-    /* defaults to 1 */
-    fprintf(stderr, "Could not detect RPi version, defaulting to 1\n");
-    fclose(fd);
-
-    _rpi_version = 1;
     return _rpi_version;
 }
 


### PR DESCRIPTION
Add a Util function on AP_HAL_Linux to detect hardware reading /proc/cpuinfo. This is valid on arm32 platforms but not on arm64, x86 or amd64 platforms.
Fix comment on GPIO_Bebop inherited from minlure.