### PR TITLE
Parachute capability bit

### DIFF
--- a/ArduCopter/capabilities.cpp
+++ b/ArduCopter/capabilities.cpp
@@ -10,4 +10,8 @@ void Copter::init_capabilities(void)
     hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_GLOBAL_INT);
     hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_FLIGHT_TERMINATION);
     hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_SET_ATTITUDE_TARGET);
+
+    #if PARACHUTE == ENABLED
+        hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_PARACHUTE);
+    #endif
 }

--- a/ArduPlane/capabilities.cpp
+++ b/ArduPlane/capabilities.cpp
@@ -6,4 +6,8 @@ void Plane::init_capabilities(void)
 {
     hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_MISSION_FLOAT);
     hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT);
+
+    #if PARACHUTE == ENABLED
+        hal.util->set_capabilities(MAV_PROTOCOL_CAPABILITY_PARACHUTE);
+    #endif
 }

--- a/libraries/GCS_MAVLink/include/mavlink/v1.0/common/common.h
+++ b/libraries/GCS_MAVLink/include/mavlink/v1.0/common/common.h
@@ -543,7 +543,8 @@ typedef enum MAV_PROTOCOL_CAPABILITY
 	MAV_PROTOCOL_CAPABILITY_SET_ACTUATOR_TARGET=1024, /* Autopilot supports direct actuator control. | */
 	MAV_PROTOCOL_CAPABILITY_FLIGHT_TERMINATION=2048, /* Autopilot supports the flight termination command. | */
 	MAV_PROTOCOL_CAPABILITY_COMPASS_CALIBRATION=4096, /* Autopilot supports onboard compass calibration. | */
-	MAV_PROTOCOL_CAPABILITY_ENUM_END=4097, /*  | */
+	MAV_PROTOCOL_CAPABILITY_PARACHUTE=8192, /* Autopilot supports parachute deployment. | */
+	MAV_PROTOCOL_CAPABILITY_ENUM_END=8193, /*  | */
 } MAV_PROTOCOL_CAPABILITY;
 #endif
 

--- a/libraries/GCS_MAVLink/message_definitions/common.xml
+++ b/libraries/GCS_MAVLink/message_definitions/common.xml
@@ -1491,6 +1491,9 @@
               <entry value="4096" name="MAV_PROTOCOL_CAPABILITY_COMPASS_CALIBRATION">
                   <description>Autopilot supports onboard compass calibration.</description>
               </entry>
+              <entry value="8192" name="MAV_PROTOCOL_CAPABILITY_PARACHUTE">
+                  <description>Autopilot supports parachute deployment.</description>
+              </entry>
           </enum>
           <enum name="MAV_ESTIMATOR_TYPE">
               <description>Enumeration of estimator types</description>


### PR DESCRIPTION
This PR adds the new capability bit for parachute deployment.  This is important because it is possible to compile copter or plane without parachute support, so version numbers wouldn't necessarily be helpful to know if the autopilot supports parachutes.