### PR TITLE
waf: remove already fixed TODOs

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -12,8 +12,6 @@ SOURCE_EXTS = [
 
 UTILITY_SOURCE_EXTS = [ 'utility/' + glob for glob in SOURCE_EXTS ]
 
-# TODO: Once HAL patches get in, need to filter out the HAL based
-# on the bld.env.BOARD.
 COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
     'AP_AccelCal',
     'AP_ADC',

--- a/wscript
+++ b/wscript
@@ -20,21 +20,11 @@ from waflib.Build import BuildContext, CleanContext, InstallContext, UninstallCo
 # pastable. Add the 'export waf="$PWD/waf"' trick to be copy-pastable
 # as well.
 
-# TODO: add support for unit tests.
-
 # TODO: replace defines with the use of a generated config.h file
 # this makes recompilation at least when defines change. which might
 # be sufficient.
 
 # TODO: set git version as part of build preparation.
-
-# TODO: Check if we should simply use the signed 'waf' "binary" (after
-# verifying it) instead of generating it ourselves from the sources.
-
-# TODO: evaluate if we need shortcut commands for the common targets
-# (vehicles). currently using waf --targets=NAME the target name must
-# contain the board extension so make it less convenient, maybe hook
-# to support automatic filling this extension?
 
 def init(ctx):
     env = ConfigSet.ConfigSet()


### PR DESCRIPTION
The TODOs removed with this patch were already fixed. Below is the explanation
for each.

 - TODO: add support for unit tests.
    - Supported already added.

 - TODO: Check if we should simply use the signed 'waf' "binary" (after
   verifying it) instead of generating it ourselves from the sources.
    - We're using a submodule for waf.

 - TODO: evaluate if we need shortcut commands for the common targets
   (vehicles). currently using waf --targets=NAME the target name must contain
   the board extension so make it less convenient, maybe hook to support
   automatic filling this extension?
    - There's no need of adding the extension anymore.

 - TODO: Once HAL patches get in, need to filter out the HAL based on the
   bld.env.BOARD.
    - The board-specific HAL library folders is indicated in
      bld.env.AP_LIBRARIES.