### PR TITLE
Added accel error threshold param

### DIFF
--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -69,6 +69,7 @@ protected:
     AP_Int8                 require;
     AP_Int8                 rudder_arming_value;
     AP_Int16                checks_to_perform;      // bitmask for which checks are required
+    AP_Float                accel_error_threshold;
 
     // references
     const AP_AHRS           &ahrs;


### PR DESCRIPTION
There is a pre-arm check for "Accelerometers inconsistent", this PR changes that hard-coded threshold of 0.75 m/s/s to a param with a default of 0.75. Since not all IMUs are created equal it would be nice to loosen the checks on certain boards. Also, the threshold is also different on EKF1 vs EKF2.