### PR TITLE
waf: fix blddestdir

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -3,6 +3,7 @@
 
 from __future__ import print_function
 from waflib import Logs, Options, Utils
+import os.path
 
 SOURCE_EXTS = [
     '*.S',
@@ -93,11 +94,12 @@ def program(bld, blddestdir='bin',
 
     kw['features'] = common_features(bld) + kw.get('features', [])
 
-    target = blddestdir + '/' + program_name
+    name = os.path.join(blddestdir, program_name)
+    target = os.path.join(bld.srcnode.path_from(bld.path), name)
 
     bld.program(
         target=target,
-        name=target,
+        name=name,
         **kw
     )
 


### PR DESCRIPTION
The destination directory for binaries should be
<build_dir>/<board>/bin/ and not
<build_dir>/<board>/<where-wscript-file-is>/bin

The same reasoning can be applied for others: tools, examples, etc
should follow the same rule.

Before this patch, compiling for example ArduPlane for navio we would
have:

    [339/339] Linking build/navio/ArduPlane/bin/ArduPlane

And now we have:

    [339/339] Linking build/navio/bin/ArduPlane