### PR TITLE
travis: move some builds to the first thread

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,5 +89,5 @@ env:
     #   via the "travis encrypt" command using the project repo's public key
     - secure: "FjIwqZQV2FhNPWYITX5LZXTE38yYqBaQdbm3QmbEg/30wnPTm1ZOLIU7o/aSvX615ImR8kHoryvFPDQDWc6wWfqTEs3Ytq2kIvcIJS2Y5l/0PFfpWJoH5gRd6hDThnoi+1oVMLvj1+bhn4yFlCCQ2vT/jxoGfiQqqgvHtv4fLzI="
   matrix:
-    - TRAVIS_BUILD_TARGET="px4-v2"
-    - TRAVIS_BUILD_TARGET="sitl linux navio raspilot minlure bebop"
+    - TRAVIS_BUILD_TARGET="px4-v2 sitl linux"
+    - TRAVIS_BUILD_TARGET="navio raspilot minlure bebop"


### PR DESCRIPTION
Now that we are build every linux board twice (one with make and one
with waf) and additionally building all examples and tests, it's taking
a long time to leave all linux boards in the same thread. Let's move
some of them to the other thread.