### PR TITLE
Param: Add support for 512 top level vehicle parameters

### DIFF
--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -68,7 +68,6 @@
 #define WGS84_E (sqrt(2*WGS84_F - WGS84_F*WGS84_F))
 
 // define AP_Param types AP_Vector3f and Ap_Matrix3f
-AP_PARAMDEFV(Matrix3f, Matrix3f, AP_PARAM_MATRIX3F);
 AP_PARAMDEFV(Vector3f, Vector3f, AP_PARAM_VECTOR3F);
 
 // are two floats equal

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -120,7 +120,7 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Description: This enables EKF2. Enabling EKF2 only makes the maths run, it does not mean it will be used for flight control. To use it for flight control set AHRS_EKF_TYPE=2. A reboot or restart will need to be performed after changing the value of EK2_ENABLE for it to take effect.
     // @Values: 0:Disabled, 1:Enabled
     // @User: Advanced
-    AP_GROUPINFO("ENABLE", 0, NavEKF2, _enable, 0),
+    AP_GROUPINFO_FLAGS("ENABLE", 0, NavEKF2, _enable, 0, AP_PARAM_FLAG_ENABLE),
 
     // GPS measurement parameters
 

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -31,7 +31,11 @@
 #include "float.h"
 
 #define AP_MAX_NAME_SIZE 16
-#define AP_NESTED_GROUPS_ENABLED
+
+/*
+  flags for variables in var_info and group tables
+ */
+#define AP_PARAM_FLAG_NESTED_OFFSET 1
 
 // a variant of offsetof() to work around C++ restrictions.
 // this can only be used when the offset of a variable in a object
@@ -45,9 +49,11 @@
 #define AP_GROUPINFO(name, idx, class, element, def) { AP_CLASSTYPE(class, element), idx, name, AP_VAROFFSET(class, element), {def_value : def} }
 
 // declare a nested group entry in a group var_info
-#ifdef AP_NESTED_GROUPS_ENABLED
- #define AP_NESTEDGROUPINFO(class, idx) { AP_PARAM_GROUP, idx, "", 0, { group_info : class::var_info } }
-#endif
+#define AP_NESTEDGROUPINFO(class, idx) { AP_PARAM_GROUP, idx, "", 0, { group_info : class::var_info }, 0 }
+
+// declare a subgroup entry in a group var_info. This is for having another arbitrary object as a member of the parameter list of
+// an object
+#define AP_SUBGROUPINFO(element, name, idx, thisclass, elclass) { AP_PARAM_GROUP, idx, name, AP_VAROFFSET(thisclass, element), { group_info : elclass::var_info }, AP_PARAM_FLAG_NESTED_OFFSET }
 
 #define AP_GROUPEND     { AP_PARAM_NONE, 0xFF, "", 0, { group_info : NULL } }
 #define AP_VAREND       { AP_PARAM_NONE, "", 0, NULL, { group_info : NULL } }
@@ -63,6 +69,7 @@ enum ap_var_type {
     AP_PARAM_MATRIX3F,
     AP_PARAM_GROUP
 };
+
 
 /// Base class for variables.
 ///
@@ -83,6 +90,7 @@ public:
             const struct GroupInfo *group_info;
             const float def_value;
         };
+        uint8_t flags;
     };
     struct Info {
         uint8_t type; // AP_PARAM_*
@@ -111,7 +119,7 @@ public:
     {
         _var_info = info;
         uint16_t i;
-        for (i = 0; info[i].type != AP_PARAM_NONE; i++) ;
+        for (i=0; info[i].type != AP_PARAM_NONE; i++) ;
         _num_vars = i;
     }
 
@@ -140,7 +148,11 @@ public:
     /// @param	buffer			The destination buffer
     /// @param	bufferSize		Total size of the destination buffer.
     ///
-    void copy_name_info(const struct AP_Param::Info *info, const struct GroupInfo *ginfo, uint8_t idx, char *buffer, size_t bufferSize, bool force_scalar=false) const;
+    void copy_name_info(const struct AP_Param::Info *info,
+                        const struct GroupInfo *ginfo,
+                        const struct GroupInfo *ginfo0,
+                        uint8_t idx, char *buffer, size_t bufferSize, bool force_scalar=false) const;
+    
     /// Copy the variable's name, prefixed by any containing group name, to a
     /// buffer.
     ///
@@ -324,23 +336,28 @@ private:
                                     uint8_t                     vindex,
                                     uint8_t                     group_base,
                                     uint8_t                     group_shift,
+                                    uint32_t                    group_offset,
                                     uint32_t *                  group_element,
-                                    const struct GroupInfo **   group_ret,
+                                    const struct GroupInfo *   &group_ret,
+                                    const struct GroupInfo *   &group_ret0,
                                     uint8_t *                   idx) const;
     const struct Info *         find_var_info(
                                     uint32_t *                group_element,
-                                    const struct GroupInfo ** group_ret,
+                                    const struct GroupInfo *  &group_ret,
+                                    const struct GroupInfo *  &group_ret0,
                                     uint8_t *                 idx) const;
     const struct Info *			find_var_info_token(const ParamToken &token,
                                                     uint32_t *                 group_element,
-                                                    const struct GroupInfo **  group_ret,
+                                                    const struct GroupInfo *  &group_ret,
+                                                    const struct GroupInfo *  &group_ret0,
                                                     uint8_t *                  idx) const;
     static const struct Info *  find_by_header_group(
                                     struct Param_header phdr, void **ptr,
                                     uint8_t vindex,
                                     const struct GroupInfo *group_info,
                                     uint8_t group_base,
-                                    uint8_t group_shift);
+                                    uint8_t group_shift,
+                                    uint32_t group_offset);
     static const struct Info *  find_by_header(
                                     struct Param_header phdr,
                                     void **ptr);
@@ -351,6 +368,7 @@ private:
     static AP_Param *           find_group(
                                     const char *name,
                                     uint8_t vindex,
+                                    uint32_t group_offset,
                                     const struct GroupInfo *group_info,
                                     enum ap_var_type *ptype);
     static void                 write_sentinal(uint16_t ofs);
@@ -368,6 +386,7 @@ private:
                                     bool *found_current,
                                     uint8_t group_base,
                                     uint8_t group_shift,
+                                    uint32_t group_offset,
                                     ParamToken *token,
                                     enum ap_var_type *ptype);
 

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -35,8 +35,16 @@
 /*
   flags for variables in var_info and group tables
  */
+
+// a nested offset is for subgroups that are not subclasses
 #define AP_PARAM_FLAG_NESTED_OFFSET 1
+
+// a pointer variable is for dynamically allocated objects
 #define AP_PARAM_FLAG_POINTER       2
+
+// an enable variable allows a whole subtree of variables to be made
+// invisible
+#define AP_PARAM_FLAG_ENABLE        4
 
 // a variant of offsetof() to work around C++ restrictions.
 // this can only be used when the offset of a variable in a object
@@ -47,7 +55,10 @@
 #define AP_CLASSTYPE(class, element) ((uint8_t)(((const class *) 1)->element.vtype))
 
 // declare a group var_info line
-#define AP_GROUPINFO(name, idx, class, element, def) { AP_CLASSTYPE(class, element), idx, name, AP_VAROFFSET(class, element), {def_value : def} }
+#define AP_GROUPINFO_FLAGS(name, idx, class, element, def, flags) { AP_CLASSTYPE(class, element), idx, name, AP_VAROFFSET(class, element), {def_value : def}, flags }
+
+// declare a group var_info line
+#define AP_GROUPINFO(name, idx, class, element, def) AP_GROUPINFO_FLAGS(name, idx, class, element, def, 0)
 
 // declare a nested group entry in a group var_info
 #define AP_NESTEDGROUPINFO(class, idx) { AP_PARAM_GROUP, idx, "", 0, { group_info : class::var_info }, 0 }


### PR DESCRIPTION
This makes it possible to have k_param_* values larger than 255.
This is forwards compatible with the existing FRAM format, so upgrading is no problem.
Downgrading is more of an issue. If you have used a firmware with a value larger than 255 and have saved a parameter with that enum and then downgrade to an older firmware that does not support 512 parms then you will get corrupted parameters.
Unfortunately I don't think this is avoidable. So I recommend we add this patch in now, but don't actually use any params above 255 until after all 3 vehicle types have had a new major release.
This builds on the two earlier AP_Param PRs
