### PR TITLE
Plane: Limit THR_MAX (and THR_MIN for reverse thrust) via max battery power

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -891,7 +891,7 @@ void Plane::set_servos(void)
         channel_throttle->servo_out = 0;
 #else
         // convert 0 to 100% into PWM
-        uint8_t min_throttle = aparm.throttle_min.get();
+        int8_t min_throttle = aparm.throttle_min.get();
         uint8_t max_throttle = aparm.throttle_max.get();
         if (control_mode == AUTO && flight_stage == AP_SpdHgtControl::FLIGHT_LAND_FINAL) {
             min_throttle = 0;
@@ -904,6 +904,49 @@ void Plane::set_servos(void)
                 max_throttle = aparm.throttle_max;
             }
         }
+
+        uint32_t now = millis();
+        if (battery.overpower_detected()) {
+            // overpower detected, cut back on the throttle if we're maxing it out by calculating a limiter value
+            // throttle limit will attack by 10% per second
+
+            if (channel_throttle->servo_out > 0 && // demanding too much positive thrust
+                throttle_watt_limit_max < max_throttle - 25 &&
+                now - throttle_watt_limit_timer_ms >= 100) {
+                // always allow for 25% throttle available regardless of battery status
+                throttle_watt_limit_timer_ms = now;
+                throttle_watt_limit_max++;
+
+            } else if (channel_throttle->servo_out < 0 &&
+                min_throttle < 0 && // reverse thrust is available
+                throttle_watt_limit_min < -(min_throttle) - 25 &&
+                now - throttle_watt_limit_timer_ms >= 100) {
+                // always allow for 25% throttle available regardless of battery status
+                throttle_watt_limit_timer_ms = now;
+                throttle_watt_limit_min++;
+            }
+
+        } else if (now - throttle_watt_limit_timer_ms >= 1000) {
+            // it has been 1 second since last over-current, check if we can resume higher throttle.
+            // this throttle release is needed to allow raising the max_throttle as the battery voltage drains down
+            // throttle limit will release by 1% per second
+            if (channel_throttle->servo_out > throttle_watt_limit_max && // demanding max forward thrust
+                throttle_watt_limit_max > 0) { // and we're currently limiting it
+                throttle_watt_limit_timer_ms = now;
+                throttle_watt_limit_max--;
+
+            } else if (channel_throttle->servo_out < throttle_watt_limit_min && // demanding max negative thrust
+                throttle_watt_limit_min > 0) { // and we're limiting it
+                throttle_watt_limit_timer_ms = now;
+                throttle_watt_limit_min--;
+            }
+        }
+
+        max_throttle = constrain_int16(max_throttle, 0, max_throttle - throttle_watt_limit_max);
+        if (min_throttle < 0) {
+            min_throttle = constrain_int16(min_throttle, min_throttle + throttle_watt_limit_min, 0);
+        }
+
         channel_throttle->servo_out = constrain_int16(channel_throttle->servo_out, 
                                                       min_throttle,
                                                       max_throttle);

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -912,7 +912,7 @@ void Plane::set_servos(void)
 
             if (channel_throttle->servo_out > 0 && // demanding too much positive thrust
                 throttle_watt_limit_max < max_throttle - 25 &&
-                now - throttle_watt_limit_timer_ms >= 100) {
+                now - throttle_watt_limit_timer_ms >= 1) {
                 // always allow for 25% throttle available regardless of battery status
                 throttle_watt_limit_timer_ms = now;
                 throttle_watt_limit_max++;
@@ -920,7 +920,7 @@ void Plane::set_servos(void)
             } else if (channel_throttle->servo_out < 0 &&
                 min_throttle < 0 && // reverse thrust is available
                 throttle_watt_limit_min < -(min_throttle) - 25 &&
-                now - throttle_watt_limit_timer_ms >= 100) {
+                now - throttle_watt_limit_timer_ms >= 1) {
                 // always allow for 25% throttle available regardless of battery status
                 throttle_watt_limit_timer_ms = now;
                 throttle_watt_limit_min++;

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -524,6 +524,11 @@ private:
     // this controls throttle suppression in auto modes
     bool throttle_suppressed;
 
+    // reduce throttle to eliminate battery over-current
+    int8_t  throttle_watt_limit_max;
+    int8_t  throttle_watt_limit_min; // for reverse thrust
+    uint32_t throttle_watt_limit_timer_ms;
+
     AP_SpdHgtControl::FlightStage flight_stage = AP_SpdHgtControl::FLIGHT_NORMAL;
 
     // probability of aircraft is currently in flight. range from 0 to

--- a/libraries/AP_BattMonitor/AP_BattMonitor.h
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.h
@@ -14,6 +14,7 @@
 
 #define AP_BATT_CAPACITY_DEFAULT            3300
 #define AP_BATT_LOW_VOLT_TIMEOUT_MS         10000   // low voltage of 10 seconds will cause battery_exhausted to return true
+#define AP_BATT_MAX_WATT_DEFAULT            0
 
 // declare backend class
 class AP_BattMonitor_Backend;
@@ -108,6 +109,13 @@ public:
     /// set_monitoring - sets the monitor type (used for example sketch only)
     void set_monitoring(uint8_t instance, uint8_t mon) { _monitoring[instance].set(mon); }
 
+    bool get_watt_max() { return get_watt_max(AP_BATT_PRIMARY_INSTANCE); }
+    bool get_watt_max(uint8_t instance) { return _watt_max[instance]; }
+
+    /// true when (voltage * current) > watt_max
+    bool overpower_detected() const;
+    bool overpower_detected(uint8_t instance) const;
+
     static const struct AP_Param::GroupInfo var_info[];
 
 protected:
@@ -120,6 +128,7 @@ protected:
     AP_Float    _curr_amp_per_volt[AP_BATT_MONITOR_MAX_INSTANCES];  /// voltage on current pin multiplied by this to calculate current in amps
     AP_Float    _curr_amp_offset[AP_BATT_MONITOR_MAX_INSTANCES];    /// offset voltage that is subtracted from current pin before conversion to amps
     AP_Int32    _pack_capacity[AP_BATT_MONITOR_MAX_INSTANCES];      /// battery pack capacity less reserve in mAh
+    AP_Int16    _watt_max[AP_BATT_MONITOR_MAX_INSTANCES];           /// max battery power allowed. Reduce max throttle to reduce current to satisfy this limit
 
 private:
     BattMonitor_State state[AP_BATT_MONITOR_MAX_INSTANCES];


### PR DESCRIPTION
new param: BATT_WATT_MAX

Description: If battery wattage (voltage * current) exceeds this value then the system will reduce max throttle (THR_MAX, TKOFF_THR_MAX and THR_MIN for reverse thrust) to satisfy this limit. This helps limit high current to low C rated batteries regardless of battery voltage. The max throttle will slowly grow back to THR_MAX (or TKOFF_THR_MAX ) and THR_MIN if demanding the current max and under the watt max. Use 0 to disable.

When using this it allows you to set arbitrarily set THR_MAX high, I suggest 100. You can also set THR_MIN to -100 when using reverse thrust. This is because the throttle limit assumes a fixed thrust during flight. however, as the battery voltage drops the effective thrust from THR_MAX drops. The intent of THR_MAX is to not over-current your battery. This does that directly instead of indirectly.