### PR TITLE
waf : use LINKFLAGS for pthread

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -91,9 +91,8 @@ def sitl(env):
 
     env.LIB += [
         'm',
-        'pthread',
     ]
-
+    env.LINKFLAGS += ['-pthread',]
     env.AP_LIBRARIES += [
         'AP_HAL_SITL',
         'SITL',
@@ -114,10 +113,9 @@ def linux(env):
 
     env.LIB += [
         'm',
-        'pthread',
         'rt',
     ]
-
+    env.LINKFLAGS += ['-pthread',]
     env.AP_LIBRARIES = [
         'AP_HAL_Linux',
     ]

--- a/Tools/ardupilotwaf/gbenchmark.py
+++ b/Tools/ardupilotwaf/gbenchmark.py
@@ -91,7 +91,7 @@ def configure(cfg):
 
     env.INCLUDES_GBENCHMARK = [prefix_node.make_node('include').abspath()]
     env.LIBPATH_GBENCHMARK = [prefix_node.make_node('lib').abspath()]
-    env.LIB_GBENCHMARK = ['benchmark','pthread']
+    env.LIB_GBENCHMARK = ['benchmark']
 
     env.HAS_GBENCHMARK = True
 


### PR DESCRIPTION
Following https://github.com/diydrones/ardupilot/pull/3498, we move pthread to LINKFLAGS in Waf. 
This allows -pthread option for linking instead of -lpthread. 

This also solves linking for gtest and gbenchmark on Ubuntu > 15.04. (revert https://github.com/diydrones/ardupilot/pull/3493)