### PR TITLE
Change param TECS_LAND_SPDWGT default from +1 to -1

### DIFF
--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -134,7 +134,7 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
     // @Range: 0.0 2.0
     // @Increment: 0.1
     // @User: Advanced
-    AP_GROUPINFO("LAND_SPDWGT", 14, AP_TECS, _spdWeightLand, 1.0f),
+    AP_GROUPINFO("LAND_SPDWGT", 14, AP_TECS, _spdWeightLand, -1.0f),
 
     // @Param: PITCH_MAX
     // @DisplayName: Maximum pitch in auto flight


### PR DESCRIPTION
Change param TECS_LAND_SPDWGT default from +1 to -1. The behavior is in v3.5.0 to give time for it to be adopted but this default is scheduled to be released in v3.5.1.