### PR TITLE
arducopter run immediately coredump on my Bebop 2

### DIFF
--- a/libraries/AP_HAL_Linux/GPIO_Bebop.cpp
+++ b/libraries/AP_HAL_Linux/GPIO_Bebop.cpp
@@ -11,6 +11,6 @@ const unsigned Linux::GPIO_Sysfs::pin_table[] = {
 const uint8_t Linux::GPIO_Sysfs::n_pins = _BEBOP_GPIO_MAX;
 
 static_assert(ARRAY_SIZE(Linux::GPIO_Sysfs::pin_table) == _BEBOP_GPIO_MAX,
-              "GPIO pin_table must have the same size of entries in enum gpio_minnow");
+              "GPIO pin_table must have the same size of entries in enum gpio_bebop");
 
 #endif

--- a/libraries/AP_HAL_Linux/RCOutput_Bebop.h
+++ b/libraries/AP_HAL_Linux/RCOutput_Bebop.h
@@ -89,6 +89,7 @@ private:
     uint16_t _max_pwm;
     uint8_t  _state;
     bool     _corking = false;
+    uint16_t _max_rpm;
 
     uint8_t _checksum(uint8_t *data, unsigned int len);
     void _start_prop();

--- a/libraries/AP_HAL_Linux/Util.cpp
+++ b/libraries/AP_HAL_Linux/Util.cpp
@@ -160,4 +160,37 @@ int Util::read_file(const char *path, const char *fmt, ...)
     return ret;
 }
 
+const char *Linux::Util::_hw_names[NUM_HARDWARES] = {
+    [HARDWARE_TYPE_BEBOP]  = "Mykonos3 board",
+    [HARDWARE_TYPE_BEBOP2] = "Milos board",
+};
+
+int Util::get_hw()
+{
+    char buf[255];
+    FILE *f = ::fopen("/proc/cpuinfo", "r");
+
+    if (f == NULL) {
+        return -errno;
+    }
+
+    /* truncate lines to 255 */
+    while (::fgets(buf, 255, f) != NULL) {
+        char *cur;
+        if ((cur = ::strstr(buf, "Hardware")) != NULL) {
+            cur += strlen("Hardware");
+            while (*cur == ' ' || *cur == ':' || *cur == '\t') {
+                cur++;
+            }
+            /* beginning of HW name */
+            for (uint8_t i = 0; i < NUM_HARDWARES; i++) {
+                if (strncmp(cur, _hw_names[i], strlen(_hw_names[i])) == 0) {
+                    return i;
+                }
+            }
+        }
+    }
+    return -ENOENT;
+}
+
 #endif // CONFIG_HAL_BOARD == HAL_BOARD_LINUX

--- a/libraries/AP_HAL_Linux/Util.cpp
+++ b/libraries/AP_HAL_Linux/Util.cpp
@@ -168,10 +168,12 @@ const char *Linux::Util::_hw_names[NUM_HARDWARES] = {
 int Util::get_hw()
 {
     char buf[255];
+    int ret = -ENOENT;
     FILE *f = ::fopen("/proc/cpuinfo", "r");
 
     if (f == NULL) {
-        return -errno;
+        ret = -errno;
+        goto end;
     }
 
     /* truncate lines to 255 */
@@ -185,12 +187,16 @@ int Util::get_hw()
             /* beginning of HW name */
             for (uint8_t i = 0; i < NUM_HARDWARES; i++) {
                 if (strncmp(cur, _hw_names[i], strlen(_hw_names[i])) == 0) {
-                    return i;
+                    ret = i;
+                    goto close_end;
                 }
             }
         }
     }
-    return -ENOENT;
+close_end:
+    fclose(f);
+end:
+    return ret;
 }
 
 #endif // CONFIG_HAL_BOARD == HAL_BOARD_LINUX

--- a/libraries/AP_HAL_Linux/Util.h
+++ b/libraries/AP_HAL_Linux/Util.h
@@ -9,6 +9,12 @@
 #include "ToneAlarmDriver.h"
 #include "Semaphores.h"
 
+enum hw_type {
+    HARDWARE_TYPE_BEBOP = 0,
+    HARDWARE_TYPE_BEBOP2,
+    NUM_HARDWARES,
+};
+
 class Linux::Util : public AP_HAL::Util {
 public:
     static Util *from(AP_HAL::Util *util) {
@@ -64,16 +70,17 @@ public:
 
     // create a new semaphore
     AP_HAL::Semaphore *new_semaphore(void) override { return new Linux::Semaphore; }
-    
+
+    int get_hw();
+
 private:
     static Linux::ToneAlarm _toneAlarm;
     Linux::Heat *_heat;
     int saved_argc;
     char* const *saved_argv;
     const char* custom_log_directory = NULL;
-    const char* custom_terrain_directory = NULL;	
+    const char* custom_terrain_directory = NULL;
+    static const char *_hw_names[NUM_HARDWARES];
 };
-
-
 
 #endif // __AP_HAL_LINUX_UTIL_H__


### PR DESCRIPTION
Hi, 

    I tried to follow the steps on http://dev.ardupilot.com/wiki/ to compile arducopter for bebop 2. 
    The compilation is done but the binary doesn't work on the bebop 2 on-board computer.  
    The console prints " Segmentation fault (core dumped)". In dmesg, it shows: 
     [....] Process 877 (crashdump) has RLIMIT_CORE set to 1
     [....] Aboring core

    With the provisioned the arducopter binary on github.com, it's still coredump. The console prints " Trace/breakpoint trap(core dumped)". These are what I saw in the dmesg :

     [....] Unhandled prefetch abort: breakpoint debug exception ( 0x002 ) at 0x00010df0
     [....] Process 913(crashdump) has RLIMIT_CORE set to 1
     [....] Aboring core

    I even tried with Sourcery CodeBench Lite 2012.03-57  to compile a simple helloworld. It still doesn't work and reported Segmentation fault ( coredump ).
     
     Here are some other info in the dmesg 
 
     [0.00000] Linux Version 3.4.11+ (jenkins@fr-pm-intc11-prd) ( gcc version 4.6.3 ( Sourcery Codebench Lite 2012.03-57 ) ) #1 SMP PREEMPT Thu Nov 12 19:27:39 CET 2015
     [0.00000] CPU ARMv7 Processor[412fc097] revision 7 ( ARMv7), cr=10c53c7d
     [0.00000] PIPT / VPIPT nonaliasing data cache, VIPT aliasing intruction cache
     [0.00000] Machine: Milos board
   
     How can I solve this ?

BRs, Jiang Pin

        

