### PR TITLE
Parse parameter metadata as part of travis build [WIP]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,7 @@ before_script:
   - ln -s /usr/bin/ccache ~/bin/arm-linux-gnueabihf-objcopy
 
 script:
+  - python Tools/autotest/param_metadata/param_parse.py
   - Tools/scripts/build_all_travis.sh
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,9 +70,9 @@ before_script:
   - ln -s /usr/bin/ccache ~/bin/arm-linux-gnueabihf-gcc
   - ln -s /usr/bin/ccache ~/bin/arm-linux-gnueabihf-size
   - ln -s /usr/bin/ccache ~/bin/arm-linux-gnueabihf-objcopy
+  - python Tools/autotest/param_metadata/param_parse.py
 
 script:
-  - python Tools/autotest/param_metadata/param_parse.py
   - Tools/scripts/build_all_travis.sh
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,9 +70,9 @@ before_script:
   - ln -s /usr/bin/ccache ~/bin/arm-linux-gnueabihf-gcc
   - ln -s /usr/bin/ccache ~/bin/arm-linux-gnueabihf-size
   - ln -s /usr/bin/ccache ~/bin/arm-linux-gnueabihf-objcopy
-  - python Tools/autotest/param_metadata/param_parse.py
 
 script:
+  - python Tools/autotest/param_metadata/param_parse.py
   - Tools/scripts/build_all_travis.sh
 
 notifications:

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -45,7 +45,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: SYSID_THISMAV
     // @DisplayName: MAVLink system ID of this vehicle
     // @Description: Allows setting an individual MAVLink system id for this vehicle to distinguish it from others on the same network
-    // @Range: 1 255
+    // @Range: 1 - 255
     // @User: Advanced
     GSCALAR(sysid_this_mav, "SYSID_THISMAV",   MAV_SYSTEM_ID),
 

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -45,7 +45,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: SYSID_THISMAV
     // @DisplayName: MAVLink system ID of this vehicle
     // @Description: Allows setting an individual MAVLink system id for this vehicle to distinguish it from others on the same network
-    // @Range: 1 - 255
+    // @Range: 1 255
     // @User: Advanced
     GSCALAR(sysid_this_mav, "SYSID_THISMAV",   MAV_SYSTEM_ID),
 


### PR DESCRIPTION
First try at mechanism to parse parameter meta data as part of Travis build. This way parameter meta data breaks will be caught prior to merge.