### PR TITLE
waf: standardize paths [v4]

### DIFF
--- a/Makefile.waf
+++ b/Makefile.waf
@@ -7,10 +7,6 @@ EXPLICIT_COMMANDS = check clean list_boards
 
 VEHICLES = copter plane rover
 
-copter_WAF_TARGET = ArduCopter
-plane_WAF_TARGET = ArduPlane
-rover_WAF_TARGET = APMrover2
-
 all: $(WAF_BINARY)
 	@$(WAF) build
 
@@ -28,7 +24,7 @@ $(EXPLICIT_COMMANDS): $(WAF_BINARY)
 
 $(VEHICLES): $(WAF_BINARY)
 	@echo Build for vehicle $@
-	@$(WAF) build --target $($@_WAF_TARGET)
+	@$(WAF) $@
 
 .DEFAULT: %-configure
 	@$(WAF) configure --board $@ build

--- a/README_waf.txt
+++ b/README_waf.txt
@@ -31,6 +31,10 @@ target:
     # List all the targets available
     waf list
 
+There are also shortcuts for vehicle builds, for example:
+    # Shortcut for waf --targets ArduCopter
+    waf copter
+
 By default all the files produced by the build will be inside the build/
 subdirectory. The binaries will also be there, with the name identifying
 the target board.

--- a/README_waf.txt
+++ b/README_waf.txt
@@ -26,13 +26,13 @@ It's possible to build for just a vehicle or an example by specifying it as the
 target:
 
     # From the top directory
-    waf --target ArduCopter
+    waf --targets bin/ArduCopter
 
     # List all the targets available
     waf list
 
 There are also shortcuts for vehicle builds, for example:
-    # Shortcut for waf --targets ArduCopter
+    # Shortcut for waf --targets bin/ArduCopter
     waf copter
 
 By default all the files produced by the build will be inside the build/

--- a/Tools/CPUInfo/wscript
+++ b/Tools/CPUInfo/wscript
@@ -7,4 +7,5 @@ def build(bld):
     ardupilotwaf.program(
         bld,
         use='ap',
+        blddestdir='tools',
     )

--- a/Tools/Hello/wscript
+++ b/Tools/Hello/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/Tools/Replay/wscript
+++ b/Tools/Replay/wscript
@@ -7,4 +7,5 @@ def build(bld):
     ardupilotwaf.program(
         bld,
         use='ap',
+        blddestdir='tools',
     )

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -98,6 +98,10 @@ def program(bld, blddestdir='bin', **kw):
         **kw
     )
 
+def example(bld, **kw):
+    kw['blddestdir'] = 'examples'
+    program(bld, **kw)
+
 # NOTE: Code in libraries/ is compiled multiple times. So ensure each
 # compilation is independent by providing different index for each.
 # The need for this should disappear when libraries change to be

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -74,7 +74,7 @@ def get_all_libraries(bld):
     libraries.extend(['AP_HAL', 'AP_HAL_Empty'])
     return libraries
 
-def program(bld, blddestdir='bin', **kw):
+def program(bld, blddestdir='bin', use_legacy_defines=True, **kw):
     if 'target' in kw:
         bld.fatal('Do not pass target for program')
     if 'defines' not in kw:
@@ -83,7 +83,9 @@ def program(bld, blddestdir='bin', **kw):
         kw['source'] = bld.path.ant_glob(SOURCE_EXTS)
 
     name = bld.path.name
-    kw['defines'].extend(_get_legacy_defines(name))
+
+    if use_legacy_defines:
+        kw['defines'].extend(_get_legacy_defines(name))
 
     kw['features'] = common_features(bld) + kw.get('features', [])
 

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -89,6 +89,9 @@ def program(bld, blddestdir='bin', **kw):
 
     target = bld.bldnode.find_or_declare(blddestdir + '/' +
                                          name + '.' + bld.env.BOARD)
+    if blddestdir != 'bin':
+        name = blddestdir + '/' + name
+
     bld.program(
         target=target,
         name=name,

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -74,7 +74,10 @@ def get_all_libraries(bld):
     libraries.extend(['AP_HAL', 'AP_HAL_Empty'])
     return libraries
 
-def program(bld, blddestdir='bin', use_legacy_defines=True, **kw):
+def program(bld, blddestdir='bin',
+            use_legacy_defines=True,
+            program_name=None,
+            **kw):
     if 'target' in kw:
         bld.fatal('Do not pass target for program')
     if 'defines' not in kw:
@@ -82,17 +85,21 @@ def program(bld, blddestdir='bin', use_legacy_defines=True, **kw):
     if 'source' not in kw:
         kw['source'] = bld.path.ant_glob(SOURCE_EXTS)
 
-    name = bld.path.name
+    if not program_name:
+        program_name = bld.path.name
 
     if use_legacy_defines:
-        kw['defines'].extend(_get_legacy_defines(name))
+        kw['defines'].extend(_get_legacy_defines(program_name))
 
     kw['features'] = common_features(bld) + kw.get('features', [])
 
+    if blddestdir == 'bin':
+        name = program_name
+    else:
+        name = blddestdir + '/' + program_name
+
     target = bld.bldnode.find_or_declare(blddestdir + '/' +
-                                         name + '.' + bld.env.BOARD)
-    if blddestdir != 'bin':
-        name = blddestdir + '/' + name
+                                         program_name + '.' + bld.env.BOARD)
 
     bld.program(
         target=target,

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -93,16 +93,11 @@ def program(bld, blddestdir='bin',
 
     kw['features'] = common_features(bld) + kw.get('features', [])
 
-    if blddestdir == 'bin':
-        name = program_name
-    else:
-        name = blddestdir + '/' + program_name
-
-    target = bld.bldnode.find_or_declare(blddestdir + '/' + program_name)
+    target = blddestdir + '/' + program_name
 
     bld.program(
         target=target,
-        name=name,
+        name=target,
         **kw
     )
 

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -74,7 +74,7 @@ def get_all_libraries(bld):
     libraries.extend(['AP_HAL', 'AP_HAL_Empty'])
     return libraries
 
-def program(bld, **kw):
+def program(bld, blddestdir='bin', **kw):
     if 'target' in kw:
         bld.fatal('Do not pass target for program')
     if 'defines' not in kw:
@@ -87,7 +87,8 @@ def program(bld, **kw):
 
     kw['features'] = common_features(bld) + kw.get('features', [])
 
-    target = bld.bldnode.make_node(name + '.' + bld.env.BOARD)
+    target = bld.bldnode.find_or_declare(blddestdir + '/' +
+                                         name + '.' + bld.env.BOARD)
     bld.program(
         target=target,
         name=name,

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -170,13 +170,15 @@ def find_tests(bld, use=[]):
     includes = [bld.srcnode.abspath() + '/tests/']
 
     for f in bld.path.ant_glob(incl='*.cpp'):
-        target = f.change_ext('.' + bld.env.BOARD)
-        bld.program(
+        program(
+            bld,
             features=features,
-            target=target,
             includes=includes,
             source=[f],
             use=use,
+            program_name=f.change_ext('.' + bld.env.BOARD).name,
+            blddestdir='tests',
+            use_legacy_defines=False,
         )
 
 def find_benchmarks(bld, use=[]):
@@ -186,13 +188,15 @@ def find_benchmarks(bld, use=[]):
     includes = [bld.srcnode.abspath() + '/benchmarks/']
 
     for f in bld.path.ant_glob(incl='*.cpp'):
-        target = f.change_ext('.' + bld.env.BOARD)
-        bld.program(
+        program(
+            bld,
             features=common_features(bld) + ['gbenchmark'],
-            target=target,
             includes=includes,
             source=[f],
             use=use,
+            program_name=f.change_ext('.' + bld.env.BOARD).name,
+            blddestdir='benchmarks',
+            use_legacy_defines=False,
         )
 
 def test_summary(bld):

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -2,7 +2,7 @@
 # encoding: utf-8
 
 from __future__ import print_function
-from waflib import Logs, Utils
+from waflib import Logs, Options, Utils
 
 SOURCE_EXTS = [
     '*.S',
@@ -239,3 +239,15 @@ def test_summary(bld):
 
     for filename in fails:
         Logs.error('    %s' % filename)
+
+def build_shortcut(targets=None):
+    def build_fn(bld):
+        if targets:
+            if Options.options.targets:
+                Options.options.targets += ',' + targets
+            else:
+                Options.options.targets = targets
+
+        Options.commands = ['build'] + Options.commands
+
+    return build_fn

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -98,8 +98,7 @@ def program(bld, blddestdir='bin',
     else:
         name = blddestdir + '/' + program_name
 
-    target = bld.bldnode.find_or_declare(blddestdir + '/' +
-                                         program_name + '.' + bld.env.BOARD)
+    target = bld.bldnode.find_or_declare(blddestdir + '/' + program_name)
 
     bld.program(
         target=target,
@@ -176,7 +175,7 @@ def find_tests(bld, use=[]):
             includes=includes,
             source=[f],
             use=use,
-            program_name=f.change_ext('.' + bld.env.BOARD).name,
+            program_name=f.change_ext('').name,
             blddestdir='tests',
             use_legacy_defines=False,
         )
@@ -194,7 +193,7 @@ def find_benchmarks(bld, use=[]):
             includes=includes,
             source=[f],
             use=use,
-            program_name=f.change_ext('.' + bld.env.BOARD).name,
+            program_name=f.change_ext('').name,
             blddestdir='benchmarks',
             use_legacy_defines=False,
         )

--- a/libraries/AC_PID/examples/AC_PID_test/wscript
+++ b/libraries/AC_PID/examples/AC_PID_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_ADC/examples/AP_ADC_test/wscript
+++ b/libraries/AP_ADC/examples/AP_ADC_test/wscript
@@ -7,7 +7,7 @@ def build(bld):
     if bld.env.BOARD in ['sitl']:
         return
 
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_AHRS/examples/AHRS_Test/wscript
+++ b/libraries/AP_AHRS/examples/AHRS_Test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Airspeed/examples/Airspeed/wscript
+++ b/libraries/AP_Airspeed/examples/Airspeed/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Baro/examples/BARO_generic/wscript
+++ b/libraries/AP_Baro/examples/BARO_generic/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_BattMonitor/examples/AP_BattMonitor_test/wscript
+++ b/libraries/AP_BattMonitor/examples/AP_BattMonitor_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Common/examples/AP_Common/wscript
+++ b/libraries/AP_Common/examples/AP_Common/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Compass/examples/AP_Compass_test/wscript
+++ b/libraries/AP_Compass/examples/AP_Compass_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Declination/examples/AP_Declination_test/wscript
+++ b/libraries/AP_Declination/examples/AP_Declination_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_GPS/examples/GPS_AUTO_test/wscript
+++ b/libraries/AP_GPS/examples/GPS_AUTO_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_GPS/examples/GPS_UBLOX_passthrough/wscript
+++ b/libraries/AP_GPS/examples/GPS_UBLOX_passthrough/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL/examples/AnalogIn/wscript
+++ b/libraries/AP_HAL/examples/AnalogIn/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL/examples/Printf/wscript
+++ b/libraries/AP_HAL/examples/Printf/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL/examples/RCInput/wscript
+++ b/libraries/AP_HAL/examples/RCInput/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL/examples/RCInputToRCOutput/wscript
+++ b/libraries/AP_HAL/examples/RCInputToRCOutput/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL/examples/RCOutput/wscript
+++ b/libraries/AP_HAL/examples/RCOutput/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL/examples/Storage/wscript
+++ b/libraries/AP_HAL/examples/Storage/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL/examples/UART_test/wscript
+++ b/libraries/AP_HAL/examples/UART_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/ArduCopterLibs/wscript
+++ b/libraries/AP_HAL_AVR/examples/ArduCopterLibs/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/ArduPlaneLibs/wscript
+++ b/libraries/AP_HAL_AVR/examples/ArduPlaneLibs/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/Blink/wscript
+++ b/libraries/AP_HAL_AVR/examples/Blink/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/Console/wscript
+++ b/libraries/AP_HAL_AVR/examples/Console/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/I2CDriver_HMC5883L/wscript
+++ b/libraries/AP_HAL_AVR/examples/I2CDriver_HMC5883L/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/LCDTest/wscript
+++ b/libraries/AP_HAL_AVR/examples/LCDTest/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/RCInputTest/wscript
+++ b/libraries/AP_HAL_AVR/examples/RCInputTest/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/RCJitterTest/wscript
+++ b/libraries/AP_HAL_AVR/examples/RCJitterTest/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/RCPassthroughTest/wscript
+++ b/libraries/AP_HAL_AVR/examples/RCPassthroughTest/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/SPIDriver_MPU6000/wscript
+++ b/libraries/AP_HAL_AVR/examples/SPIDriver_MPU6000/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/Scheduler/wscript
+++ b/libraries/AP_HAL_AVR/examples/Scheduler/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/Semaphore/wscript
+++ b/libraries/AP_HAL_AVR/examples/Semaphore/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/Storage/wscript
+++ b/libraries/AP_HAL_AVR/examples/Storage/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/UARTDriver/wscript
+++ b/libraries/AP_HAL_AVR/examples/UARTDriver/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/UtilityStringTest/wscript
+++ b/libraries/AP_HAL_AVR/examples/UtilityStringTest/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/AP_Baro_BMP085_test/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/AP_Baro_BMP085_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/AnalogIn/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/AnalogIn/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/Blink/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/Blink/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/Console/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/Console/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/I2CDriver_HMC5883L/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/I2CDriver_HMC5883L/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/RCInput/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/RCInput/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/RCPassthroughTest/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/RCPassthroughTest/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/SPIDriver/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/SPIDriver/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/Scheduler/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/Scheduler/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/Semaphore/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/Semaphore/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/Storage/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/Storage/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/UARTDriver/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/UARTDriver/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/UtilityStringTest/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/UtilityStringTest/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/empty_example/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/empty_example/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_Linux/examples/BusTest/wscript
+++ b/libraries/AP_HAL_Linux/examples/BusTest/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_HAL_PX4/examples/simple/wscript
+++ b/libraries/AP_HAL_PX4/examples/simple/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_InertialSensor/examples/INS_generic/wscript
+++ b/libraries/AP_InertialSensor/examples/INS_generic/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_InertialSensor/examples/VibTest/wscript
+++ b/libraries/AP_InertialSensor/examples/VibTest/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Math/examples/eulers/wscript
+++ b/libraries/AP_Math/examples/eulers/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Math/examples/location/wscript
+++ b/libraries/AP_Math/examples/location/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Math/examples/polygon/wscript
+++ b/libraries/AP_Math/examples/polygon/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Math/examples/rotations/wscript
+++ b/libraries/AP_Math/examples/rotations/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Mission/examples/AP_Mission_test/wscript
+++ b/libraries/AP_Mission/examples/AP_Mission_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Motors/examples/AP_Motors_Time_test/wscript
+++ b/libraries/AP_Motors/examples/AP_Motors_Time_test/wscript
@@ -7,7 +7,7 @@ def build(bld):
     # TODO: Test code doesn't build. Fix or delete the test.
     return
 
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Motors/examples/AP_Motors_test/wscript
+++ b/libraries/AP_Motors/examples/AP_Motors_test/wscript
@@ -7,7 +7,7 @@ def build(bld):
     # TODO: Test code doesn't build. Fix or delete the test.
     return
 
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Mount/examples/trivial_AP_Mount/wscript
+++ b/libraries/AP_Mount/examples/trivial_AP_Mount/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Notify/examples/AP_Notify_test/wscript
+++ b/libraries/AP_Notify/examples/AP_Notify_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Notify/examples/ToshibaLED_test/wscript
+++ b/libraries/AP_Notify/examples/ToshibaLED_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_OpticalFlow/examples/AP_OpticalFlow_test/wscript
+++ b/libraries/AP_OpticalFlow/examples/AP_OpticalFlow_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Parachute/examples/AP_Parachute_test/wscript
+++ b/libraries/AP_Parachute/examples/AP_Parachute_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_RangeFinder/examples/RFIND_test/wscript
+++ b/libraries/AP_RangeFinder/examples/RFIND_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/AP_Scheduler/examples/Scheduler_test/wscript
+++ b/libraries/AP_Scheduler/examples/Scheduler_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/DataFlash/examples/DataFlash_test/wscript
+++ b/libraries/DataFlash/examples/DataFlash_test/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/Filter/examples/Derivative/wscript
+++ b/libraries/Filter/examples/Derivative/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/Filter/examples/Filter/wscript
+++ b/libraries/Filter/examples/Filter/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/Filter/examples/LowPassFilter/wscript
+++ b/libraries/Filter/examples/LowPassFilter/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/Filter/examples/LowPassFilter2p/wscript
+++ b/libraries/Filter/examples/LowPassFilter2p/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/GCS_Console/examples/Console/wscript
+++ b/libraries/GCS_Console/examples/Console/wscript
@@ -7,7 +7,7 @@ def build(bld):
     # TODO: Test code doesn't build. Fix or delete the test.
     return
 
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/GCS_MAVLink/examples/routing/wscript
+++ b/libraries/GCS_MAVLink/examples/routing/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/PID/examples/pid/wscript
+++ b/libraries/PID/examples/pid/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/RC_Channel/examples/RC_Channel/wscript
+++ b/libraries/RC_Channel/examples/RC_Channel/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/RC_Channel/examples/RC_UART/wscript
+++ b/libraries/RC_Channel/examples/RC_UART/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/libraries/StorageManager/examples/StorageTest/wscript
+++ b/libraries/StorageManager/examples/StorageTest/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.example(
         bld,
         use='ap',
     )

--- a/wscript
+++ b/wscript
@@ -170,6 +170,6 @@ class CheckContext(BuildContext):
     '''executes tests after build'''
     cmd = 'check'
 
-copter = ardupilotwaf.build_shortcut(targets='ArduCopter')
-plane = ardupilotwaf.build_shortcut(targets='ArduPlane')
-rover = ardupilotwaf.build_shortcut(targets='APMrover2')
+copter = ardupilotwaf.build_shortcut(targets='bin/ArduCopter')
+plane = ardupilotwaf.build_shortcut(targets='bin/ArduPlane')
+rover = ardupilotwaf.build_shortcut(targets='bin/APMrover2')

--- a/wscript
+++ b/wscript
@@ -169,3 +169,7 @@ def build(bld):
 class CheckContext(BuildContext):
     '''executes tests after build'''
     cmd = 'check'
+
+copter = ardupilotwaf.build_shortcut(targets='ArduCopter')
+plane = ardupilotwaf.build_shortcut(targets='ArduPlane')
+rover = ardupilotwaf.build_shortcut(targets='APMrover2')


### PR DESCRIPTION
Hi all,

this is the next version of #3472.

Diff is:
 - No more helper called `sketch`. It was a bad choice for a name. Just using `program`.
 - Option `destdir` renamed to `blddestdir` so that there's no confusion with installation option `destdir`.
 - Removed the `is_sketch` option and added the options `use_legacy_defines` and `program_name`.

@cmarcelo would you mind taking a look?