### PR TITLE
Plane: Reverse Thrust

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -516,6 +516,7 @@ void Plane::handle_auto_mode(void)
             steer_state.hold_course_cd = -1;
         }
         auto_state.land_complete = false;
+        auto_state.land_pre_flare = false;
         calc_nav_roll();
         calc_nav_pitch();
         calc_throttle();
@@ -872,6 +873,7 @@ void Plane::update_alt()
         SpdHgt_Controller->update_pitch_throttle(relative_target_altitude_cm(),
                                                  target_airspeed_cm,
                                                  flight_stage,
+                                                 mission.get_current_nav_cmd().id,
                                                  auto_state.takeoff_pitch_cd,
                                                  throttle_nudge,
                                                  tecs_hgt_afe(),
@@ -903,6 +905,8 @@ void Plane::update_flight_stage(void)
                     set_flight_stage(AP_SpdHgtControl::FLIGHT_LAND_ABORT);
                 } else if (auto_state.land_complete == true) {
                     set_flight_stage(AP_SpdHgtControl::FLIGHT_LAND_FINAL);
+                } else if (auto_state.land_pre_flare == true) {
+                    set_flight_stage(AP_SpdHgtControl::FLIGHT_LAND_PREFLARE);
                 } else if (flight_stage != AP_SpdHgtControl::FLIGHT_LAND_APPROACH) {
                     float path_progress = location_path_proportion(current_loc, prev_WP_loc, next_WP_loc);
                     bool lined_up = abs(nav_controller->bearing_error_cd()) < 1000;

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -831,6 +831,7 @@ void Plane::set_flight_stage(AP_SpdHgtControl::FlightStage fs)
         gcs_send_text_fmt(MAV_SEVERITY_NOTICE, "Landing aborted via throttle. Climbing to %dm", auto_state.takeoff_altitude_rel_cm/100);
         break;
 
+    case AP_SpdHgtControl::FLIGHT_LAND_PREFLARE:
     case AP_SpdHgtControl::FLIGHT_LAND_FINAL:
     case AP_SpdHgtControl::FLIGHT_NORMAL:
     case AP_SpdHgtControl::FLIGHT_VTOL:

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -1110,7 +1110,7 @@ void Plane::demo_servos(uint8_t i)
  */
 void Plane::adjust_nav_pitch_throttle(void)
 {
-    uint8_t throttle = throttle_percentage();
+    int8_t throttle = throttle_percentage();
     if (throttle < aparm.throttle_cruise && flight_stage != AP_SpdHgtControl::FLIGHT_VTOL) {
         float p = (aparm.throttle_cruise - throttle) / (float)aparm.throttle_cruise;
         nav_pitch_cd -= g.stab_pitch_down * 100.0f * p;

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -217,7 +217,9 @@ void Plane::stabilize_yaw(float speed_scaler)
         // are below the GROUND_STEER_ALT
         steering_control.ground_steering = (channel_roll->control_in == 0 && 
                                             fabsf(relative_altitude()) < g.ground_steer_alt);
-        if (control_mode == AUTO && flight_stage == AP_SpdHgtControl::FLIGHT_LAND_APPROACH) {
+        if (control_mode == AUTO &&
+                (flight_stage == AP_SpdHgtControl::FLIGHT_LAND_APPROACH ||
+                flight_stage == AP_SpdHgtControl::FLIGHT_LAND_PREFLARE)) {
             // don't use ground steering on landing approach
             steering_control.ground_steering = false;
         }
@@ -987,6 +989,7 @@ void Plane::set_servos(void)
                 }
                 break;
             case AP_SpdHgtControl::FLIGHT_LAND_APPROACH:
+            case AP_SpdHgtControl::FLIGHT_LAND_PREFLARE:
             case AP_SpdHgtControl::FLIGHT_LAND_FINAL:
                 if (g.land_flap_percent != 0) {
                     auto_flap_percent = g.land_flap_percent;

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1389,7 +1389,9 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
 
             //Not allowing go around at FLIGHT_LAND_FINAL stage on purpose --
             //if plane is close to the ground a go around coudld be dangerous.
-            if (plane.flight_stage == AP_SpdHgtControl::FLIGHT_LAND_APPROACH) {
+            if (plane.flight_stage == AP_SpdHgtControl::FLIGHT_LAND_APPROACH ||
+                plane.flight_stage == AP_SpdHgtControl::FLIGHT_LAND_PREFLARE ||
+                plane.flight_stage == AP_SpdHgtControl::FLIGHT_LAND_FINAL) {
                 // Initiate an aborted landing. This will trigger a pitch-up and
                 // climb-out to a safe altitude holding heading then one of the
                 // following actions will occur, check for in this order:

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -244,6 +244,41 @@ const AP_Param::Info Plane::var_info[] = {
     // @User: Advanced
     ASCALAR(land_flare_sec,          "LAND_FLARE_SEC",  2.0),
 
+    // @Param: LAND_PF_ALT
+    // @DisplayName: Landing pre-flare altitude
+    // @Description: Altitude to trigger pre-flare flight stage where LAND_PF_ARSPD controls airspeed. The pre-flare flight stage trigger works just like LAND_FLARE_ALT but higher. Disabled when LAND_PF_ARSPD is 0.
+    // @Units: meters
+    // @Range: 0 30
+    // @Increment: 0.1
+    // @User: Advanced
+    GSCALAR(land_pre_flare_alt     , "LAND_PF_ALT",  10.0),
+
+    // @Param: LAND_PF_SEC
+    // @DisplayName: Landing pre-flare time
+    // @Description: Vertical time to ground to trigger pre-flare flight stage where LAND_PF_ARSPD controls airspeed. This pre-flare flight stage trigger works just like LAND_FLARE_SEC but earlier. Disabled when LAND_PF_ARSPD is 0.
+    // @Units: seconds
+    // @Range: 0 10
+    // @Increment: 0.1
+    // @User: Advanced
+    GSCALAR(land_pre_flare_sec     , "LAND_PF_SEC",  6.0),
+
+    // @Param: LAND_PF_ARSPD
+    // @DisplayName: Landing pre-flare airspeed
+    // @Description: Desired airspeed during pre-flare flight stage. This is useful to reduce airspeed just before the flare. Use 0 to disable.
+    // @Units: m/s
+    // @Range: 0 30
+    // @Increment: 0.1
+    // @User: Advanced
+    ASCALAR(land_pre_flare_airspeed, "LAND_PF_ARSPD",  0),
+
+    // @Param: USE_REV_THRUST
+    // @DisplayName: Bitmask for when to allow negative reverse thrust
+    // @Description: Typically THR_MIN will be clipped to zero unless reverse thrust is available. Since you may not want negative thrust available at all times this bitmask allows THR_MIN to go below 0 while executing certain auto-mission commands.
+    // @Values: 0:Disabled,1:AlwaysAllowed,2:LandApproach,4:LoiterToAlt,8:Loiter,16:Waypoint
+    // @Bitmask: 0:ALWAYS,1:LAND,2:LOITER_TO_ALT,3:LOITER_ALL,4:WAYPOINTS
+    // @User: Advanced
+    GSCALAR(use_reverse_thrust,     "USE_REV_THRUST",  USE_REVERSE_THRUST_AUTO_LAND_APPROACH),
+
     // @Param: LAND_DISARMDELAY
     // @DisplayName: Landing disarm delay
     // @Description: After a landing has completed using a LAND waypoint, automatically disarm after this many seconds have passed. Use 0 to not disarm.

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -177,6 +177,7 @@ public:
         k_param_acro_roll_rate,
         k_param_acro_pitch_rate,
         k_param_acro_locking,
+        k_param_use_reverse_thrust = 129,
 
         //
         // 130: Sensor parameters
@@ -200,6 +201,8 @@ public:
         k_param_mission, // mission library
         k_param_serial_manager, // serial manager library
         k_param_NavEKF2,  // EKF2
+        k_param_land_pre_flare_alt,
+        k_param_land_pre_flare_airspeed = 149,
 
         //
         // 150: Navigation parameters
@@ -224,6 +227,7 @@ public:
         k_param_camera_mount2,      // unused
         k_param_adsb,
         k_param_notify,
+        k_param_land_pre_flare_sec = 165,
 
         //
         // Battery monitoring parameters
@@ -409,6 +413,7 @@ public:
     AP_Int8 throttle_fs_enabled;
     AP_Int16 throttle_fs_value;
     AP_Int8 throttle_nudge;
+    AP_Int16 use_reverse_thrust;
 
     // Failsafe
     AP_Int8 short_fs_action;
@@ -458,6 +463,8 @@ public:
     AP_Float land_flare_alt;
     AP_Int8 land_disarm_delay;
     AP_Int8 land_abort_throttle_enable;
+    AP_Float land_pre_flare_alt;
+    AP_Float land_pre_flare_sec;
     AP_Int32 min_gndspeed_cm;
     AP_Int16 pitch_trim_cd;
     AP_Int16 FBWB_min_altitude_cm;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -910,7 +910,7 @@ private:
     void servo_write(uint8_t ch, uint16_t pwm);
     bool should_log(uint32_t mask);
     void frsky_telemetry_send(void);
-    uint8_t throttle_percentage(void);
+    int8_t throttle_percentage(void);
     void change_arm_state(void);
     bool disarm_motors(void);
     bool arm_motors(AP_Arming::ArmingMethod method);

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -427,6 +427,9 @@ private:
         // Set land_complete if we are within 2 seconds distance or within 3 meters altitude of touchdown
         bool land_complete:1;
 
+        // Flag to indicate if we have triggered pre-flare. This occurs when we have reached LAND_PF_ALT
+        bool land_pre_flare:1;
+
         // should we fly inverted?
         bool inverted_flight:1;
 
@@ -946,6 +949,7 @@ private:
     void stabilize();
     void set_servos_idle(void);
     void set_servos();
+    bool allow_reverse_thrust(void);
     void update_aux();
     void update_is_flying_5Hz(void);
     void crash_detection_update(void);

--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -34,7 +34,8 @@ void Plane::adjust_altitude_target()
         // in land final TECS uses TECS_LAND_SINK as a target sink
         // rate, and ignores the target altitude
         set_target_altitude_location(next_WP_loc);
-    } else if (flight_stage == AP_SpdHgtControl::FLIGHT_LAND_APPROACH) {
+    } else if (flight_stage == AP_SpdHgtControl::FLIGHT_LAND_APPROACH ||
+            flight_stage == AP_SpdHgtControl::FLIGHT_LAND_PREFLARE) {
         setup_landing_glide_slope();
     } else if (nav_controller->reached_loiter_target()) {
         // once we reach a loiter target then lock to the final
@@ -357,7 +358,8 @@ void Plane::set_offset_altitude_location(const Location &loc)
     }
 #endif
 
-    if (flight_stage != AP_SpdHgtControl::FLIGHT_LAND_APPROACH &&
+    if (flight_stage != AP_SpdHgtControl::FLIGHT_LAND_PREFLARE &&
+        flight_stage != AP_SpdHgtControl::FLIGHT_LAND_APPROACH &&
         flight_stage != AP_SpdHgtControl::FLIGHT_LAND_FINAL) {
         // if we are within GLIDE_SLOPE_MIN meters of the target altitude
         // then reset the offset to not use a glide slope. This allows for
@@ -536,6 +538,7 @@ float Plane::rangefinder_correction(void)
     bool using_rangefinder = (g.rangefinder_landing &&
                               control_mode == AUTO && 
                               (flight_stage == AP_SpdHgtControl::FLIGHT_LAND_APPROACH ||
+                               flight_stage == AP_SpdHgtControl::FLIGHT_LAND_PREFLARE ||
                                flight_stage == AP_SpdHgtControl::FLIGHT_LAND_FINAL));
     if (!using_rangefinder) {
         return 0;
@@ -576,7 +579,9 @@ void Plane::rangefinder_height_update(void)
         } else {
             rangefinder_state.in_range = true;
             if (!rangefinder_state.in_use &&
-                flight_stage == AP_SpdHgtControl::FLIGHT_LAND_APPROACH &&
+                (flight_stage == AP_SpdHgtControl::FLIGHT_LAND_APPROACH ||
+                flight_stage == AP_SpdHgtControl::FLIGHT_LAND_PREFLARE ||
+                flight_stage == AP_SpdHgtControl::FLIGHT_LAND_FINAL) &&
                 g.rangefinder_landing) {
                 rangefinder_state.in_use = true;
                 gcs_send_text_fmt(MAV_SEVERITY_INFO, "Rangefinder engaged at %.2fm", (double)height_estimate);

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -16,6 +16,7 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
     if (AP_Mission::is_nav_cmd(cmd)) {
         // set land_complete to false to stop us zeroing the throttle
         auto_state.land_complete = false;
+        auto_state.land_pre_flare = false;
         auto_state.sink_rate = 0;
 
         // set takeoff_complete to true so we don't add extra evevator

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -193,4 +193,20 @@ enum {
     CRASH_DETECT_ACTION_BITMASK_DISARM = (1<<0),
     // note: next enum will be (1<<1), then (1<<2), then (1<<3)
 };
+
+enum {
+    USE_REVERSE_THRUST_NEVER                    = 0,
+    USE_REVERSE_THRUST_AUTO_ALWAYS              = (1<<0),
+    USE_REVERSE_THRUST_AUTO_LAND_APPROACH       = (1<<1),
+    USE_REVERSE_THRUST_AUTO_LOITER_TO_ALT       = (1<<2),
+    USE_REVERSE_THRUST_AUTO_LOITER_ALL          = (1<<3),
+    USE_REVERSE_THRUST_AUTO_WAYPOINT            = (1<<4),
+    USE_REVERSE_THRUST_LOITER                   = (1<<5),
+    USE_REVERSE_THRUST_RTL                      = (1<<6),
+    USE_REVERSE_THRUST_CIRCLE                   = (1<<7),
+    USE_REVERSE_THRUST_CRUISE                   = (1<<8),
+    USE_REVERSE_THRUST_FBWB                     = (1<<9),
+    USE_REVERSE_THRUST_GUIDED                   = (1<<10),
+};
+
 #endif // _DEFINES_H

--- a/ArduPlane/events.cpp
+++ b/ArduPlane/events.cpp
@@ -138,6 +138,7 @@ void Plane::low_battery_event(void)
     gcs_send_text_fmt(MAV_SEVERITY_WARNING, "Low battery %.2fV used %.0f mAh",
                       (double)battery.voltage(), (double)battery.current_total_mah());
     if (flight_stage != AP_SpdHgtControl::FLIGHT_LAND_FINAL &&
+        flight_stage != AP_SpdHgtControl::FLIGHT_LAND_PREFLARE &&
         flight_stage != AP_SpdHgtControl::FLIGHT_LAND_APPROACH) {
     	set_mode(RTL);
     	aparm.throttle_cruise.load();

--- a/ArduPlane/is_flying.cpp
+++ b/ArduPlane/is_flying.cpp
@@ -93,6 +93,7 @@ void Plane::update_is_flying_5Hz(void)
                 }
                 break;
 
+            case AP_SpdHgtControl::FLIGHT_LAND_PREFLARE:
             case AP_SpdHgtControl::FLIGHT_LAND_FINAL:
                 break;
 
@@ -218,6 +219,7 @@ void Plane::crash_detection_update(void)
             // a crash into a tree would be caught here.
             break;
 
+        case AP_SpdHgtControl::FLIGHT_LAND_PREFLARE:
         case AP_SpdHgtControl::FLIGHT_LAND_FINAL:
             // We should be nice and level-ish in this flight stage. If not, we most
             // likely had a crazy landing. Throttle is inhibited already at the flare

--- a/ArduPlane/landing.cpp
+++ b/ArduPlane/landing.cpp
@@ -314,6 +314,7 @@ float Plane::tecs_hgt_afe(void)
     */
     float hgt_afe;
     if (flight_stage == AP_SpdHgtControl::FLIGHT_LAND_FINAL ||
+        flight_stage == AP_SpdHgtControl::FLIGHT_LAND_PREFLARE ||
         flight_stage == AP_SpdHgtControl::FLIGHT_LAND_APPROACH) {
         hgt_afe = height_above_target();
         hgt_afe -= rangefinder_correction();

--- a/ArduPlane/landing.cpp
+++ b/ArduPlane/landing.cpp
@@ -22,6 +22,7 @@ bool Plane::verify_land()
 
         throttle_suppressed = false;
         auto_state.land_complete = false;
+        auto_state.land_pre_flare = false;
         nav_controller->update_heading_hold(get_bearing_cd(prev_WP_loc, next_WP_loc));
 
         // see if we have reached abort altitude
@@ -72,8 +73,10 @@ bool Plane::verify_land()
                                   (double)gps.ground_speed(),
                                   (double)get_distance(current_loc, next_WP_loc));
             }
+            auto_state.land_complete = true;
+            update_flight_stage();
         }
-        auto_state.land_complete = true;
+
 
         if (gps.ground_speed() < 3) {
             // reload any airspeed or groundspeed parameters that may have
@@ -83,6 +86,13 @@ bool Plane::verify_land()
             g.airspeed_cruise_cm.load();
             g.min_gndspeed_cm.load();
             aparm.throttle_cruise.load();
+        }
+    } else if (!auto_state.land_complete && !auto_state.land_pre_flare && aparm.land_pre_flare_airspeed > 0) {
+        bool reached_pre_flare_alt = g.land_pre_flare_alt > 0 && (height <= g.land_pre_flare_alt);
+        bool reached_pre_flare_sec = g.land_pre_flare_sec > 0 && (height <= auto_state.sink_rate * g.land_pre_flare_sec);
+        if (reached_pre_flare_alt || reached_pre_flare_sec) {
+            auto_state.land_pre_flare = true;
+            update_flight_stage();
         }
     }
 

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -25,7 +25,13 @@ void Plane::set_control_channels(void)
     channel_roll->set_angle(SERVO_MAX);
     channel_pitch->set_angle(SERVO_MAX);
     channel_rudder->set_angle(SERVO_MAX);
-    channel_throttle->set_range(0, 100);
+    if (aparm.throttle_min >= 0) {
+        // normal operation
+        channel_throttle->set_range(0, 100);
+    } else {
+        // reverse thrust
+        channel_throttle->set_angle(100);
+    }
 
     if (!arming.is_armed() && arming.arming_required() == AP_Arming::YES_MIN_PWM) {
         hal.rcout->set_safety_pwm(1UL<<(rcmap.throttle()-1), throttle_min());

--- a/ArduPlane/sensors.cpp
+++ b/ArduPlane/sensors.cpp
@@ -36,6 +36,7 @@ void Plane::read_rangefinder(void)
     {
         // use the best available alt estimate via baro above home
         if (flight_stage == AP_SpdHgtControl::FLIGHT_LAND_APPROACH ||
+            flight_stage == AP_SpdHgtControl::FLIGHT_LAND_PREFLARE ||
             flight_stage == AP_SpdHgtControl::FLIGHT_LAND_FINAL) {
             // ensure the rangefinder is powered-on when land alt is higher than home altitude.
             // This is done using the target alt which we know is below us and we are sinking to it

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -753,9 +753,9 @@ void Plane::frsky_telemetry_send(void)
 
 
 /*
-  return throttle percentage from 0 to 100
+  return throttle percentage from 0 to 100 for normal use and -100 to 100 when using reverse thrust
  */
-uint8_t Plane::throttle_percentage(void)
+int8_t Plane::throttle_percentage(void)
 {
     if (auto_state.vtol_mode) {
         return quadplane.throttle_percentage();

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -528,7 +528,9 @@ void Plane::check_long_failsafe()
     uint32_t tnow = millis();
     // only act on changes
     // -------------------
-    if(failsafe.state != FAILSAFE_LONG && failsafe.state != FAILSAFE_GCS && flight_stage != AP_SpdHgtControl::FLIGHT_LAND_FINAL &&
+    if(failsafe.state != FAILSAFE_LONG && failsafe.state != FAILSAFE_GCS &&
+            flight_stage != AP_SpdHgtControl::FLIGHT_LAND_FINAL &&
+            flight_stage != AP_SpdHgtControl::FLIGHT_LAND_PREFLARE &&
             flight_stage != AP_SpdHgtControl::FLIGHT_LAND_APPROACH) {
         if (failsafe.state == FAILSAFE_SHORT &&
                    (tnow - failsafe.ch3_timer_ms) > g.long_fs_timeout*1000) {
@@ -562,8 +564,10 @@ void Plane::check_short_failsafe()
 {
     // only act on changes
     // -------------------
-    if(failsafe.state == FAILSAFE_NONE && (flight_stage != AP_SpdHgtControl::FLIGHT_LAND_FINAL &&
-            flight_stage != AP_SpdHgtControl::FLIGHT_LAND_APPROACH)) {
+    if(failsafe.state == FAILSAFE_NONE &&
+            flight_stage != AP_SpdHgtControl::FLIGHT_LAND_FINAL &&
+            flight_stage != AP_SpdHgtControl::FLIGHT_LAND_PREFLARE &&
+            flight_stage != AP_SpdHgtControl::FLIGHT_LAND_APPROACH) {
         if(failsafe.ch3_failsafe) {                                              // The condition is checked and the flag ch3_failsafe is set in radio.pde
             failsafe_short_on_event(FAILSAFE_SHORT);
         }

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -405,10 +405,10 @@ void SITL_State::_simulator_servos(Aircraft::sitl_input &input)
         // simulate simple battery setup
         float throttle = _sitl->motors_on?(input.servos[2]-1000) / 1000.0f:0;
         // lose 0.7V at full throttle
-        voltage = _sitl->batt_voltage - 0.7f*throttle;
+        voltage = _sitl->batt_voltage - 0.7f*fabsf(throttle);
 
         // assume 50A at full throttle
-        _current = 50.0f * throttle;
+        _current = 50.0f * fabsf(throttle);
     } else {
         // FDM provides voltage and current
         voltage = _sitl->state.battery_voltage;

--- a/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
+++ b/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
@@ -43,6 +43,7 @@ public:
 	virtual void update_pitch_throttle( int32_t hgt_dem_cm,
 										int32_t EAS_dem_cm,
 										enum FlightStage flight_stage,
+										uint8_t mission_cmd_id,
 										int32_t ptchMinCO_cd,
 										int16_t throttle_nudge,
                                         float hgt_afe,

--- a/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
+++ b/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
@@ -29,12 +29,13 @@ public:
 	   prioritise height or speed
 	 */
 	enum FlightStage {
-		FLIGHT_NORMAL        = 1,
-		FLIGHT_TAKEOFF       = 2,
-        FLIGHT_VTOL          = 3,
+		FLIGHT_TAKEOFF       = 1,
+        FLIGHT_VTOL          = 2,
+        FLIGHT_NORMAL        = 3,
 		FLIGHT_LAND_APPROACH = 4,
-        FLIGHT_LAND_FINAL    = 5,
-        FLIGHT_LAND_ABORT    = 6
+		FLIGHT_LAND_PREFLARE = 5,
+        FLIGHT_LAND_FINAL    = 6,
+        FLIGHT_LAND_ABORT    = 7
 	};
 
 	// Update of the pitch and throttle demands

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -47,13 +47,14 @@ public:
     void update_pitch_throttle(int32_t hgt_dem_cm,
                                int32_t EAS_dem_cm,
                                enum FlightStage flight_stage,
+                               uint8_t mission_cmd_id,
                                int32_t ptchMinCO_cd,
                                int16_t throttle_nudge,
                                float hgt_afe,
                                float load_factor);
 
     // demanded throttle in percentage
-    // should return 0 to 100
+    // should return -100 to 100, usually positive unless reverse thrust is enabled via _THRminf < 0
     int32_t get_throttle_demand(void) {
         return int32_t(_throttle_dem * 100.0f);
     }
@@ -159,6 +160,7 @@ private:
     AP_Int8  _pitch_max;
     AP_Int8  _pitch_min;
     AP_Int8  _land_pitch_max;
+    AP_Float _maxSinkRate_approach;
 
     // temporary _pitch_max_limit. Cleared on each loop. Clear when >= 90
     int8_t _pitch_max_limit = 90;
@@ -166,7 +168,7 @@ private:
     // current height estimate (above field elevation)
     float _height;
 
-    // throttle demand in the range from 0.0 to 1.0
+    // throttle demand in the range from -1.0 to 1.0, usually positive unless reverse thrust is enabled via _THRminf < 0
     float _throttle_dem;
 
     // pitch angle demand in radians
@@ -247,8 +249,11 @@ private:
     // Bad descent condition caused by unachievable airspeed demand
     bool _badDescent;
 
-    // climbout mode
+    // auto mode flightstage
     enum FlightStage _flight_stage;
+
+    // auto mode mission item
+    uint8_t _mission_cmd_id;
 
     // pitch demand before limiting
     float _pitch_dem_unc;
@@ -325,6 +330,9 @@ private:
 
     // current time constant
     float timeConstant(void) const;
+
+    // return true if on landing approach
+    bool is_on_land_approach(bool include_segment_between_NORMAL_and_APPROACH);
 };
 
 #define TECS_LOG_FORMAT(msg) { msg, sizeof(AP_TECS::log_TECS_Tuning),	\

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -40,6 +40,7 @@ public:
         AP_Int8  autotune_level;
         AP_Int16 land_pitch_cd;
         AP_Float land_flare_sec;
+        AP_Float land_pre_flare_airspeed;
         AP_Int8  stall_prevention;
     };
 

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -218,10 +218,10 @@ void Aircraft::add_noise(float throttle)
 {
     gyro += Vector3f(rand_normal(0, 1),
                      rand_normal(0, 1),
-                     rand_normal(0, 1)) * gyro_noise * throttle;
+                     rand_normal(0, 1)) * gyro_noise * fabsf(throttle);
     accel_body += Vector3f(rand_normal(0, 1),
                            rand_normal(0, 1),
-                           rand_normal(0, 1)) * accel_noise * throttle;
+                           rand_normal(0, 1)) * accel_noise * fabsf(throttle);
 }
 
 /*

--- a/libraries/SITL/SIM_Plane.cpp
+++ b/libraries/SITL/SIM_Plane.cpp
@@ -35,6 +35,10 @@ Plane::Plane(const char *home_str, const char *frame_str) :
     */
     thrust_scale = (mass * GRAVITY_MSS) / hover_throttle;
     frame_height = 0.1f;
+
+    if (strstr(frame_str, "-revthrust")) {
+        reverse_thrust = true;
+    }
 }
 
 /*
@@ -190,7 +194,13 @@ void Plane::calculate_forces(const struct sitl_input &input, Vector3f &rot_accel
     float aileron  = (input.servos[0]-1500)/500.0f;
     float elevator = (input.servos[1]-1500)/500.0f;
     float rudder   = (input.servos[3]-1500)/500.0f;
-    float throttle = constrain_float((input.servos[2]-1000)/1000.0f, 0, 1);
+    float throttle;
+
+    if (reverse_thrust) {
+        throttle = constrain_float((input.servos[2]-1500)/500.0f, -1, 1);
+    } else {
+        throttle = constrain_float((input.servos[2]-1000)/1000.0f, 0, 1);
+    }
     
     float thrust     = throttle;
 
@@ -211,7 +221,7 @@ void Plane::calculate_forces(const struct sitl_input &input, Vector3f &rot_accel
     accel_body += force;
 
     // add some noise
-    add_noise(thrust / thrust_scale);
+    add_noise(fabsf(thrust) / thrust_scale);
 }
     
 /*

--- a/libraries/SITL/SIM_Plane.h
+++ b/libraries/SITL/SIM_Plane.h
@@ -92,6 +92,7 @@ protected:
     } coefficient;
 
     float thrust_scale;
+    bool reverse_thrust;
 
     float liftCoeff(float alpha) const;
     float dragCoeff(float alpha) const;


### PR DESCRIPTION
Ever wanted to have a steep landing slope but you can't because you come in too fast? Well now you can! With Reverse Thrust you can dictate whatever airspeed you want and the motor will spin up backwards to maintain that. Depending on the mass of your aircraft and the thrust force of your motor+prop, you can have a glide slope very very steep. This is not throttle based, it's airspeed based so it works with full and empty batteries the same way. I definitely recommend an airspeed sensor for this feature.

I'll be writing something up on the wiki soon. but here's a summary:

The TECS controller can now calculate a negative throttle demand. If you're too steep you gain speed and TECS says to slow down and with reverse thrust ESC you can actually do that! If you have a rangefinder then you have accurate height and with an airspeed sensor you have a very accurate airspeed. The beauty of this is we now have a very repeatable total energy/momentum at the moment we flare so its much easier to fine-tune a soft perfect landing even with a large baro offset causing the lidar to bump us up. It's magic!

I was using a BLHeli ESC but any bi-directional ESC will work. Does not need to be symmetric. 

Configuration
Step 1: set THR_MIN (Throttle min) to something negative, probably whatever you have for THR_MAX but negative.

Step 2: set RC3_TRIM to your ESC's neutral positon. That is, the PWM that is throttle-off. Does not need to be symmetric (1500).

Step 3: set TECS_APPR_SMAX (optional) approach sink max. Normal sink max is a couple m/s but in a steep approach you may want this around 10m/s depending on how steep you're willing to push the aircraft. If you leave this as zero then it uses the normal TECS_SINK_MAX.

Step 4: set LAND_PF_ALT (Pre-flare altitude) to a non-zero value. This triggers the pre-flare flight stage which is before the LAND_FLARE stage. Try values between 7m - 15m.

Step 5: set LAND_PF_ARSPD (pre-flare airspeed) The airspeed demand you want during pre-flare. This should be just above your stall speed. While sinking from LAND_PF_ALT to LAND_FLARE_ALT it'll put the brakes on to try to achieve this airspeed.

Step 5: tweak the other existing flare params to smooth out the touchdown.

Special thanks to the folks at Event 38 to help get this going. Shout out to Daniel Cironi and Jeff Taylor. See:
http://diydrones.com/profiles/blogs/introducing-the-e386-mapping-drone?xg_source=activity
and
http://diydrones.com/profiles/blogs/instructions-for-using-the-event-38-reverse-throttle-feature-on?xg_source=activity

I worked with Daniel to bring their design to master for a Pull-request but I ended up just starting over and going with a totally different approach.

This fixes https://github.com/diydrones/ardupilot/issues/2087
