### PR TITLE
waf: fix legacy defines

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -50,11 +50,11 @@ COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
     'StorageManager',
 ]
 
-def _get_legacy_defines(name):
+def _get_legacy_defines(sketch_name):
     return [
-        'APM_BUILD_DIRECTORY=' + name,
-        'SKETCH="' + name + '"',
-        'SKETCHNAME="' + name + '"',
+        'APM_BUILD_DIRECTORY=APM_BUILD_' + sketch_name,
+        'SKETCH="' + sketch_name + '"',
+        'SKETCHNAME="' + sketch_name + '"',
     ]
 
 IGNORED_AP_LIBRARIES = [
@@ -90,7 +90,7 @@ def program(bld, blddestdir='bin',
         program_name = bld.path.name
 
     if use_legacy_defines:
-        kw['defines'].extend(_get_legacy_defines(program_name))
+        kw['defines'].extend(_get_legacy_defines(bld.path.name))
 
     kw['features'] = common_features(bld) + kw.get('features', [])
 


### PR DESCRIPTION
The following fixes where applied:
 - Value for APM_BUILD_DIRECTORY must be prefixed with APM_BUILD_
 - Renamed parameter name to sketchname, so we differentiate the real program
   name from the legacy sketch name
 - Use directory name instead of program name as argument for
   _get_legacy_defines()