### PR TITLE
waf: ardupilotwaf as a waf tool

### DIFF
--- a/APMrover2/wscript
+++ b/APMrover2/wscript
@@ -27,7 +27,7 @@ def build(bld):
         use='mavlink',
     )
 
-    ardupilotwaf.program(
+    ardupilotwaf.ap_program(
         bld,
         program_name='ardurover',
         use=vehicle + '_libs',

--- a/APMrover2/wscript
+++ b/APMrover2/wscript
@@ -5,7 +5,7 @@ import ardupilotwaf
 
 def build(bld):
     vehicle = bld.path.name
-    ardupilotwaf.vehicle_stlib(
+    ardupilotwaf.ap_stlib(
         bld,
         name=vehicle + '_libs',
         vehicle=vehicle,

--- a/APMrover2/wscript
+++ b/APMrover2/wscript
@@ -1,15 +1,12 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
     vehicle = bld.path.name
-    ardupilotwaf.ap_stlib(
-        bld,
+    bld.ap_stlib(
         name=vehicle + '_libs',
         vehicle=vehicle,
-        libraries=ardupilotwaf.COMMON_VEHICLE_DEPENDENT_LIBRARIES + [
+        libraries=bld.common_vehicle_libraries() + [
             'APM_Control',
             'AP_Arming',
             'AP_Camera',
@@ -27,8 +24,7 @@ def build(bld):
         use='mavlink',
     )
 
-    ardupilotwaf.ap_program(
-        bld,
+    bld.ap_program(
         program_name='ardurover',
         use=vehicle + '_libs',
     )

--- a/APMrover2/wscript
+++ b/APMrover2/wscript
@@ -6,7 +6,7 @@ def build(bld):
     bld.ap_stlib(
         name=vehicle + '_libs',
         vehicle=vehicle,
-        libraries=bld.common_vehicle_libraries() + [
+        libraries=bld.ap_common_vehicle_libraries() + [
             'APM_Control',
             'AP_Arming',
             'AP_Camera',

--- a/AntennaTracker/wscript
+++ b/AntennaTracker/wscript
@@ -5,7 +5,7 @@ import ardupilotwaf
 
 def build(bld):
     vehicle = bld.path.name
-    ardupilotwaf.vehicle_stlib(
+    ardupilotwaf.ap_stlib(
         bld,
         name=vehicle + '_libs',
         vehicle=vehicle,

--- a/AntennaTracker/wscript
+++ b/AntennaTracker/wscript
@@ -15,7 +15,7 @@ def build(bld):
         use='mavlink',
     )
 
-    ardupilotwaf.program(
+    ardupilotwaf.ap_program(
         bld,
         program_name='antennatracker',
         use=vehicle + '_libs',

--- a/AntennaTracker/wscript
+++ b/AntennaTracker/wscript
@@ -6,7 +6,7 @@ def build(bld):
     bld.ap_stlib(
         name=vehicle + '_libs',
         vehicle=vehicle,
-        libraries=bld.common_vehicle_libraries() + [
+        libraries=bld.ap_common_vehicle_libraries() + [
             'PID',
         ],
         use='mavlink',

--- a/AntennaTracker/wscript
+++ b/AntennaTracker/wscript
@@ -1,22 +1,18 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
     vehicle = bld.path.name
-    ardupilotwaf.ap_stlib(
-        bld,
+    bld.ap_stlib(
         name=vehicle + '_libs',
         vehicle=vehicle,
-        libraries=ardupilotwaf.COMMON_VEHICLE_DEPENDENT_LIBRARIES + [
+        libraries=bld.common_vehicle_libraries() + [
             'PID',
         ],
         use='mavlink',
     )
 
-    ardupilotwaf.ap_program(
-        bld,
+    bld.ap_program(
         program_name='antennatracker',
         use=vehicle + '_libs',
     )

--- a/ArduCopter/wscript
+++ b/ArduCopter/wscript
@@ -6,7 +6,7 @@ def build(bld):
     bld.ap_stlib(
         name=vehicle + '_libs',
         vehicle=vehicle,
-        libraries=bld.common_vehicle_libraries() + [
+        libraries=bld.ap_common_vehicle_libraries() + [
             'AP_ADSB',
             'AC_AttitudeControl',
             'AC_Fence',

--- a/ArduCopter/wscript
+++ b/ArduCopter/wscript
@@ -36,7 +36,7 @@ def build(bld):
         use='mavlink',
     )
 
-    ardupilotwaf.program(
+    ardupilotwaf.ap_program(
         bld,
         program_name='arducopter',
         use=vehicle + '_libs',

--- a/ArduCopter/wscript
+++ b/ArduCopter/wscript
@@ -1,15 +1,12 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
     vehicle = bld.path.name
-    ardupilotwaf.ap_stlib(
-        bld,
+    bld.ap_stlib(
         name=vehicle + '_libs',
         vehicle=vehicle,
-        libraries=ardupilotwaf.COMMON_VEHICLE_DEPENDENT_LIBRARIES + [
+        libraries=bld.common_vehicle_libraries() + [
             'AP_ADSB',
             'AC_AttitudeControl',
             'AC_Fence',
@@ -36,8 +33,7 @@ def build(bld):
         use='mavlink',
     )
 
-    ardupilotwaf.ap_program(
-        bld,
+    bld.ap_program(
         program_name='arducopter',
         use=vehicle + '_libs',
     )

--- a/ArduCopter/wscript
+++ b/ArduCopter/wscript
@@ -5,7 +5,7 @@ import ardupilotwaf
 
 def build(bld):
     vehicle = bld.path.name
-    ardupilotwaf.vehicle_stlib(
+    ardupilotwaf.ap_stlib(
         bld,
         name=vehicle + '_libs',
         vehicle=vehicle,

--- a/ArduPlane/wscript
+++ b/ArduPlane/wscript
@@ -5,7 +5,7 @@ import ardupilotwaf
 
 def build(bld):
     vehicle = bld.path.name
-    ardupilotwaf.vehicle_stlib(
+    ardupilotwaf.ap_stlib(
         bld,
         name=vehicle + '_libs',
         vehicle=vehicle,

--- a/ArduPlane/wscript
+++ b/ArduPlane/wscript
@@ -6,7 +6,7 @@ def build(bld):
     bld.ap_stlib(
         name=vehicle + '_libs',
         vehicle=vehicle,
-        libraries=bld.common_vehicle_libraries() + [
+        libraries=bld.ap_common_vehicle_libraries() + [
             'APM_Control',
             'APM_OBC',
             'AP_ADSB',

--- a/ArduPlane/wscript
+++ b/ArduPlane/wscript
@@ -1,15 +1,12 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
     vehicle = bld.path.name
-    ardupilotwaf.ap_stlib(
-        bld,
+    bld.ap_stlib(
         name=vehicle + '_libs',
         vehicle=vehicle,
-        libraries=ardupilotwaf.COMMON_VEHICLE_DEPENDENT_LIBRARIES + [
+        libraries=bld.common_vehicle_libraries() + [
             'APM_Control',
             'APM_OBC',
             'AP_ADSB',
@@ -37,8 +34,7 @@ def build(bld):
         use='mavlink',
     )
 
-    ardupilotwaf.ap_program(
-        bld,
+    bld.ap_program(
         program_name='arduplane',
         use=vehicle + '_libs',
     )

--- a/ArduPlane/wscript
+++ b/ArduPlane/wscript
@@ -37,7 +37,7 @@ def build(bld):
         use='mavlink',
     )
 
-    ardupilotwaf.program(
+    ardupilotwaf.ap_program(
         bld,
         program_name='arduplane',
         use=vehicle + '_libs',

--- a/Tools/CPUInfo/wscript
+++ b/Tools/CPUInfo/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.ap_program(
         bld,
         use='ap',
         blddestdir='tools',

--- a/Tools/CPUInfo/wscript
+++ b/Tools/CPUInfo/wscript
@@ -1,11 +1,8 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.ap_program(
-        bld,
+    bld.ap_program(
         use='ap',
         blddestdir='tools',
     )

--- a/Tools/Hello/wscript
+++ b/Tools/Hello/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/Tools/Hello/wscript
+++ b/Tools/Hello/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/Tools/Replay/wscript
+++ b/Tools/Replay/wscript
@@ -4,7 +4,7 @@
 import ardupilotwaf
 
 def build(bld):
-    ardupilotwaf.program(
+    ardupilotwaf.ap_program(
         bld,
         use='ap',
         blddestdir='tools',

--- a/Tools/Replay/wscript
+++ b/Tools/Replay/wscript
@@ -1,11 +1,8 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.ap_program(
-        bld,
+    bld.ap_program(
         use='ap',
         blddestdir='tools',
     )

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -65,7 +65,7 @@ IGNORED_AP_LIBRARIES = [
 ]
 
 @conf
-def get_all_libraries(bld):
+def ap_get_all_libraries(bld):
     libraries = []
     for lib_node in bld.srcnode.ant_glob('libraries/*', dir=True):
         name = lib_node.name
@@ -78,7 +78,7 @@ def get_all_libraries(bld):
     return libraries
 
 @conf
-def common_vehicle_libraries(bld):
+def ap_common_vehicle_libraries(bld):
     return COMMON_VEHICLE_DEPENDENT_LIBRARIES
 
 @conf
@@ -111,7 +111,7 @@ def ap_program(bld, blddestdir='bin',
     )
 
 @conf
-def example(bld, **kw):
+def ap_example(bld, **kw):
     kw['blddestdir'] = 'examples'
     ap_program(bld, **kw)
 
@@ -159,7 +159,7 @@ def ap_stlib(bld, **kw):
     bld.stlib(**kw)
 
 @conf
-def find_tests(bld, use=[]):
+def ap_find_tests(bld, use=[]):
     if not bld.env.HAS_GTEST:
         return
 
@@ -185,7 +185,7 @@ def find_tests(bld, use=[]):
         )
 
 @conf
-def find_benchmarks(bld, use=[]):
+def ap_find_benchmarks(bld, use=[]):
     if not bld.env.HAS_GBENCHMARK:
         return
 

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -124,13 +124,13 @@ def common_features(bld):
         features.append('static_linking')
     return features
 
-def vehicle_stlib(bld, **kw):
+def ap_stlib(bld, **kw):
     if 'name' not in kw:
-        bld.fatal('Missing name for vehicle_stlib')
+        bld.fatal('Missing name for ap_stlib')
     if 'vehicle' not in kw:
-        bld.fatal('Missing vehicle for vehicle_stlib')
+        bld.fatal('Missing vehicle for ap_stlib')
     if 'libraries' not in kw:
-        bld.fatal('Missing libraries for vehicle_stlib')
+        bld.fatal('Missing libraries for ap_stlib')
 
     sources = []
     libraries = kw['libraries'] + bld.env.AP_LIBRARIES

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -75,7 +75,7 @@ def get_all_libraries(bld):
     libraries.extend(['AP_HAL', 'AP_HAL_Empty'])
     return libraries
 
-def program(bld, blddestdir='bin',
+def ap_program(bld, blddestdir='bin',
             use_legacy_defines=True,
             program_name=None,
             **kw):
@@ -105,7 +105,7 @@ def program(bld, blddestdir='bin',
 
 def example(bld, **kw):
     kw['blddestdir'] = 'examples'
-    program(bld, **kw)
+    ap_program(bld, **kw)
 
 # NOTE: Code in libraries/ is compiled multiple times. So ensure each
 # compilation is independent by providing different index for each.
@@ -163,7 +163,7 @@ def find_tests(bld, use=[]):
     includes = [bld.srcnode.abspath() + '/tests/']
 
     for f in bld.path.ant_glob(incl='*.cpp'):
-        program(
+        ap_program(
             bld,
             features=features,
             includes=includes,
@@ -181,7 +181,7 @@ def find_benchmarks(bld, use=[]):
     includes = [bld.srcnode.abspath() + '/benchmarks/']
 
     for f in bld.path.ant_glob(incl='*.cpp'):
-        program(
+        ap_program(
             bld,
             features=common_features(bld) + ['gbenchmark'],
             includes=includes,

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -3,6 +3,7 @@
 
 from __future__ import print_function
 from waflib import Logs, Options, Utils
+from waflib.Configure import conf
 import os.path
 
 SOURCE_EXTS = [
@@ -63,6 +64,7 @@ IGNORED_AP_LIBRARIES = [
     'GCS_Console',
 ]
 
+@conf
 def get_all_libraries(bld):
     libraries = []
     for lib_node in bld.srcnode.ant_glob('libraries/*', dir=True):
@@ -75,6 +77,11 @@ def get_all_libraries(bld):
     libraries.extend(['AP_HAL', 'AP_HAL_Empty'])
     return libraries
 
+@conf
+def common_vehicle_libraries(bld):
+    return COMMON_VEHICLE_DEPENDENT_LIBRARIES
+
+@conf
 def ap_program(bld, blddestdir='bin',
             use_legacy_defines=True,
             program_name=None,
@@ -103,6 +110,7 @@ def ap_program(bld, blddestdir='bin',
         **kw
     )
 
+@conf
 def example(bld, **kw):
     kw['blddestdir'] = 'examples'
     ap_program(bld, **kw)
@@ -124,6 +132,7 @@ def common_features(bld):
         features.append('static_linking')
     return features
 
+@conf
 def ap_stlib(bld, **kw):
     if 'name' not in kw:
         bld.fatal('Missing name for ap_stlib')
@@ -149,6 +158,7 @@ def ap_stlib(bld, **kw):
 
     bld.stlib(**kw)
 
+@conf
 def find_tests(bld, use=[]):
     if not bld.env.HAS_GTEST:
         return
@@ -174,6 +184,7 @@ def find_tests(bld, use=[]):
             use_legacy_defines=False,
         )
 
+@conf
 def find_benchmarks(bld, use=[]):
     if not bld.env.HAS_GBENCHMARK:
         return

--- a/libraries/AC_PID/examples/AC_PID_test/wscript
+++ b/libraries/AC_PID/examples/AC_PID_test/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AC_PID/examples/AC_PID_test/wscript
+++ b/libraries/AC_PID/examples/AC_PID_test/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_ADC/examples/AP_ADC_test/wscript
+++ b/libraries/AP_ADC/examples/AP_ADC_test/wscript
@@ -1,13 +1,10 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
     if bld.env.BOARD in ['sitl']:
         return
 
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_ADC/examples/AP_ADC_test/wscript
+++ b/libraries/AP_ADC/examples/AP_ADC_test/wscript
@@ -5,6 +5,6 @@ def build(bld):
     if bld.env.BOARD in ['sitl']:
         return
 
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_AHRS/examples/AHRS_Test/wscript
+++ b/libraries/AP_AHRS/examples/AHRS_Test/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_AHRS/examples/AHRS_Test/wscript
+++ b/libraries/AP_AHRS/examples/AHRS_Test/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_Airspeed/examples/Airspeed/wscript
+++ b/libraries/AP_Airspeed/examples/Airspeed/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_Airspeed/examples/Airspeed/wscript
+++ b/libraries/AP_Airspeed/examples/Airspeed/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_Baro/examples/BARO_generic/wscript
+++ b/libraries/AP_Baro/examples/BARO_generic/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_Baro/examples/BARO_generic/wscript
+++ b/libraries/AP_Baro/examples/BARO_generic/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_BattMonitor/examples/AP_BattMonitor_test/wscript
+++ b/libraries/AP_BattMonitor/examples/AP_BattMonitor_test/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_BattMonitor/examples/AP_BattMonitor_test/wscript
+++ b/libraries/AP_BattMonitor/examples/AP_BattMonitor_test/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_Common/examples/AP_Common/wscript
+++ b/libraries/AP_Common/examples/AP_Common/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_Common/examples/AP_Common/wscript
+++ b/libraries/AP_Common/examples/AP_Common/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_Compass/examples/AP_Compass_test/wscript
+++ b/libraries/AP_Compass/examples/AP_Compass_test/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_Compass/examples/AP_Compass_test/wscript
+++ b/libraries/AP_Compass/examples/AP_Compass_test/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_Declination/examples/AP_Declination_test/wscript
+++ b/libraries/AP_Declination/examples/AP_Declination_test/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_Declination/examples/AP_Declination_test/wscript
+++ b/libraries/AP_Declination/examples/AP_Declination_test/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_GPS/examples/GPS_AUTO_test/wscript
+++ b/libraries/AP_GPS/examples/GPS_AUTO_test/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_GPS/examples/GPS_AUTO_test/wscript
+++ b/libraries/AP_GPS/examples/GPS_AUTO_test/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_GPS/examples/GPS_UBLOX_passthrough/wscript
+++ b/libraries/AP_GPS/examples/GPS_UBLOX_passthrough/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_GPS/examples/GPS_UBLOX_passthrough/wscript
+++ b/libraries/AP_GPS/examples/GPS_UBLOX_passthrough/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL/examples/AnalogIn/wscript
+++ b/libraries/AP_HAL/examples/AnalogIn/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL/examples/AnalogIn/wscript
+++ b/libraries/AP_HAL/examples/AnalogIn/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL/examples/Printf/wscript
+++ b/libraries/AP_HAL/examples/Printf/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL/examples/Printf/wscript
+++ b/libraries/AP_HAL/examples/Printf/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL/examples/RCInput/wscript
+++ b/libraries/AP_HAL/examples/RCInput/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL/examples/RCInput/wscript
+++ b/libraries/AP_HAL/examples/RCInput/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL/examples/RCInputToRCOutput/wscript
+++ b/libraries/AP_HAL/examples/RCInputToRCOutput/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL/examples/RCInputToRCOutput/wscript
+++ b/libraries/AP_HAL/examples/RCInputToRCOutput/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL/examples/RCOutput/wscript
+++ b/libraries/AP_HAL/examples/RCOutput/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL/examples/RCOutput/wscript
+++ b/libraries/AP_HAL/examples/RCOutput/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL/examples/Storage/wscript
+++ b/libraries/AP_HAL/examples/Storage/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL/examples/Storage/wscript
+++ b/libraries/AP_HAL/examples/Storage/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL/examples/UART_test/wscript
+++ b/libraries/AP_HAL/examples/UART_test/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL/examples/UART_test/wscript
+++ b/libraries/AP_HAL/examples/UART_test/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/ArduCopterLibs/wscript
+++ b/libraries/AP_HAL_AVR/examples/ArduCopterLibs/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/ArduCopterLibs/wscript
+++ b/libraries/AP_HAL_AVR/examples/ArduCopterLibs/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/ArduPlaneLibs/wscript
+++ b/libraries/AP_HAL_AVR/examples/ArduPlaneLibs/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/ArduPlaneLibs/wscript
+++ b/libraries/AP_HAL_AVR/examples/ArduPlaneLibs/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/Blink/wscript
+++ b/libraries/AP_HAL_AVR/examples/Blink/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/Blink/wscript
+++ b/libraries/AP_HAL_AVR/examples/Blink/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/Console/wscript
+++ b/libraries/AP_HAL_AVR/examples/Console/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/Console/wscript
+++ b/libraries/AP_HAL_AVR/examples/Console/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/I2CDriver_HMC5883L/wscript
+++ b/libraries/AP_HAL_AVR/examples/I2CDriver_HMC5883L/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/I2CDriver_HMC5883L/wscript
+++ b/libraries/AP_HAL_AVR/examples/I2CDriver_HMC5883L/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/LCDTest/wscript
+++ b/libraries/AP_HAL_AVR/examples/LCDTest/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/LCDTest/wscript
+++ b/libraries/AP_HAL_AVR/examples/LCDTest/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/RCInputTest/wscript
+++ b/libraries/AP_HAL_AVR/examples/RCInputTest/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/RCInputTest/wscript
+++ b/libraries/AP_HAL_AVR/examples/RCInputTest/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/RCJitterTest/wscript
+++ b/libraries/AP_HAL_AVR/examples/RCJitterTest/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/RCJitterTest/wscript
+++ b/libraries/AP_HAL_AVR/examples/RCJitterTest/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/RCPassthroughTest/wscript
+++ b/libraries/AP_HAL_AVR/examples/RCPassthroughTest/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/RCPassthroughTest/wscript
+++ b/libraries/AP_HAL_AVR/examples/RCPassthroughTest/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/SPIDriver_MPU6000/wscript
+++ b/libraries/AP_HAL_AVR/examples/SPIDriver_MPU6000/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/SPIDriver_MPU6000/wscript
+++ b/libraries/AP_HAL_AVR/examples/SPIDriver_MPU6000/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/Scheduler/wscript
+++ b/libraries/AP_HAL_AVR/examples/Scheduler/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/Scheduler/wscript
+++ b/libraries/AP_HAL_AVR/examples/Scheduler/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/Semaphore/wscript
+++ b/libraries/AP_HAL_AVR/examples/Semaphore/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/Semaphore/wscript
+++ b/libraries/AP_HAL_AVR/examples/Semaphore/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/Storage/wscript
+++ b/libraries/AP_HAL_AVR/examples/Storage/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/Storage/wscript
+++ b/libraries/AP_HAL_AVR/examples/Storage/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/UARTDriver/wscript
+++ b/libraries/AP_HAL_AVR/examples/UARTDriver/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/UARTDriver/wscript
+++ b/libraries/AP_HAL_AVR/examples/UARTDriver/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/UtilityStringTest/wscript
+++ b/libraries/AP_HAL_AVR/examples/UtilityStringTest/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_AVR/examples/UtilityStringTest/wscript
+++ b/libraries/AP_HAL_AVR/examples/UtilityStringTest/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/AP_Baro_BMP085_test/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/AP_Baro_BMP085_test/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/AP_Baro_BMP085_test/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/AP_Baro_BMP085_test/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/AnalogIn/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/AnalogIn/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/AnalogIn/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/AnalogIn/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/Blink/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/Blink/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/Blink/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/Blink/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/Console/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/Console/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/Console/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/Console/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/I2CDriver_HMC5883L/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/I2CDriver_HMC5883L/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/I2CDriver_HMC5883L/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/I2CDriver_HMC5883L/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/RCInput/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/RCInput/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/RCInput/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/RCInput/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/RCPassthroughTest/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/RCPassthroughTest/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/RCPassthroughTest/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/RCPassthroughTest/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/SPIDriver/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/SPIDriver/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/SPIDriver/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/SPIDriver/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/Scheduler/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/Scheduler/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/Scheduler/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/Scheduler/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/Semaphore/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/Semaphore/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/Semaphore/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/Semaphore/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/Storage/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/Storage/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/Storage/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/Storage/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/UARTDriver/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/UARTDriver/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/UARTDriver/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/UARTDriver/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/UtilityStringTest/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/UtilityStringTest/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/UtilityStringTest/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/UtilityStringTest/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/empty_example/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/empty_example/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_FLYMAPLE/examples/empty_example/wscript
+++ b/libraries/AP_HAL_FLYMAPLE/examples/empty_example/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_Linux/benchmarks/wscript
+++ b/libraries/AP_HAL_Linux/benchmarks/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.find_benchmarks(
+    bld.ap_find_benchmarks(
         use='ap',
     )

--- a/libraries/AP_HAL_Linux/benchmarks/wscript
+++ b/libraries/AP_HAL_Linux/benchmarks/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.find_benchmarks(
-        bld,
+    bld.find_benchmarks(
         use='ap',
     )

--- a/libraries/AP_HAL_Linux/examples/BusTest/wscript
+++ b/libraries/AP_HAL_Linux/examples/BusTest/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_Linux/examples/BusTest/wscript
+++ b/libraries/AP_HAL_Linux/examples/BusTest/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_HAL_PX4/examples/simple/wscript
+++ b/libraries/AP_HAL_PX4/examples/simple/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_HAL_PX4/examples/simple/wscript
+++ b/libraries/AP_HAL_PX4/examples/simple/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_InertialSensor/examples/INS_generic/wscript
+++ b/libraries/AP_InertialSensor/examples/INS_generic/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_InertialSensor/examples/INS_generic/wscript
+++ b/libraries/AP_InertialSensor/examples/INS_generic/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_InertialSensor/examples/VibTest/wscript
+++ b/libraries/AP_InertialSensor/examples/VibTest/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_InertialSensor/examples/VibTest/wscript
+++ b/libraries/AP_InertialSensor/examples/VibTest/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_Math/benchmarks/wscript
+++ b/libraries/AP_Math/benchmarks/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.find_benchmarks(
+    bld.ap_find_benchmarks(
         use='ap',
     )

--- a/libraries/AP_Math/benchmarks/wscript
+++ b/libraries/AP_Math/benchmarks/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.find_benchmarks(
-        bld,
+    bld.find_benchmarks(
         use='ap',
     )

--- a/libraries/AP_Math/examples/eulers/wscript
+++ b/libraries/AP_Math/examples/eulers/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_Math/examples/eulers/wscript
+++ b/libraries/AP_Math/examples/eulers/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_Math/examples/location/wscript
+++ b/libraries/AP_Math/examples/location/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_Math/examples/location/wscript
+++ b/libraries/AP_Math/examples/location/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_Math/examples/polygon/wscript
+++ b/libraries/AP_Math/examples/polygon/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_Math/examples/polygon/wscript
+++ b/libraries/AP_Math/examples/polygon/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_Math/examples/rotations/wscript
+++ b/libraries/AP_Math/examples/rotations/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_Math/examples/rotations/wscript
+++ b/libraries/AP_Math/examples/rotations/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_Math/tests/wscript
+++ b/libraries/AP_Math/tests/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.find_tests(
-        bld,
+    bld.find_tests(
         use='ap',
     )

--- a/libraries/AP_Math/tests/wscript
+++ b/libraries/AP_Math/tests/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.find_tests(
+    bld.ap_find_tests(
         use='ap',
     )

--- a/libraries/AP_Mission/examples/AP_Mission_test/wscript
+++ b/libraries/AP_Mission/examples/AP_Mission_test/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_Mission/examples/AP_Mission_test/wscript
+++ b/libraries/AP_Mission/examples/AP_Mission_test/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_Motors/examples/AP_Motors_Time_test/wscript
+++ b/libraries/AP_Motors/examples/AP_Motors_Time_test/wscript
@@ -5,6 +5,6 @@ def build(bld):
     # TODO: Test code doesn't build. Fix or delete the test.
     return
 
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_Motors/examples/AP_Motors_Time_test/wscript
+++ b/libraries/AP_Motors/examples/AP_Motors_Time_test/wscript
@@ -1,13 +1,10 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
     # TODO: Test code doesn't build. Fix or delete the test.
     return
 
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_Motors/examples/AP_Motors_test/wscript
+++ b/libraries/AP_Motors/examples/AP_Motors_test/wscript
@@ -5,6 +5,6 @@ def build(bld):
     # TODO: Test code doesn't build. Fix or delete the test.
     return
 
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_Motors/examples/AP_Motors_test/wscript
+++ b/libraries/AP_Motors/examples/AP_Motors_test/wscript
@@ -1,13 +1,10 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
     # TODO: Test code doesn't build. Fix or delete the test.
     return
 
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_Mount/examples/trivial_AP_Mount/wscript
+++ b/libraries/AP_Mount/examples/trivial_AP_Mount/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_Mount/examples/trivial_AP_Mount/wscript
+++ b/libraries/AP_Mount/examples/trivial_AP_Mount/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_Notify/examples/AP_Notify_test/wscript
+++ b/libraries/AP_Notify/examples/AP_Notify_test/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_Notify/examples/AP_Notify_test/wscript
+++ b/libraries/AP_Notify/examples/AP_Notify_test/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_Notify/examples/ToshibaLED_test/wscript
+++ b/libraries/AP_Notify/examples/ToshibaLED_test/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_Notify/examples/ToshibaLED_test/wscript
+++ b/libraries/AP_Notify/examples/ToshibaLED_test/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_OpticalFlow/examples/AP_OpticalFlow_test/wscript
+++ b/libraries/AP_OpticalFlow/examples/AP_OpticalFlow_test/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_OpticalFlow/examples/AP_OpticalFlow_test/wscript
+++ b/libraries/AP_OpticalFlow/examples/AP_OpticalFlow_test/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_Parachute/examples/AP_Parachute_test/wscript
+++ b/libraries/AP_Parachute/examples/AP_Parachute_test/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_Parachute/examples/AP_Parachute_test/wscript
+++ b/libraries/AP_Parachute/examples/AP_Parachute_test/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_RangeFinder/examples/RFIND_test/wscript
+++ b/libraries/AP_RangeFinder/examples/RFIND_test/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_RangeFinder/examples/RFIND_test/wscript
+++ b/libraries/AP_RangeFinder/examples/RFIND_test/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/AP_Scheduler/examples/Scheduler_test/wscript
+++ b/libraries/AP_Scheduler/examples/Scheduler_test/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/AP_Scheduler/examples/Scheduler_test/wscript
+++ b/libraries/AP_Scheduler/examples/Scheduler_test/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/DataFlash/examples/DataFlash_test/wscript
+++ b/libraries/DataFlash/examples/DataFlash_test/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/DataFlash/examples/DataFlash_test/wscript
+++ b/libraries/DataFlash/examples/DataFlash_test/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/Filter/examples/Derivative/wscript
+++ b/libraries/Filter/examples/Derivative/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/Filter/examples/Derivative/wscript
+++ b/libraries/Filter/examples/Derivative/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/Filter/examples/Filter/wscript
+++ b/libraries/Filter/examples/Filter/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/Filter/examples/Filter/wscript
+++ b/libraries/Filter/examples/Filter/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/Filter/examples/LowPassFilter/wscript
+++ b/libraries/Filter/examples/LowPassFilter/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/Filter/examples/LowPassFilter/wscript
+++ b/libraries/Filter/examples/LowPassFilter/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/Filter/examples/LowPassFilter2p/wscript
+++ b/libraries/Filter/examples/LowPassFilter2p/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/Filter/examples/LowPassFilter2p/wscript
+++ b/libraries/Filter/examples/LowPassFilter2p/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/GCS_Console/examples/Console/wscript
+++ b/libraries/GCS_Console/examples/Console/wscript
@@ -5,6 +5,6 @@ def build(bld):
     # TODO: Test code doesn't build. Fix or delete the test.
     return
 
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/GCS_Console/examples/Console/wscript
+++ b/libraries/GCS_Console/examples/Console/wscript
@@ -1,13 +1,10 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
     # TODO: Test code doesn't build. Fix or delete the test.
     return
 
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/GCS_MAVLink/examples/routing/wscript
+++ b/libraries/GCS_MAVLink/examples/routing/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/GCS_MAVLink/examples/routing/wscript
+++ b/libraries/GCS_MAVLink/examples/routing/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/PID/examples/pid/wscript
+++ b/libraries/PID/examples/pid/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/PID/examples/pid/wscript
+++ b/libraries/PID/examples/pid/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/RC_Channel/examples/RC_Channel/wscript
+++ b/libraries/RC_Channel/examples/RC_Channel/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/RC_Channel/examples/RC_Channel/wscript
+++ b/libraries/RC_Channel/examples/RC_Channel/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/RC_Channel/examples/RC_UART/wscript
+++ b/libraries/RC_Channel/examples/RC_UART/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/RC_Channel/examples/RC_UART/wscript
+++ b/libraries/RC_Channel/examples/RC_UART/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/libraries/StorageManager/examples/StorageTest/wscript
+++ b/libraries/StorageManager/examples/StorageTest/wscript
@@ -2,6 +2,6 @@
 # encoding: utf-8
 
 def build(bld):
-    bld.example(
+    bld.ap_example(
         use='ap',
     )

--- a/libraries/StorageManager/examples/StorageTest/wscript
+++ b/libraries/StorageManager/examples/StorageTest/wscript
@@ -1,10 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import ardupilotwaf
-
 def build(bld):
-    ardupilotwaf.example(
-        bld,
+    bld.example(
         use='ap',
     )

--- a/wscript
+++ b/wscript
@@ -137,7 +137,7 @@ def build(bld):
     # the tools and examples. This is the first step until the
     # dependency on the vehicles is reduced. Later we may consider
     # split into smaller pieces with well defined boundaries.
-    ardupilotwaf.vehicle_stlib(
+    ardupilotwaf.ap_stlib(
         bld,
         name='ap',
         vehicle='UNKNOWN',

--- a/wscript
+++ b/wscript
@@ -117,6 +117,7 @@ def list_boards(ctx):
     print(*boards.get_boards_names())
 
 def build(bld):
+    bld.load('ardupilotwaf')
     bld.load('gtest')
 
     #generate mavlink headers
@@ -137,11 +138,10 @@ def build(bld):
     # the tools and examples. This is the first step until the
     # dependency on the vehicles is reduced. Later we may consider
     # split into smaller pieces with well defined boundaries.
-    ardupilotwaf.ap_stlib(
-        bld,
+    bld.ap_stlib(
         name='ap',
         vehicle='UNKNOWN',
-        libraries=ardupilotwaf.get_all_libraries(bld),
+        libraries=bld.get_all_libraries(),
         use='mavlink',
     )
     # TODO: Currently each vehicle also generate its own copy of the

--- a/wscript
+++ b/wscript
@@ -141,7 +141,7 @@ def build(bld):
     bld.ap_stlib(
         name='ap',
         vehicle='UNKNOWN',
-        libraries=bld.get_all_libraries(),
+        libraries=bld.ap_get_all_libraries(),
         use='mavlink',
     )
     # TODO: Currently each vehicle also generate its own copy of the


### PR DESCRIPTION
Hi all,

This series of patches makes ardupilotwaf be used as a Waf tool for wscript files.
Here go some advantages of this approach:
 - there is no need to import ardupilotwaf in every single wscript
 - it follows the same standard used by c and cxx tools (like bld.program, bld.stlib etc)
 - semantically, ap_program, ap_stlib, example etc are all build related methods, so it makes sense to bind them to the build context
 - from the wscripts' perspective, the code is cleaner, since ardupilotwaf, which is not specific to just build contexts, isn't *explictly* used

Best regards,
Gustavo Sousa