### PR TITLE
Fix incorrect reporting of EKF status over Mavlink

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF_core.cpp
+++ b/libraries/AP_NavEKF/AP_NavEKF_core.cpp
@@ -4708,7 +4708,7 @@ void NavEKF_core::send_status_report(mavlink_channel_t chan)
     getVariances(velVar, posVar, hgtVar, magVar, tasVar, offset);
 
     // send message
-    mavlink_msg_ekf_status_report_send(chan, flags, velVar, posVar, hgtVar, magVar.length(), tasVar);
+    mavlink_msg_ekf_status_report_send(chan, flags, velVar, posVar, hgtVar, magVar.length(), sqrtf(auxRngTestRatio));
 
 }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -535,7 +535,7 @@ void NavEKF2_core::send_status_report(mavlink_channel_t chan)
     getVariances(velVar, posVar, hgtVar, magVar, tasVar, offset);
 
     // send message
-    mavlink_msg_ekf_status_report_send(chan, flags, velVar, posVar, hgtVar, magVar.length(), tasVar);
+    mavlink_msg_ekf_status_report_send(chan, flags, velVar, posVar, hgtVar, magVar.length(), sqrtf(auxRngTestRatio));
 
 }
 


### PR DESCRIPTION
Both EKF and EKF2 were sending the true airspeed instead innovation variance instead of  height above terrain innovation variance.

This PR partially fixes #3569 noting that the true airspeed innovation variance still needs to be added to the Mavlink message.