### PR TITLE
waf: always run failed tests

### DIFF
--- a/Makefile.waf
+++ b/Makefile.waf
@@ -10,6 +10,9 @@ VEHICLES = copter plane rover
 all: $(WAF_BINARY)
 	@$(WAF) build
 
+check-all: $(WAF_BINARY)
+	@$(WAF) check --alltests
+
 $(WAF_BINARY):
 	@git submodule init && git submodule update
 
@@ -60,6 +63,13 @@ help:
 	@echo "Not that if it's your first time building or you want to change the target "
 	@echo "board/platform, you'll need to configure the build before (e.g"
 	@echo "make linux-configure)"
+	@echo ""
+	@echo "Check"
+	@echo "-----"
+	@echo "Check targets are used for running tests. There are two targets available:"
+	@echo "    check:     for running tests that are still failing or that are new or"
+	@echo "               have been modified"
+	@echo "    check-all: to run all tests"
 	@echo ""
 	@echo "Waf commands"
 	@echo "------------"

--- a/wscript
+++ b/wscript
@@ -178,6 +178,7 @@ def build(bld):
         bld.recurse(d)
 
     if bld.cmd == 'check':
+        bld.options.clear_failed_tests = True
         if not bld.env.HAS_GTEST:
             bld.fatal('check: gtest library is required')
         bld.add_post_fun(ardupilotwaf.test_summary)


### PR DESCRIPTION
This PR makes `waf check` run tests that:
 - are new
 - have been modified
 - have failed previously

Also, a target called  `check-all` is added to the make wrapper.

This PR addresses issue #3400.

-------------------------------------

Now, about the following:
> Arguably the tests should only be build by make check as well.

I'm not doing that now. I don't have a defined opinion on that yet. But I think we should decide before if only tests are excluded; or if other type of programs should be as well (e.g. benchmarks); or even if that's a good decision, since it changes waf's default behavior.

Best regards,
Gustavo Sousa