### PR TITLE
dynamic parameters and enable variables

### DIFF
--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -68,7 +68,6 @@
 #define WGS84_E (sqrt(2*WGS84_F - WGS84_F*WGS84_F))
 
 // define AP_Param types AP_Vector3f and Ap_Matrix3f
-AP_PARAMDEFV(Matrix3f, Matrix3f, AP_PARAM_MATRIX3F);
 AP_PARAMDEFV(Vector3f, Vector3f, AP_PARAM_VECTOR3F);
 
 // are two floats equal

--- a/libraries/AP_NavEKF/AP_NavEKF.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF.cpp
@@ -118,6 +118,12 @@ extern const AP_HAL::HAL& hal;
 
 // Define tuning parameters
 const AP_Param::GroupInfo NavEKF::var_info[] = {
+    // @Param: ENABLE
+    // @DisplayName: Enable EKF1
+    // @Description: This enables EKF1 to be disabled when using alternative algorithms. When disabling it, the alternate EKF2 estimator must be enabled by setting EK2_ENABLED = 1 and flight control algorithms must be set to use the alternative estimator by setting AHRS_EKF_TYPE = 2.
+    // @Values: 0:Disabled, 1:Enabled
+    // @User: Advanced
+    AP_GROUPINFO_FLAGS("ENABLE", 34, NavEKF, _enable, 1, AP_PARAM_FLAG_ENABLE),
 
     // @Param: VELNE_NOISE
     // @DisplayName: GPS horizontal velocity measurement noise scaler
@@ -395,13 +401,6 @@ const AP_Param::GroupInfo NavEKF::var_info[] = {
     // @Bitmask: 0:NSats,1:HDoP,2:speed error,3:horiz pos error,4:yaw error,5:pos drift,6:vert speed,7:horiz speed
     // @User: Advanced
     AP_GROUPINFO("GPS_CHECK",    33, NavEKF, _gpsCheck, 31),
-
-    // @Param: ENABLE
-    // @DisplayName: Enable EKF1
-    // @Description: This enables EKF1 to be disabled when using alternative algorithms. When disabling it, the alternate EKF2 estimator must be enabled by setting EK2_ENABLED = 1 and flight control algorithms must be set to use the alternative estimator by setting AHRS_EKF_TYPE = 2.
-    // @Values: 0:Disabled, 1:Enabled
-    // @User: Advanced
-    AP_GROUPINFO("ENABLE", 34, NavEKF, _enable, 1),
 
     AP_GROUPEND
 };

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -120,7 +120,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Description: This enables EKF2. Enabling EKF2 only makes the maths run, it does not mean it will be used for flight control. To use it for flight control set AHRS_EKF_TYPE=2. A reboot or restart will need to be performed after changing the value of EK2_ENABLE for it to take effect.
     // @Values: 0:Disabled, 1:Enabled
     // @User: Advanced
-    AP_GROUPINFO("ENABLE", 0, NavEKF2, _enable, 0),
+    AP_GROUPINFO_FLAGS("ENABLE", 0, NavEKF2, _enable, 0, AP_PARAM_FLAG_ENABLE),
 
     // GPS measurement parameters
 

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -35,7 +35,7 @@
 
 extern const AP_HAL::HAL &hal;
 
-#define ENABLE_DEBUG 0
+#define ENABLE_DEBUG 1
 
 #if ENABLE_DEBUG
  # define Debug(fmt, args ...)  do {hal.console->printf("%s:%d: " fmt "\n", __FUNCTION__, __LINE__, ## args); } while(0)
@@ -98,8 +98,6 @@ void AP_Param::write_sentinal(uint16_t ofs)
 void AP_Param::erase_all(void)
 {
     struct EEPROM_header hdr;
-
-    Debug("erase_all");
 
     // write the header
     hdr.magic[0] = k_EEPROM_magic0;
@@ -217,8 +215,6 @@ bool AP_Param::check_var_info(void)
 bool AP_Param::setup(void)
 {
     struct EEPROM_header hdr;
-
-    Debug("setup %u vars", (unsigned)_num_vars);
 
     // check the header
     _storage.read_block(&hdr, 0, sizeof(hdr));

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -117,10 +117,20 @@ bool AP_Param::check_group_info(const struct AP_Param::GroupInfo *  group_info,
                                 uint8_t                             prefix_length)
 {
     uint8_t type;
-    int8_t max_idx = -1;
+    uint64_t used_mask = 0;
     for (uint8_t i=0;
          (type=group_info[i].type) != AP_PARAM_NONE;
          i++) {
+        uint8_t idx = group_info[i].idx;
+        if (idx >= (1<<_group_level_shift)) {
+            Debug("idx too large (%u) in %s", idx, group_info[i].name);
+            return false;
+        }
+        if (used_mask & (1ULL<<idx)) {
+            Debug("Duplicate group idx %u for %s", idx, group_info[i].name);
+            return false;
+        }
+        used_mask |= (1ULL<<idx);
         if (type == AP_PARAM_GROUP) {
             // a nested group
             const struct GroupInfo *ginfo = group_info[i].group_info;
@@ -134,16 +144,6 @@ bool AP_Param::check_group_info(const struct AP_Param::GroupInfo *  group_info,
             }
             continue;
         }
-        uint8_t idx = group_info[i].idx;
-        if (idx >= (1<<_group_level_shift)) {
-            Debug("idx too large (%u) in %s", idx, group_info[i].name);
-            return false;
-        }
-        if ((int8_t)idx <= max_idx) {
-            Debug("indexes must be in increasing order in %s", group_info[i].name);
-            return false;
-        }
-        max_idx = (int8_t)idx;
         uint8_t size = type_size((enum ap_var_type)type);
         if (size == 0) {
             Debug("invalid type in %s", group_info[i].name);

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -35,8 +35,16 @@
 /*
   flags for variables in var_info and group tables
  */
+
+// a nested offset is for subgroups that are not subclasses
 #define AP_PARAM_FLAG_NESTED_OFFSET 1
+
+// a pointer variable is for dynamically allocated objects
 #define AP_PARAM_FLAG_POINTER       2
+
+// an enable variable allows a whole subtree of variables to be made
+// invisible
+#define AP_PARAM_FLAG_ENABLE        4
 
 // a variant of offsetof() to work around C++ restrictions.
 // this can only be used when the offset of a variable in a object
@@ -47,7 +55,10 @@
 #define AP_CLASSTYPE(class, element) ((uint8_t)(((const class *) 1)->element.vtype))
 
 // declare a group var_info line
-#define AP_GROUPINFO(name, idx, class, element, def) { AP_CLASSTYPE(class, element), idx, name, AP_VAROFFSET(class, element), {def_value : def} }
+#define AP_GROUPINFO_FLAGS(name, idx, class, element, def, flags) { AP_CLASSTYPE(class, element), idx, name, AP_VAROFFSET(class, element), {def_value : def}, flags }
+
+// declare a group var_info line
+#define AP_GROUPINFO(name, idx, class, element, def) AP_GROUPINFO_FLAGS(name, idx, class, element, def, 0)
 
 // declare a nested group entry in a group var_info
 #define AP_NESTEDGROUPINFO(class, idx) { AP_PARAM_GROUP, idx, "", 0, { group_info : class::var_info }, 0 }


### PR DESCRIPTION
This adds support for dynamically allocated objects containing parameters and for parameters marked as enable variables.
When an enable variable is disabled all the parameters after that variable in the parameter table for that object are hidden
Note that this PR builds on PR#3382