### PR TITLE
Copter: finish removal of OF_LOITER, add convenience function for looping through modes

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -828,6 +828,7 @@ private:
     void failsafe_disable();
     void fence_check();
     void fence_send_mavlink_status(mavlink_channel_t chan);
+    bool is_valid_flight_mode(uint8_t mode);
     bool set_mode(uint8_t mode);
     void update_flight_mode();
     void exit_mode(uint8_t old_control_mode, uint8_t new_control_mode);

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -161,7 +161,6 @@ NOINLINE void Copter::send_extended_status1(mavlink_channel_t chan)
     case RTL:
     case CIRCLE:
     case LAND:
-    case OF_LOITER:
     case POSHOLD:
     case BRAKE:
         control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL;

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -95,7 +95,6 @@ enum autopilot_modes {
     RTL =           6,  // automatic return to launching point
     CIRCLE =        7,  // automatic circular flight with automatic throttle
     LAND =          9,  // automatic landing with horizontal position control
-    OF_LOITER =    10,  // deprecated
     DRIFT =        11,  // semi-automous position, yaw and throttle control
     SPORT =        13,  // manual earth-frame angular rate control with manual throttle
     FLIP =         14,  // automatically flip the vehicle on the roll axis

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -100,7 +100,8 @@ enum autopilot_modes {
     FLIP =         14,  // automatically flip the vehicle on the roll axis
     AUTOTUNE =     15,  // automatically tune the vehicle's roll and pitch gains
     POSHOLD =      16,  // automatic position hold with manual override, with automatic throttle
-    BRAKE =        17   // full-brake using inertial/GPS system, no pilot input
+    BRAKE =        17,  // full-brake using inertial/GPS system, no pilot input
+    FLIGHT_MODE_MAX
 };
 
 // Tuning enumeration

--- a/ArduCopter/flight_mode.cpp
+++ b/ArduCopter/flight_mode.cpp
@@ -7,6 +7,31 @@
  *      logic for individual flight modes is in control_acro.pde, control_stabilize.pde, etc
  */
 
+
+bool Copter::is_valid_flight_mode(uint8_t mode)
+{
+    switch (mode) {
+        case STABILIZE:
+        case ACRO:
+        case ALT_HOLD:
+        case AUTO:
+        case GUIDED:
+        case LOITER:
+        case RTL:
+        case CIRCLE:
+        case LAND:
+        case DRIFT:
+        case SPORT:
+        case FLIP:
+        case AUTOTUNE:
+        case POSHOLD:
+        case BRAKE:
+            return true;
+    }
+
+    return false;
+}
+
 // set_mode - change flight mode and perform any necessary initialisation
 // optional force parameter used to force the flight mode change (used only first time mode is set)
 // returns true if mode was succesfully set

--- a/ArduCopter/flight_mode.cpp
+++ b/ArduCopter/flight_mode.cpp
@@ -352,9 +352,6 @@ void Copter::print_flight_mode(AP_HAL::BetterStream *port, uint8_t mode)
     case LAND:
         port->print("LAND");
         break;
-    case OF_LOITER:
-        port->print("OF_LOITER");
-        break;
     case DRIFT:
         port->print("DRIFT");
         break;


### PR DESCRIPTION
Need to loop through valid modes for one of Solo's functionalities - is_valid_flight_mode and FLIGHT_MODE_MAX are needed for that.