### PR TITLE
Implemented auxillary Relay Switching for Relays 2, 3 and 4.

### DIFF
--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -72,7 +72,7 @@ enum aux_sw_func {
 };
 
 // Frame types
-#define UNDEFINED_FRAME 0
+#define UNDEFINED_FRAME 0 
 #define QUAD_FRAME 1
 #define TRI_FRAME 2
 #define HEXA_FRAME 3

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -66,6 +66,9 @@ enum aux_sw_func {
     AUXSW_MOTOR_ESTOP =         31, // Emergency Stop Switch
     AUXSW_MOTOR_INTERLOCK =     32, // Motor On/Off switch
     AUXSW_BRAKE =               33  // Brake flight mode
+	AUXSW_RELAY2 =              34, // Relay2 pin on/off (in Mission planner set CH8_OPT  = 34)
+    AUXSW_RELAY3 =              35, // Relay3 pin on/off (in Mission planner set CH9_OPT  = 35)
+    AUXSW_RELAY4 =              36  // Relay4 pin on/off (in Mission planner set CH10_OPT = 36)
 };
 
 // Frame types

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -65,7 +65,7 @@ enum aux_sw_func {
     AUXSW_LOST_COPTER_SOUND =   30, // Play lost copter sound
     AUXSW_MOTOR_ESTOP =         31, // Emergency Stop Switch
     AUXSW_MOTOR_INTERLOCK =     32, // Motor On/Off switch
-    AUXSW_BRAKE =               33  // Brake flight mode
+    AUXSW_BRAKE =               33, // Brake flight mode
 	AUXSW_RELAY2 =              34, // Relay2 pin on/off (in Mission planner set CH8_OPT  = 34)
     AUXSW_RELAY3 =              35, // Relay3 pin on/off (in Mission planner set CH9_OPT  = 35)
     AUXSW_RELAY4 =              36  // Relay4 pin on/off (in Mission planner set CH10_OPT = 36)

--- a/ArduCopter/switches.cpp
+++ b/ArduCopter/switches.cpp
@@ -235,7 +235,6 @@ void Copter::init_aux_switch_function(int8_t ch_option, uint8_t ch_flag)
         case AUXSW_MISSION_RESET:
         case AUXSW_ATTCON_FEEDFWD:
         case AUXSW_ATTCON_ACCEL_LIM:
-        case AUXSW_RELAY:
         case AUXSW_LANDING_GEAR:
         case AUXSW_MOTOR_ESTOP:
         case AUXSW_MOTOR_INTERLOCK:
@@ -521,6 +520,18 @@ void Copter::do_aux_switch_function(int8_t ch_function, uint8_t ch_flag)
             ServoRelayEvents.do_set_relay(0, ch_flag == AUX_SWITCH_HIGH);
             break;
 
+		case AUXSW_RELAY2:
+			ServoRelayEvents.do_set_relay(1, ch_flag == AUX_SWITCH_HIGH);
+			break;
+
+		case AUXSW_RELAY3:
+			ServoRelayEvents.do_set_relay(2, ch_flag == AUX_SWITCH_HIGH);
+			break;
+	   
+	   case AUXSW_RELAY4:
+			ServoRelayEvents.do_set_relay(3, ch_flag == AUX_SWITCH_HIGH);
+			break;			
+			
         case AUXSW_LANDING_GEAR:
             switch (ch_flag) {
                 case AUX_SWITCH_LOW:


### PR DESCRIPTION
http://ardupilot.com/forum/viewtopic.php?f=111&t=14300

Hi,
I have tested these changes on Pixhawk hardware and they seem to work well. The only query I have is with the function      
void Copter::init_aux_switch_function(int8_t ch_option, uint8_t ch_flag)  in
switches.cpp
I removed the RELAY case statement as the initial state of relays did not work with the code inplace - probably not the best solution but I couldn't find why it wouldn't work.
thanks Gavin ... 