### PR TITLE
waf: change env.LIB to env.LDFLAGS

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -86,9 +86,9 @@ def sitl(env):
         '-O3',
     ]
 
-    env.LIB += [
-        'm',
-        'pthread',
+    env.LDFLAGS += [
+        '-lm',
+        '-lpthread',
     ]
 
     env.AP_LIBRARIES += [
@@ -109,10 +109,10 @@ def linux(env):
         '-O3',
     ]
 
-    env.LIB += [
-        'm',
-        'pthread',
-        'rt',
+    env.LDFLAGS += [
+        '-lm',
+        '-lpthread',
+        '-lrt',
     ]
 
     env.AP_LIBRARIES = [


### PR DESCRIPTION
There is an issue with gbenchmark with waf on Ubuntu (15.04 and 15.10, ) with the order of compile flags.
````
[1652/1652] Linking build/linux/libraries/AP_Math/benchmarks/benchmark_matrix.linux
/home/khancyr/Workspace/APM/ardupilot/build/linux/gbenchmark/lib/libbenchmark.a(benchmark.cc.o): dans la fonction « benchmark::RunSpecifiedBenchmarks(benchmark::BenchmarkReporter*) »:
benchmark.cc:(.text+0x2e21): référence indéfinie vers « pthread_create »
/usr/bin/ld generated: référence indéfinie vers « pthread_create »
collect2: error: ld returned 1 exit status

Waf: Leaving directory `/home/khancyr/Workspace/APM/ardupilot/build/linux'
Build failed
 -> task in 'benchmark_matrix.linux' failed (exit status 1): 
	{task 139784788162576: cxxprogram benchmark_matrix.cpp.1.o -> benchmark_matrix.linux}
['/usr/lib/ccache/g++', '-Wl,--gc-sections', 'libraries/AP_Math/benchmarks/benchmark_matrix.cpp.1.o', '-o', '/home/khancyr/Workspace/APM/ardupilot/build/linux/libraries/AP_Math/benchmarks/benchmark_matrix.linux', '-Wl,-Bstatic', '-L.', '-lap', '-Wl,-Bdynamic', '-L/home/khancyr/Workspace/APM/ardupilot/build/linux/gbenchmark/lib', '-lm', '-lpthread', '-lrt', '-lbenchmark']
````
Using LDFLAGS instead of LIB make sure that gbenchmark is linked to pthread