### PR TITLE
Worker Thread

### DIFF
--- a/libraries/AP_Compass/AP_Compass_AK8963.cpp
+++ b/libraries/AP_Compass/AP_Compass_AK8963.cpp
@@ -236,7 +236,7 @@ void AP_Compass_AK8963::_update()
         goto end;
     }
 
-    if (!_sem_take_nonblocking()) {
+    if (!_bus_sem->take_nonblocking()) {
         goto end;
     }
 
@@ -287,7 +287,7 @@ void AP_Compass_AK8963::_update()
 
     _last_update_timestamp = AP_HAL::micros();
 fail:
-    _sem_give();
+    _bus_sem->give();
 end:
     return;
 }
@@ -333,37 +333,6 @@ bool AP_Compass_AK8963::_calibrate()
     }
 
     return true;
-}
-
-bool AP_Compass_AK8963::_sem_take_blocking()
-{
-    return _bus_sem->take(10);
-}
-
-bool AP_Compass_AK8963::_sem_give()
-{
-    return _bus_sem->give();
-}
-
-bool AP_Compass_AK8963::_sem_take_nonblocking()
-{
-    static int _sem_failure_count = 0;
-
-    if (_bus_sem->take_nonblocking()) {
-        _sem_failure_count = 0;
-        return true;
-    }
-
-    if (!hal.scheduler->system_initializing() ) {
-        _sem_failure_count++;
-        if (_sem_failure_count > 100) {
-            AP_HAL::panic("PANIC: failed to take _bus->sem "
-                                 "100 times in a row, in "
-                                 "AP_Compass_AK8963");
-        }
-    }
-
-    return false;
 }
 
 void AP_Compass_AK8963::_dump_registers()

--- a/libraries/AP_Compass/AP_Compass_AK8963.h
+++ b/libraries/AP_Compass/AP_Compass_AK8963.h
@@ -68,9 +68,6 @@ private:
 
     void _update();
     void _dump_registers();
-    bool _sem_take_blocking();
-    bool _sem_take_nonblocking();
-    bool _sem_give();
 
     float               _magnetometer_ASA[3] {0, 0, 0};
     uint8_t             _compass_instance;

--- a/libraries/AP_HAL/Scheduler.h
+++ b/libraries/AP_HAL/Scheduler.h
@@ -54,7 +54,6 @@ public:
     virtual void     register_timer_failsafe(AP_HAL::Proc,
                                              uint32_t period_us) = 0;
 
-    virtual bool     system_initializing() = 0;
     virtual void     system_initialized() = 0;
 
     virtual void     reboot(bool hold_in_bootloader) = 0;

--- a/libraries/AP_HAL_Empty/Scheduler.cpp
+++ b/libraries/AP_HAL_Empty/Scheduler.cpp
@@ -42,12 +42,6 @@ bool Scheduler::in_timerprocess() {
     return false;
 }
 
-void Scheduler::begin_atomic()
-{}
-
-void Scheduler::end_atomic()
-{}
-
 void Scheduler::system_initialized()
 {}
 

--- a/libraries/AP_HAL_Empty/Scheduler.cpp
+++ b/libraries/AP_HAL_Empty/Scheduler.cpp
@@ -48,10 +48,6 @@ void Scheduler::begin_atomic()
 void Scheduler::end_atomic()
 {}
 
-bool Scheduler::system_initializing() {
-    return false;
-}
-
 void Scheduler::system_initialized()
 {}
 

--- a/libraries/AP_HAL_Empty/Scheduler.h
+++ b/libraries/AP_HAL_Empty/Scheduler.h
@@ -25,7 +25,6 @@ public:
     void     begin_atomic();
     void     end_atomic();
 
-    bool     system_initializing();
     void     system_initialized();
 
     void     reboot(bool hold_in_bootloader);

--- a/libraries/AP_HAL_Empty/Scheduler.h
+++ b/libraries/AP_HAL_Empty/Scheduler.h
@@ -22,9 +22,6 @@ public:
 
     void     register_timer_failsafe(AP_HAL::Proc, uint32_t period_us);
 
-    void     begin_atomic();
-    void     end_atomic();
-
     void     system_initialized();
 
     void     reboot(bool hold_in_bootloader);

--- a/libraries/AP_HAL_FLYMAPLE/Scheduler.cpp
+++ b/libraries/AP_HAL_FLYMAPLE/Scheduler.cpp
@@ -193,10 +193,6 @@ void FLYMAPLEScheduler::_run_timer_procs(bool called_from_isr)
     _in_timer_proc = false;
 }
 
-bool FLYMAPLEScheduler::system_initializing() {
-    return !_initialized;
-}
-
 void FLYMAPLEScheduler::system_initialized()
 {
     if (_initialized) {

--- a/libraries/AP_HAL_FLYMAPLE/Scheduler.cpp
+++ b/libraries/AP_HAL_FLYMAPLE/Scheduler.cpp
@@ -165,16 +165,6 @@ void FLYMAPLEScheduler::_failsafe_timer_event()
         _failsafe();
 }
 
-void FLYMAPLEScheduler::begin_atomic()
-{
-    noInterrupts();
-}
-
-void FLYMAPLEScheduler::end_atomic()
-{
-    interrupts();
-}
-
 void FLYMAPLEScheduler::_run_timer_procs(bool called_from_isr) 
 {
     _in_timer_proc = true;

--- a/libraries/AP_HAL_FLYMAPLE/Scheduler.h
+++ b/libraries/AP_HAL_FLYMAPLE/Scheduler.h
@@ -43,9 +43,6 @@ public:
 
     void     register_timer_failsafe(AP_HAL::Proc, uint32_t period_us);
 
-    void     begin_atomic();
-    void     end_atomic();
-
     void     system_initialized();
 
     void     reboot(bool hold_in_bootloader);

--- a/libraries/AP_HAL_FLYMAPLE/Scheduler.h
+++ b/libraries/AP_HAL_FLYMAPLE/Scheduler.h
@@ -46,7 +46,6 @@ public:
     void     begin_atomic();
     void     end_atomic();
 
-    bool     system_initializing();
     void     system_initialized();
 
     void     reboot(bool hold_in_bootloader);

--- a/libraries/AP_HAL_Linux/AP_HAL_Linux_Namespace.h
+++ b/libraries/AP_HAL_Linux/AP_HAL_Linux_Namespace.h
@@ -19,6 +19,7 @@ namespace Linux {
     class Storage_FRAM;
     class DigitalSource;
     class DigitalSource_Sysfs;
+    class PeriodicThread;
     class PWM_Sysfs;
     class PWM_Sysfs_Bebop;
     class PWM_Sysfs_Base;

--- a/libraries/AP_HAL_Linux/AP_HAL_Linux_Namespace.h
+++ b/libraries/AP_HAL_Linux/AP_HAL_Linux_Namespace.h
@@ -44,6 +44,7 @@ namespace Linux {
     class Util;
     class UtilRPI;
     class ToneAlarm;
+    class Thread;
     class Heat;
     class HeatPwm;
     class CameraSensor;

--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -397,12 +397,6 @@ bool Scheduler::in_timerprocess()
     return _in_timer_proc;
 }
 
-void Scheduler::begin_atomic()
-{}
-
-void Scheduler::end_atomic()
-{}
-
 void Scheduler::_wait_all_threads()
 {
     int r = pthread_barrier_wait(&_initialized_barrier);

--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -403,10 +403,6 @@ void Scheduler::begin_atomic()
 void Scheduler::end_atomic()
 {}
 
-bool Scheduler::system_initializing() {
-    return !_initialized;
-}
-
 void Scheduler::_wait_all_threads()
 {
     int r = pthread_barrier_wait(&_initialized_barrier);

--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -227,7 +227,7 @@ void Scheduler::resume_timer_procs()
     _timer_semaphore.give();
 }
 
-void Scheduler::_run_timers(bool called_from_timer_thread)
+void Scheduler::_run_timers()
 {
     int i;
 
@@ -300,7 +300,7 @@ void Scheduler::_timer_task()
         }
         next_run_usec += 1000;
         // run registered timers
-        _run_timers(true);
+        _run_timers();
 
 #if HAL_LINUX_UARTS_ON_TIMER_THREAD
         /*

--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -52,7 +52,6 @@ extern const AP_HAL::HAL& hal;
 #define APM_LINUX_IO_PERIOD             20000
 #endif // CONFIG_HAL_BOARD_SUBTYPE
 
-
 Scheduler::Scheduler()
 { }
 
@@ -280,10 +279,6 @@ void Scheduler::_run_timers(bool called_from_timer_thread)
 
 void Scheduler::_timer_task()
 {
-    while (system_initializing()) {
-        poll(NULL, 0, 1);
-    }
-
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_QFLIGHT
     printf("Initialising rpcmem\n");
     rpcmem_init();
@@ -336,9 +331,6 @@ void Scheduler::_run_io(void)
 
 void Scheduler::_rcin_task()
 {
-    while (system_initializing()) {
-        poll(NULL, 0, 1);
-    }
     while (true) {
         microsleep(APM_LINUX_RCIN_PERIOD);
 #if !HAL_LINUX_UARTS_ON_TIMER_THREAD
@@ -368,9 +360,6 @@ void Scheduler::_run_uarts()
 
 void Scheduler::_uart_task()
 {
-    while (system_initializing()) {
-        poll(NULL, 0, 1);
-    }
     while (true) {
         microsleep(APM_LINUX_UART_PERIOD);
 #if !HAL_LINUX_UARTS_ON_TIMER_THREAD
@@ -381,9 +370,6 @@ void Scheduler::_uart_task()
 
 void Scheduler::_tonealarm_task()
 {
-    while (system_initializing()) {
-        poll(NULL, 0, 1);
-    }
     while (true) {
         microsleep(APM_LINUX_TONEALARM_PERIOD);
 
@@ -394,9 +380,6 @@ void Scheduler::_tonealarm_task()
 
 void Scheduler::_io_task()
 {
-    while (system_initializing()) {
-        poll(NULL, 0, 1);
-    }
     while (true) {
         microsleep(APM_LINUX_IO_PERIOD);
 
@@ -442,4 +425,13 @@ void Scheduler::stop_clock(uint64_t time_usec)
         _stopped_clock_usec = time_usec;
         _run_io();
     }
+}
+
+bool Scheduler::SchedulerThread::run()
+{
+    while (_sched.system_initializing()) {
+        poll(NULL, 0, 1);
+    }
+
+    return Thread::run();
 }

--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -139,7 +139,7 @@ void Scheduler::init()
                                 iter->start_routine);
 }
 
-void Scheduler::_microsleep(uint32_t usec)
+void Scheduler::microsleep(uint32_t usec)
 {
     struct timespec ts;
     ts.tv_sec = 0;
@@ -156,7 +156,7 @@ void Scheduler::delay(uint16_t ms)
 
     while ((AP_HAL::millis64() - start) < ms) {
         // this yields the CPU to other apps
-        _microsleep(1000);
+        microsleep(1000);
         if (_min_delay_cb_ms <= ms) {
             if (_delay_cb) {
                 _delay_cb();
@@ -170,7 +170,7 @@ void Scheduler::delay_microseconds(uint16_t us)
     if (_stopped_clock_usec) {
         return;
     }
-    _microsleep(us);
+    microsleep(us);
 }
 
 void Scheduler::register_delay_callback(AP_HAL::Proc proc,
@@ -356,7 +356,7 @@ void *Scheduler::_timer_thread(void* arg)
     rpcmem_init();
 #endif
     
-/*
+    /*
       this aims to run at an average of 1kHz, so that it can be used
       to drive 1kHz processes without drift
      */
@@ -367,7 +367,7 @@ void *Scheduler::_timer_thread(void* arg)
             // we've lost sync - restart
             next_run_usec = AP_HAL::micros64();
         } else {
-            sched->_microsleep(dt);
+            sched->microsleep(dt);
         }
         next_run_usec += 1000;
         // run registered timers
@@ -410,7 +410,7 @@ void *Scheduler::_rcin_thread(void *arg)
         poll(NULL, 0, 1);
     }
     while (true) {
-        sched->_microsleep(APM_LINUX_RCIN_PERIOD);
+        sched->microsleep(APM_LINUX_RCIN_PERIOD);
 #if !HAL_LINUX_UARTS_ON_TIMER_THREAD
         RCInput::from(hal.rcin)->_timer_tick();
 #endif
@@ -446,7 +446,7 @@ void *Scheduler::_uart_thread(void* arg)
         poll(NULL, 0, 1);
     }
     while (true) {
-        sched->_microsleep(APM_LINUX_UART_PERIOD);
+        sched->microsleep(APM_LINUX_UART_PERIOD);
 #if !HAL_LINUX_UARTS_ON_TIMER_THREAD
         _run_uarts();
 #endif
@@ -462,7 +462,7 @@ void *Scheduler::_tonealarm_thread(void* arg)
         poll(NULL, 0, 1);
     }
     while (true) {
-        sched->_microsleep(APM_LINUX_TONEALARM_PERIOD);
+        sched->microsleep(APM_LINUX_TONEALARM_PERIOD);
 
         // process tone command
         Util::from(hal.util)->_toneAlarm_timer_tick();
@@ -478,7 +478,7 @@ void *Scheduler::_io_thread(void* arg)
         poll(NULL, 0, 1);
     }
     while (true) {
-        sched->_microsleep(APM_LINUX_IO_PERIOD);
+        sched->microsleep(APM_LINUX_IO_PERIOD);
 
         // process any pending storage writes
         Storage::from(hal.storage)->_timer_tick();

--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -1,21 +1,22 @@
+#include "Scheduler.h"
+
+#include <algorithm>
+#include <errno.h>
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <sys/time.h>
+#include <unistd.h>
+
 #include <AP_HAL/AP_HAL.h>
 
-#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
-
-#include "Scheduler.h"
-#include "Storage.h"
 #include "RCInput.h"
+#include "RPIOUARTDriver.h"
+#include "SPIUARTDriver.h"
+#include "Storage.h"
 #include "UARTDriver.h"
 #include "Util.h"
-#include "SPIUARTDriver.h"
-#include "RPIOUARTDriver.h"
-#include <algorithm>
-#include <poll.h>
-#include <unistd.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <errno.h>
-#include <sys/mman.h>
 
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_QFLIGHT
 #include <rpcmem.h>
@@ -23,7 +24,6 @@
 #include <AP_HAL_Linux/qflight/qflight_dsp.h>
 #include <AP_HAL_Linux/qflight/qflight_buffer.h>
 #endif
-
 
 using namespace Linux;
 
@@ -50,8 +50,6 @@ extern const AP_HAL::HAL& hal;
 #define APM_LINUX_TONEALARM_PERIOD      10000
 #define APM_LINUX_IO_PERIOD             20000
 #endif // CONFIG_HAL_BOARD_SUBTYPE
-
-
 
 
 Scheduler::Scheduler()
@@ -355,7 +353,7 @@ void *Scheduler::_timer_thread(void* arg)
     printf("Initialising rpcmem\n");
     rpcmem_init();
 #endif
-    
+
     /*
       this aims to run at an average of 1kHz, so that it can be used
       to drive 1kHz processes without drift
@@ -524,5 +522,3 @@ void Scheduler::stop_clock(uint64_t time_usec)
         _run_io();
     }
 }
-
-#endif // CONFIG_HAL_BOARD

--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -280,11 +280,6 @@ void Scheduler::_run_timers()
 
 void Scheduler::_timer_task()
 {
-#if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_QFLIGHT
-    printf("Initialising rpcmem\n");
-    rpcmem_init();
-#endif
-
     /*
       this aims to run at an average of 1kHz, so that it can be used
       to drive 1kHz processes without drift
@@ -431,6 +426,14 @@ void Scheduler::stop_clock(uint64_t time_usec)
 
 bool Scheduler::SchedulerThread::run()
 {
+#if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_QFLIGHT
+    if (_sched._timer_thread.is_current_thread()) {
+        /* make rpcmem initialization on timer thread */
+        printf("Initialising rpcmem\n");
+        rpcmem_init();
+    }
+#endif
+
     _sched._wait_all_threads();
 
     return Thread::run();

--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -36,20 +36,20 @@ extern const AP_HAL::HAL& hal;
 #define APM_LINUX_TONEALARM_PRIORITY    11
 #define APM_LINUX_IO_PRIORITY           10
 
+#define APM_LINUX_TIMER_RATE            1000
+#define APM_LINUX_UART_RATE             100
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO ||    \
     CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_ERLEBRAIN2 || \
     CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_BH || \
     CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_PXFMINI
-#define APM_LINUX_UART_PERIOD           10000
-#define APM_LINUX_RCIN_PERIOD           500
-#define APM_LINUX_TONEALARM_PERIOD      10000
-#define APM_LINUX_IO_PERIOD             20000
+#define APM_LINUX_RCIN_RATE             2000
+#define APM_LINUX_TONEALARM_RATE        100
+#define APM_LINUX_IO_RATE               50
 #else
-#define APM_LINUX_UART_PERIOD           10000
-#define APM_LINUX_RCIN_PERIOD           10000
-#define APM_LINUX_TONEALARM_PERIOD      10000
-#define APM_LINUX_IO_PERIOD             20000
-#endif // CONFIG_HAL_BOARD_SUBTYPE
+#define APM_LINUX_RCIN_RATE             100
+#define APM_LINUX_TONEALARM_RATE        100
+#define APM_LINUX_IO_RATE               50
+#endif
 
 Scheduler::Scheduler()
 { }
@@ -64,6 +64,12 @@ void Scheduler::init()
 
     struct sched_param param = { .sched_priority = APM_LINUX_MAIN_PRIORITY };
     sched_setscheduler(0, SCHED_FIFO, &param);
+
+    _timer_thread.set_rate(APM_LINUX_TIMER_RATE);
+    _uart_thread.set_rate(APM_LINUX_UART_RATE);
+    _rcin_thread.set_rate(APM_LINUX_RCIN_RATE);
+    _tonealarm_thread.set_rate(APM_LINUX_TONEALARM_RATE);
+    _io_thread.set_rate(APM_LINUX_IO_RATE);
 
     /* set barrier to 6 threads: worker threads below + main thread */
     pthread_barrier_init(&_initialized_barrier, nullptr, 6);
@@ -227,7 +233,7 @@ void Scheduler::resume_timer_procs()
     _timer_semaphore.give();
 }
 
-void Scheduler::_run_timers()
+void Scheduler::_timer_task()
 {
     int i;
 
@@ -237,7 +243,7 @@ void Scheduler::_run_timers()
     _in_timer_proc = true;
 
     if (!_timer_semaphore.take(0)) {
-        printf("Failed to take timer semaphore in _run_timers\n");
+        printf("Failed to take timer semaphore in %s\n", __PRETTY_FUNCTION__);
     }
     // now call the timer based drivers
     for (i = 0; i < _num_timer_procs; i++) {
@@ -248,8 +254,7 @@ void Scheduler::_run_timers()
 
 #if CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_RASPILOT
     //SPI UART use SPI
-    if (!((RPIOUARTDriver *)hal.uartC)->isExternal() )
-    {
+    if (!((RPIOUARTDriver *)hal.uartC)->isExternal()) {
         ((RPIOUARTDriver *)hal.uartC)->_timer_tick();
     }
 #endif
@@ -276,37 +281,16 @@ void Scheduler::_run_timers()
     }
 
     _in_timer_proc = false;
-}
-
-void Scheduler::_timer_task()
-{
-    /*
-      this aims to run at an average of 1kHz, so that it can be used
-      to drive 1kHz processes without drift
-     */
-    uint64_t next_run_usec = AP_HAL::micros64() + 1000;
-    while (true) {
-        uint64_t dt = next_run_usec - AP_HAL::micros64();
-        if (dt > 2000) {
-            // we've lost sync - restart
-            next_run_usec = AP_HAL::micros64();
-        } else {
-            microsleep(dt);
-        }
-        next_run_usec += 1000;
-        // run registered timers
-        _run_timers();
 
 #if HAL_LINUX_UARTS_ON_TIMER_THREAD
-        /*
-          some boards require that UART calls happen on the same
-          thread as other calls of the same time. This impacts the
-          QFLIGHT calls where UART output is an RPC call to the DSPs
-         */
-        _run_uarts();
-        RCInput::from(hal.rcin)->_timer_tick();
+    /*
+       some boards require that UART calls happen on the same
+       thread as other calls of the same time. This impacts the
+       QFLIGHT calls where UART output is an RPC call to the DSPs
+       */
+    _run_uarts();
+    RCInput::from(hal.rcin)->_timer_tick();
 #endif
-    }
 }
 
 void Scheduler::_run_io(void)
@@ -323,16 +307,6 @@ void Scheduler::_run_io(void)
     }
 
     _io_semaphore.give();
-}
-
-void Scheduler::_rcin_task()
-{
-    while (true) {
-        microsleep(APM_LINUX_RCIN_PERIOD);
-#if !HAL_LINUX_UARTS_ON_TIMER_THREAD
-        RCInput::from(hal.rcin)->_timer_tick();
-#endif
-    }
 }
 
 /*
@@ -354,37 +328,33 @@ void Scheduler::_run_uarts()
     UARTDriver::from(hal.uartE)->_timer_tick();
 }
 
+void Scheduler::_rcin_task()
+{
+#if !HAL_LINUX_UARTS_ON_TIMER_THREAD
+    RCInput::from(hal.rcin)->_timer_tick();
+#endif
+}
+
 void Scheduler::_uart_task()
 {
-    while (true) {
-        microsleep(APM_LINUX_UART_PERIOD);
 #if !HAL_LINUX_UARTS_ON_TIMER_THREAD
-        _run_uarts();
+    _run_uarts();
 #endif
-    }
 }
 
 void Scheduler::_tonealarm_task()
 {
-    while (true) {
-        microsleep(APM_LINUX_TONEALARM_PERIOD);
-
-        // process tone command
-        Util::from(hal.util)->_toneAlarm_timer_tick();
-    }
+    // process tone command
+    Util::from(hal.util)->_toneAlarm_timer_tick();
 }
 
 void Scheduler::_io_task()
 {
-    while (true) {
-        microsleep(APM_LINUX_IO_PERIOD);
+    // process any pending storage writes
+    Storage::from(hal.storage)->_timer_tick();
 
-        // process any pending storage writes
-        Storage::from(hal.storage)->_timer_tick();
-
-        // run registered IO procepsses
-        _run_io();
-    }
+    // run registered IO processes
+    _run_io();
 }
 
 bool Scheduler::in_timerprocess()
@@ -436,5 +406,5 @@ bool Scheduler::SchedulerThread::run()
 
     _sched._wait_all_threads();
 
-    return Thread::run();
+    return PeriodicThread::run();
 }

--- a/libraries/AP_HAL_Linux/Scheduler.cpp
+++ b/libraries/AP_HAL_Linux/Scheduler.cpp
@@ -3,7 +3,6 @@
 #include <algorithm>
 #include <errno.h>
 #include <poll.h>
-#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/mman.h>
@@ -66,6 +65,8 @@ void Scheduler::init()
     struct sched_param param = { .sched_priority = APM_LINUX_MAIN_PRIORITY };
     sched_setscheduler(0, SCHED_FIFO, &param);
 
+    /* set barrier to 6 threads: worker threads below + main thread */
+    pthread_barrier_init(&_initialized_barrier, nullptr, 6);
     _timer_thread.start("sched-timer", SCHED_FIFO, APM_LINUX_TIMER_PRIORITY);
     _uart_thread.start("sched-uart", SCHED_FIFO, APM_LINUX_UART_PRIORITY);
     _rcin_thread.start("sched-rcin", SCHED_FIFO, APM_LINUX_RCIN_PRIORITY);
@@ -406,12 +407,23 @@ bool Scheduler::system_initializing() {
     return !_initialized;
 }
 
+void Scheduler::_wait_all_threads()
+{
+    int r = pthread_barrier_wait(&_initialized_barrier);
+    if (r == PTHREAD_BARRIER_SERIAL_THREAD) {
+        pthread_barrier_destroy(&_initialized_barrier);
+    }
+}
+
 void Scheduler::system_initialized()
 {
     if (_initialized) {
         AP_HAL::panic("PANIC: scheduler::system_initialized called more than once");
     }
+
     _initialized = true;
+
+    _wait_all_threads();
 }
 
 void Scheduler::reboot(bool hold_in_bootloader)
@@ -429,9 +441,7 @@ void Scheduler::stop_clock(uint64_t time_usec)
 
 bool Scheduler::SchedulerThread::run()
 {
-    while (_sched.system_initializing()) {
-        poll(NULL, 0, 1);
-    }
+    _sched._wait_all_threads();
 
     return Thread::run();
 }

--- a/libraries/AP_HAL_Linux/Scheduler.h
+++ b/libraries/AP_HAL_Linux/Scheduler.h
@@ -37,7 +37,6 @@ public:
     void     begin_atomic();
     void     end_atomic();
 
-    bool     system_initializing();
     void     system_initialized();
 
     void     reboot(bool hold_in_bootloader);

--- a/libraries/AP_HAL_Linux/Scheduler.h
+++ b/libraries/AP_HAL_Linux/Scheduler.h
@@ -34,9 +34,6 @@ public:
 
     void     register_timer_failsafe(AP_HAL::Proc, uint32_t period_us);
 
-    void     begin_atomic();
-    void     end_atomic();
-
     void     system_initialized();
 
     void     reboot(bool hold_in_bootloader);

--- a/libraries/AP_HAL_Linux/Scheduler.h
+++ b/libraries/AP_HAL_Linux/Scheduler.h
@@ -58,7 +58,6 @@ private:
     };
 
     void _wait_all_threads();
-    void _timer_handler(int signum);
 
     AP_HAL::Proc _delay_cb;
     uint16_t _min_delay_cb_ms;
@@ -67,7 +66,6 @@ private:
 
     bool _initialized;
     pthread_barrier_t _initialized_barrier;
-    volatile bool _timer_pending;
 
     AP_HAL::MemberProc _timer_proc[LINUX_SCHEDULER_MAX_TIMER_PROCS];
     uint8_t _num_timer_procs;

--- a/libraries/AP_HAL_Linux/Scheduler.h
+++ b/libraries/AP_HAL_Linux/Scheduler.h
@@ -101,7 +101,7 @@ private:
     void _uart_task();
     void _tonealarm_task();
 
-    void _run_timers(bool called_from_timer_thread);
+    void _run_timers();
     void _run_io();
     void _run_uarts();
     bool _register_timesliced_proc(AP_HAL::MemberProc, uint8_t);

--- a/libraries/AP_HAL_Linux/Scheduler.h
+++ b/libraries/AP_HAL_Linux/Scheduler.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <pthread.h>
+
 #include "AP_HAL_Linux.h"
 #include "Semaphores.h"
 #include "Thread.h"
@@ -59,6 +61,7 @@ private:
         Scheduler &_sched;
     };
 
+    void _wait_all_threads();
     void _timer_handler(int signum);
 
     AP_HAL::Proc _delay_cb;
@@ -67,6 +70,7 @@ private:
     AP_HAL::Proc _failsafe;
 
     bool _initialized;
+    pthread_barrier_t _initialized_barrier;
     volatile bool _timer_pending;
 
     AP_HAL::MemberProc _timer_proc[LINUX_SCHEDULER_MAX_TIMER_PROCS];

--- a/libraries/AP_HAL_Linux/Scheduler.h
+++ b/libraries/AP_HAL_Linux/Scheduler.h
@@ -52,9 +52,10 @@ public:
 
     uint64_t stopped_clock_usec() const { return _stopped_clock_usec; }
 
+    void microsleep(uint32_t usec);
+
 private:
     void _timer_handler(int signum);
-    void _microsleep(uint32_t usec);
 
     AP_HAL::Proc _delay_cb;
     uint16_t _min_delay_cb_ms;

--- a/libraries/AP_HAL_Linux/Scheduler.h
+++ b/libraries/AP_HAL_Linux/Scheduler.h
@@ -85,8 +85,6 @@ private:
     uint8_t _num_io_procs;
     volatile bool _in_io_proc;
 
-    volatile bool _timer_event_missed;
-
     SchedulerThread _timer_thread{FUNCTOR_BIND_MEMBER(&Scheduler::_timer_task, void), *this};
     SchedulerThread _io_thread{FUNCTOR_BIND_MEMBER(&Scheduler::_io_task, void), *this};
     SchedulerThread _rcin_thread{FUNCTOR_BIND_MEMBER(&Scheduler::_rcin_task, void), *this};

--- a/libraries/AP_HAL_Linux/Scheduler.h
+++ b/libraries/AP_HAL_Linux/Scheduler.h
@@ -45,10 +45,10 @@ public:
     void microsleep(uint32_t usec);
 
 private:
-    class SchedulerThread : public Thread {
+    class SchedulerThread : public PeriodicThread {
     public:
         SchedulerThread(Thread::task_t t, Scheduler &sched)
-            : Thread(t)
+            : PeriodicThread(t)
             , _sched(sched)
         { }
 
@@ -101,7 +101,6 @@ private:
     void _uart_task();
     void _tonealarm_task();
 
-    void _run_timers();
     void _run_io();
     void _run_uarts();
     bool _register_timesliced_proc(AP_HAL::MemberProc, uint8_t);

--- a/libraries/AP_HAL_Linux/Scheduler.h
+++ b/libraries/AP_HAL_Linux/Scheduler.h
@@ -83,7 +83,6 @@ private:
 
     AP_HAL::MemberProc _io_proc[LINUX_SCHEDULER_MAX_IO_PROCS];
     uint8_t _num_io_procs;
-    volatile bool _in_io_proc;
 
     SchedulerThread _timer_thread{FUNCTOR_BIND_MEMBER(&Scheduler::_timer_task, void), *this};
     SchedulerThread _io_thread{FUNCTOR_BIND_MEMBER(&Scheduler::_io_task, void), *this};

--- a/libraries/AP_HAL_Linux/Scheduler.h
+++ b/libraries/AP_HAL_Linux/Scheduler.h
@@ -1,11 +1,8 @@
-
-#ifndef __AP_HAL_LINUX_SCHEDULER_H__
-#define __AP_HAL_LINUX_SCHEDULER_H__
+#pragma once
 
 #include "AP_HAL_Linux.h"
 #include "Semaphores.h"
 
-#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
 #include <sys/time.h>
 #include <pthread.h>
 
@@ -109,7 +106,3 @@ private:
     Semaphore _timer_semaphore;
     Semaphore _io_semaphore;
 };
-
-#endif // CONFIG_HAL_BOARD
-
-#endif // __AP_HAL_LINUX_SCHEDULER_H__

--- a/libraries/AP_HAL_Linux/Scheduler.h
+++ b/libraries/AP_HAL_Linux/Scheduler.h
@@ -47,6 +47,18 @@ public:
     void microsleep(uint32_t usec);
 
 private:
+    class SchedulerThread : public Thread {
+    public:
+        SchedulerThread(Thread::task_t t, Scheduler &sched)
+            : Thread(t)
+            , _sched(sched)
+        { }
+
+        bool run() override;
+    protected:
+        Scheduler &_sched;
+    };
+
     void _timer_handler(int signum);
 
     AP_HAL::Proc _delay_cb;
@@ -77,11 +89,11 @@ private:
 
     volatile bool _timer_event_missed;
 
-    Thread _timer_thread{FUNCTOR_BIND_MEMBER(&Scheduler::_timer_task, void)};
-    Thread _io_thread{FUNCTOR_BIND_MEMBER(&Scheduler::_io_task, void)};
-    Thread _rcin_thread{FUNCTOR_BIND_MEMBER(&Scheduler::_rcin_task, void)};
-    Thread _uart_thread{FUNCTOR_BIND_MEMBER(&Scheduler::_uart_task, void)};
-    Thread _tonealarm_thread{FUNCTOR_BIND_MEMBER(&Scheduler::_tonealarm_task, void)};
+    SchedulerThread _timer_thread{FUNCTOR_BIND_MEMBER(&Scheduler::_timer_task, void), *this};
+    SchedulerThread _io_thread{FUNCTOR_BIND_MEMBER(&Scheduler::_io_task, void), *this};
+    SchedulerThread _rcin_thread{FUNCTOR_BIND_MEMBER(&Scheduler::_rcin_task, void), *this};
+    SchedulerThread _uart_thread{FUNCTOR_BIND_MEMBER(&Scheduler::_uart_task, void), *this};
+    SchedulerThread _tonealarm_thread{FUNCTOR_BIND_MEMBER(&Scheduler::_tonealarm_task, void), *this};
 
     void _timer_task();
     void _io_task();

--- a/libraries/AP_HAL_Linux/Thread.cpp
+++ b/libraries/AP_HAL_Linux/Thread.cpp
@@ -33,10 +33,20 @@ namespace Linux {
 void *Thread::run_trampoline(void *arg)
 {
     Thread *thread = static_cast<Thread *>(arg);
-
-    thread->_task();
+    thread->run();
 
     return nullptr;
+}
+
+bool Thread::run()
+{
+    if (!_task) {
+        return false;
+    }
+
+    _task();
+
+    return true;
 }
 
 bool Thread::start(const char *name, int policy, int prio)

--- a/libraries/AP_HAL_Linux/Thread.cpp
+++ b/libraries/AP_HAL_Linux/Thread.cpp
@@ -93,4 +93,35 @@ bool Thread::is_current_thread()
     return pthread_equal(pthread_self(), _ctx);
 }
 
+bool PeriodicThread::set_rate(uint32_t rate_hz)
+{
+    if (_started || rate_hz == 0) {
+        return false;
+    }
+
+    _period_usec = hz_to_usec(rate_hz);
+
+    return true;
+}
+
+bool PeriodicThread::run()
+{
+    uint64_t next_run_usec = AP_HAL::micros64() + _period_usec;
+
+    while (true) {
+        uint64_t dt = next_run_usec - AP_HAL::micros64();
+        if (dt > _period_usec) {
+            // we've lost sync - restart
+            next_run_usec = AP_HAL::micros64();
+        } else {
+            Scheduler::from(hal.scheduler)->microsleep(dt);
+        }
+        next_run_usec += _period_usec;
+
+        _task();
+    }
+
+    return true;
+}
+
 }

--- a/libraries/AP_HAL_Linux/Thread.cpp
+++ b/libraries/AP_HAL_Linux/Thread.cpp
@@ -1,0 +1,81 @@
+/// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+/*
+ * Copyright (C) 2016  Intel Corporation. All rights reserved.
+ *
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "Thread.h"
+
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Math/AP_Math.h>
+
+#include "Scheduler.h"
+
+extern const AP_HAL::HAL &hal;
+
+namespace Linux {
+
+
+void *Thread::run_trampoline(void *arg)
+{
+    Thread *thread = static_cast<Thread *>(arg);
+
+    thread->_task();
+
+    return nullptr;
+}
+
+bool Thread::start(const char *name, int policy, int prio)
+{
+    if (_started) {
+        return false;
+    }
+
+    struct sched_param param = { .sched_priority = prio };
+    pthread_attr_t attr;
+    int r;
+
+    pthread_attr_init(&attr);
+
+    /*
+      we need to run as root to get realtime scheduling. Allow it to
+      run as non-root for debugging purposes, plus to allow the Replay
+      tool to run
+     */
+    if (geteuid() == 0) {
+        pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED);
+        pthread_attr_setschedpolicy(&attr, SCHED_FIFO);
+        pthread_attr_setschedparam(&attr, &param);
+    }
+
+    r = pthread_create(&_ctx, &attr, &Thread::run_trampoline, this);
+    if (r != 0) {
+        AP_HAL::panic("Failed to create thread '%s': %s\n",
+                      name, strerror(r));
+    }
+    pthread_attr_destroy(&attr);
+
+    if (name) {
+        pthread_setname_np(_ctx, name);
+    }
+
+    _started = true;
+
+    return true;
+}
+
+}

--- a/libraries/AP_HAL_Linux/Thread.cpp
+++ b/libraries/AP_HAL_Linux/Thread.cpp
@@ -88,4 +88,9 @@ bool Thread::start(const char *name, int policy, int prio)
     return true;
 }
 
+bool Thread::is_current_thread()
+{
+    return pthread_equal(pthread_self(), _ctx);
+}
+
 }

--- a/libraries/AP_HAL_Linux/Thread.h
+++ b/libraries/AP_HAL_Linux/Thread.h
@@ -1,0 +1,51 @@
+/// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+/*
+ * Copyright (C) 2016  Intel Corporation. All rights reserved.
+ *
+ * This file is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <pthread.h>
+#include <inttypes.h>
+#include <stdlib.h>
+
+#include <AP_HAL/utility/functor.h>
+
+#include "AP_HAL_Linux_Namespace.h"
+
+namespace Linux {
+
+/*
+ * Interface abstracting threads
+ */
+class Thread {
+public:
+    FUNCTOR_TYPEDEF(task_t, void);
+
+    Thread(task_t t) : _task(t) { }
+
+    virtual ~Thread() { }
+
+    bool start(const char *name, int policy, int prio);
+
+protected:
+    static void *run_trampoline(void *arg);
+
+    task_t _task;
+    bool _started;
+    pthread_t _ctx;
+};
+
+}

--- a/libraries/AP_HAL_Linux/Thread.h
+++ b/libraries/AP_HAL_Linux/Thread.h
@@ -38,6 +38,13 @@ public:
 
     virtual ~Thread() { }
 
+    /*
+     * Run the task assigned in the constructor. May be overriden in case it's
+     * preferred to use Thread as an interface or when user wants to aggregate
+     * some initialization or teardown for the thread.
+     */
+    virtual bool run();
+
     bool start(const char *name, int policy, int prio);
 
 protected:

--- a/libraries/AP_HAL_Linux/Thread.h
+++ b/libraries/AP_HAL_Linux/Thread.h
@@ -57,4 +57,18 @@ protected:
     pthread_t _ctx;
 };
 
+class PeriodicThread : public Thread {
+public:
+    PeriodicThread(Thread::task_t t)
+        : Thread(t)
+    { }
+
+    bool set_rate(uint32_t rate_hz);
+
+    bool run() override;
+
+protected:
+    uint64_t _period_usec;
+};
+
 }

--- a/libraries/AP_HAL_Linux/Thread.h
+++ b/libraries/AP_HAL_Linux/Thread.h
@@ -47,6 +47,8 @@ public:
 
     bool start(const char *name, int policy, int prio);
 
+    bool is_current_thread();
+
 protected:
     static void *run_trampoline(void *arg);
 

--- a/libraries/AP_HAL_PX4/Scheduler.cpp
+++ b/libraries/AP_HAL_PX4/Scheduler.cpp
@@ -367,10 +367,6 @@ bool PX4Scheduler::in_timerprocess()
     return getpid() != _main_task_pid;
 }
 
-bool PX4Scheduler::system_initializing() {
-    return !_initialized;
-}
-
 void PX4Scheduler::system_initialized() {
     if (_initialized) {
         AP_HAL::panic("PANIC: scheduler::system_initialized called"

--- a/libraries/AP_HAL_PX4/Scheduler.h
+++ b/libraries/AP_HAL_PX4/Scheduler.h
@@ -58,7 +58,6 @@ public:
     void     reboot(bool hold_in_bootloader);
 
     bool     in_timerprocess();
-    bool     system_initializing();
     void     system_initialized();
     void     hal_initialized() { _hal_initialized = true; }
     

--- a/libraries/AP_HAL_PX4/Scheduler.h
+++ b/libraries/AP_HAL_PX4/Scheduler.h
@@ -67,7 +67,6 @@ private:
     AP_HAL::Proc _delay_cb;
     uint16_t _min_delay_cb_ms;
     AP_HAL::Proc _failsafe;
-    volatile bool _timer_pending;
 
     volatile bool _timer_suspended;
 

--- a/libraries/AP_HAL_QURT/Scheduler.cpp
+++ b/libraries/AP_HAL_QURT/Scheduler.cpp
@@ -272,10 +272,6 @@ bool Scheduler::in_timerprocess()
     return getpid() != _main_task_pid;
 }
 
-bool Scheduler::system_initializing() {
-    return !_initialized;
-}
-
 void Scheduler::system_initialized() {
     if (_initialized) {
         AP_HAL::panic("PANIC: scheduler::system_initialized called"

--- a/libraries/AP_HAL_QURT/Scheduler.h
+++ b/libraries/AP_HAL_QURT/Scheduler.h
@@ -41,7 +41,6 @@ private:
     AP_HAL::Proc _delay_cb;
     uint16_t _min_delay_cb_ms;
     AP_HAL::Proc _failsafe;
-    volatile bool _timer_pending;
 
     volatile bool _timer_suspended;
 

--- a/libraries/AP_HAL_QURT/Scheduler.h
+++ b/libraries/AP_HAL_QURT/Scheduler.h
@@ -32,7 +32,6 @@ public:
     void     reboot(bool hold_in_bootloader);
 
     bool     in_timerprocess();
-    bool     system_initializing();
     void     system_initialized();
     void     hal_initialized();
     

--- a/libraries/AP_HAL_SITL/Scheduler.cpp
+++ b/libraries/AP_HAL_SITL/Scheduler.cpp
@@ -122,10 +122,6 @@ bool Scheduler::in_timerprocess() {
     return _in_timer_proc || _in_io_proc;
 }
 
-bool Scheduler::system_initializing() {
-    return !_initialized;
-}
-
 void Scheduler::system_initialized() {
     if (_initialized) {
         AP_HAL::panic(

--- a/libraries/AP_HAL_SITL/Scheduler.h
+++ b/libraries/AP_HAL_SITL/Scheduler.h
@@ -31,7 +31,6 @@ public:
 
     void     register_timer_failsafe(AP_HAL::Proc, uint32_t period_us);
 
-    bool     system_initializing();
     void     system_initialized();
 
     void     reboot(bool hold_in_bootloader);

--- a/libraries/AP_HAL_VRBRAIN/Scheduler.cpp
+++ b/libraries/AP_HAL_VRBRAIN/Scheduler.cpp
@@ -310,10 +310,6 @@ bool VRBRAINScheduler::in_timerprocess()
     return getpid() != _main_task_pid;
 }
 
-bool VRBRAINScheduler::system_initializing() {
-    return !_initialized;
-}
-
 void VRBRAINScheduler::system_initialized() {
     if (_initialized) {
         AP_HAL::panic("PANIC: scheduler::system_initialized called"

--- a/libraries/AP_HAL_VRBRAIN/Scheduler.h
+++ b/libraries/AP_HAL_VRBRAIN/Scheduler.h
@@ -37,7 +37,6 @@ public:
     void     reboot(bool hold_in_bootloader);
 
     bool     in_timerprocess();
-    bool     system_initializing();
     void     system_initialized();
     void     hal_initialized() { _hal_initialized = true; }
     

--- a/libraries/AP_HAL_VRBRAIN/Scheduler.h
+++ b/libraries/AP_HAL_VRBRAIN/Scheduler.h
@@ -46,7 +46,6 @@ private:
     AP_HAL::Proc _delay_cb;
     uint16_t _min_delay_cb_ms;
     AP_HAL::Proc _failsafe;
-    volatile bool _timer_pending;
 
     volatile bool _timer_suspended;
 


### PR DESCRIPTION
This adds an abstraction for handling threads.  In order to use a thread per bus the intention is to follow this:

1. Add another Thread variant, just like the PeriodicThread here, but which maintains the tasks for each bus (and order them correctly based on their update rate)
1. Get the #3544 PR applied
1. Move the register_timer_process() to register in the correct bus thread
1. Generalize the implementation from AP_HAL_Linux to AP_HAL

As is, this PR is already an improvement to the current state of Linux scheduler. It has been tested on erlebrain2 and minlure.