### PR TITLE
Wundef

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -88,6 +88,18 @@
 #include <AP_BattMonitor/AP_BattMonitor.h>     // Battery monitor library
 #include <AP_BoardConfig/AP_BoardConfig.h>     // board configuration library
 #include <AP_Frsky_Telem/AP_Frsky_Telem.h>
+#include <AP_LandingGear/AP_LandingGear.h>     // Landing Gear library
+#include <AP_Terrain/AP_Terrain.h>
+#include <AP_ADSB/AP_ADSB.h>
+#include <AP_RPM/AP_RPM.h>
+#include <AC_InputManager/AC_InputManager.h>        // Pilot input handling library
+#include <AC_InputManager/AC_InputManager_Heli.h>   // Heli specific pilot input handling library
+
+// Configuration
+#include "defines.h"
+#include "config.h"
+
+// libraries which are dependent on #defines in defines.h and/or config.h
 #if SPRAYER == ENABLED
 #include <AC_Sprayer/AC_Sprayer.h>         // crop sprayer library
 #endif
@@ -97,20 +109,10 @@
 #if PARACHUTE == ENABLED
 #include <AP_Parachute/AP_Parachute.h>       // Parachute release library
 #endif
-#include <AP_LandingGear/AP_LandingGear.h>     // Landing Gear library
-#include <AP_Terrain/AP_Terrain.h>
-#include <AP_ADSB/AP_ADSB.h>
-#include <AP_RPM/AP_RPM.h>
 #if PRECISION_LANDING == ENABLED
 #include <AC_PrecLand/AC_PrecLand.h>
 #include <AP_IRLock/AP_IRLock.h>
 #endif
-#include <AC_InputManager/AC_InputManager.h>        // Pilot input handling library
-#include <AC_InputManager/AC_InputManager_Heli.h>   // Heli specific pilot input handling library
-
-// Configuration
-#include "defines.h"
-#include "config.h"
 
 // Local modules
 #include "Parameters.h"

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -116,10 +116,8 @@ enum log_messages {
     LOG_RC_MSG,
     LOG_SONAR_MSG,
     LOG_ARM_DISARM_MSG,
-    LOG_STATUS_MSG 
-#if OPTFLOW == ENABLED
-    ,LOG_OPTFLOW_MSG
-#endif
+    LOG_STATUS_MSG,
+    LOG_OPTFLOW_MSG
 };
 
 #define MASK_LOG_ATTITUDE_FAST          (1<<0)

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -72,6 +72,7 @@ PROJECT_ENV.CXXFLAGS += [
     '-Werror=uninitialized',
     '-Werror=init-self',
     '-Wfatal-errors',
+    '-Wundef',
 ]
 
 PROJECT_ENV.LINKFLAGS += [

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -3,6 +3,15 @@
 #ifndef AP_MATH_H
 #define AP_MATH_H
 
+// MATH_CHECK_INDEXES modifies some objects (e.g. SoloGimbalEKF) to
+// include more debug information.  It is also used by some functions
+// to add extra code for debugging purposes.  If you wish to activate
+// this, do it here or as part of the top-level Makefile -
+// e.g. Tools/Replay/Makefile
+#ifndef MATH_CHECK_INDEXES
+#define MATH_CHECK_INDEXES 0
+#endif
+
 // Assorted useful math operations for ArduPilot(Mega)
 
 #include <AP_Common/AP_Common.h>

--- a/libraries/AP_Math/matrix3.h
+++ b/libraries/AP_Math/matrix3.h
@@ -128,7 +128,7 @@ public:
     // allow a Matrix3 to be used as an array of vectors, 0 indexed
     Vector3<T> & operator[](uint8_t i) {
         Vector3<T> *_v = &a;
-#if defined(MATH_CHECK_INDEXES) && (MATH_CHECK_INDEXES == 1)
+#if MATH_CHECK_INDEXES
         assert(i >= 0 && i < 3);
 #endif
         return _v[i];
@@ -136,7 +136,7 @@ public:
 
     const Vector3<T> & operator[](uint8_t i) const {
         const Vector3<T> *_v = &a;
-#if defined(MATH_CHECK_INDEXES) && (MATH_CHECK_INDEXES == 1)
+#if MATH_CHECK_INDEXES
         assert(i >= 0 && i < 3);
 #endif
         return _v[i];

--- a/libraries/AP_Math/quaternion.h
+++ b/libraries/AP_Math/quaternion.h
@@ -21,7 +21,7 @@
 #define QUATERNION_H
 
 #include <math.h>
-#if defined(MATH_CHECK_INDEXES) && (MATH_CHECK_INDEXES == 1)
+#if MATH_CHECK_INDEXES
 #include <assert.h>
 #endif
 
@@ -106,7 +106,7 @@ public:
     // allow a quaternion to be used as an array, 0 indexed
     float & operator[](uint8_t i) {
         float *_v = &q1;
-#if defined(MATH_CHECK_INDEXES) && (MATH_CHECK_INDEXES == 1)
+#if MATH_CHECK_INDEXES
         assert(i < 4);
 #endif
         return _v[i];
@@ -114,7 +114,7 @@ public:
 
     const float & operator[](uint8_t i) const {
         const float *_v = &q1;
-#if defined(MATH_CHECK_INDEXES) && (MATH_CHECK_INDEXES == 1)
+#if MATH_CHECK_INDEXES
         assert(i < 4);
 #endif
         return _v[i];

--- a/libraries/AP_Math/vector3.h
+++ b/libraries/AP_Math/vector3.h
@@ -55,7 +55,7 @@
 #include <string.h>
 
 
-#if defined(MATH_CHECK_INDEXES) && (MATH_CHECK_INDEXES == 1)
+#if MATH_CHECK_INDEXES
 #include <assert.h>
 #endif
 
@@ -120,7 +120,7 @@ public:
     // allow a vector3 to be used as an array, 0 indexed
     T & operator[](uint8_t i) {
         T *_v = &x;
-#if defined(MATH_CHECK_INDEXES) && (MATH_CHECK_INDEXES == 1)
+#if MATH_CHECK_INDEXES
         assert(i >= 0 && i < 3);
 #endif
         return _v[i];
@@ -128,7 +128,7 @@ public:
 
     const T & operator[](uint8_t i) const {
         const T *_v = &x;
-#if defined(MATH_CHECK_INDEXES) && (MATH_CHECK_INDEXES == 1)
+#if MATH_CHECK_INDEXES
         assert(i >= 0 && i < 3);
 #endif
         return _v[i];

--- a/libraries/AP_Math/vectorN.h
+++ b/libraries/AP_Math/vectorN.h
@@ -19,7 +19,7 @@
 
 #include <math.h>
 #include <string.h>
-#if defined(MATH_CHECK_INDEXES) && (MATH_CHECK_INDEXES == 1)
+#if MATH_CHECK_INDEXES
 #include <assert.h>
 #endif
 
@@ -33,14 +33,14 @@ public:
     }
 
     inline T & operator[](uint8_t i) {
-#if defined(MATH_CHECK_INDEXES) && (MATH_CHECK_INDEXES == 1)
+#if MATH_CHECK_INDEXES
         assert(i >= 0 && i < N);
 #endif
         return _v[i];
     }
 
     inline const T & operator[](uint8_t i) const {
-#if defined(MATH_CHECK_INDEXES) && (MATH_CHECK_INDEXES == 1)
+#if MATH_CHECK_INDEXES
         assert(i >= 0 && i < N);
 #endif
         return _v[i];

--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -31,8 +31,6 @@
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include <AP_RangeFinder/AP_RangeFinder.h>
 
-// #define MATH_CHECK_INDEXES 1
-
 #include <AP_Math/vectorN.h>
 
 // GPS pre-flight check bit locations

--- a/libraries/AP_NavEKF/AP_NavEKF_core.h
+++ b/libraries/AP_NavEKF/AP_NavEKF_core.h
@@ -35,8 +35,7 @@
 #define OPT_MATHS
 #endif
 
-// #define MATH_CHECK_INDEXES 1
-// #define EKF_DISABLE_INTERRUPTS 1
+#define EKF_DISABLE_INTERRUPTS 0
 
 #include <AP_Math/vectorN.h>
 
@@ -58,7 +57,7 @@ public:
     friend class NavEKF;
     
     typedef float ftype;
-#if defined(MATH_CHECK_INDEXES) && (MATH_CHECK_INDEXES == 1)
+#if MATH_CHECK_INDEXES
     typedef VectorN<ftype,2> Vector2;
     typedef VectorN<ftype,3> Vector3;
     typedef VectorN<ftype,4> Vector4;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -23,8 +23,7 @@
 
 #pragma GCC optimize("O3")
 
-// #define MATH_CHECK_INDEXES 1
-// #define EK2_DISABLE_INTERRUPTS 1
+#define EK2_DISABLE_INTERRUPTS 0
 
 
 #include <AP_Math/AP_Math.h>
@@ -269,7 +268,7 @@ private:
     uint8_t imu_buffer_length;
 
     typedef float ftype;
-#if defined(MATH_CHECK_INDEXES) && (MATH_CHECK_INDEXES == 1)
+#if MATH_CHECK_INDEXES
     typedef VectorN<ftype,2> Vector2;
     typedef VectorN<ftype,3> Vector3;
     typedef VectorN<ftype,4> Vector4;

--- a/mk/board_native.mk
+++ b/mk/board_native.mk
@@ -19,7 +19,9 @@ WARNFLAGSCXX    = \
         -Werror=unused-but-set-variable \
         -Werror=uninitialized \
         -Werror=init-self \
-        -Wfatal-errors
+        -Wfatal-errors \
+	-Wundef
+
 DEPFLAGS        =   -MD -MP -MT $@
 
 CXXOPTS         =   -ffunction-sections -fdata-sections -fno-exceptions -fsigned-char


### PR DESCRIPTION
Having include files in the wrong order caused an object within the global plane object to have a different shape depending on which class was being compiled.

Adding -Wundef to the compiler options may have saved some pain.
