### PR TITLE
Plane: is_crashed to run at 5 Hz to match is_flying

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -328,8 +328,6 @@ void Plane::one_second_loop()
     AP_Notify::flags.pre_arm_gps_check = true;
     AP_Notify::flags.armed = arming.is_armed() || arming.arming_required() == AP_Arming::NO;
 
-    crash_detection_update();
-
 #if AP_TERRAIN_AVAILABLE
     if (should_log(MASK_LOG_GPS)) {
         terrain.log_terrain_data(DataFlash);

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -333,10 +333,6 @@ void Plane::one_second_loop()
         terrain.log_terrain_data(DataFlash);
     }
 #endif
-    // piggyback the status log entry on the MODE log entry flag
-    if (should_log(MASK_LOG_MODE)) {
-        Log_Write_Status();
-    }
 
     ins.set_raw_logging(should_log(MASK_LOG_IMU_RAW));
 }

--- a/ArduPlane/is_flying.cpp
+++ b/ArduPlane/is_flying.cpp
@@ -154,6 +154,8 @@ void Plane::update_is_flying_5Hz(void)
     }
     previous_is_flying = new_is_flying;
 
+    crash_detection_update();
+
     if (should_log(MASK_LOG_MODE)) {
         Log_Write_Status();
     }


### PR DESCRIPTION
This was running at 1 Hz, should be 5 Hz. Also removed a redundant STAT log entry where it was logged at 5 Hz and at 1 Hz. This removes the extra 1 Hz entry. STAT logs armed state plus is_flying and is_crashed state data