### PR TITLE
AP_RangeFinder: Change firmware load procedure to load .data section …

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_BBB_PRU.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_BBB_PRU.cpp
@@ -63,7 +63,7 @@ bool AP_RangeFinder_BBB_PRU::detect(RangeFinder &_ranger, uint8_t instance)
     *ctrl = 0;
     hal.scheduler->delay(1);
 
-    // Load firmware
+    // Load firmware (.text)
     FILE *file = fopen("/lib/firmware/rangefinderprutext.bin", "rb");
     if(file == NULL)
     {
@@ -78,6 +78,24 @@ bool AP_RangeFinder_BBB_PRU::detect(RangeFinder &_ranger, uint8_t instance)
     fclose(file);
 
     munmap(ram, PRU0_IRAM_SIZE);
+
+    ram = mmap(0, PRU0_DRAM_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, mem_fd, PRU0_DRAM_BASE);
+
+    // Load firmware (.data)
+    file = fopen("/lib/firmware/rangefinderprudata.bin", "rb");
+    if(file == NULL)
+    {
+        result = false;
+    }
+
+    if(fread(ram, PRU0_DRAM_SIZE, 1, file) != 1)
+    {
+        result = false;
+    }
+
+    fclose(file);
+
+    munmap(ram, PRU0_DRAM_SIZE);
 
     // Map PRU RAM
     ram = mmap(0, 0x1000, PROT_READ | PROT_WRITE, MAP_SHARED, mem_fd, PRU0_DRAM_BASE);

--- a/libraries/AP_RangeFinder/AP_RangeFinder_BBB_PRU.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_BBB_PRU.h
@@ -11,6 +11,7 @@
 #define PRU0_IRAM_SIZE 0x2000
 
 #define PRU0_DRAM_BASE 0x4a300000
+#define PRU0_DRAM_SIZE 0x2000
 
 struct range {
         uint32_t distance;


### PR DESCRIPTION
…for HC-SR04 PRU driver used by [BBBMINI](https://github.com/mirkix/BBBMINI)

This PR add .data section loading to the HC-SR04 range finder driver used by [BBBMINI](https://github.com/mirkix/BBBMINI). The firmware is running inside a [PRU](http://beagleboard.org/pru). It is necessary to develop more complex driver software inside the [PRU](http://beagleboard.org/pru). 

Rework of #3521