### PR TITLE
Perf lttng

### DIFF
--- a/libraries/AP_HAL_Linux/AP_HAL_Linux_Namespace.h
+++ b/libraries/AP_HAL_Linux/AP_HAL_Linux_Namespace.h
@@ -51,6 +51,7 @@ namespace Linux {
     class VideoIn;
     class OpticalFlow_Onboard;
     class Flow_PX4;
+    class Perf_Lttng;
 }
 
 #endif // __AP_HAL_LINUX_NAMESPACE_H__

--- a/libraries/AP_HAL_Linux/Perf.cpp
+++ b/libraries/AP_HAL_Linux/Perf.cpp
@@ -18,7 +18,7 @@
 
 #include <AP_HAL/AP_HAL.h>
 
-#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
+#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX && !defined(PERF_LTTNG)
 
 #include <limits.h>
 #include <time.h>

--- a/libraries/AP_HAL_Linux/Perf_Lttng.cpp
+++ b/libraries/AP_HAL_Linux/Perf_Lttng.cpp
@@ -1,0 +1,90 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <AP_HAL/AP_HAL.h>
+
+#pragma GCC diagnostic ignored "-Wcast-align"
+#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX && defined(PERF_LTTNG)
+#define TRACEPOINT_CREATE_PROBES
+#define TRACEPOINT_DEFINE
+#include "Perf_Lttng_TracePoints.h"
+
+#include <string.h>
+#include "Perf_Lttng.h"
+#include "AP_HAL_Linux.h"
+#include "Util.h"
+
+using namespace Linux;
+
+Perf_Lttng::Perf_Lttng(AP_HAL::Util::perf_counter_type type, const char *name)
+     : _type(type)
+{
+    strncpy(_name, name, MAX_TRACEPOINT_NAME_LEN);
+}
+
+void Perf_Lttng::begin()
+{
+    if (_type != AP_HAL::Util::PC_ELAPSED) {
+        return;
+    } else {
+        tracepoint(ardupilot, begin, _name);
+    }
+}
+
+void Perf_Lttng::end()
+{
+    if (_type != AP_HAL::Util::PC_ELAPSED) {
+        return;
+    } else {
+        tracepoint(ardupilot, end, _name);
+    }
+}
+
+void Perf_Lttng::count()
+{
+    if (_type != AP_HAL::Util::PC_COUNT) {
+        return;
+    } else {
+        tracepoint(ardupilot, count, _name, ++_count);
+    }
+}
+
+Util::perf_counter_t Util::perf_alloc(perf_counter_type type, const char *name)
+{
+    return new Linux::Perf_Lttng(type, name);
+}
+
+void Util::perf_begin(perf_counter_t perf)
+{
+    Linux::Perf_Lttng *perf_lttng = (Linux::Perf_Lttng *)perf;
+
+    perf_lttng->begin();
+}
+
+void Util::perf_end(perf_counter_t perf)
+{
+    Linux::Perf_Lttng *perf_lttng = (Linux::Perf_Lttng *)perf;
+
+    perf_lttng->end();
+}
+
+void Util::perf_count(perf_counter_t perf)
+{
+    Linux::Perf_Lttng *perf_lttng = (Linux::Perf_Lttng *)perf;
+
+    perf_lttng->count();
+}
+
+#endif

--- a/libraries/AP_HAL_Linux/Perf_Lttng.h
+++ b/libraries/AP_HAL_Linux/Perf_Lttng.h
@@ -1,0 +1,32 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include "AP_HAL_Linux.h"
+#include <AP_HAL/Util.h>
+
+#define MAX_TRACEPOINT_NAME_LEN 128
+
+class Linux::Perf_Lttng {
+public:
+    Perf_Lttng(enum AP_HAL::Util::perf_counter_type type, const char *name);
+    void begin();
+    void end();
+    void count();
+private:
+    char _name[MAX_TRACEPOINT_NAME_LEN];
+    uint64_t _count;
+    enum AP_HAL::Util::perf_counter_type _type;
+};

--- a/libraries/AP_HAL_Linux/Perf_Lttng_TracePoints.h
+++ b/libraries/AP_HAL_Linux/Perf_Lttng_TracePoints.h
@@ -1,0 +1,65 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#undef TRACEPOINT_PROVIDER
+#define TRACEPOINT_PROVIDER ardupilot
+
+#undef TRACEPOINT_INCLUDE
+#define TRACEPOINT_INCLUDE <AP_HAL_Linux/Perf_Lttng_TracePoints.h>
+
+#if !defined(_PERF_LTTNG_TRACEPOINT_H) || defined(TRACEPOINT_HEADER_MULTI_READ)
+#define _PERF_LTTNG_TRACEPOINT_H
+
+#include <lttng/tracepoint.h>
+
+TRACEPOINT_EVENT(
+    ardupilot,
+    begin,
+    TP_ARGS(
+        char*, name_arg
+    ),
+    TP_FIELDS(
+        ctf_string(name_field, name_arg)
+    )
+)
+
+TRACEPOINT_EVENT(
+    ardupilot,
+    end,
+    TP_ARGS(
+        char*, name_arg
+    ),
+    TP_FIELDS(
+        ctf_string(name_field, name_arg)
+    )
+)
+
+TRACEPOINT_EVENT(
+    ardupilot,
+    count,
+    TP_ARGS(
+        char*, name_arg,
+        int, count_arg
+    ),
+    TP_FIELDS(
+        ctf_string(name_field, name_arg)
+        ctf_integer(int, count_field, count_arg)
+    )
+)
+
+#endif /* _HELLO_TP_H */
+
+#include <lttng/tracepoint-event.h>
+

--- a/mk/board_linux.mk
+++ b/mk/board_linux.mk
@@ -3,6 +3,6 @@ TOOLCHAIN = NATIVE
 include $(MK_DIR)/find_tools.mk
 
 # Linux build is just the same as SITL for now
-LIBS = -lm -lpthread -lrt
+LIBS = -lm -pthread -lrt
 include $(MK_DIR)/board_native.mk
 include $(MK_DIR)/upload_firmware.mk

--- a/mk/board_native.mk
+++ b/mk/board_native.mk
@@ -26,6 +26,14 @@ COPTS           =   -ffunction-sections -fdata-sections -fsigned-char
 
 ASOPTS          =   -x assembler-with-cpp 
 
+# features: TODO detect dependecy and make them optional
+HAVE_LTTNG=
+
+ifeq ($(HAVE_LTTNG),1)
+DEFINES        += -DPERF_LTTNG=1
+LIBS           += -llttng-ust -ldl
+endif
+
 # disable as this breaks distcc
 #ifneq ($(SYSTYPE),Darwin)
 #LISTOPTS        =   -adhlns=$(@:.o=.lst)


### PR DESCRIPTION
Add support for perf on linux usign lttng. Also replace -lpthread by -pthread option for linking
https://lttng.org/docs/ for more information.