### PR TITLE
waf: add support for automatic submodule init and update

### DIFF
--- a/Tools/ardupilotwaf/gbenchmark.py
+++ b/Tools/ardupilotwaf/gbenchmark.py
@@ -49,13 +49,6 @@ def configure(cfg):
         )
         return
 
-    cfg.start_msg('Checking for gbenchmark submodule')
-    cmake_lists = cfg.srcnode.find_resource('modules/gbenchmark/CMakeLists.txt')
-    if not cmake_lists:
-        cfg.end_msg('not initialized', color='YELLOW')
-        return
-    cfg.end_msg('yes')
-
     cfg.find_program('cmake', mandatory=False)
 
     if not env.CMAKE:
@@ -74,25 +67,18 @@ def configure(cfg):
     bldnode = cfg.bldnode.make_node(cfg.variant)
     prefix_node = bldnode.make_node('gbenchmark')
     my_build_node = bldnode.make_node('gbenchmark_build')
-    my_src_node = cfg.srcnode.find_dir('modules/gbenchmark')
+    my_src_node = cfg.srcnode.make_node('modules/gbenchmark')
 
     env.GBENCHMARK_PREFIX_REL = prefix_node.path_from(bldnode)
     env.GBENCHMARK_BUILD = my_build_node.abspath()
     env.GBENCHMARK_BUILD_REL = my_build_node.path_from(bldnode)
     env.GBENCHMARK_SRC = my_src_node.abspath()
 
-    cfg.start_msg('Configuring gbenchmark')
-    try:
-        _configure_cmake(cfg, bldnode)
-        cfg.end_msg('done')
-    except:
-        cfg.end_msg('failed', color='YELLOW')
-        return
-
     env.INCLUDES_GBENCHMARK = [prefix_node.make_node('include').abspath()]
     env.LIBPATH_GBENCHMARK = [prefix_node.make_node('lib').abspath()]
     env.LIB_GBENCHMARK = ['benchmark']
 
+    env.append_value('GIT_SUBMODULES', 'gbenchmark')
     env.HAS_GBENCHMARK = True
 
 class gbenchmark_build(Task.Task):
@@ -115,10 +101,6 @@ class gbenchmark_build(Task.Task):
     def run(self):
         bld = self.generator.bld
         cmds = []
-
-        cmake_lists = bld.srcnode.find_resource('modules/gbenchmark/CMakeLists.txt')
-        if not cmake_lists:
-            bld.fatal('Submodule gbenchmark not initialized, please run configure again')
 
         try:
             # Generate build system first, if necessary

--- a/Tools/ardupilotwaf/git_submodule.py
+++ b/Tools/ardupilotwaf/git_submodule.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+"""
+Waf tool for defining ardupilot's submodules, so that they are kept up to date.
+Submodules can be considered dynamic sources, since they are updated during the
+build. Furthermore, they can be used to generate other dynamic sources (mavlink
+headers generation, for example). Thus, the correct use of this tool should
+have three build groups: first one for updating the submodules, second for
+generating any dynamic source from them, and the last one for the build. And
+post_mode should be set to POST_LAZY. Example::
+
+    def build(bld):
+        bld.post_mode = waflib.Build.POST_LAZY
+
+        bld.add_group('git_submodules')
+        # gtest submodule
+        bld(
+            features='git_submodule'
+            git_submodule='gtest',
+        )
+        # mavlink submodule with syntactic sugar
+        bld.git_submodule('mavlink')
+        ...
+
+        # now, for the dynamic sources
+        bld.add_group('dynamic_sources')
+        ...
+
+        # now, below go the task generators for normal build process
+        bld.add_group('build')
+        ...
+"""
+
+from waflib import Context, Task, Utils
+from waflib.Configure import conf
+from waflib.TaskGen import before_method, feature, taskgen_method
+
+import os.path
+
+class update_submodule(Task.Task):
+    color = 'BLUE'
+    run_str = '${GIT} -C ${SRC_ROOT} submodule update --init -- ${SUBMODULE_PATH}'
+
+    def runnable_status(self):
+        e = self.env.get_flat
+        cmd = e('GIT'), '-C', e('SRC_ROOT'), 'submodule', 'status', '--', e('SUBMODULE_PATH')
+        out = self.generator.bld.cmd_and_log(cmd, quiet=Context.BOTH)
+
+        # git submodule status uses a blank prefix for submodules that are up
+        # to date
+        if out[0] != ' ':
+            return Task.RUN_ME
+
+        return Task.SKIP_ME
+
+    def __str__(self):
+        return 'Submodule update: %s' % self.submodule
+
+def configure(cfg):
+    cfg.find_program('git')
+
+_submodules_tasks = {}
+
+@taskgen_method
+def git_submodule_update(self, name):
+    if name not in _submodules_tasks:
+        module_node = self.bld.srcnode.make_node(os.path.join('modules', name))
+
+        tsk = self.create_task('update_submodule', submodule=name)
+        tsk.env.SRC_ROOT = self.bld.srcnode.abspath()
+        tsk.env.SUBMODULE_PATH = module_node.abspath()
+
+        _submodules_tasks[name] = tsk
+
+    return _submodules_tasks[name]
+
+
+@feature('git_submodule')
+@before_method('process_source')
+def process_module_dependencies(self):
+    self.git_submodule = getattr(self, 'git_submodule', '')
+    if not self.git_submodule:
+        self.bld.fatal('git_submodule: empty or missing git_submodule argument')
+    self.git_submodule_update(self.git_submodule)
+
+@conf
+def git_submodule(bld, git_submodule, **kw):
+    kw['git_submodule'] = git_submodule
+    kw['features'] = Utils.to_list(kw.get('features', ''))
+    kw['features'].append('git_submodule')
+
+    return bld(**kw)

--- a/Tools/ardupilotwaf/gtest.py
+++ b/Tools/ardupilotwaf/gtest.py
@@ -20,13 +20,7 @@ def configure(cfg):
         )
         return
 
-    cfg.start_msg('Checking for gtest submodule')
-    readme = cfg.srcnode.find_resource('modules/gtest/README')
-    if not readme:
-        cfg.end_msg('not initialized', color='YELLOW')
-        return
-    cfg.end_msg('yes')
-
+    cfg.env.append_value('GIT_SUBMODULES', 'gtest')
     cfg.env.HAS_GTEST = True
 
 @conf

--- a/Tools/ardupilotwaf/gtest.py
+++ b/Tools/ardupilotwaf/gtest.py
@@ -5,6 +5,8 @@
 gtest is a Waf tool for test builds in Ardupilot
 """
 
+from waflib.Configure import conf
+
 def configure(cfg):
     cfg.env.HAS_GTEST = False
 
@@ -27,11 +29,13 @@ def configure(cfg):
 
     cfg.env.HAS_GTEST = True
 
-def build(bld):
-    bld.stlib(
+@conf
+def libgtest(bld, **kw):
+    kw.update(
         source='modules/gtest/src/gtest-all.cc',
         target='gtest/gtest',
         includes='modules/gtest/ modules/gtest/include',
         export_includes='modules/gtest/include',
         name='GTEST',
     )
+    return bld.stlib(**kw)

--- a/Tools/ardupilotwaf/mavgen.py
+++ b/Tools/ardupilotwaf/mavgen.py
@@ -53,11 +53,5 @@ def configure(cfg):
 
     env = cfg.env
 
-    cfg.start_msg('Checking for mavgen')
-    if not cfg.srcnode.find_resource('modules/mavlink/pymavlink/tools/mavgen.py'):
-        cfg.fatal('not found, please run: git submodule init && git submodule update')
-        return
-    cfg.end_msg('yes')
-
-    env.MAVLINK_DIR = cfg.srcnode.find_dir('modules/mavlink/').abspath()
+    env.MAVLINK_DIR = cfg.srcnode.make_node('modules/mavlink/').abspath()
     env.MAVGEN = env.MAVLINK_DIR  + '/pymavlink/tools/mavgen.py'

--- a/wscript
+++ b/wscript
@@ -155,6 +155,8 @@ def _build_common_taskgens(bld):
         use='mavlink',
     )
 
+    bld.libgtest()
+
 def _build_recursion(bld):
     common_dirs_patterns = [
         # TODO: Currently each vehicle also generate its own copy of the
@@ -203,7 +205,6 @@ def build(bld):
     bld.post_mode = Build.POST_LAZY
 
     bld.load('ardupilotwaf')
-    bld.load('gtest')
 
     _build_cmd_tweaks(bld)
 

--- a/wscript
+++ b/wscript
@@ -10,9 +10,7 @@ sys.path.insert(0, 'Tools/ardupilotwaf/')
 import ardupilotwaf
 import boards
 
-from waflib import ConfigSet, Utils
-from waflib.Build import BuildContext
-import waflib.Context
+from waflib import Build, ConfigSet, Context, Utils
 
 # TODO: implement a command 'waf help' that shows the basic tasks a
 # developer might want to do: e.g. how to configure a board, compile a
@@ -35,8 +33,8 @@ def init(ctx):
         return
 
     # define the variant build commands according to the board
-    for c in waflib.Context.classes:
-        if not issubclass(c, BuildContext):
+    for c in Context.classes:
+        if not issubclass(c, Build.BuildContext):
             continue
         c.variant = env.BOARD
 

--- a/wscript
+++ b/wscript
@@ -97,6 +97,8 @@ def configure(cfg):
     else:
         cfg.end_msg('disabled', color='YELLOW')
 
+    cfg.env.append_value('GIT_SUBMODULES', 'mavlink')
+
     cfg.env.prepend_value('INCLUDES', [
         cfg.srcnode.abspath() + '/libraries/',
     ])


### PR DESCRIPTION
Hi all,

This PR enables automatic init and update for git submodules in the waf build system.

The idea here is to do that only for the required submodules. So for example, if benchmarks are disabled due to cross-compilation, the submodule gbenchmark doesn't have to be checked. In the same way, when PX4 build is added to the waf build system, the respective submodules will be checked only if a px4-based board is select during configuration.

Best regards,
Gustavo Sousa