### PR TITLE
Arming: add GPS is configured pre-arm 

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -38,8 +38,8 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
     // @Param: CHECK
     // @DisplayName: Arm Checks to Peform (bitmask)
     // @Description: Checks prior to arming motor. This is a bitmask of checks that will be performed befor allowing arming. The default is no checks, allowing arming at any time. You can select whatever checks you prefer by adding together the values of each check type to set this parameter. For example, to only allow arming when you have GPS lock and no RC failsafe you would set ARMING_CHECK to 72. For most users it is recommended that you set this to 1 to enable all checks.
-    // @Values: 0:None,1:All,2:Barometer,4:Compass,8:GPS,16:INS(INertial Sensors - accels & gyros),32:Parameters(unused),64:RC Failsafe,128:Board voltage,256:Battery Level,512:Airspeed,1024:LoggingAvailable,2048:Hardware safety switch
-    // @Bitmask: 0:All,1:Barometer,2:Compass,3:GPS,4:INS,5:Parameters,6:RC,7:Board voltage,8:Battery Level,9:Airspeed,10:Logging Available,11:Hardware safety switch
+    // @Values: 0:None,1:All,2:Barometer,4:Compass,8:GPS lock,16:INS(INertial Sensors - accels & gyros),32:Parameters(unused),64:RC Failsafe,128:Board voltage,256:Battery Level,512:Airspeed,1024:LoggingAvailable,2048:Hardware safety switch,4096:GPS configured
+    // @Bitmask: 0:All,1:Barometer,2:Compass,3:GPS,4:INS,5:Parameters,6:RC,7:Board voltage,8:Battery Level,9:Airspeed,10:Logging Available,11:Hardware safety switch,12:GPS configured
     // @User: Standard
     AP_GROUPINFO("CHECK",        2,     AP_Arming,  checks_to_perform,       ARMING_CHECK_ALL),
 
@@ -305,15 +305,24 @@ bool AP_Arming::compass_checks(bool report)
 
 bool AP_Arming::gps_checks(bool report)
 {
-    if ((checks_to_perform & ARMING_CHECK_ALL) ||
-        (checks_to_perform & ARMING_CHECK_GPS)) {
+    bool check_gps_fix = (checks_to_perform & ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_GPS);
+    bool check_gps_cfg = (checks_to_perform & ARMING_CHECK_ALL) || (checks_to_perform & ARMING_CHECK_GPS_CONFIG);
+
+    if (check_gps_fix || check_gps_cfg) {
         const AP_GPS &gps = ahrs.get_gps();
 
         //GPS OK?
-        if (home_is_set == HOME_UNSET || 
-            gps.status() < AP_GPS::GPS_OK_FIX_3D) {
+        if (check_gps_fix && (home_is_set == HOME_UNSET || gps.status() < AP_GPS::GPS_OK_FIX_3D)) {
             if (report) {
                 GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "PreArm: Bad GPS Position");
+            }
+            return false;
+        }
+
+        // GPS fully configured?
+        if (check_gps_cfg && !gps.all_detected_devices_are_configured()) {
+            if (report) {
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "PreArm: GPS not yet configured");
             }
             return false;
         }

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -24,6 +24,7 @@ public:
         ARMING_CHECK_AIRSPEED   = 0x0200,
         ARMING_CHECK_LOGGING    = 0x0400,
         ARMING_CHECK_SWITCH     = 0x0800,
+        ARMING_CHECK_GPS_CONFIG = 0x1000,
     };
 
     enum ArmingMethod {

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -580,3 +580,16 @@ AP_GPS::send_mavlink_gps2_rtk(mavlink_channel_t chan)
         drivers[1]->send_mavlink_gps_rtk(chan);
     }
 }
+
+// are all GPS instance configured
+bool AP_GPS::all_detected_devices_are_configured(void) const
+{
+    bool is_all_configured = true;
+    for (uint8_t i=0; i<GPS_MAX_INSTANCES; i++) {
+        if (drivers[i] != NULL) {
+            is_all_configured &= drivers[i]->is_configured();
+        }
+    }
+    return is_all_configured;
+}
+

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -270,6 +270,9 @@ public:
         return last_fix_time_ms(primary_instance);
     }
 
+    // is GPS configured
+    bool all_detected_devices_are_configured(void) const;
+
     // the time we last processed a message in milliseconds. This is
     // used to indicate that we have new GPS data to process
     uint32_t last_message_time_ms(uint8_t instance) const {

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -72,6 +72,8 @@ public:
 
     static bool _detect(struct UBLOX_detect_state &state, uint8_t data);
 
+    bool is_configured(void) { return (_needs_configuring == 0); }
+
 private:
     // u-blox UBX protocol essentials
     struct PACKED ubx_header {
@@ -386,6 +388,15 @@ private:
         UBLOX_7,
         UBLOX_M8
     };
+    enum ubx_config_bitmask {
+        BITMASK_CFG_PRT             = 0x0001,
+        BITMASK_CFG_RATE            = 0x0002,
+        BITMASK_CFG_SET_RATE        = 0x0004,
+        BITMASK_CFG_NAV_SETTINGS    = 0x0008,
+        BITMASK_CFG_SBAS            = 0x0010,
+        BITMASK_CFG_GNSS            = 0x0020,
+        BITMASK_CFG_ALL             = 0x003F,
+    };
 
     // Packet checksum accumulators
     uint8_t         _ck_a;
@@ -426,6 +437,9 @@ private:
     uint32_t _last_5hz_time;
 
     bool noReceivedHdop;
+
+    // config settings that still need to be set where 0 means all verified as configured. Bitmask definition is UBLOX_BITMASK_CFG_xxxx
+    uint8_t _needs_configuring;
 
     void 	    _configure_navigation_rate(uint16_t rate_ms);
     void        _configure_message_rate(uint8_t msg_class, uint8_t msg_id, uint8_t rate);

--- a/libraries/AP_GPS/GPS_Backend.h
+++ b/libraries/AP_GPS/GPS_Backend.h
@@ -43,6 +43,9 @@ public:
     // Allows external system to identify type of receiver connected.
     virtual AP_GPS::GPS_Status highest_supported_status(void) { return AP_GPS::GPS_OK_FIX_3D; }
 
+    // assume configured unless the GPS driver overrides with additional configuration states
+    virtual bool is_configured(void) { return true; }
+
     //MAVLink methods
     virtual void send_mavlink_gps_rtk(mavlink_channel_t chan) { return ; }
 


### PR DESCRIPTION
Prevent arming if there is a problem with setting the configuration - namely if it is not yet set or detected as set incorrectly. This is currently only implemented in the uBlox GPS driver. All other drivers are treated as always configured.

This helps address a bug I found where my uBlox was not configured, possibly due to a hardware/wire issue. The GPS's incorrect boot-up default navigation settings gave a wandering altitude.