### PR TITLE
AP_Arming: Allow arming without the hardware safety switch having been pressed

### DIFF
--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -23,6 +23,7 @@ public:
         ARMING_CHECK_BATTERY    = 0x0100,
         ARMING_CHECK_AIRSPEED   = 0x0200,
         ARMING_CHECK_LOGGING    = 0x0400,
+        ARMING_CHECK_SWITCH     = 0x0800,
     };
 
     enum ArmingMethod {


### PR DESCRIPTION
Added an enum to the check type that allows for arming without the hardware switch having been enabled