### PR TITLE
waf: standardize paths [v2]

### DIFF
--- a/APMrover2/wscript
+++ b/APMrover2/wscript
@@ -26,7 +26,7 @@ def build(bld):
         ],
     )
 
-    ardupilotwaf.program(
+    ardupilotwaf.sketch(
         bld,
         use=vehicle + '_libs',
     )

--- a/AntennaTracker/wscript
+++ b/AntennaTracker/wscript
@@ -14,7 +14,7 @@ def build(bld):
         ],
     )
 
-    ardupilotwaf.program(
+    ardupilotwaf.sketch(
         bld,
         use=vehicle + '_libs',
     )

--- a/ArduCopter/wscript
+++ b/ArduCopter/wscript
@@ -35,7 +35,7 @@ def build(bld):
         ],
     )
 
-    ardupilotwaf.program(
+    ardupilotwaf.sketch(
         bld,
         use=vehicle + '_libs',
     )

--- a/ArduPlane/wscript
+++ b/ArduPlane/wscript
@@ -36,7 +36,7 @@ def build(bld):
         ],
     )
 
-    ardupilotwaf.program(
+    ardupilotwaf.sketch(
         bld,
         use=vehicle + '_libs',
     )

--- a/Tools/CPUInfo/wscript
+++ b/Tools/CPUInfo/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.sketch(
         bld,
         use='ap',
     )

--- a/Tools/CPUInfo/wscript
+++ b/Tools/CPUInfo/wscript
@@ -7,4 +7,5 @@ def build(bld):
     ardupilotwaf.sketch(
         bld,
         use='ap',
+        destdir='tools',
     )

--- a/Tools/Hello/wscript
+++ b/Tools/Hello/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.sketch(
         bld,
         use='ap',
     )

--- a/Tools/Hello/wscript
+++ b/Tools/Hello/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.sketch(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/Tools/Replay/wscript
+++ b/Tools/Replay/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.sketch(
         bld,
         use='ap',
     )

--- a/Tools/Replay/wscript
+++ b/Tools/Replay/wscript
@@ -7,4 +7,5 @@ def build(bld):
     ardupilotwaf.sketch(
         bld,
         use='ap',
+        destdir='tools',
     )

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -93,6 +93,10 @@ def program(bld, destdir='bin', **kw):
         **kw
     )
 
+def example(bld, **kw):
+    kw['destdir'] = 'examples'
+    program(bld, **kw)
+
 # NOTE: Code in libraries/ is compiled multiple times. So ensure each
 # compilation is independent by providing different index for each.
 # The need for this should disappear when libraries change to be

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -163,12 +163,13 @@ def find_tests(bld, use=[]):
 
     for f in bld.path.ant_glob(incl='*.cpp'):
         target = f.change_ext('.' + bld.env.BOARD)
-        bld.program(
+        program(
+            bld,
             features=features,
-            target=target,
             includes=includes,
             source=[f],
             use=use,
+            destdir='tests',
         )
 
 def find_benchmarks(bld, use=[]):
@@ -179,12 +180,13 @@ def find_benchmarks(bld, use=[]):
 
     for f in bld.path.ant_glob(incl='*.cpp'):
         target = f.change_ext('.' + bld.env.BOARD)
-        bld.program(
+        program(
+            bld,
             features=['gbenchmark'],
-            target=target,
             includes=includes,
             source=[f],
             use=use,
+            destdir='benchmarks',
         )
 
 def test_summary(bld):

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -93,8 +93,7 @@ def program(bld, destdir='bin', is_sketch=False, **kw):
     else:
         name = kw['name']
 
-    target = bld.bldnode.find_or_declare(destdir + '/' +
-                                         name + '.' + bld.env.BOARD)
+    target = bld.bldnode.find_or_declare(destdir + '/' + name)
     bld.program(
         target=target,
         name=name if destdir == 'bin' else target.path_from(bld.bldnode),
@@ -162,7 +161,7 @@ def find_tests(bld, use=[]):
     includes = [bld.srcnode.abspath() + '/tests/']
 
     for f in bld.path.ant_glob(incl='*.cpp'):
-        target = f.change_ext('.' + bld.env.BOARD)
+        target = f.change_ext('')
         program(
             bld,
             features=features,
@@ -179,7 +178,7 @@ def find_benchmarks(bld, use=[]):
     includes = [bld.srcnode.abspath() + '/benchmarks/']
 
     for f in bld.path.ant_glob(incl='*.cpp'):
-        target = f.change_ext('.' + bld.env.BOARD)
+        target = f.change_ext('')
         program(
             bld,
             features=['gbenchmark'],

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -74,7 +74,7 @@ def get_all_libraries(bld):
     libraries.extend(['AP_HAL', 'AP_HAL_Empty'])
     return libraries
 
-def program(bld, **kw):
+def program(bld, destdir='bin', **kw):
     if 'target' in kw:
         bld.fatal('Do not pass target for program')
     if 'defines' not in kw:
@@ -85,10 +85,11 @@ def program(bld, **kw):
     name = bld.path.name
     kw['defines'].extend(_get_legacy_defines(name))
 
-    target = bld.bldnode.make_node(name + '.' + bld.env.BOARD)
+    target = bld.bldnode.find_or_declare(destdir + '/' +
+                                         name + '.' + bld.env.BOARD)
     bld.program(
         target=target,
-        name=name,
+        name=name if destdir == 'bin' else target.path_from(bld.bldnode),
         **kw
     )
 

--- a/libraries/AC_PID/examples/AC_PID_test/wscript
+++ b/libraries/AC_PID/examples/AC_PID_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_ADC/examples/AP_ADC_test/wscript
+++ b/libraries/AP_ADC/examples/AP_ADC_test/wscript
@@ -7,7 +7,7 @@ def build(bld):
     if bld.env.BOARD in ['sitl']:
         return
 
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_AHRS/examples/AHRS_Test/wscript
+++ b/libraries/AP_AHRS/examples/AHRS_Test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Airspeed/examples/Airspeed/wscript
+++ b/libraries/AP_Airspeed/examples/Airspeed/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Baro/examples/BARO_generic/wscript
+++ b/libraries/AP_Baro/examples/BARO_generic/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_BattMonitor/examples/AP_BattMonitor_test/wscript
+++ b/libraries/AP_BattMonitor/examples/AP_BattMonitor_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Common/examples/AP_Common/wscript
+++ b/libraries/AP_Common/examples/AP_Common/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Compass/examples/AP_Compass_test/wscript
+++ b/libraries/AP_Compass/examples/AP_Compass_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Declination/examples/AP_Declination_test/wscript
+++ b/libraries/AP_Declination/examples/AP_Declination_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_GPS/examples/GPS_AUTO_test/wscript
+++ b/libraries/AP_GPS/examples/GPS_AUTO_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_GPS/examples/GPS_UBLOX_passthrough/wscript
+++ b/libraries/AP_GPS/examples/GPS_UBLOX_passthrough/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL/examples/AnalogIn/wscript
+++ b/libraries/AP_HAL/examples/AnalogIn/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL/examples/Printf/wscript
+++ b/libraries/AP_HAL/examples/Printf/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL/examples/RCInput/wscript
+++ b/libraries/AP_HAL/examples/RCInput/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL/examples/RCInputToRCOutput/wscript
+++ b/libraries/AP_HAL/examples/RCInputToRCOutput/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL/examples/RCOutput/wscript
+++ b/libraries/AP_HAL/examples/RCOutput/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL/examples/Storage/wscript
+++ b/libraries/AP_HAL/examples/Storage/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL/examples/UART_test/wscript
+++ b/libraries/AP_HAL/examples/UART_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/ArduCopterLibs/wscript
+++ b/libraries/AP_HAL_AVR/examples/ArduCopterLibs/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/ArduPlaneLibs/wscript
+++ b/libraries/AP_HAL_AVR/examples/ArduPlaneLibs/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/Blink/wscript
+++ b/libraries/AP_HAL_AVR/examples/Blink/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/Console/wscript
+++ b/libraries/AP_HAL_AVR/examples/Console/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/I2CDriver_HMC5883L/wscript
+++ b/libraries/AP_HAL_AVR/examples/I2CDriver_HMC5883L/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/LCDTest/wscript
+++ b/libraries/AP_HAL_AVR/examples/LCDTest/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/RCInputTest/wscript
+++ b/libraries/AP_HAL_AVR/examples/RCInputTest/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/RCJitterTest/wscript
+++ b/libraries/AP_HAL_AVR/examples/RCJitterTest/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/RCPassthroughTest/wscript
+++ b/libraries/AP_HAL_AVR/examples/RCPassthroughTest/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/SPIDriver_MPU6000/wscript
+++ b/libraries/AP_HAL_AVR/examples/SPIDriver_MPU6000/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/Scheduler/wscript
+++ b/libraries/AP_HAL_AVR/examples/Scheduler/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/Semaphore/wscript
+++ b/libraries/AP_HAL_AVR/examples/Semaphore/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/Storage/wscript
+++ b/libraries/AP_HAL_AVR/examples/Storage/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/UARTDriver/wscript
+++ b/libraries/AP_HAL_AVR/examples/UARTDriver/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/UtilityStringTest/wscript
+++ b/libraries/AP_HAL_AVR/examples/UtilityStringTest/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/AP_Baro_BMP085_test/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/AP_Baro_BMP085_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/AnalogIn/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/AnalogIn/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/Blink/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/Blink/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/Console/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/Console/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/I2CDriver_HMC5883L/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/I2CDriver_HMC5883L/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/RCInput/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/RCInput/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/RCPassthroughTest/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/RCPassthroughTest/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/SPIDriver/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/SPIDriver/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/Scheduler/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/Scheduler/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/Semaphore/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/Semaphore/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/Storage/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/Storage/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/UARTDriver/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/UARTDriver/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/UtilityStringTest/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/UtilityStringTest/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/empty_example/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/empty_example/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_Linux/examples/BusTest/wscript
+++ b/libraries/AP_HAL_Linux/examples/BusTest/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_PX4/examples/simple/wscript
+++ b/libraries/AP_HAL_PX4/examples/simple/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_InertialSensor/examples/INS_generic/wscript
+++ b/libraries/AP_InertialSensor/examples/INS_generic/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_InertialSensor/examples/VibTest/wscript
+++ b/libraries/AP_InertialSensor/examples/VibTest/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Math/examples/eulers/wscript
+++ b/libraries/AP_Math/examples/eulers/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Math/examples/location/wscript
+++ b/libraries/AP_Math/examples/location/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Math/examples/polygon/wscript
+++ b/libraries/AP_Math/examples/polygon/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Math/examples/rotations/wscript
+++ b/libraries/AP_Math/examples/rotations/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Mission/examples/AP_Mission_test/wscript
+++ b/libraries/AP_Mission/examples/AP_Mission_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Motors/examples/AP_Motors_Time_test/wscript
+++ b/libraries/AP_Motors/examples/AP_Motors_Time_test/wscript
@@ -7,7 +7,7 @@ def build(bld):
     # TODO: Test code doesn't build. Fix or delete the test.
     return
 
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Motors/examples/AP_Motors_test/wscript
+++ b/libraries/AP_Motors/examples/AP_Motors_test/wscript
@@ -7,7 +7,7 @@ def build(bld):
     # TODO: Test code doesn't build. Fix or delete the test.
     return
 
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Mount/examples/trivial_AP_Mount/wscript
+++ b/libraries/AP_Mount/examples/trivial_AP_Mount/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Notify/examples/AP_Notify_test/wscript
+++ b/libraries/AP_Notify/examples/AP_Notify_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Notify/examples/ToshibaLED_test/wscript
+++ b/libraries/AP_Notify/examples/ToshibaLED_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_OpticalFlow/examples/AP_OpticalFlow_test/wscript
+++ b/libraries/AP_OpticalFlow/examples/AP_OpticalFlow_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Parachute/examples/AP_Parachute_test/wscript
+++ b/libraries/AP_Parachute/examples/AP_Parachute_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_RangeFinder/examples/RFIND_test/wscript
+++ b/libraries/AP_RangeFinder/examples/RFIND_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Scheduler/examples/Scheduler_test/wscript
+++ b/libraries/AP_Scheduler/examples/Scheduler_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/DataFlash/examples/DataFlash_test/wscript
+++ b/libraries/DataFlash/examples/DataFlash_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/Filter/examples/Derivative/wscript
+++ b/libraries/Filter/examples/Derivative/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/Filter/examples/Filter/wscript
+++ b/libraries/Filter/examples/Filter/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/Filter/examples/LowPassFilter/wscript
+++ b/libraries/Filter/examples/LowPassFilter/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/Filter/examples/LowPassFilter2p/wscript
+++ b/libraries/Filter/examples/LowPassFilter2p/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/GCS_Console/examples/Console/wscript
+++ b/libraries/GCS_Console/examples/Console/wscript
@@ -7,7 +7,7 @@ def build(bld):
     # TODO: Test code doesn't build. Fix or delete the test.
     return
 
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/GCS_MAVLink/examples/routing/wscript
+++ b/libraries/GCS_MAVLink/examples/routing/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/PID/examples/pid/wscript
+++ b/libraries/PID/examples/pid/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/RC_Channel/examples/RC_Channel/wscript
+++ b/libraries/RC_Channel/examples/RC_Channel/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/RC_Channel/examples/RC_UART/wscript
+++ b/libraries/RC_Channel/examples/RC_UART/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/StorageManager/examples/StorageTest/wscript
+++ b/libraries/StorageManager/examples/StorageTest/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )


### PR DESCRIPTION
Hi guys,

This is next version of #3455.
Diff is:
 - Now, binaries are placed in specific directories based on their types: `bin`, `tools`, `benchmarks`, `tests` and `examples`.

Furthermore, some enhancements were added:
 - Make all programs definitions use `ardupilotwaf.program`.
 - Two helper functions for defining programs were added: `sketch()` and `example()`.

Best regards,
Gustavo Sousa