### PR TITLE
Rover: add item_reached_msg to GUIDED

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -407,6 +407,9 @@ void Rover::update_current_mode(void)
         set_reverse(false);
         if (rtl_complete || verify_RTL()) {
             // we have reached destination so stop where we are
+            if (channel_throttle->servo_out != g.throttle_min.get()) {
+                gcs_send_mission_item_reached_message(0);
+            }
             channel_throttle->servo_out = g.throttle_min.get();
             channel_steer->servo_out = 0;
             lateral_acceleration = 0;


### PR DESCRIPTION
When reaching a GUIDED waypoint, send MISSION_ITEM_REACHED msg. This helps for triggering a companion computer to send the next waypoint.

See also Copter https://github.com/diydrones/ardupilot/pull/3360 and Plane https://github.com/diydrones/ardupilot/pull/3361