### PR TITLE
Copter: initialize capabilities earlier

### DIFF
--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -94,6 +94,9 @@ void Copter::init_ardupilot()
     // initialise serial port
     serial_manager.init_console();
 
+    // init vehicle capabilties
+    init_capabilities();
+
     cliSerial->printf("\n\nInit " FIRMWARE_STRING
                          "\n\nFree RAM: %u\n",
                       (unsigned)hal.util->available_memory());
@@ -277,9 +280,6 @@ void Copter::init_ardupilot()
 
     ins.set_raw_logging(should_log(MASK_LOG_IMU_RAW));
     ins.set_dataflash(&DataFlash);
-
-    // init vehicle capabilties
-    init_capabilities();
 
     cliSerial->print("\nReady to FLY ");
 


### PR DESCRIPTION
@rmackay9 I was working on a PR for dronekit-python that added capability reporting.  On connection, dronekit would send `MAV_CMD_REQUEST_CAPABILITIES`, but ArduCopter responded with an `AUTOPILOT_VERSION` that had an empty `capabilities` field.  Problem didn't happen with other vehicles.  This fixed it.