### PR TITLE
Copter: Fix Ch6 Tuning when no RC Receiver on Boot.

### DIFF
--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -169,6 +169,11 @@ void Copter::failsafe_gcs_check()
 {
     uint32_t last_gcs_update_ms;
 
+    // do nothing if gcs failsafe already triggered or motors disarmed
+    if (failsafe.gcs || !motors.armed()) {
+        return;
+    }
+
     // return immediately if gcs failsafe is disabled, gcs has never been connected or we are not overriding rc controls from the gcs and we are not in guided mode
     // this also checks to see if we have a GCS failsafe active, if we do, then must continue to process the logic for recovery from this state.
     if ((!failsafe.gcs)&&(g.failsafe_gcs == FS_GCS_DISABLED || failsafe.last_heartbeat_ms == 0 || (!failsafe.rc_override_active && control_mode != GUIDED))) {
@@ -189,12 +194,7 @@ void Copter::failsafe_gcs_check()
         return;
     }
 
-    // do nothing if gcs failsafe already triggered or motors disarmed
-    if (failsafe.gcs || !motors.armed()) {
-        return;
-    }
-
-    // GCS failsafe event has occured
+    // If we have gotten this far then new GCS failsafe event has occured
     // update state, log to dataflash
     set_failsafe_gcs(true);
     Log_Write_Error(ERROR_SUBSYSTEM_FAILSAFE_GCS, ERROR_CODE_FAILSAFE_OCCURRED);

--- a/ArduCopter/tuning.cpp
+++ b/ArduCopter/tuning.cpp
@@ -11,8 +11,8 @@
 //  should be called at 3.3hz
 void Copter::tuning() {
 
-    // exit immediately if not tuning of when radio failsafe is invoked so tuning values are not set to zero
-    if ((g.radio_tuning <= 0) || failsafe.radio || failsafe.radio_counter != 0) {
+    // exit immediately if not using tuning function, or when radio failsafe is invoked, so tuning values are not set to zero
+    if ((g.radio_tuning <= 0) || failsafe.radio || failsafe.radio_counter != 0 || g.rc_6.radio_in == 0) {
         return;
     }
 

--- a/ArduCopter/tuning.cpp
+++ b/ArduCopter/tuning.cpp
@@ -16,8 +16,11 @@ void Copter::tuning() {
         return;
     }
 
-    float tuning_value = (float)g.rc_6.control_in / 1000.0f;
+    // set tuning range and then get new value
     g.rc_6.set_range(g.radio_tuning_low,g.radio_tuning_high);
+    float tuning_value = (float)g.rc_6.control_in / 1000.0f;
+    // Tuning Value should never be outside the bounds of the specified low and high value
+    tuning_value = constrain_float(tuning_value, g.radio_tuning_low/1000.0f, g.radio_tuning_high/1000.0f);
 
     Log_Write_Parameter_Tuning(g.radio_tuning, tuning_value, g.rc_6.control_in, g.radio_tuning_low, g.radio_tuning_high);
 


### PR DESCRIPTION
Currently, Tuned Param will end up being Zero if no RC Receiver present on Boot-up.  This patch results in the Param remaining as the last saved number, which is *not* the last tuned param.