### PR TITLE
EKF2: Improve ability to tune non-GPS operation

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -419,6 +419,14 @@ const AP_Param::GroupInfo NavEKF2::var_info[] = {
     // @Units: %
     AP_GROUPINFO("CHECK_SCALE", 34, NavEKF2, _gpsCheckScaler, CHECK_SCALER_DEFAULT),
 
+    // @Param: NOAID_NOISE
+    // @DisplayName: Non-GPS operation velocity change (m/s)
+    // @Description: This sets the amount of velocity change that the EKF allows for when operating without external measurements (eg GPs or optical flow). Increasing this parameter makes the EKF attitude estimate less affected by changes in vehicle velocity but also makes the EKF attitude estimate more affected by IMU errors.
+    // @Range: 0.5 25.0
+    // @User: Advanced
+    // @Units: m/s
+    AP_GROUPINFO("NOAID_NOISE", 35, NavEKF2, _noaidHorizVelNoise, 10.0f),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -311,6 +311,7 @@ private:
     AP_Int8 _gpsCheck;              // Bitmask controlling which preflight GPS checks are bypassed
     AP_Int8 _imuMask;               // Bitmask of IMUs to instantiate EKF2 for
     AP_Int16 _gpsCheckScaler;       // Percentage increase to be applied to GPS pre-flight accuracy and drift thresholds
+    AP_Float _noaidHorizVelNoise;   // horizontal velocity measurement noise assuned when synthesised zero velocity measurements are used to constrain attitude drift : m/s
 
     // Tuning parameters
     const float gpsNEVelVarAccScale;    // Scale factor applied to NE velocity measurement variance due to manoeuvre acceleration

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -173,16 +173,13 @@ void NavEKF2_core::SelectVelPosFusion()
     // Do this to coincide with the height fusion
     if (fuseHgtData && PV_AidingMode == AID_NONE) {
         gpsDataDelayed.vel.zero();
-        gpsDataDelayed.pos.x = lastKnownPositionNE.x;
-        gpsDataDelayed.pos.y = lastKnownPositionNE.y;
         // only fuse synthetic measurements when rate of change of velocity is less than 1g to reduce attitude errors due to launch acceleration
         if (accNavMag < 9.8f) {
-            fusePosData = true;
             fuseVelData = true;
         } else {
-            fusePosData = false;
             fuseVelData = false;
         }
+        fusePosData = false;
     }
 
     // perform fusion
@@ -245,20 +242,18 @@ void NavEKF2_core::FuseVelPosNED()
         posErr = frontend->gpsPosVarAccScale * accNavMag;
 
         // estimate the GPS Velocity, GPS horiz position and height measurement variances.
-        // if the GPS is able to report a speed error, we use it to adjust the observation noise for GPS velocity
-        // otherwise we scale it using manoeuvre acceleration
-        // Use different errors if flying without GPS using synthetic position and velocity data
-        if (PV_AidingMode == AID_NONE && motorsArmed) {
-            // Assume the vehicle will be flown with velocity changes less than 10 m/s in this mode (realistic for indoor use)
-            // This is a compromise between corrections for gyro errors and reducing angular errors due to maneouvres
-            R_OBS[0] = sq(10.0f);
+        // Use different errors if operating without external aiding using an assumed velocity of zero
+        if (PV_AidingMode == AID_NONE) {
+            if (tiltAlignComplete && motorsArmed) {
+            // This is a compromise between corrections for gyro errors and reducing effect of manoeuvre accelerations on tilt estimate
+                R_OBS[0] = sq(constrain_float(frontend->_noaidHorizVelNoise, 0.5f, 25.0f));
+            } else {
+                // Use a smaller value to give faster initial alignment
+                R_OBS[0] = sq(0.5f);
+            }
             R_OBS[1] = R_OBS[0];
             R_OBS[2] = R_OBS[0];
-            // Assume a large position uncertainty so as to contrain position states in this mode but minimise angular errors due to manoeuvres
-            R_OBS[3] = sq(25.0f);
-            R_OBS[4] = R_OBS[3];
-            R_OBS[5] = posDownObsNoise;
-            for (uint8_t i=0; i<=5; i++) R_OBS_DATA_CHECKS[i] = R_OBS[i];
+            for (uint8_t i=0; i<=2; i++) R_OBS_DATA_CHECKS[i] = R_OBS[i];
         } else {
             if (gpsSpdAccuracy > 0.0f) {
                 // use GPS receivers reported speed accuracy if available and floor at value set by gps noise parameter
@@ -270,16 +265,15 @@ void NavEKF2_core::FuseVelPosNED()
                 R_OBS[2] = sq(constrain_float(frontend->_gpsVertVelNoise,  0.05f, 5.0f)) + sq(frontend->gpsDVelVarAccScale  * accNavMag);
             }
             R_OBS[1] = R_OBS[0];
-            R_OBS[3] = sq(constrain_float(frontend->_gpsHorizPosNoise, 0.1f, 10.0f)) + sq(posErr);
-            R_OBS[4] = R_OBS[3];
-            R_OBS[5] = posDownObsNoise;
             // For data integrity checks we use the same measurement variances as used to calculate the Kalman gains for all measurements except GPS horizontal velocity
             // For horizontal GPs velocity we don't want the acceptance radius to increase with reported GPS accuracy so we use a value based on best GPs perfomrance
             // plus a margin for manoeuvres. It is better to reject GPS horizontal velocity errors early
             for (uint8_t i=0; i<=2; i++) R_OBS_DATA_CHECKS[i] = sq(constrain_float(frontend->_gpsHorizVelNoise, 0.05f, 5.0f)) + sq(frontend->gpsNEVelVarAccScale * accNavMag);
-            for (uint8_t i=3; i<=5; i++) R_OBS_DATA_CHECKS[i] = R_OBS[i];
         }
-
+        R_OBS[3] = sq(constrain_float(frontend->_gpsHorizPosNoise, 0.1f, 10.0f)) + sq(posErr);
+        R_OBS[4] = R_OBS[3];
+        R_OBS[5] = posDownObsNoise;
+        for (uint8_t i=3; i<=5; i++) R_OBS_DATA_CHECKS[i] = R_OBS[i];
 
         // if vertical GPS velocity data and an independant height source is being used, check to see if the GPS vertical velocity and altimeter
         // innovations have the same sign and are outside limits. If so, then it is likely aliasing is affecting
@@ -310,30 +304,27 @@ void NavEKF2_core::FuseVelPosNED()
             posHealth = ((posTestRatio < 1.0f) || badIMUdata);
             // declare a timeout condition if we have been too long without data or not aiding
             posTimeout = (((imuSampleTime_ms - lastPosPassTime_ms) > gpsRetryTime) || PV_AidingMode == AID_NONE);
-            // use position data if healthy, timed out, or in constant position mode
-            if (posHealth || posTimeout || (PV_AidingMode == AID_NONE)) {
+            // use position data if healthy or timed out
+            if (posHealth || posTimeout) {
                 posHealth = true;
-                // only reset the failed time and do glitch timeout checks if we are doing full aiding
-                if (PV_AidingMode == AID_ABSOLUTE) {
-                    lastPosPassTime_ms = imuSampleTime_ms;
-                    // if timed out or outside the specified uncertainty radius, reset to the GPS
-                    if (posTimeout || ((P[6][6] + P[7][7]) > sq(float(frontend->_gpsGlitchRadiusMax)))) {
-                        // reset the position to the current GPS position
-                        ResetPosition();
-                        // reset the velocity to the GPS velocity
-                        ResetVelocity();
-                        // don't fuse GPS data on this time step
-                        fusePosData = false;
-                        fuseVelData = false;
-                        // Reset the position variances and corresponding covariances to a value that will pass the checks
-                        zeroRows(P,6,7);
-                        zeroCols(P,6,7);
-                        P[6][6] = sq(float(0.5f*frontend->_gpsGlitchRadiusMax));
-                        P[7][7] = P[6][6];
-                        // Reset the normalised innovation to avoid failing the bad fusion tests
-                        posTestRatio = 0.0f;
-                        velTestRatio = 0.0f;
-                    }
+                lastPosPassTime_ms = imuSampleTime_ms;
+                // if timed out or outside the specified uncertainty radius, reset to the GPS
+                if (posTimeout || ((P[6][6] + P[7][7]) > sq(float(frontend->_gpsGlitchRadiusMax)))) {
+                    // reset the position to the current GPS position
+                    ResetPosition();
+                    // reset the velocity to the GPS velocity
+                    ResetVelocity();
+                    // don't fuse GPS data on this time step
+                    fusePosData = false;
+                    fuseVelData = false;
+                    // Reset the position variances and corresponding covariances to a value that will pass the checks
+                    zeroRows(P,6,7);
+                    zeroCols(P,6,7);
+                    P[6][6] = sq(float(0.5f*frontend->_gpsGlitchRadiusMax));
+                    P[7][7] = P[6][6];
+                    // Reset the normalised innovation to avoid failing the bad fusion tests
+                    posTestRatio = 0.0f;
+                    velTestRatio = 0.0f;
                 }
             } else {
                 posHealth = false;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -359,11 +359,11 @@ void NavEKF2_core::CovarianceInit()
     P[1][1]   = 0.1f;
     P[2][2]   = 0.1f;
     // velocities
-    P[3][3]   = sq(0.7f);
+    P[3][3]   = sq(frontend->_gpsHorizVelNoise);
     P[4][4]   = P[3][3];
-    P[5][5]   = sq(0.7f);
+    P[5][5]   = sq(frontend->_gpsVertVelNoise);
     // positions
-    P[6][6]   = sq(15.0f);
+    P[6][6]   = sq(frontend->_gpsHorizPosNoise);
     P[7][7]   = P[6][6];
     P[8][8]   = sq(frontend->_baroAltNoise);
     // gyro delta angle biases

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -513,7 +513,12 @@ void NavEKF2_core::UpdateStrapdownEquationsNED()
     stateStruct.velocity += delVelNav;
 
     // apply a trapezoidal integration to velocities to calculate position
-    stateStruct.position += (stateStruct.velocity + lastVelocity) * (imuDataDelayed.delVelDT*0.5f);
+    // if we are not doing aiding, then the horizontal position states are not predicted
+    if (PV_AidingMode != AID_NONE) {
+        stateStruct.position += (stateStruct.velocity + lastVelocity) * (imuDataDelayed.delVelDT*0.5f);
+    } else {
+        stateStruct.position.z += (stateStruct.velocity.z + lastVelocity.z) * (imuDataDelayed.delVelDT*0.5f);
+    }
 
     // accumulate the bias delta angle and time since last reset by an OF measurement arrival
     delAngBodyOF += imuDataDelayed.delAng - stateStruct.gyro_bias;
@@ -1114,6 +1119,14 @@ void NavEKF2_core::CovariancePrediction()
     for (uint8_t i=0; i<=stateIndexLim; i++)
     {
         nextP[i][i] = nextP[i][i] + processNoise[i];
+    }
+
+    // If we are not using the position states, keep their covariances at the initialisation values
+    if (PV_AidingMode == AID_NONE) {
+        zeroRows(P,6,7);
+        zeroCols(P,6,7);
+        P[6][6]   = sq(frontend->_gpsHorizPosNoise);
+        P[7][7]   = P[6][6];
     }
 
     // if the total position variance exceeds 1e4 (100m), then stop covariance


### PR DESCRIPTION
This PR enables the user to tune the non-GPS mode of operation to allow for the type of flying that is performed. It introduces an additional parameter EK2_NOAID_NOISE that represents the amount of variation in velocity allowed for during operation without external aiding. The default value has been set to 10m/s which allows for some manoeuvring in an outdoor setting, but still provides enough attitude correction to compensate for the gyro errors seen in most setups.

If large velocity change flight manoeuvres are corrupting the attitude estimates, then this parameter can be increased to slow down the rate of attitude corrections due to the sensed gravity vector. If IMU gyro errors are corrupting the attitude estimates, then this parameter can be reduced to increase the rate of attitude corrections due to the sensed gravity vector.

The horizontal position states and covariances have been disabled during non-GPS operation and a separate hardcoded tuning parameter is used for initial alignment to prevent user tuning affecting the alignment speed and stability and to make the non-GPs mode easier to tune.

These patches have been flight tested on an Iris+ with small innovations and no problems with attitude or height estimation observed. The GPS_TYPE parameter was set to 0 for this test to force operation without GPS.

![normalised innovations](https://cloud.githubusercontent.com/assets/3596952/12214534/fc11a310-b6eb-11e5-956e-544d0dc30255.png)
![roll and pitch](https://cloud.githubusercontent.com/assets/3596952/12214536/fc75c99e-b6eb-11e5-9865-9e4b5032e6d4.png)
![vertical innovations](https://cloud.githubusercontent.com/assets/3596952/12214535/fc72708c-b6eb-11e5-8707-eee0446d251c.png)

