### PR TITLE
waf: use better and simpler syntax to find program

### DIFF
--- a/Tools/ardupilotwaf/gbenchmark.py
+++ b/Tools/ardupilotwaf/gbenchmark.py
@@ -26,10 +26,7 @@ def configure(cfg):
 
     env.GBENCHMARK_CMAKE_GENERATOR = None
 
-    cfg.find_program('ninja', mandatory=False)
-    if not env.NINJA:
-        cfg.find_program('ninja-build', var='NINJA', mandatory=False)
-
+    cfg.find_program(['ninja', 'ninja-build'], var='NINJA', mandatory=False)
     if env.NINJA:
         env.GBENCHMARK_CMAKE_GENERATOR = 'Ninja'
 


### PR DESCRIPTION
We can pass a list of possible binaries to find_program. This gives us a
better output while configuring:

	Checking for program 'ninja, ninja-build' : /usr/bin/ninja-build

instead of:

	Checking for program 'ninja'             : not found
	Checking for program 'ninja-build'       : /usr/bin/ninja-build