### PR TITLE
Scale TECS_LAND_SPDWGT from TECS_SPDWGT to 0 on land approach

### DIFF
--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -64,6 +64,7 @@ void Plane::setup_glide_slope(void)
     auto_state.wp_distance = get_distance(current_loc, next_WP_loc);
     auto_state.wp_proportion = location_path_proportion(current_loc, 
                                                         prev_WP_loc, next_WP_loc);
+    SpdHgt_Controller->set_path_proportion(auto_state.wp_proportion);
 
     /*
       work out if we will gradually change altitude, or try to get to

--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -64,6 +64,7 @@ void Plane::navigate()
     auto_state.wp_distance = get_distance(current_loc, next_WP_loc);
     auto_state.wp_proportion = location_path_proportion(current_loc, 
                                                         prev_WP_loc, next_WP_loc);
+    SpdHgt_Controller->set_path_proportion(auto_state.wp_proportion);
 
     // update total loiter angle
     loiter_angle_update();

--- a/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
+++ b/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
@@ -69,6 +69,9 @@ public:
 	// return landing sink rate
 	virtual float get_land_sinkrate(void) const = 0;
 
+	// set path_proportion accessor
+    virtual void set_path_proportion(float path_proportion) = 0;
+
 	// add new controllers to this enum. Users can then
 	// select which controller to use by setting the
 	// SPDHGT_CONTROLLER parameter

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -667,7 +667,13 @@ void AP_TECS::_update_pitch(void)
     } else if ( _underspeed || _flight_stage == AP_TECS::FLIGHT_TAKEOFF || _flight_stage == AP_TECS::FLIGHT_LAND_ABORT) {
         SKE_weighting = 2.0f;
     } else if (_flight_stage == AP_TECS::FLIGHT_LAND_APPROACH || _flight_stage == AP_TECS::FLIGHT_LAND_FINAL) {
-        SKE_weighting = constrain_float(_spdWeightLand, 0.0f, 2.0f);
+        if (_spdWeightLand < 0) {
+            // use sliding scale from normal weight down to zero at landing
+            float scaled_weight = _spdWeight * (1.0f - _path_proportion);
+            SKE_weighting = constrain_float(scaled_weight, 0.0f, 2.0f);
+        } else {
+            SKE_weighting = constrain_float(_spdWeightLand, 0.0f, 2.0f);
+        }
     }
 
     float SPE_weighting = 2.0f - SKE_weighting;

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -91,7 +91,12 @@ public:
     float get_height_rate_demand(void) const {
         return _hgt_rate_dem;
     }
-    
+
+    // set path_proportion
+    void set_path_proportion(float path_proportion) {
+        _path_proportion = constrain_float(path_proportion, 0.0f, 1.0f);
+    }
+
     // this supports the TECS_* user settable parameters
     static const struct AP_Param::GroupInfo var_info[];
 
@@ -270,6 +275,9 @@ private:
 
     // counter for demanded sink rate on land final
     uint8_t _flare_counter;
+
+    // percent traveled along the previous and next waypoints
+    float _path_proportion;
 
     // Update the airspeed internal state using a second order complementary filter
     void _update_speed(float load_factor);


### PR DESCRIPTION
Instead of using TECS_SPDWGT and a TECS_LAND_SPDWGT for weighing height accuracy vs airspeed, always use TECS_SPDWGT and scale it down to zero proportional to the path along landing slope. Start of approach is the weight is TECS_SPDWGT and the landing point the weight is zero.

To enable, set TECS_LAND_SPDWGT = (-1)