### PR TITLE
AP_HAL: RingBuffer: fix macro expansion

### DIFF
--- a/libraries/AP_HAL/utility/RingBuffer.h
+++ b/libraries/AP_HAL/utility/RingBuffer.h
@@ -18,7 +18,7 @@
  */
 #define BUF_AVAILABLE(buf) ((buf##_head > (_tail=buf##_tail))? (buf##_size - buf##_head) + _tail: _tail - buf##_head)
 #define BUF_SPACE(buf) (((_head=buf##_head) > buf##_tail)?(_head - buf##_tail) - 1:((buf##_size - buf##_tail) + _head) - 1)
-#define BUF_EMPTY(buf) buf##_head == buf##_tail
+#define BUF_EMPTY(buf) (buf##_head == buf##_tail)
 #define BUF_ADVANCETAIL(buf, n) buf##_tail = (buf##_tail + n) % buf##_size
 #define BUF_ADVANCEHEAD(buf, n) buf##_head = (buf##_head + n) % buf##_size
 


### PR DESCRIPTION
@tridge any reason for the removal in https://github.com/diydrones/ardupilot/commit/7c431b40f2682bb3bf89d7ea4c933d55ef9c88c6 or was it a leftover?

The commit message contains the warning that was added after this commit.