### PR TITLE
waf: add most linux boards

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -87,6 +87,8 @@ def program(bld, **kw):
     name = bld.path.name
     kw['defines'].extend(_get_legacy_defines(name))
 
+    kw['features'] = common_features(bld) + kw.get('features', [])
+
     target = bld.bldnode.make_node(name + '.' + bld.env.BOARD)
     bld.program(
         target=target,
@@ -104,6 +106,12 @@ def _get_next_idx():
     global LAST_IDX
     LAST_IDX += 1
     return LAST_IDX
+
+def common_features(bld):
+    features = []
+    if bld.env.STATIC_LINKING:
+        features.append('static_linking')
+    return features
 
 def vehicle_stlib(bld, **kw):
     if 'name' not in kw:
@@ -137,9 +145,9 @@ def find_tests(bld, use=[]):
     if not bld.env.HAS_GTEST:
         return
 
-    features = ''
+    features = common_features(bld)
     if bld.cmd == 'check':
-        features='test'
+        features.append('test')
 
     use = Utils.to_list(use)
     use.append('GTEST')
@@ -165,7 +173,7 @@ def find_benchmarks(bld, use=[]):
     for f in bld.path.ant_glob(incl='*.cpp'):
         target = f.change_ext('.' + bld.env.BOARD)
         bld.program(
-            features=['gbenchmark'],
+            features=common_features(bld) + ['gbenchmark'],
             target=target,
             includes=includes,
             source=[f],

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -25,6 +25,9 @@ def define_board(func, name, parent_name=None):
     BOARDS[name] = env
     func(env)
 
+def get_boards_names():
+    return sorted(list(BOARDS.keys()))
+
 # Use a dictionary instead of the convetional list for definitions to
 # make easy to override them. Convert back to list before consumption.
 PROJECT_ENV.DEFINES = {}
@@ -129,5 +132,104 @@ def minlure(env):
 
 define_board(minlure, 'minlure', 'linux')
 
-def get_boards_names():
-    return sorted(list(BOARDS.keys()))
+
+def erleboard(env):
+    env.TOOLCHAIN = 'bbone'
+
+    env.DEFINES.update(
+        CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_LINUX_ERLEBOARD',
+    )
+
+define_board(erleboard, 'erleboard', 'linux')
+
+
+def navio(env):
+    env.TOOLCHAIN = 'rpi'
+
+    env.DEFINES.update(
+        CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_LINUX_NAVIO',
+    )
+
+define_board(navio, 'navio', 'linux')
+
+
+def zynq(env):
+    env.TOOLCHAIN = 'zynq'
+
+    env.DEFINES.update(
+        CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_LINUX_ZYNQ',
+    )
+
+define_board(zynq, 'zynq', 'linux')
+
+
+def bbbmini(env):
+    env.TOOLCHAIN = 'bbone'
+
+    env.DEFINES.update(
+        CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_LINUX_BBBMINI',
+    )
+
+define_board(bbbmini, 'bbbmini', 'linux')
+
+
+def pxf(env):
+    env.TOOLCHAIN = 'bbone'
+
+    env.DEFINES.update(
+        CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_LINUX_PXF',
+    )
+
+define_board(pxf, 'pxf', 'linux')
+
+
+def bebop(env):
+    env.TOOLCHAIN = 'bbone'
+
+    env.DEFINES.update(
+        CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_LINUX_BEBOP',
+    )
+
+    env.STATIC_LINKING = [True]
+
+define_board(bebop, 'bebop', 'linux')
+
+
+def raspilot(env):
+    env.TOOLCHAIN = 'rpi'
+
+    env.DEFINES.update(
+        CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_LINUX_RASPILOT',
+    )
+
+define_board(raspilot, 'raspilot', 'linux')
+
+
+def erlebrain2(env):
+    env.TOOLCHAIN = 'rpi'
+
+    env.DEFINES.update(
+        CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_LINUX_ERLEBRAIN2',
+    )
+
+define_board(erlebrain2, 'erlebrain2', 'linux')
+
+
+def bhat(env):
+    env.TOOLCHAIN = 'rpi'
+
+    env.DEFINES.update(
+        CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_LINUX_BH',
+    )
+
+define_board(bhat, 'bhat', 'linux')
+
+
+def pxfmini(env):
+    env.TOOLCHAIN = 'rpi'
+
+    env.DEFINES.update(
+        CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_LINUX_PXFMINI',
+    )
+
+define_board(pxfmini, 'pxfmini', 'linux')

--- a/Tools/ardupilotwaf/gbenchmark.py
+++ b/Tools/ardupilotwaf/gbenchmark.py
@@ -73,6 +73,14 @@ def configure(cfg):
     env.GBENCHMARK_BUILD_REL = my_build_node.path_from(bldnode)
     env.GBENCHMARK_SRC = my_src_node.abspath()
 
+    cfg.start_msg('Configuring gbenchmark')
+    try:
+        _configure_cmake(cfg, bldnode)
+        cfg.end_msg('done')
+    except:
+        cfg.end_msg('failed', color='YELLOW')
+        return
+
     env.INCLUDES_GBENCHMARK = [prefix_node.make_node('include').abspath()]
     env.LIBPATH_GBENCHMARK = [prefix_node.make_node('lib').abspath()]
     env.LIB_GBENCHMARK = ['benchmark']

--- a/Tools/ardupilotwaf/gbenchmark.py
+++ b/Tools/ardupilotwaf/gbenchmark.py
@@ -82,10 +82,16 @@ class gbenchmark_build(Task.Task):
             if not my_build_node:
                 bld.bldnode.make_node(self.env.GBENCHMARK_BUILD_REL).mkdir()
 
-            cmds.append('%s %s -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX:PATH=%s %s' % (
+            cmake_vars = {
+                'CMAKE_BUILD_TYPE': 'Release',
+                'CMAKE_INSTALL_PREFIX:PATH': bld.bldnode.make_node(self.env.GBENCHMARK_PREFIX_REL).abspath(),
+            }
+            cmake_vars = ' '.join("-D%s='%s'" % v for v in cmake_vars.items())
+
+            cmds.append('%s %s %s %s' % (
                             self.env.CMAKE[0],
                             self.env.GBENCHMARK_SRC,
-                            bld.bldnode.make_node(self.env.GBENCHMARK_PREFIX_REL).abspath(),
+                            cmake_vars,
                             self.env.GBENCHMARK_GENERATOR_OPTION
                         ))
 

--- a/Tools/ardupilotwaf/gbenchmark.py
+++ b/Tools/ardupilotwaf/gbenchmark.py
@@ -41,6 +41,14 @@ def configure(cfg):
     env = cfg.env
     env.HAS_GBENCHMARK = False
 
+    if env.TOOLCHAIN != 'native':
+        cfg.msg(
+            'Gbenchmark',
+            'cross-compilation currently not supported',
+             color='YELLOW',
+        )
+        return
+
     cfg.start_msg('Checking for gbenchmark submodule')
     cmake_lists = cfg.srcnode.find_resource('modules/gbenchmark/CMakeLists.txt')
     if not cmake_lists:

--- a/Tools/ardupilotwaf/gbenchmark.py
+++ b/Tools/ardupilotwaf/gbenchmark.py
@@ -9,6 +9,34 @@ from waflib import Build, Context, Task
 from waflib.TaskGen import feature, before_method, after_method
 from waflib.Errors import WafError
 
+def _configure_cmake(ctx, bldnode):
+    env = ctx.env
+    my_build_node = bldnode.find_dir(env.GBENCHMARK_BUILD_REL)
+    if not my_build_node:
+        bldnode.make_node(env.GBENCHMARK_BUILD_REL).mkdir()
+
+    prefix_node = bldnode.make_node(env.GBENCHMARK_PREFIX_REL)
+
+    cmake_vars = {
+        'CMAKE_BUILD_TYPE': 'Release',
+        'CMAKE_INSTALL_PREFIX:PATH': prefix_node.abspath(),
+    }
+
+    cmake_vars = ' '.join("-D%s='%s'" % v for v in cmake_vars.items())
+
+    cmd = '%s %s %s %s' % (
+              env.CMAKE[0],
+              env.GBENCHMARK_SRC,
+              cmake_vars,
+              env.GBENCHMARK_GENERATOR_OPTION
+          )
+
+    ctx.cmd_and_log(
+        cmd,
+        cwd=env.GBENCHMARK_BUILD,
+        quiet=Context.BOTH,
+    )
+
 def configure(cfg):
     env = cfg.env
     env.HAS_GBENCHMARK = False
@@ -76,36 +104,22 @@ class gbenchmark_build(Task.Task):
         if not cmake_lists:
             bld.fatal('Submodule gbenchmark not initialized, please run configure again')
 
-        # Generate build system first, if necessary
-        my_build_node = bld.bldnode.find_dir(self.env.GBENCHMARK_BUILD_REL)
-        if not (my_build_node and my_build_node.find_resource('CMakeCache.txt')):
-            if not my_build_node:
-                bld.bldnode.make_node(self.env.GBENCHMARK_BUILD_REL).mkdir()
-
-            cmake_vars = {
-                'CMAKE_BUILD_TYPE': 'Release',
-                'CMAKE_INSTALL_PREFIX:PATH': bld.bldnode.make_node(self.env.GBENCHMARK_PREFIX_REL).abspath(),
-            }
-            cmake_vars = ' '.join("-D%s='%s'" % v for v in cmake_vars.items())
-
-            cmds.append('%s %s %s %s' % (
-                            self.env.CMAKE[0],
-                            self.env.GBENCHMARK_SRC,
-                            cmake_vars,
-                            self.env.GBENCHMARK_GENERATOR_OPTION
-                        ))
-
-        cmds.append('%s --build %s --target install' % (
-                      self.env.CMAKE[0],
-                      self.env.GBENCHMARK_BUILD
-                    ))
         try:
-            for cmd in cmds:
-                bld.cmd_and_log(
-                    cmd,
-                    cwd=self.env.GBENCHMARK_BUILD,
-                    quiet=Context.BOTH,
-                )
+            # Generate build system first, if necessary
+            my_build_node = bld.bldnode.find_dir(self.env.GBENCHMARK_BUILD_REL)
+            if not (my_build_node and my_build_node.find_resource('CMakeCache.txt')):
+                _configure_cmake(bld, bld.bldnode)
+
+            # Build gbenchmark
+            cmd = '%s --build %s --target install' % (
+                    self.env.CMAKE[0],
+                    self.env.GBENCHMARK_BUILD
+                  )
+            bld.cmd_and_log(
+                cmd,
+                cwd=self.env.GBENCHMARK_BUILD,
+                quiet=Context.BOTH,
+            )
             return 0
         except WafError as e:
             print(e)

--- a/Tools/ardupilotwaf/static_linking.py
+++ b/Tools/ardupilotwaf/static_linking.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+"""
+WAF Tool to force programs to be statically linked
+
+This is expected to work with GNU compilers. OTHER COMPILERS HAVE NOT BEEN
+TESTED.
+"""
+
+from waflib.TaskGen import after_method, feature
+
+@feature('static_linking')
+@after_method('apply_link')
+def force_static_linking(self):
+	env = self.link_task.env
+	env.STLIB += env.LIB
+	env.LIB = []
+	env.STLIB_MARKER = '-static'
+	env.SHLIB_MARKER = ''

--- a/Tools/ardupilotwaf/toolchain.py
+++ b/Tools/ardupilotwaf/toolchain.py
@@ -1,0 +1,78 @@
+"""
+WAF Tool to select the correct toolchain based on the target archtecture.
+"""
+
+from waflib import Utils
+
+default = dict(
+    CXX='g++',
+    CC='gcc',
+    AS='gcc',
+    AR='ar',
+    LD='g++',
+    GDB='gdb',
+    OBJCOPY='objcopy',
+)
+
+toolchains = {}
+
+def toolchain(name, **kw):
+    chain = dict(default)
+    chain.update(kw)
+    toolchains[name] = chain
+
+toolchain('native')
+
+toolchain('arm',
+    CXX='arm-none-eabi-g++',
+    CC='arm-none-eabi-gcc',
+    AS='arm-none-eabi-gcc',
+    AR='arm-none-eabi-ar',
+    LD='arm-none-eabi-g++',
+    GDB='arm-none-eabi-gdb',
+    OBJCOPY='arm-none-eabi-objcopy',
+)
+
+toolchain('bbone',
+    CXX='arm-linux-gnueabihf-g++',
+    CC='arm-linux-gnueabihf-gcc',
+    AS='arm-linux-gnueabihf-gcc',
+    LD='arm-linux-gnueabihf-g++',
+)
+
+toolchain('rpi',
+    CXX='arm-linux-gnueabihf-g++',
+    CC='arm-linux-gnueabihf-gcc',
+    AS='arm-linux-gnueabihf-gcc',
+    AR='arm-linux-gnueabihf-ar',
+    LD='arm-linux-gnueabihf-g++',
+    GDB='arm-linux-gnueabihf-gdb',
+    OBJCOPY='arm-linux-gnueabihf-obj',
+)
+
+toolchain('zynq',
+    CXX='arm-xilinx-linux-gnueabi-g++',
+    CC='arm-xilinx-linux-gnueabi-gcc',
+    AS='arm-xilinx-linux-gnueabi-gcc',
+    AR='arm-xilinx-linux-gnueabi-ar',
+    LD='arm-xilinx-linux-gnueabi-g++',
+    GDB='arm-xilinx-linux-gnueabi-gdb',
+    OBJCOPY='arm-xilinx-linux-gnueabi-objcopy',
+)
+
+def configure(cfg):
+    if not cfg.env.TOOLCHAIN:
+        cfg.env.TOOLCHAIN = 'native'
+    else:
+        cfg.env.TOOLCHAIN = Utils.to_list(cfg.env.TOOLCHAIN)[0]
+
+    name = cfg.env.TOOLCHAIN
+    cfg.msg('Using toolchain', name)
+
+    if name not in toolchains:
+        cfg.fatal('Toolchain %s not found' % name)
+
+    chain = toolchains[name]
+
+    for k in default:
+        cfg.env.append_value(k, chain[k])

--- a/Tools/scripts/build_all_travis.sh
+++ b/Tools/scripts/build_all_travis.sh
@@ -7,6 +7,8 @@ set -ex
 
 . ~/.profile
 
+unset CXX CC
+
 # If TRAVIS_BUILD_TARGET is not set, default to all of them
 if [ -z "$TRAVIS_BUILD_TARGET" ]; then
     TRAVIS_BUILD_TARGET="sitl linux navio raspilot minlure bebop px4-v2 px4-v4"

--- a/wscript
+++ b/wscript
@@ -89,6 +89,7 @@ def configure(cfg):
     cfg.load('clang_compilation_database')
     cfg.load('waf_unit_test')
     cfg.load('gbenchmark')
+    cfg.load('static_linking')
 
     cfg.start_msg('Benchmarks')
     if cfg.env.HAS_GBENCHMARK:

--- a/wscript
+++ b/wscript
@@ -84,6 +84,7 @@ def configure(cfg):
         else:
             cfg.env.prepend_value(k, val)
 
+    cfg.load('toolchain')
     cfg.load('compiler_cxx compiler_c')
     cfg.load('clang_compilation_database')
     cfg.load('waf_unit_test')

--- a/wscript
+++ b/wscript
@@ -68,6 +68,22 @@ def configure(cfg):
     # use a different variant for each board
     cfg.setenv(cfg.env.BOARD)
 
+    cfg.msg('Setting board to', cfg.options.board)
+    cfg.env.BOARD = cfg.options.board
+    board_dict = boards.BOARDS[cfg.env.BOARD].get_merged_dict()
+
+    # Always prepend so that arguments passed in the command line get
+    # the priority.
+    for k in board_dict:
+        val = board_dict[k]
+        # Dictionaries (like 'DEFINES') are converted to lists to
+        # conform to waf conventions.
+        if isinstance(val, dict):
+            for item in val.items():
+                cfg.env.prepend_value(k, '%s=%s' % item)
+        else:
+            cfg.env.prepend_value(k, val)
+
     cfg.load('compiler_cxx compiler_c')
     cfg.load('clang_compilation_database')
     cfg.load('waf_unit_test')
@@ -85,22 +101,6 @@ def configure(cfg):
         uselib_store='GTEST',
         errmsg='not found, unit tests disabled',
     )
-
-    cfg.msg('Setting board to', cfg.options.board)
-    cfg.env.BOARD = cfg.options.board
-    board_dict = boards.BOARDS[cfg.env.BOARD].get_merged_dict()
-
-    # Always prepend so that arguments passed in the command line get
-    # the priority.
-    for k in board_dict:
-        val = board_dict[k]
-        # Dictionaries (like 'DEFINES') are converted to lists to
-        # conform to waf conventions.
-        if isinstance(val, dict):
-            for item in val.items():
-                cfg.env.prepend_value(k, '%s=%s' % item)
-        else:
-            cfg.env.prepend_value(k, val)
 
     cfg.env.prepend_value('INCLUDES', [
         cfg.srcnode.abspath() + '/libraries/'


### PR DESCRIPTION
Hi all,

This PR adds most linux boards to the waf build system.

I couldn't test the build for `zynq` (also, I find it strange that it isn't in travis build). I tested the build for the other added boards locally.

I think feedback from the boards' maintainers is quite relevant for this PR.

Best regards,
Gustavo Sousa