### PR TITLE
travis: fix verification for calling waf check

### DIFF
--- a/Tools/scripts/build_all_travis.sh
+++ b/Tools/scripts/build_all_travis.sh
@@ -69,6 +69,8 @@ for t in $TRAVIS_BUILD_TARGET; do
         $waf configure --board $t
         $waf clean
         $waf ${build_concurrency[$t]} build
-        [[ $t == linux ]] && $waf check
+        if [[ $t == linux ]]; then
+            $waf check
+        fi
     fi
 done


### PR DESCRIPTION
The use of `[[ $t == linux ]] && $waf check` makes the script exit with
non-zero status when $t isn't linux *and* that's the last thing executed.