### PR TITLE
Fail build on parameter parse errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,7 @@ before_script:
   - ln -s /usr/bin/ccache ~/bin/arm-linux-gnueabihf-objcopy
 
 script:
+  - python Tools/autotest/param_metadata/param_parse.py
   - Tools/scripts/build_all_travis.sh
 
 notifications:


### PR DESCRIPTION
This runs the parameter parser on travis builds in order to catch parse errors and fail build.

After this goes through, I'll update the parser to validate the remainder of the parameter info and clean up what I find.