### PR TITLE
waf: force pthread linking with gbenchmark

### DIFF
--- a/Tools/ardupilotwaf/gbenchmark.py
+++ b/Tools/ardupilotwaf/gbenchmark.py
@@ -91,7 +91,7 @@ def configure(cfg):
 
     env.INCLUDES_GBENCHMARK = [prefix_node.make_node('include').abspath()]
     env.LIBPATH_GBENCHMARK = [prefix_node.make_node('lib').abspath()]
-    env.LIB_GBENCHMARK = ['benchmark']
+    env.LIB_GBENCHMARK = ['benchmark','pthread']
 
     env.HAS_GBENCHMARK = True
 


### PR DESCRIPTION
There is an issue with gbenchmark and waf on Ubuntu (15.04 and 15.10, ). Waf doesn't link pthread to gbenchmark and build failed : 

````
[1652/1652] Linking build/linux/libraries/AP_Math/benchmarks/benchmark_matrix.linux
/home/khancyr/Workspace/APM/ardupilot/build/linux/gbenchmark/lib/libbenchmark.a(benchmark.cc.o): dans la fonction « benchmark::RunSpecifiedBenchmarks(benchmark::BenchmarkReporter*) »:
benchmark.cc:(.text+0x2e21): référence indéfinie vers « pthread_create »
/usr/bin/ld generated: référence indéfinie vers « pthread_create »
collect2: error: ld returned 1 exit status

Waf: Leaving directory `/home/khancyr/Workspace/APM/ardupilot/build/linux'
Build failed
 -> task in 'benchmark_matrix.linux' failed (exit status 1): 
    {task 139784788162576: cxxprogram benchmark_matrix.cpp.1.o -> benchmark_matrix.linux}
['/usr/lib/ccache/g++', '-Wl,--gc-sections', 'libraries/AP_Math/benchmarks/benchmark_matrix.cpp.1.o', '-o', '/home/khancyr/Workspace/APM/ardupilot/build/linux/libraries/AP_Math/benchmarks/benchmark_matrix.linux', '-Wl,-Bstatic', '-L.', '-lap', '-Wl,-Bdynamic', '-L/home/khancyr/Workspace/APM/ardupilot/build/linux/gbenchmark/lib', '-lm', '-lpthread', '-lrt', '-lbenchmark']
`````

Adding 'pthread' to env.LIB_GBENCHMARK solve the issue

see https://github.com/diydrones/ardupilot/pull/3460 and https://github.com/diydrones/ardupilot/issues/3461