### PR TITLE
add L1 xtrack error to DF log

### DIFF
--- a/APMrover2/Log.cpp
+++ b/APMrover2/Log.cpp
@@ -256,9 +256,10 @@ struct PACKED log_Nav_Tuning {
     uint16_t target_bearing_cd;
     uint16_t nav_bearing_cd;
     int8_t   throttle;
+    float xtrack_error;
 };
 
-// Write a navigation tuning packet. Total length : 18 bytes
+// Write a navigation tuning packet
 void Rover::Log_Write_Nav_Tuning()
 {
     struct log_Nav_Tuning pkt = {
@@ -268,7 +269,8 @@ void Rover::Log_Write_Nav_Tuning()
         wp_distance         : wp_distance,
         target_bearing_cd   : (uint16_t)nav_controller->target_bearing_cd(),
         nav_bearing_cd      : (uint16_t)nav_controller->nav_bearing_cd(),
-        throttle            : (int8_t)(100 * channel_throttle->norm_output())
+        throttle            : (int8_t)(100 * channel_throttle->norm_output()),
+        xtrack_error        : nav_controller->crosstrack_error()
     };
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
 }
@@ -393,7 +395,7 @@ const LogStructure Rover::log_structure[] = {
     { LOG_CTUN_MSG, sizeof(log_Control_Tuning),     
       "CTUN", "Qhcchf",     "TimeUS,Steer,Roll,Pitch,ThrOut,AccY" },
     { LOG_NTUN_MSG, sizeof(log_Nav_Tuning),         
-      "NTUN", "QHfHHb",     "TimeUS,Yaw,WpDist,TargBrg,NavBrg,Thr" },
+      "NTUN", "QHfHHbf",    "TimeUS,Yaw,WpDist,TargBrg,NavBrg,Thr,XT" },
     { LOG_SONAR_MSG, sizeof(log_Sonar),             
       "SONR", "QfHHHbHCb",  "TimeUS,LatAcc,S1Dist,S2Dist,DCnt,TAng,TTim,Spd,Thr" },
     { LOG_ARM_DISARM_MSG, sizeof(log_Arm_Disarm),

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -280,9 +280,10 @@ struct PACKED log_Nav_Tuning {
     int16_t airspeed_cm;
     float   altitude;
     uint32_t groundspeed_cm;
+    float   xtrack_error;
 };
 
-// Write a navigation tuning packe
+// Write a navigation tuning packet
 void Plane::Log_Write_Nav_Tuning()
 {
     struct log_Nav_Tuning pkt = {
@@ -295,7 +296,8 @@ void Plane::Log_Write_Nav_Tuning()
         altitude_error_cm   : (int16_t)altitude_error_cm,
         airspeed_cm         : (int16_t)airspeed.get_airspeed_cm(),
         altitude            : barometer.get_altitude(),
-        groundspeed_cm      : (uint32_t)(gps.ground_speed()*100)
+        groundspeed_cm      : (uint32_t)(gps.ground_speed()*100),
+        xtrack_error        : nav_controller->crosstrack_error()
     };
     DataFlash.WriteBlock(&pkt, sizeof(pkt));
 }
@@ -483,7 +485,7 @@ static const struct LogStructure log_structure[] = {
     { LOG_CTUN_MSG, sizeof(log_Control_Tuning),     
       "CTUN", "Qcccchhf",    "TimeUS,NavRoll,Roll,NavPitch,Pitch,ThrOut,RdrOut,AccY" },
     { LOG_NTUN_MSG, sizeof(log_Nav_Tuning),         
-      "NTUN", "QCfccccfI",   "TimeUS,Yaw,WpDist,TargBrg,NavBrg,AltErr,Arspd,Alt,GSpdCM" },
+      "NTUN", "QCfccccfIf",  "TimeUS,Yaw,WpDist,TargBrg,NavBrg,AltErr,Arspd,Alt,GSpdCM,XT" },
     { LOG_SONAR_MSG, sizeof(log_Sonar),             
       "SONR", "QHfffBBf",   "TimeUS,DistCM,Volt,BaroAlt,GSpd,Thr,Cnt,Corr" },
     { LOG_ARM_DISARM_MSG, sizeof(log_Arm_Disarm),


### PR DESCRIPTION
Add L1 xtrack error to DF log for Plane and Rover. Copter does not use the L1 controller. Fixes https://github.com/diydrones/ardupilot/issues/1538