### PR TITLE
AP_Baro: tolerate GND_ALT_OFFSET step inputs

### DIFF
--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -148,6 +148,7 @@ private:
     } sensors[BARO_MAX_INSTANCES];
 
     AP_Float                            _alt_offset;
+    float                               _alt_offset_active;
     AP_Int8                             _primary_baro; // primary chosen by user
     float                               _last_altitude_EAS2TAS;
     float                               _EAS2TAS;


### PR DESCRIPTION
large GND_ALT_OFFSET changes (10m) make the EKF angry, this will allow the param update to slew over a few seconds