### PR TITLE
waf: gtest as a submodule and travis runs check

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "modules/mavlink"]
 	path = modules/mavlink
 	url = git://github.com/diydrones/mavlink
+[submodule "gtest"]
+	path = modules/gtest
+	url = git://github.com/diydrones/googletest

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -232,6 +232,8 @@ def test_summary(bld):
     for filename in fails:
         Logs.error('    %s' % filename)
 
+    bld.fatal('check: some tests failed')
+
 def build_shortcut(targets=None):
     def build_fn(bld):
         if targets:

--- a/Tools/ardupilotwaf/gtest.py
+++ b/Tools/ardupilotwaf/gtest.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+"""
+gtest is a Waf tool for test builds in Ardupilot
+"""
+
+def configure(cfg):
+    cfg.env.HAS_GTEST = False
+
+    if cfg.env.STATIC_LINKING:
+        # gtest uses a function (getaddrinfo) that is supposed to be linked
+        # dynamically
+        cfg.msg(
+            'Gtest',
+            'statically linked tests not supported',
+            color='YELLOW',
+        )
+        return
+
+    cfg.start_msg('Checking for gtest submodule')
+    readme = cfg.srcnode.find_resource('modules/gtest/README')
+    if not readme:
+        cfg.end_msg('not initialized', color='YELLOW')
+        return
+    cfg.end_msg('yes')
+
+    cfg.env.HAS_GTEST = True
+
+def build(bld):
+    bld.stlib(
+        source='modules/gtest/src/gtest-all.cc',
+        target='gtest/gtest',
+        includes='modules/gtest/ modules/gtest/include',
+        export_includes='modules/gtest/include',
+        name='GTEST',
+    )

--- a/Tools/ardupilotwaf/gtest.py
+++ b/Tools/ardupilotwaf/gtest.py
@@ -18,6 +18,16 @@ def configure(cfg):
         )
         return
 
+    cfg.env.SYSTEM_HAS_GTEST = cfg.env.HAS_GTEST = cfg.check_cxx(
+        lib='gtest',
+        mandatory=False,
+        uselib_store='GTEST',
+        errmsg='not found, falling back to submodule',
+    )
+
+    if cfg.env.HAS_GTEST:
+        return
+
     cfg.start_msg('Checking for gtest submodule')
     readme = cfg.srcnode.find_resource('modules/gtest/README')
     if not readme:
@@ -28,6 +38,9 @@ def configure(cfg):
     cfg.env.HAS_GTEST = True
 
 def build(bld):
+    if bld.env.SYSTEM_HAS_GTEST:
+        return
+
     bld.stlib(
         source='modules/gtest/src/gtest-all.cc',
         target='gtest/gtest',

--- a/Tools/scripts/build_all_travis.sh
+++ b/Tools/scripts/build_all_travis.sh
@@ -66,5 +66,6 @@ for t in $TRAVIS_BUILD_TARGET; do
         $waf configure --board $t
         $waf clean
         $waf ${build_concurrency[$t]} build
+        [[ $t == linux ]] && $waf check
     fi
 done

--- a/wscript
+++ b/wscript
@@ -80,6 +80,7 @@ def configure(cfg):
     cfg.load('waf_unit_test')
     cfg.load('mavgen')
     cfg.load('gbenchmark')
+    cfg.load('gtest')
     cfg.load('static_linking')
 
     cfg.start_msg('Benchmarks')
@@ -88,12 +89,11 @@ def configure(cfg):
     else:
         cfg.end_msg('disabled', color='YELLOW')
 
-    cfg.env.HAS_GTEST = cfg.check_cxx(
-        lib='gtest',
-        mandatory=False,
-        uselib_store='GTEST',
-        errmsg='not found, unit tests disabled',
-    )
+    cfg.start_msg('Unit tests')
+    if cfg.env.HAS_GTEST:
+        cfg.end_msg('enabled')
+    else:
+        cfg.end_msg('disabled', color='YELLOW')
 
     cfg.env.prepend_value('INCLUDES', [
         cfg.srcnode.abspath() + '/libraries/',
@@ -117,6 +117,7 @@ def list_boards(ctx):
     print(*boards.get_boards_names())
 
 def build(bld):
+    bld.load('gtest')
 
     #generate mavlink headers
     bld(


### PR DESCRIPTION
Hi guys,

This PR is addressing #3409.

It does the following:
 - Adds gtest submodule with remote to our fork
 - Creates a tool called gtest, for configuring and/or building gtest
 - Makes travis script run `waf check` for linux board

In the issue, there ins't yet a consensus of whether we try to detect a installed version of gtest before we build one ourselves or we just go with the submodule. Because of that, I left the patch that verifies for a installed version as the last one in the commit list. Comments regarding this topic are valuable!

Best regards,
Gustavo Sousa