### PR TITLE
waf: git_submodule: override uid()

### DIFF
--- a/Tools/ardupilotwaf/git_submodule.py
+++ b/Tools/ardupilotwaf/git_submodule.py
@@ -54,6 +54,15 @@ class update_submodule(Task.Task):
 
         return Task.SKIP_ME
 
+    def uid(self):
+        if not hasattr(self, 'uid_'):
+            m = Utils.md5()
+            m.update(self.__class__.__name__)
+            m.update(self.env.get_flat('SUBMODULE_PATH'))
+            self.uid_ = m.digest()
+
+        return self.uid_
+
     def __str__(self):
         return 'Submodule update: %s' % self.submodule
 


### PR DESCRIPTION
By running waf with option -v, waf was complaining about the update_submodule
tasks having the same identifier. That happened because the default uid()
method depended on the class name, inputs and outputs. Since this type of task
doesn't have input nor output file, we need to override uid() so that it uses
the submodule path for the task identifier.