### PR TITLE
Plane: make throttle_percentage() signed and add to SYS_STATUS

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -1194,7 +1194,7 @@ void Plane::demo_servos(uint8_t i)
 void Plane::adjust_nav_pitch_throttle(void)
 {
     int8_t throttle = throttle_percentage();
-    if (throttle < aparm.throttle_cruise && flight_stage != AP_SpdHgtControl::FLIGHT_VTOL) {
+    if (throttle >= 0 && throttle < aparm.throttle_cruise && flight_stage != AP_SpdHgtControl::FLIGHT_VTOL) {
         float p = (aparm.throttle_cruise - throttle) / (float)aparm.throttle_cruise;
         nav_pitch_cd -= g.stab_pitch_down * 100.0f * p;
     }

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -765,7 +765,12 @@ int8_t Plane::throttle_percentage(void)
     }
     // to get the real throttle we need to use norm_output() which
     // returns a number from -1 to 1.
-    return constrain_int16(50*(channel_throttle->norm_output()+1), 0, 100);
+    if (aparm.throttle_min >= 0) {
+        return constrain_int16(50*(channel_throttle->norm_output()+1), 0, 100);
+    } else {
+        // reverse thrust
+        return constrain_int16(100*channel_throttle->norm_output(), -100, 100);
+    }
 }
 
 /*


### PR DESCRIPTION
add SYS_STATUS reverse_motor

- helpful to tell GCS to interpret VFR_HUD as negative when bit is enabled
- throttle is sent as abs()