### PR TITLE
Change scheduler task table to Hz

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -37,12 +37,7 @@ const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
 Rover rover;
 
-#define SCHED_TASK(func, _interval_ticks, _max_time_micros) {\
-    .function = FUNCTOR_BIND(&rover, &Rover::func, void),\
-    AP_SCHEDULER_NAME_INITIALIZER(func)\
-    .interval_ticks = _interval_ticks,\
-    .max_time_micros = _max_time_micros,\
-}
+#define SCHED_TASK(func, _interval_ticks, _max_time_micros) SCHED_TASK_CLASS(Rover, &rover, func, _interval_ticks, _max_time_micros)
 
 /*
   scheduler table - all regular tasks should be listed here, along
@@ -50,38 +45,38 @@ Rover rover;
   time they are expected to take (in microseconds)
 */
 const AP_Scheduler::Task Rover::scheduler_tasks[] = {
-    SCHED_TASK(read_radio,              1,   1000),
-    SCHED_TASK(ahrs_update,             1,   6400),
-    SCHED_TASK(read_sonars,             1,   2000),
-    SCHED_TASK(update_current_mode,     1,   1500),
-    SCHED_TASK(set_servos,              1,   1500),
-    SCHED_TASK(update_GPS_50Hz,         1,   2500),
-    SCHED_TASK(update_GPS_10Hz,         5,   2500),
-    SCHED_TASK(update_alt,              5,   3400),
-    SCHED_TASK(navigate,                5,   1600),
-    SCHED_TASK(update_compass,          5,   2000),
-    SCHED_TASK(update_commands,         5,   1000),
-    SCHED_TASK(update_logging1,         5,   1000),
-    SCHED_TASK(update_logging2,         5,   1000),
-    SCHED_TASK(gcs_retry_deferred,      1,   1000),
-    SCHED_TASK(gcs_update,              1,   1700),
-    SCHED_TASK(gcs_data_stream_send,    1,   3000),
+    SCHED_TASK(read_radio,             50,   1000),
+    SCHED_TASK(ahrs_update,            50,   6400),
+    SCHED_TASK(read_sonars,            50,   2000),
+    SCHED_TASK(update_current_mode,    50,   1500),
+    SCHED_TASK(set_servos,             50,   1500),
+    SCHED_TASK(update_GPS_50Hz,        50,   2500),
+    SCHED_TASK(update_GPS_10Hz,        10,   2500),
+    SCHED_TASK(update_alt,             10,   3400),
+    SCHED_TASK(navigate,               10,   1600),
+    SCHED_TASK(update_compass,         10,   2000),
+    SCHED_TASK(update_commands,        10,   1000),
+    SCHED_TASK(update_logging1,        10,   1000),
+    SCHED_TASK(update_logging2,        10,   1000),
+    SCHED_TASK(gcs_retry_deferred,     50,   1000),
+    SCHED_TASK(gcs_update,             50,   1700),
+    SCHED_TASK(gcs_data_stream_send,   50,   3000),
     SCHED_TASK(read_control_switch,     7,   1000),
-    SCHED_TASK(read_trim_switch,        5,   1000),
-    SCHED_TASK(read_battery,            5,   1000),
-    SCHED_TASK(read_receiver_rssi,      5,   1000),
-    SCHED_TASK(update_events,           1,   1000),
-    SCHED_TASK(check_usb_mux,          15,   1000),
-    SCHED_TASK(mount_update,            1,    600),
-    SCHED_TASK(gcs_failsafe_check,      5,    600),
-    SCHED_TASK(compass_accumulate,      1,    900),
-    SCHED_TASK(update_notify,           1,    300),
-    SCHED_TASK(one_second_loop,        50,   3000),
-    SCHED_TASK(compass_cal_update,      1,    100), 
+    SCHED_TASK(read_trim_switch,       10,   1000),
+    SCHED_TASK(read_battery,           10,   1000),
+    SCHED_TASK(read_receiver_rssi,     10,   1000),
+    SCHED_TASK(update_events,          50,   1000),
+    SCHED_TASK(check_usb_mux,           3,   1000),
+    SCHED_TASK(mount_update,           50,    600),
+    SCHED_TASK(gcs_failsafe_check,     10,    600),
+    SCHED_TASK(compass_accumulate,     50,    900),
+    SCHED_TASK(update_notify,          50,    300),
+    SCHED_TASK(one_second_loop,         1,   3000),
+    SCHED_TASK(compass_cal_update,     50,    100), 
 #if FRSKY_TELEM_ENABLED == ENABLED
-    SCHED_TASK(frsky_telemetry_send,   10,    100),
+    SCHED_TASK(frsky_telemetry_send,    5,    100),
 #endif
-    SCHED_TASK(dataflash_periodic,      1,    300),
+    SCHED_TASK(dataflash_periodic,     50,    300),
 };
 
 /*

--- a/APMrover2/Rover.cpp
+++ b/APMrover2/Rover.cpp
@@ -21,7 +21,6 @@
 
 Rover::Rover(void) :
     param_loader(var_info),
-    ins_sample_rate(AP_InertialSensor::RATE_50HZ),
     channel_steer(NULL),
     channel_throttle(NULL),
     channel_learn(NULL),

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -112,9 +112,6 @@ private:
     // variables
     AP_Param param_loader;
 
-    // the rate we run the main loop at
-    const AP_InertialSensor::Sample_rate ins_sample_rate;
-
     // all settable parameters
     Parameters g;
 

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -396,7 +396,7 @@ void Rover::startup_INS_ground(void)
 	ahrs.set_fly_forward(true);
     ahrs.set_vehicle_class(AHRS_VEHICLE_GROUND);
 
-	ins.init(ins_sample_rate);
+	ins.init(scheduler.get_loop_rate_hz());
 
     ahrs.reset();
 }

--- a/APMrover2/test.cpp
+++ b/APMrover2/test.cpp
@@ -308,7 +308,7 @@ int8_t Rover::test_ins(uint8_t argc, const Menu::arg *argv)
 	//cliSerial->printf("Calibrating.");
 	ahrs.init();
     ahrs.set_fly_forward(true);
-	ins.init(ins_sample_rate);
+	ins.init(scheduler.get_loop_rate_hz());
     ahrs.reset();
 
 	print_hit_enter();
@@ -371,7 +371,7 @@ int8_t Rover::test_mag(uint8_t argc, const Menu::arg *argv)
     ahrs.set_compass(&compass);
 
     // we need the AHRS initialised for this test
-	ins.init(ins_sample_rate);
+	ins.init(scheduler.get_loop_rate_hz());
     ahrs.reset();
 
 	int counter = 0;

--- a/AntennaTracker/AntennaTracker.cpp
+++ b/AntennaTracker/AntennaTracker.cpp
@@ -21,12 +21,7 @@
 
 #include "Tracker.h"
 
-#define SCHED_TASK(func, _interval_ticks, _max_time_micros) {\
-    .function = FUNCTOR_BIND(&tracker, &Tracker::func, void),\
-    AP_SCHEDULER_NAME_INITIALIZER(func)\
-    .interval_ticks = _interval_ticks,\
-    .max_time_micros = _max_time_micros,\
-}
+#define SCHED_TASK(func, _interval_ticks, _max_time_micros) SCHED_TASK_CLASS(Tracker, &tracker, func, _interval_ticks, _max_time_micros)
 
 /*
   scheduler table - all regular tasks apart from the fast_loop()
@@ -35,21 +30,21 @@
   microseconds)
  */
 const AP_Scheduler::Task Tracker::scheduler_tasks[] = {
-    SCHED_TASK(update_ahrs,             1,   1000),
-    SCHED_TASK(read_radio,              1,    200),
-    SCHED_TASK(update_tracking,         1,   1000),
-    SCHED_TASK(update_GPS,              5,   4000),
-    SCHED_TASK(update_compass,          5,   1500),
-    SCHED_TASK(update_barometer,        5,   1500),
-    SCHED_TASK(gcs_update,              1,   1700),
-    SCHED_TASK(gcs_data_stream_send,    1,   3000),
-    SCHED_TASK(compass_accumulate,      1,   1500),
-    SCHED_TASK(barometer_accumulate,    1,    900),
-    SCHED_TASK(update_notify,           1,    100),
-    SCHED_TASK(check_usb_mux,           5,    300),
-    SCHED_TASK(gcs_retry_deferred,      1,   1000),
-    SCHED_TASK(one_second_loop,        50,   3900),
-    SCHED_TASK(compass_cal_update,      1,    100),
+    SCHED_TASK(update_ahrs,            50,   1000),
+    SCHED_TASK(read_radio,             50,    200),
+    SCHED_TASK(update_tracking,        50,   1000),
+    SCHED_TASK(update_GPS,             10,   4000),
+    SCHED_TASK(update_compass,         10,   1500),
+    SCHED_TASK(update_barometer,       10,   1500),
+    SCHED_TASK(gcs_update,             50,   1700),
+    SCHED_TASK(gcs_data_stream_send,   50,   3000),
+    SCHED_TASK(compass_accumulate,     50,   1500),
+    SCHED_TASK(barometer_accumulate,   50,    900),
+    SCHED_TASK(update_notify,          50,    100),
+    SCHED_TASK(check_usb_mux,          10,    300),
+    SCHED_TASK(gcs_retry_deferred,     50,   1000),
+    SCHED_TASK(one_second_loop,         1,   3900),
+    SCHED_TASK(compass_cal_update,     50,    100),
 };
 
 /**

--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -88,8 +88,6 @@ public:
     void loop() override;
 
 private:
-    const AP_InertialSensor::Sample_rate ins_sample_rate = AP_InertialSensor::RATE_50HZ;
-
     Parameters g;
 
     // main loop scheduler

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -77,7 +77,7 @@ void Tracker::init_tracker()
     ahrs.init();
     ahrs.set_fly_forward(false);
 
-    ins.init(ins_sample_rate);
+    ins.init(scheduler.get_loop_rate_hz());
     ahrs.reset();
 
     init_barometer();

--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -75,12 +75,7 @@
 
 #include "Copter.h"
 
-#define SCHED_TASK(func, _interval_ticks, _max_time_micros) {\
-    .function = FUNCTOR_BIND(&copter, &Copter::func, void),\
-    AP_SCHEDULER_NAME_INITIALIZER(func)\
-    .interval_ticks = _interval_ticks,\
-    .max_time_micros = _max_time_micros,\
-}
+#define SCHED_TASK(func, rate_hz, max_time_micros) SCHED_TASK_CLASS(Copter, &copter, func, rate_hz, max_time_micros)
 
 /*
   scheduler table for fast CPUs - all regular tasks apart from the fast_loop()
@@ -99,70 +94,70 @@
   
  */
 const AP_Scheduler::Task Copter::scheduler_tasks[] = {
-    SCHED_TASK(rc_loop,                4,    130),
-    SCHED_TASK(throttle_loop,          8,     75),
-    SCHED_TASK(update_GPS,             8,    200),
+    SCHED_TASK(rc_loop,              100,    130),
+    SCHED_TASK(throttle_loop,         50,     75),
+    SCHED_TASK(update_GPS,            50,    200),
 #if OPTFLOW == ENABLED
-    SCHED_TASK(update_optical_flow,    2,    160),
+    SCHED_TASK(update_optical_flow,  200,    160),
 #endif
-    SCHED_TASK(update_batt_compass,   40,    120),
-    SCHED_TASK(read_aux_switches,     40,     50),
-    SCHED_TASK(arm_motors_check,      40,     50),
-    SCHED_TASK(auto_disarm_check,     40,     50),
-    SCHED_TASK(auto_trim,             40,     75),
-    SCHED_TASK(update_altitude,       40,    140),
-    SCHED_TASK(run_nav_updates,        8,    100),
-    SCHED_TASK(update_thr_average,     4,     90),
-    SCHED_TASK(three_hz_loop,        133,     75),
-    SCHED_TASK(compass_accumulate,     4,    100),
-    SCHED_TASK(barometer_accumulate,   8,     90),
+    SCHED_TASK(update_batt_compass,   10,    120),
+    SCHED_TASK(read_aux_switches,     10,     50),
+    SCHED_TASK(arm_motors_check,      10,     50),
+    SCHED_TASK(auto_disarm_check,     10,     50),
+    SCHED_TASK(auto_trim,             10,     75),
+    SCHED_TASK(update_altitude,       10,    140),
+    SCHED_TASK(run_nav_updates,       50,    100),
+    SCHED_TASK(update_thr_average,   100,     90),
+    SCHED_TASK(three_hz_loop,          3,     75),
+    SCHED_TASK(compass_accumulate,   100,    100),
+    SCHED_TASK(barometer_accumulate,  50,     90),
 #if PRECISION_LANDING == ENABLED
-    SCHED_TASK(update_precland,        8,     50),
+    SCHED_TASK(update_precland,       50,     50),
 #endif
 #if FRAME_CONFIG == HELI_FRAME
-    SCHED_TASK(check_dynamic_flight,   8,     75),
+    SCHED_TASK(check_dynamic_flight,  50,     75),
 #endif
-    SCHED_TASK(update_notify,          8,     90),
-    SCHED_TASK(one_hz_loop,          400,    100),
-    SCHED_TASK(ekf_check,             40,     75),
-    SCHED_TASK(landinggear_update,    40,     75),
-    SCHED_TASK(lost_vehicle_check,    40,     50),
-    SCHED_TASK(gcs_check_input,        1,    180),
-    SCHED_TASK(gcs_send_heartbeat,   400,    110),
-    SCHED_TASK(gcs_send_deferred,      8,    550),
-    SCHED_TASK(gcs_data_stream_send,   8,    550),
-    SCHED_TASK(update_mount,           8,     75),
-    SCHED_TASK(ten_hz_logging_loop,   40,    350),
-    SCHED_TASK(fifty_hz_logging_loop,  8,    110),
-    SCHED_TASK(full_rate_logging_loop, 1,    100),
-    SCHED_TASK(dataflash_periodic,     1,    300),
-    SCHED_TASK(perf_update,         4000,     75),
-    SCHED_TASK(read_receiver_rssi,    40,     75),
-    SCHED_TASK(rpm_update,            40,    200),
-    SCHED_TASK(compass_cal_update,    4,    100),
+    SCHED_TASK(update_notify,         50,     90),
+    SCHED_TASK(one_hz_loop,            1,    100),
+    SCHED_TASK(ekf_check,             10,     75),
+    SCHED_TASK(landinggear_update,    10,     75),
+    SCHED_TASK(lost_vehicle_check,    10,     50),
+    SCHED_TASK(gcs_check_input,      400,    180),
+    SCHED_TASK(gcs_send_heartbeat,     1,    110),
+    SCHED_TASK(gcs_send_deferred,     50,    550),
+    SCHED_TASK(gcs_data_stream_send,  50,    550),
+    SCHED_TASK(update_mount,          50,     75),
+    SCHED_TASK(ten_hz_logging_loop,   10,    350),
+    SCHED_TASK(fifty_hz_logging_loop, 50,    110),
+    SCHED_TASK(full_rate_logging_loop,400,    100),
+    SCHED_TASK(dataflash_periodic,    400,    300),
+    SCHED_TASK(perf_update,           0.1,    75),
+    SCHED_TASK(read_receiver_rssi,    10,     75),
+    SCHED_TASK(rpm_update,            10,    200),
+    SCHED_TASK(compass_cal_update,   100,    100),
 #if ADSB_ENABLED == ENABLED
-    SCHED_TASK(adsb_update,          400,    100),
+    SCHED_TASK(adsb_update,            1,    100),
 #endif
 #if FRSKY_TELEM_ENABLED == ENABLED
-    SCHED_TASK(frsky_telemetry_send,  80,     75),
+    SCHED_TASK(frsky_telemetry_send,   5,     75),
 #endif
 #if EPM_ENABLED == ENABLED
-    SCHED_TASK(epm_update,            40,     75),
+    SCHED_TASK(epm_update,            10,     75),
 #endif
 #ifdef USERHOOK_FASTLOOP
-    SCHED_TASK(userhook_FastLoop,      4,     75),
+    SCHED_TASK(userhook_FastLoop,    100,     75),
 #endif
 #ifdef USERHOOK_50HZLOOP
-    SCHED_TASK(userhook_50Hz,          8,     75),
+    SCHED_TASK(userhook_50Hz,         50,     75),
 #endif
 #ifdef USERHOOK_MEDIUMLOOP
-    SCHED_TASK(userhook_MediumLoop,   40,     75),
+    SCHED_TASK(userhook_MediumLoop,   10,     75),
 #endif
 #ifdef USERHOOK_SLOWLOOP
-    SCHED_TASK(userhook_SlowLoop,     120,    75),
+    SCHED_TASK(userhook_SlowLoop,     3.3,    75),
 #endif
 #ifdef USERHOOK_SUPERSLOWLOOP
-    SCHED_TASK(userhook_SuperSlowLoop, 400,   75),
+    SCHED_TASK(userhook_SuperSlowLoop, 1,   75),
 #endif
 };
 

--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -22,7 +22,6 @@
 const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 
 Copter::Copter(void) :
-    ins_sample_rate(AP_InertialSensor::RATE_400HZ),
     flight_modes(&g.flight_mode1),
     sonar_enabled(true),
     mission(ahrs, 

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -166,9 +166,6 @@ private:
     // Dataflash
     DataFlash_Class DataFlash{FIRMWARE_STRING};
 
-    // the rate we run the main loop at
-    const AP_InertialSensor::Sample_rate ins_sample_rate;
-
     AP_GPS gps;
 
     // flight modes convenience array

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -298,7 +298,7 @@ void Copter::startup_INS_ground()
     ahrs.set_vehicle_class(AHRS_VEHICLE_COPTER);
 
     // Warm up and calibrate gyro offsets
-    ins.init(ins_sample_rate);
+    ins.init(scheduler.get_loop_rate_hz());
 
     // reset ahrs including gyro bias
     ahrs.reset();

--- a/ArduCopter/test.cpp
+++ b/ArduCopter/test.cpp
@@ -84,7 +84,7 @@ int8_t Copter::test_compass(uint8_t argc, const Menu::arg *argv)
     report_compass();
 
     // we need the AHRS initialised for this test
-    ins.init(ins_sample_rate);
+    ins.init(scheduler.get_loop_rate_hz());
     ahrs.reset();
     int16_t counter = 0;
     float heading = 0;
@@ -152,7 +152,7 @@ int8_t Copter::test_ins(uint8_t argc, const Menu::arg *argv)
     delay(1000);
 
     ahrs.init();
-    ins.init(ins_sample_rate);
+    ins.init(scheduler.get_loop_rate_hz());
     cliSerial->printf("...done\n");
 
     delay(50);

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -24,12 +24,8 @@
 
 #include "Plane.h"
 
-#define SCHED_TASK(func, _interval_ticks, _max_time_micros) {\
-    .function = FUNCTOR_BIND(&plane, &Plane::func, void),\
-    AP_SCHEDULER_NAME_INITIALIZER(func)\
-    .interval_ticks = _interval_ticks,\
-    .max_time_micros = _max_time_micros,\
-}
+#define SCHED_TASK(func, rate_hz, max_time_micros) SCHED_TASK_CLASS(Plane, &plane, func, rate_hz, max_time_micros)
+
 
 /*
   scheduler table - all regular tasks are listed here, along with how
@@ -37,54 +33,54 @@
   they are expected to take (in microseconds)
  */
 const AP_Scheduler::Task Plane::scheduler_tasks[] = {
-    SCHED_TASK(read_radio,              1,    700),
-    SCHED_TASK(check_short_failsafe,    1,   1000),
-    SCHED_TASK(ahrs_update,             1,   6400),
-    SCHED_TASK(update_speed_height,     1,   1600),
-    SCHED_TASK(update_flight_mode,      1,   1400),
-    SCHED_TASK(stabilize,               1,   3500),
-    SCHED_TASK(set_servos,              1,   1600),
+    SCHED_TASK(read_radio,             50,    700),
+    SCHED_TASK(check_short_failsafe,   50,   1000),
+    SCHED_TASK(ahrs_update,            50,   6400),
+    SCHED_TASK(update_speed_height,    50,   1600),
+    SCHED_TASK(update_flight_mode,     50,   1400),
+    SCHED_TASK(stabilize,              50,   3500),
+    SCHED_TASK(set_servos,             50,   1600),
     SCHED_TASK(read_control_switch,     7,   1000),
-    SCHED_TASK(gcs_retry_deferred,      1,   1000),
-    SCHED_TASK(update_GPS_50Hz,         1,   2500),
-    SCHED_TASK(update_GPS_10Hz,         5,   2500),
-    SCHED_TASK(navigate,                5,   3000),
-    SCHED_TASK(update_compass,          5,   1200),
-    SCHED_TASK(read_airspeed,           5,   1200),
-    SCHED_TASK(update_alt,              5,   3400),
-    SCHED_TASK(adjust_altitude_target,  5,   1000),
-    SCHED_TASK(obc_fs_check,            5,   1000),
-    SCHED_TASK(gcs_update,              1,   1700),
-    SCHED_TASK(gcs_data_stream_send,    1,   3000),
-    SCHED_TASK(update_events,           1,   1500),
-    SCHED_TASK(check_usb_mux,           5,    300),
-    SCHED_TASK(read_battery,            5,   1000),
-    SCHED_TASK(compass_accumulate,      1,   1500),
-    SCHED_TASK(barometer_accumulate,    1,    900),
-    SCHED_TASK(update_notify,           1,    300),
-    SCHED_TASK(read_rangefinder,        1,    500),
-    SCHED_TASK(compass_cal_update,      1,    100),
+    SCHED_TASK(gcs_retry_deferred,     50,   1000),
+    SCHED_TASK(update_GPS_50Hz,        50,   2500),
+    SCHED_TASK(update_GPS_10Hz,        10,   2500),
+    SCHED_TASK(navigate,               10,   3000),
+    SCHED_TASK(update_compass,         10,   1200),
+    SCHED_TASK(read_airspeed,          10,   1200),
+    SCHED_TASK(update_alt,             10,   3400),
+    SCHED_TASK(adjust_altitude_target, 10,   1000),
+    SCHED_TASK(obc_fs_check,           10,   1000),
+    SCHED_TASK(gcs_update,             50,   1700),
+    SCHED_TASK(gcs_data_stream_send,   50,   3000),
+    SCHED_TASK(update_events,          50,   1500),
+    SCHED_TASK(check_usb_mux,          10,    300),
+    SCHED_TASK(read_battery,           10,   1000),
+    SCHED_TASK(compass_accumulate,     50,   1500),
+    SCHED_TASK(barometer_accumulate,   50,    900),
+    SCHED_TASK(update_notify,          50,    300),
+    SCHED_TASK(read_rangefinder,       50,    500),
+    SCHED_TASK(compass_cal_update,     50,    100),
 #if OPTFLOW == ENABLED
-    SCHED_TASK(update_optical_flow,     1,    500),
+    SCHED_TASK(update_optical_flow,    50,    500),
 #endif
-    SCHED_TASK(one_second_loop,        50,   1000),
-    SCHED_TASK(check_long_failsafe,    15,   1000),
-    SCHED_TASK(read_receiver_rssi,      5,   1000),
-    SCHED_TASK(rpm_update,              5,    200),
-    SCHED_TASK(airspeed_ratio_update,  50,   1000),
-    SCHED_TASK(update_mount,            1,   1500),
-    SCHED_TASK(log_perf_info,         500,   1000),
-    SCHED_TASK(compass_save,         3000,   2500),
-    SCHED_TASK(update_logging1,         5,   1700),
-    SCHED_TASK(update_logging2,         5,   1700),
-    SCHED_TASK(parachute_check,         5,    500),
+    SCHED_TASK(one_second_loop,         1,   1000),
+    SCHED_TASK(check_long_failsafe,     3,   1000),
+    SCHED_TASK(read_receiver_rssi,     10,   1000),
+    SCHED_TASK(rpm_update,             10,    200),
+    SCHED_TASK(airspeed_ratio_update,   1,   1000),
+    SCHED_TASK(update_mount,           50,   1500),
+    SCHED_TASK(log_perf_info,         0.1,   1000),
+    SCHED_TASK(compass_save,        0.016,   2500),
+    SCHED_TASK(update_logging1,        10,   1700),
+    SCHED_TASK(update_logging2,        10,   1700),
+    SCHED_TASK(parachute_check,        10,    500),
 #if FRSKY_TELEM_ENABLED == ENABLED
-    SCHED_TASK(frsky_telemetry_send,   10,    100),
+    SCHED_TASK(frsky_telemetry_send,    5,    100),
 #endif
-    SCHED_TASK(terrain_update,          5,    500),
-    SCHED_TASK(update_is_flying_5Hz,   10,    100),
-    SCHED_TASK(dataflash_periodic,      1,    300),
-    SCHED_TASK(adsb_update,            50,    500),
+    SCHED_TASK(terrain_update,         10,    500),
+    SCHED_TASK(update_is_flying_5Hz,    5,    100),
+    SCHED_TASK(dataflash_periodic,     50,    300),
+    SCHED_TASK(adsb_update,             1,    500),
 };
 
 void Plane::setup() 

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -146,9 +146,6 @@ private:
     AP_Vehicle::FixedWing aparm;
     AP_HAL::BetterStream* cliSerial;
 
-    // the rate we run the main loop 
-    const AP_InertialSensor::Sample_rate ins_sample_rate = AP_InertialSensor::RATE_50HZ;
-
     // Global parameters are all contained within the 'g' class.
     Parameters g;
 

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -569,7 +569,7 @@ void Plane::startup_INS_ground(void)
     ahrs.set_vehicle_class(AHRS_VEHICLE_FIXED_WING);
     ahrs.set_wind_estimation(true);
 
-    ins.init(ins_sample_rate);
+    ins.init(scheduler.get_loop_rate_hz());
     ahrs.reset();
 
     // read Baro pressure at ground

--- a/ArduPlane/test.cpp
+++ b/ArduPlane/test.cpp
@@ -350,7 +350,7 @@ int8_t Plane::test_ins(uint8_t argc, const Menu::arg *argv)
     ahrs.set_fly_forward(true);
     ahrs.set_wind_estimation(true);
 
-    ins.init(ins_sample_rate);
+    ins.init(scheduler.get_loop_rate_hz());
     ahrs.reset();
 
     print_hit_enter();
@@ -411,7 +411,7 @@ int8_t Plane::test_mag(uint8_t argc, const Menu::arg *argv)
     ahrs.set_compass(&compass);
 
     // we need the AHRS initialised for this test
-    ins.init(ins_sample_rate);
+    ins.init(scheduler.get_loop_rate_hz());
     ahrs.reset();
 
     uint16_t counter = 0;

--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -633,23 +633,7 @@ void Replay::setup()
 }
 
 void Replay::set_ins_update_rate(uint16_t _update_rate) {
-    switch (_update_rate) {
-    case 50:
-        _vehicle.ins.init(AP_InertialSensor::RATE_50HZ);
-        break;
-    case 100:
-        _vehicle.ins.init(AP_InertialSensor::RATE_100HZ);
-        break;
-    case 200:
-        _vehicle.ins.init(AP_InertialSensor::RATE_200HZ);
-        break;
-    case 400:
-        _vehicle.ins.init(AP_InertialSensor::RATE_400HZ);
-        break;
-    default:
-        printf("Invalid update rate (%d); use 50, 100, 200 or 400\n", _update_rate);
-        exit(1);
-    }
+    _vehicle.ins.init(_update_rate);
 }
 
 void Replay::inhibit_gyro_cal() {

--- a/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.cpp
+++ b/libraries/AP_AHRS/examples/AHRS_Test/AHRS_Test.cpp
@@ -29,7 +29,7 @@ AP_AHRS_DCM  ahrs(ins, baro, gps);
 
 void setup(void)
 {
-    ins.init(AP_InertialSensor::RATE_100HZ);
+    ins.init(100);
     ahrs.init();
     serial_manager.init();
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -434,6 +434,7 @@ AP_InertialSensor::init(Sample_rate sample_rate)
 {
     // remember the sample rate
     _sample_rate = sample_rate;
+    _loop_delta_t = 1.0f / sample_rate;
 
     if (_gyro_count == 0 && _accel_count == 0) {
         _start_backends();

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -430,7 +430,7 @@ AP_InertialSensor_Backend *AP_InertialSensor::_find_backend(int16_t backend_id, 
 }
 
 void
-AP_InertialSensor::init(Sample_rate sample_rate)
+AP_InertialSensor::init(uint16_t sample_rate)
 {
     // remember the sample rate
     _sample_rate = sample_rate;
@@ -453,21 +453,7 @@ AP_InertialSensor::init(Sample_rate sample_rate)
         _init_gyro();
     }
 
-    switch (sample_rate) {
-    case RATE_50HZ:
-        _sample_period_usec = 20000;
-        break;
-    case RATE_100HZ:
-        _sample_period_usec = 10000;
-        break;
-    case RATE_200HZ:
-        _sample_period_usec = 5000;
-        break;
-    case RATE_400HZ:
-    default:
-        _sample_period_usec = 2500;
-        break;
-    }
+    _sample_period_usec = 1000*1000UL / _sample_rate;
 
     // establish the baseline time between samples
     _delta_time = 0;

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -49,14 +49,6 @@ public:
     AP_InertialSensor();
     static AP_InertialSensor *get_instance();
 
-    // the rate that updates will be available to the application
-    enum Sample_rate {
-        RATE_50HZ  = 50,
-        RATE_100HZ = 100,
-        RATE_200HZ = 200,
-        RATE_400HZ = 400
-    };
-
     enum Gyro_Calibration_Timing {
         GYRO_CAL_NEVER = 0,
         GYRO_CAL_STARTUP_ONLY = 1
@@ -70,7 +62,7 @@ public:
     ///
     /// @param style	The initialisation startup style.
     ///
-    void init(Sample_rate sample_rate);
+    void init(uint16_t sample_rate_hz);
 
     /// Register a new gyro/accel driver, allocating an instance
     /// number
@@ -179,7 +171,7 @@ public:
     }
 
     // return the selected sample rate
-    Sample_rate get_sample_rate(void) const { return _sample_rate; }
+    uint16_t get_sample_rate(void) const { return _sample_rate; }
 
     // return the main loop delta_t in seconds
     float get_loop_delta_t(void) const { return _loop_delta_t; }
@@ -275,7 +267,7 @@ private:
     uint8_t _backend_count;
 
     // the selected sample rate
-    Sample_rate _sample_rate;
+    uint16_t _sample_rate;
     float _loop_delta_t;
     
     // Most recent accelerometer reading

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -181,6 +181,9 @@ public:
     // return the selected sample rate
     Sample_rate get_sample_rate(void) const { return _sample_rate; }
 
+    // return the main loop delta_t in seconds
+    float get_loop_delta_t(void) const { return _loop_delta_t; }
+    
     uint16_t error_count(void) const { return 0; }
     bool healthy(void) const { return get_gyro_health() && get_accel_health(); }
 
@@ -273,6 +276,7 @@ private:
 
     // the selected sample rate
     Sample_rate _sample_rate;
+    float _loop_delta_t;
     
     // Most recent accelerometer reading
     Vector3f _accel[INS_MAX_INSTANCES];

--- a/libraries/AP_InertialSensor/examples/INS_generic/INS_generic.cpp
+++ b/libraries/AP_InertialSensor/examples/INS_generic/INS_generic.cpp
@@ -20,7 +20,7 @@ void setup(void)
 {
     hal.console->println("AP_InertialSensor startup...");
 
-    ins.init(AP_InertialSensor::RATE_100HZ);
+    ins.init(100);
 
     // display initial values
     display_offsets_and_scaling();

--- a/libraries/AP_NavEKF/AP_NavEKF_core.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_core.cpp
@@ -226,7 +226,7 @@ bool NavEKF_core::InitialiseFilterDynamic(void)
     InitialiseVariables();
 
     // get initial time deltat between IMU measurements (sec)
-    dtDelAng = dtIMUavg = 1.0f/_ahrs->get_ins().get_sample_rate();
+    dtDelAng = dtIMUavg = _ahrs->get_ins().get_loop_delta_t();
 
     // set number of updates over which gps and baro measurements are applied to the velocity and position states
     gpsUpdateCountMaxInv = (dtIMUavg * 1000.0f)/float(msecGpsAvg);
@@ -288,7 +288,7 @@ bool NavEKF_core::InitialiseFilterBootstrap(void)
     InitialiseVariables();
 
     // get initial time deltat between IMU measurements (sec)
-    dtDelAng = dtIMUavg = 1.0f/_ahrs->get_ins().get_sample_rate();
+    dtDelAng = dtIMUavg = _ahrs->get_ins().get_loop_delta_t();
 
     // set number of updates over which gps and baro measurements are applied to the velocity and position states
     gpsUpdateCountMaxInv = (dtIMUavg * 1000.0f)/float(msecGpsAvg);
@@ -3824,7 +3824,7 @@ void NavEKF_core::readIMUData()
     const AP_InertialSensor &ins = _ahrs->get_ins();
 
     // calculate the average time between IMU updates
-    dtIMUavg = 1.0f/(float)ins.get_sample_rate();
+    dtIMUavg = ins.get_loop_delta_t();
 
     // calculate the most recent time between gyro delta angle updates
     if (ins.get_delta_time() > 0.0f) {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Measurements.cpp
@@ -233,7 +233,7 @@ void NavEKF2_core::readIMUData()
     const AP_InertialSensor &ins = _ahrs->get_ins();
 
     // average IMU sampling rate
-    dtIMUavg = 1.0f/ins.get_sample_rate();
+    dtIMUavg = ins.get_loop_delta_t();
 
     // the imu sample time is used as a common time reference throughout the filter
     imuSampleTime_ms = AP_HAL::millis();

--- a/libraries/AP_Scheduler/examples/Scheduler_test/Scheduler_test.cpp
+++ b/libraries/AP_Scheduler/examples/Scheduler_test/Scheduler_test.cpp
@@ -30,12 +30,7 @@ private:
 
 static SchedTest schedtest;
 
-#define SCHED_TASK(func, _interval_ticks, _max_time_micros) {\
-    .function = FUNCTOR_BIND(&schedtest, &SchedTest::func, void),\
-    AP_SCHEDULER_NAME_INITIALIZER(func)\
-    .interval_ticks = _interval_ticks,\
-    .max_time_micros = _max_time_micros,\
-}
+#define SCHED_TASK(func, _interval_ticks, _max_time_micros) SCHED_TASK_CLASS(SchedTest, &schedtest, func, _interval_ticks, _max_time_micros)
 
 /*
   scheduler table - all regular tasks are listed here, along with how
@@ -43,16 +38,15 @@ static SchedTest schedtest;
   they are expected to take (in microseconds)
  */
 const AP_Scheduler::Task SchedTest::scheduler_tasks[] = {
-    SCHED_TASK(ins_update,              1,   1000),
-    SCHED_TASK(one_hz_print,           50,   1000),
-    SCHED_TASK(five_second_call,      250,   1800),
+    SCHED_TASK(ins_update,             50,   1000),
+    SCHED_TASK(one_hz_print,            1,   1000),
+    SCHED_TASK(five_second_call,      0.2,   1800),
 };
 
 
 void SchedTest::setup(void)
 {
-    // we 
-    ins.init(AP_InertialSensor::RATE_50HZ);
+    ins.init(scheduler.get_loop_rate_hz());
 
     // initialise the scheduler
     scheduler.init(&scheduler_tasks[0], ARRAY_SIZE(scheduler_tasks));


### PR DESCRIPTION
This adds a SCHED_LOOP_RATE (suppressed on copter) to allow the main loop rate to be set. It also converts the main task tables to be in Hz
This is needed before the quadplane code can run at greater than 50Hz

