### PR TITLE
Plane: add item_reached_msg to GUIDED

### DIFF
--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -145,6 +145,10 @@ void Plane::update_loiter()
         if (nav_controller->reached_loiter_target()) {
             // we've reached the target, start the timer
             loiter.start_time_ms = millis();
+            if (control_mode == GUIDED) {
+                // starting a loiter in GUIDED means we just reached the target point
+                gcs_send_mission_item_reached_message(0);
+            }
         }
     }
 }


### PR DESCRIPTION
When reaching a GUIDED waypoint, send MISSION_ITEM_REACHED msg. This helps for triggering a companion computer to send the next waypoint.

See also Copter https://github.com/diydrones/ardupilot/pull/3360 ad Rover https://github.com/diydrones/ardupilot/pull/3362