### PR TITLE
Use pragma once

### DIFF
--- a/APMrover2/Parameters.h
+++ b/APMrover2/Parameters.h
@@ -1,7 +1,5 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef PARAMETERS_H
-#define PARAMETERS_H
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 
@@ -322,6 +320,3 @@ public:
 };
 
 extern const AP_Param::Info var_info[];
-
-#endif // PARAMETERS_H
-

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -16,9 +16,7 @@
 /* 
    main Rover class, containing all vehicle specific state
 */
-
-#ifndef _ROVER_H_
-#define _ROVER_H_
+#pragma once
 
 #define THISFIRMWARE "ArduRover v2.51-beta"
 #define FIRMWARE_VERSION 2,51,0,FIRMWARE_VERSION_TYPE_BETA
@@ -564,5 +562,3 @@ extern Rover rover;
 
 using AP_HAL::millis;
 using AP_HAL::micros;
-
-#endif // _ROVER_H_

--- a/APMrover2/compat.h
+++ b/APMrover2/compat.h
@@ -1,9 +1,4 @@
-
-#ifndef __COMPAT_H__
-#define __COMPAT_H__
+#pragma once
 
 #define HIGH 1
 #define LOW 0
-
-#endif // __COMPAT_H__
-

--- a/APMrover2/config.h
+++ b/APMrover2/config.h
@@ -19,6 +19,7 @@
 //
 // - Try to keep this file organised in the same order as APM_Config.h.example
 //
+#pragma once
 
 #include "defines.h"
 

--- a/APMrover2/defines.h
+++ b/APMrover2/defines.h
@@ -1,7 +1,5 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef _DEFINES_H
-#define _DEFINES_H
+#pragma once
 
 // Internal defines, don't edit and expect things to work
 // -------------------------------------------------------
@@ -126,5 +124,3 @@ enum mode {
 
 // convert a boolean (0 or 1) to a sign for multiplying (0 maps to 1, 1 maps to -1)
 #define BOOL_TO_SIGN(bvalue) ((bvalue)?-1:1)
-
-#endif // _DEFINES_H

--- a/AntennaTracker/Parameters.h
+++ b/AntennaTracker/Parameters.h
@@ -1,7 +1,5 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef PARAMETERS_H
-#define PARAMETERS_H
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 
@@ -163,5 +161,3 @@ public:
 };
 
 extern const AP_Param::Info var_info[];
-
-#endif // PARAMETERS_H

--- a/AntennaTracker/config.h
+++ b/AntennaTracker/config.h
@@ -1,5 +1,7 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
 //
+#pragma once
+
 #include "defines.h"
 
 #include "APM_Config.h" // <== THIS INCLUDE, DO NOT EDIT IT. EVER.

--- a/AntennaTracker/defines.h
+++ b/AntennaTracker/defines.h
@@ -1,7 +1,5 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef _DEFINES_H
-#define _DEFINES_H
+#pragma once
 
 // Command/Waypoint/Location Options Bitmask
 //--------------------
@@ -34,6 +32,3 @@ enum ServoType {
 #define MASK_LOG_RCOUT                  (1<<4)
 #define MASK_LOG_COMPASS                (1<<5)
 #define MASK_LOG_ANY                    0xFFFF
-
-#endif // _DEFINES_H
-

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -1,7 +1,5 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef _COPTER_H
-#define _COPTER_H
+#pragma once
 
 #define THISFIRMWARE "APM:Copter V3.4-dev"
 #define FIRMWARE_VERSION 3,4,0,FIRMWARE_VERSION_TYPE_DEV
@@ -1068,5 +1066,3 @@ extern Copter copter;
 
 using AP_HAL::millis;
 using AP_HAL::micros;
-
-#endif // _COPTER_H_

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -1,7 +1,5 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef PARAMETERS_H
-#define PARAMETERS_H
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 
@@ -589,6 +587,3 @@ public:
 };
 
 extern const AP_Param::Info        var_info[];
-
-#endif // PARAMETERS_H
-

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -1,7 +1,7 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
 //
-#ifndef __ARDUCOPTER_CONFIG_H__
-#define __ARDUCOPTER_CONFIG_H__
+#pragma once
+
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 //
@@ -769,5 +769,3 @@
 #else
 #define FIRMWARE_STRING THISFIRMWARE " (" GIT_VERSION ")"
 #endif
-
-#endif // __ARDUCOPTER_CONFIG_H__

--- a/ArduCopter/defines.h
+++ b/ArduCopter/defines.h
@@ -1,7 +1,5 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef _DEFINES_H
-#define _DEFINES_H
+#pragma once
 
 #include <AP_HAL/AP_HAL_Boards.h>
 
@@ -436,5 +434,3 @@ enum ThrowModeState {
 // for PILOT_THR_BHV parameter
 #define THR_BEHAVE_FEEDBACK_FROM_MID_STICK (1<<0)
 #define THR_BEHAVE_HIGH_THROTTLE_CANCELS_LAND (1<<1)
-
-#endif // _DEFINES_H

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -1,7 +1,5 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef PARAMETERS_H
-#define PARAMETERS_H
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 
@@ -552,5 +550,3 @@ public:
 };
 
 extern const AP_Param::Info var_info[];
-
-#endif // PARAMETERS_H

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1,7 +1,5 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef _PLANE_H
-#define _PLANE_H
+#pragma once
 
 #define THISFIRMWARE "ArduPlane V3.5.0"
 #define FIRMWARE_VERSION 3,5,0,FIRMWARE_VERSION_TYPE_OFFICIAL
@@ -1067,5 +1065,3 @@ extern Plane plane;
 
 using AP_HAL::millis;
 using AP_HAL::micros;
-
-#endif // _PLANE_H_

--- a/ArduPlane/config.h
+++ b/ArduPlane/config.h
@@ -19,6 +19,7 @@
 //
 // - Try to keep this file organised in the same order as APM_Config.h.example
 //
+#pragma once
 
 #include "defines.h"
 

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -1,7 +1,5 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef _DEFINES_H
-#define _DEFINES_H
+#pragma once
 
 // Internal defines, don't edit and expect things to work
 // -------------------------------------------------------
@@ -207,5 +205,3 @@ enum {
     USE_REVERSE_THRUST_FBWB                     = (1<<9),
     USE_REVERSE_THRUST_GUIDED                   = (1<<10),
 };
-
-#endif // _DEFINES_H

--- a/Tools/ArduPPM/Libraries/PPM_Encoder.h
+++ b/Tools/ArduPPM/Libraries/PPM_Encoder.h
@@ -147,9 +147,7 @@
 //         - ppm_encoder_init() will now make sure PPM output always starts with fail-safe (900us) value on throttle after a brown-out reset
 
 // -------------------------------------------------------------
-
-#ifndef _PPM_ENCODER_H_
-#define _PPM_ENCODER_H_
+#pragma once
 
 #include <avr/io.h>
 
@@ -1055,6 +1053,3 @@ void ppm_encoder_init( void )
     }
 }
 // ------------------------------------------------------------------------------
-
-#endif // _PPM_ENCODER_H_
-

--- a/Tools/ArduPPM/Libraries/PPM_Encoder_v3.h
+++ b/Tools/ArduPPM/Libraries/PPM_Encoder_v3.h
@@ -14,9 +14,7 @@
 // -------------------------------------------------------------
 
 // Not for production - Work in progress
-
-#ifndef _PPM_ENCODER_H_
-#define _PPM_ENCODER_H_
+#pragma once
 
 #include <avr/io.h>
 #include <avr/interrupt.h>
@@ -1474,6 +1472,3 @@ void ppm_encoder_init( void )
 	
 }
 // ------------------------------------------------------------------------------
-
-#endif // _PPM_ENCODER_H_
-

--- a/Tools/Linux_HAL_Essentials/pru/pwmpru/linux_types.h
+++ b/Tools/Linux_HAL_Essentials/pru/pwmpru/linux_types.h
@@ -1,5 +1,4 @@
-#ifndef LINUX_TYPES_H
-#define LINUX_TYPES_H
+#pragma once
 
 #include <stdint.h>
 
@@ -14,6 +13,3 @@ typedef uint32_t u32;
 typedef uint64_t u64;
 
 #define __packed __attribute__((packed))
-
-
-#endif

--- a/Tools/Linux_HAL_Essentials/pru/pwmpru/pru_defs.h
+++ b/Tools/Linux_HAL_Essentials/pru/pwmpru/pru_defs.h
@@ -1,5 +1,4 @@
-#ifndef PRU_DEFS_H
-#define PRU_DEFS_H
+#pragma once
 
 volatile register unsigned int __R31;
 volatile register unsigned int __R30;
@@ -643,7 +642,5 @@ static inline void pru_other_and_or_reg(u16 reg, u32 andmsk, u32 ormsk)
 	PDBG_OTHER(reg) = (PDBG_OTHER(reg) & andmsk) | ormsk;
 	pru_other_resume();
 }
-
-#endif
 
 #endif

--- a/Tools/Linux_HAL_Essentials/pru/pwmpru/prucomm.h
+++ b/Tools/Linux_HAL_Essentials/pru/pwmpru/prucomm.h
@@ -2,8 +2,7 @@
  * prucomm.h - structure definitions for communication
  *
  */
-#ifndef PRUCOMM_H
-#define PRUCOMM_H
+#pragma once
 
 #include "pru_defs.h"
 
@@ -71,5 +70,3 @@ struct cxt {
 
 /* the command is at the start of shared DPRAM */
 #define PWM_CMD		((volatile struct pwm_cmd *)DPRAM_SHARED)
-
-#endif

--- a/Tools/Linux_HAL_Essentials/pru/rcinpru/linux_types.h
+++ b/Tools/Linux_HAL_Essentials/pru/rcinpru/linux_types.h
@@ -1,5 +1,4 @@
-#ifndef LINUX_TYPES_H
-#define LINUX_TYPES_H
+#pragma once
 
 #include <stdint.h>
 
@@ -14,6 +13,3 @@ typedef uint32_t u32;
 typedef uint64_t u64;
 
 #define __packed __attribute__((packed))
-
-
-#endif

--- a/Tools/Linux_HAL_Essentials/pru/rcinpru/pru_defs.h
+++ b/Tools/Linux_HAL_Essentials/pru/rcinpru/pru_defs.h
@@ -1,5 +1,4 @@
-#ifndef PRU_DEFS_H
-#define PRU_DEFS_H
+#pragma once
 
 volatile register unsigned int __R31;
 volatile register unsigned int __R30;
@@ -643,7 +642,5 @@ static inline void pru_other_and_or_reg(u16 reg, u32 andmsk, u32 ormsk)
 	PDBG_OTHER(reg) = (PDBG_OTHER(reg) & andmsk) | ormsk;
 	pru_other_resume();
 }
-
-#endif
 
 #endif

--- a/Tools/Linux_HAL_Essentials/pru/rcinpru/prucomm.h
+++ b/Tools/Linux_HAL_Essentials/pru/rcinpru/prucomm.h
@@ -2,8 +2,7 @@
  * prucomm.h - structure definitions for communication
  *
  */
-#ifndef PRUCOMM_H
-#define PRUCOMM_H
+#pragma once
 
 #include "pru_defs.h"
 
@@ -23,5 +22,3 @@ struct ring_buffer {
 
 /* the command is at the start of shared DPRAM */
 #define RBUFF        ((volatile struct ring_buffer *)DPRAM_SHARED)
-
-#endif

--- a/Tools/Replay/DataFlashFileReader.h
+++ b/Tools/Replay/DataFlashFileReader.h
@@ -1,5 +1,4 @@
-#ifndef REPLAY_DATAFLASHREADER_H
-#define REPLAY_DATAFLASHREADER_H
+#pragma once
 
 #include <DataFlash/DataFlash.h>
 
@@ -20,5 +19,3 @@ protected:
 #define LOGREADER_MAX_FORMATS 255 // must be >= highest MESSAGE
     struct log_Format formats[LOGREADER_MAX_FORMATS] {};
 };
-
-#endif

--- a/Tools/Replay/LR_MsgHandler.h
+++ b/Tools/Replay/LR_MsgHandler.h
@@ -1,5 +1,4 @@
-#ifndef AP_LR_MSGHANDLER_H
-#define AP_LR_MSGHANDLER_H
+#pragma once
 
 #include "MsgHandler.h"
 
@@ -414,6 +413,3 @@ public:
 private:
     Vector3f &sim_attitude;
 };
-
-
-#endif

--- a/Tools/Replay/MsgHandler.h
+++ b/Tools/Replay/MsgHandler.h
@@ -1,5 +1,4 @@
-#ifndef AP_MSGHANDLER_H
-#define AP_MSGHANDLER_H
+#pragma once
 
 #include <DataFlash/DataFlash.h>
 #include "VehicleType.h"
@@ -152,5 +151,3 @@ inline void MsgHandler::field_value_for_type_at_offset(uint8_t *msg,
         exit(1);
     }
 }
-
-#endif

--- a/Tools/Replay/Parameters.h
+++ b/Tools/Replay/Parameters.h
@@ -1,7 +1,5 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef PARAMETERS_H
-#define PARAMETERS_H
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 
@@ -23,5 +21,3 @@ public:
 };
 
 extern const AP_Param::Info var_info[];
-
-#endif // PARAMETERS_H

--- a/Tools/Replay/VehicleType.h
+++ b/Tools/Replay/VehicleType.h
@@ -1,5 +1,4 @@
-#ifndef AP_VEHICLETYPE_H
-#define AP_VEHICLETYPE_H
+#pragma once
 
 class VehicleType {
 public:
@@ -10,5 +9,3 @@ public:
         VEHICLE_ROVER
     };
 };
-
-#endif

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -1,10 +1,8 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: t -*-
+#pragma once
 
 /// @file    AC_AttitudeControl.h
 /// @brief   ArduCopter attitude control library
-
-#ifndef AC_AttitudeControl_H
-#define AC_AttitudeControl_H
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
@@ -354,5 +352,3 @@ protected:
 
 #define AC_ATTITUDE_CONTROL_LOG_FORMAT(msg) { msg, sizeof(AC_AttitudeControl::log_Attitude),	\
                             "ATT", "cccccCC",      "RollIn,Roll,PitchIn,Pitch,YawIn,Yaw,NavYaw" }
-
-#endif //AC_AttitudeControl_H

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.h
@@ -1,10 +1,8 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: t -*-
+#pragma once
 
 /// @file    AC_AttitudeControl_Heli.h
 /// @brief   ArduCopter attitude control library for traditional helicopters
-
-#ifndef AC_ATTITUDECONTROL_HELI_H
-#define AC_ATTITUDECONTROL_HELI_H
 
 #include "AC_AttitudeControl.h"
 #include <AP_Motors/AP_MotorsHeli.h>
@@ -133,5 +131,3 @@ private:
     LowPassFilterFloat yaw_acceleration_feedforward_filter;
 
 };
-
-#endif //AC_ATTITUDECONTROL_HELI_H

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.h
@@ -1,10 +1,8 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: t -*-
+#pragma once
 
 /// @file    AC_AttitudeControl_Multi.h
 /// @brief   ArduCopter attitude control library
-
-#ifndef AC_AttitudeControl_Multi_H
-#define AC_AttitudeControl_Multi_H
 
 #include "AC_AttitudeControl.h"
 #include <AP_Motors/AP_MotorsMulticopter.h>
@@ -34,5 +32,3 @@ protected:
 
     AP_MotorsMulticopter& _motors_multi;
 };
-
-#endif // AC_AttitudeControl_Multi_H

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -1,6 +1,5 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-#ifndef AC_POSCONTROL_H
-#define AC_POSCONTROL_H
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
@@ -407,4 +406,3 @@ private:
     Vector2f    _accel_target_jerk_limited; // acceleration target jerk limited to 100deg/s/s
     LowPassFilterVector2f _accel_target_filter; // acceleration target filter
 };
-#endif	// AC_POSCONTROL_H

--- a/libraries/AC_Fence/AC_Fence.h
+++ b/libraries/AC_Fence/AC_Fence.h
@@ -1,6 +1,5 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-#ifndef AC_FENCE_H
-#define AC_FENCE_H
+#pragma once
 
 #include <inttypes.h>
 #include <AP_Common/AP_Common.h>
@@ -124,4 +123,3 @@ private:
 
     uint32_t        _manual_recovery_start_ms;  // system time in milliseconds that pilot re-took manual control
 };
-#endif	// AC_FENCE_H

--- a/libraries/AC_InputManager/AC_InputManager.h
+++ b/libraries/AC_InputManager/AC_InputManager.h
@@ -1,10 +1,8 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+#pragma once
 
 /// @file   AC_InputManager.h
 /// @brief  Pilot manual control input library
-
-#ifndef AC_INPUTMANAGER_H
-#define AC_INPUTMANAGER_H
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
@@ -29,5 +27,3 @@ protected:
     uint16_t            _loop_rate;             // rate at which output() function is called (normally 400hz)
 
 };
-
-#endif /* AC_INPUTMANAGER_H */

--- a/libraries/AC_InputManager/AC_InputManager_Heli.h
+++ b/libraries/AC_InputManager/AC_InputManager_Heli.h
@@ -1,10 +1,8 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+#pragma once
 
 /// @file   AC_InputManager_Heli.h
 /// @brief  Pilot manual control input library for Conventional Helicopter
-
-#ifndef AC_INPUTMANAGER_HELI_H
-#define AC_INPUTMANAGER_HELI_H
 
 #include <AP_Param/AP_Param.h>
 #include <AP_Common/AP_Common.h>
@@ -54,5 +52,3 @@ private:
     AP_Float        _acro_col_expo;                 // used to soften collective pitch inputs near center point in Acro mode
 
 };
-
-#endif /* AC_INPUTMANAGER_HELI_H */

--- a/libraries/AC_PID/AC_HELI_PID.h
+++ b/libraries/AC_PID/AC_HELI_PID.h
@@ -1,10 +1,8 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+#pragma once
 
 /// @file	AC_HELI_PID.h
 /// @brief	Helicopter Specific Rate PID algorithm, with EEPROM-backed storage of constants.
-
-#ifndef __AC_HELI_PID_H__
-#define __AC_HELI_PID_H__
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
@@ -45,5 +43,3 @@ private:
     float           _last_requested_rate;       // Requested rate from last iteration, used to calculate rate change of requested rate
     
 };
-
-#endif // __AC_HELI_PID_H__

--- a/libraries/AC_PID/AC_P.h
+++ b/libraries/AC_PID/AC_P.h
@@ -1,10 +1,8 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+#pragma once
 
 /// @file	AC_PD.h
 /// @brief	Generic PID algorithm, with EEPROM-backed storage of constants.
-
-#ifndef __AC_P_H__
-#define __AC_P_H__
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
@@ -67,5 +65,3 @@ public:
 private:
     AP_Float        _kp;
 };
-
-#endif // __AC_P_H__

--- a/libraries/AC_PID/AC_PID.h
+++ b/libraries/AC_PID/AC_PID.h
@@ -1,10 +1,8 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+#pragma once
 
 /// @file	AC_PID.h
 /// @brief	Generic PID algorithm, with EEPROM-backed storage of constants.
-
-#ifndef __AC_PID_H__
-#define __AC_PID_H__
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
@@ -106,5 +104,3 @@ protected:
 
     DataFlash_Class::PID_Info        _pid_info;
 };
-
-#endif // __AC_PID_H__

--- a/libraries/AC_PID/AC_PI_2D.h
+++ b/libraries/AC_PID/AC_PI_2D.h
@@ -1,10 +1,8 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+#pragma once
 
 /// @file	AC_PI_2D.h
 /// @brief	Generic PID algorithm, with EEPROM-backed storage of constants.
-
-#ifndef __AC_PI_2D_H__
-#define __AC_PI_2D_H__
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
@@ -94,5 +92,3 @@ protected:
     Vector2f        _input;         // last input for derivative
     float           _filt_alpha;    // input filter alpha
 };
-
-#endif // __AC_PI_2D_H__

--- a/libraries/AC_PrecLand/AC_PrecLand.h
+++ b/libraries/AC_PrecLand/AC_PrecLand.h
@@ -1,6 +1,5 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-#ifndef __AC_PRECLAND_H__
-#define __AC_PRECLAND_H__
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Math/AP_Math.h>
@@ -108,4 +107,3 @@ private:
     } _backend_state;
     AC_PrecLand_Backend         *_backend;  // pointers to backend precision landing driver
 };
-#endif	// __AC_PRECLAND_H__

--- a/libraries/AC_PrecLand/AC_PrecLand_Backend.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_Backend.h
@@ -1,6 +1,5 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-#ifndef __AC_PRECLAND_BACKEND_H__
-#define __AC_PRECLAND_BACKEND_H__
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Math/AP_Math.h>
@@ -43,4 +42,3 @@ protected:
     const AC_PrecLand&  _frontend;          // reference to precision landing front end
     AC_PrecLand::precland_state &_state;    // reference to this instances state
 };
-#endif	// __AC_PRECLAND_BACKEND_H__

--- a/libraries/AC_PrecLand/AC_PrecLand_Companion.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_Companion.h
@@ -1,6 +1,5 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-#ifndef __AC_PRECLAND_COMPANION_H__
-#define __AC_PRECLAND_COMPANION_H__
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Math/AP_Math.h>
@@ -45,4 +44,3 @@ private:
     uint64_t            _timestamp_us;          // timestamp when the image was captured(synced via UAVCAN)
     bool                _new_estimate;          // true if new data from the camera has been received
 };
-#endif	// __AC_PRECLAND_COMPANION_H__

--- a/libraries/AC_PrecLand/AC_PrecLand_IRLock.h
+++ b/libraries/AC_PrecLand/AC_PrecLand_IRLock.h
@@ -1,6 +1,5 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-#ifndef __AC_PRECLAND_IRLOCK_H__
-#define __AC_PRECLAND_IRLOCK_H__
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Math/AP_Math.h>
@@ -45,4 +44,3 @@ private:
 
 };
 #endif
-#endif	// __AC_PRECLAND_IRLOCK_H__

--- a/libraries/AC_Sprayer/AC_Sprayer.h
+++ b/libraries/AC_Sprayer/AC_Sprayer.h
@@ -16,9 +16,7 @@
         8. set the SPRAY_PUMP_MIN to the minimum value that the pump servo should move to while engaged expressed as a percentage (i.e. 0 ~ 100) of the full servo range
         9. set the SPRAY_SPEED_MIN to the minimum speed (in cm/s) the vehicle should be moving at before the pump and sprayer are turned on.  0 will mean the pump and spinner will always be on when the system is enabled with ch7/ch8 switch
 **/
-
-#ifndef AC_SPRAYER_H
-#define AC_SPRAYER_H
+#pragma once
 
 #include <inttypes.h>
 #include <AP_Common/AP_Common.h>
@@ -83,5 +81,3 @@ private:
     uint32_t        _speed_over_min_time;   // time at which we reached speed minimum
     uint32_t        _speed_under_min_time;  // time at which we fell below speed minimum
 };
-
-#endif /* AC_SPRAYER_H */

--- a/libraries/AC_WPNav/AC_Circle.h
+++ b/libraries/AC_WPNav/AC_Circle.h
@@ -1,6 +1,5 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-#ifndef AC_CIRCLE_H
-#define AC_CIRCLE_H
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
@@ -101,4 +100,3 @@ private:
     float       _angular_vel_max;   // maximum velocity in radians/sec
     float       _angular_accel; // angular acceleration in radians/sec/sec
 };
-#endif	// AC_CIRCLE_H

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -1,6 +1,5 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-#ifndef AC_WPNAV_H
-#define AC_WPNAV_H
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
@@ -321,4 +320,3 @@ protected:
     float       _spline_vel_scaler;	    //
     float       _yaw;                   // heading according to yaw
 };
-#endif	// AC_WPNAV_H

--- a/libraries/APM_Control/AP_AutoTune.h
+++ b/libraries/APM_Control/AP_AutoTune.h
@@ -1,7 +1,5 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef __AP_AUTOTUNE_H__
-#define __AP_AUTOTUNE_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
@@ -100,6 +98,3 @@ private:
     void save_float_if_changed(AP_Float &v, float value, const char *suffix);
     void save_int16_if_changed(AP_Int16 &v, int16_t value, const char *suffix);
 };
-
-#endif // __AP_AUTOTUNE_H__
-

--- a/libraries/APM_Control/AP_PitchController.h
+++ b/libraries/APM_Control/AP_PitchController.h
@@ -1,7 +1,5 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef __AP_PITCH_CONTROLLER_H__
-#define __AP_PITCH_CONTROLLER_H__
+#pragma once
 
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Common/AP_Common.h>
@@ -49,5 +47,3 @@ private:
 	AP_AHRS &_ahrs;
 	
 };
-
-#endif // __AP_PITCH_CONTROLLER_H__

--- a/libraries/APM_Control/AP_RollController.h
+++ b/libraries/APM_Control/AP_RollController.h
@@ -1,7 +1,5 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef __AP_ROLL_CONTROLLER_H__
-#define __AP_ROLL_CONTROLLER_H__
+#pragma once
 
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Common/AP_Common.h>
@@ -46,5 +44,3 @@ private:
 	AP_AHRS &_ahrs;
 
 };
-
-#endif // __AP_ROLL_CONTROLLER_H__

--- a/libraries/APM_Control/AP_SteerController.h
+++ b/libraries/APM_Control/AP_SteerController.h
@@ -1,7 +1,5 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef __AP_STEER_CONTROLLER_H__
-#define __AP_STEER_CONTROLLER_H__
+#pragma once
 
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Common/AP_Common.h>
@@ -62,5 +60,3 @@ private:
 
 	AP_AHRS &_ahrs;
 };
-
-#endif // __AP_STEER_CONTROLLER_H__

--- a/libraries/APM_Control/AP_YawController.h
+++ b/libraries/APM_Control/AP_YawController.h
@@ -1,7 +1,5 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef __AP_YAW_CONTROLLER_H__
-#define __AP_YAW_CONTROLLER_H__
+#pragma once
 
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Common/AP_Common.h>
@@ -49,5 +47,3 @@ private:
 
 	AP_AHRS &_ahrs;
 };
-
-#endif // __AP_YAW_CONTROLLER_H__

--- a/libraries/APM_OBC/APM_OBC.h
+++ b/libraries/APM_OBC/APM_OBC.h
@@ -1,7 +1,6 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+#pragma once
 
-#ifndef APM_OBC_H
-#define APM_OBC_H
 /*
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -132,5 +131,3 @@ private:
 
 // map from ArduPlane control_mode to APM_OBC::control_mode
 #define OBC_MODE(control_mode) (auto_throttle_mode?APM_OBC::OBC_AUTO:(control_mode==MANUAL?APM_OBC::OBC_MANUAL:APM_OBC::OBC_FBW))
-
-#endif // APM_OBC_H

--- a/libraries/AP_ADSB/AP_ADSB.h
+++ b/libraries/AP_ADSB/AP_ADSB.h
@@ -1,7 +1,6 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+#pragma once
 
-#ifndef AP_ADSB_H
-#define AP_ADSB_H
 /*
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -117,4 +116,3 @@ private:
     uint16_t    _highest_threat_index = 0;
     float       _highest_threat_distance = 0;
 };
-#endif // AP_ADSB_H

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -1,7 +1,6 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+#pragma once
 
-#ifndef __AP_AHRS_H__
-#define __AP_AHRS_H__
 /*
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -513,5 +512,3 @@ protected:
 #else
 #define AP_AHRS_TYPE AP_AHRS
 #endif
-
-#endif // __AP_AHRS_H__

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -1,6 +1,6 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-#ifndef __AP_AHRS_DCM_H__
-#define __AP_AHRS_DCM_H__
+#pragma once
+
 /*
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -206,5 +206,3 @@ private:
     // time when DCM was last reset
     uint32_t _last_startup_ms;
 };
-
-#endif // __AP_AHRS_DCM_H__

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF.h
@@ -1,6 +1,6 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-#ifndef __AP_AHRS_NAVEKF_H__
-#define __AP_AHRS_NAVEKF_H__
+#pragma once
+
 /*
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -245,5 +245,3 @@ private:
 #endif    
 };
 #endif
-
-#endif // __AP_AHRS_NAVEKF_H__

--- a/libraries/AP_AccelCal/AP_AccelCal.h
+++ b/libraries/AP_AccelCal/AP_AccelCal.h
@@ -1,5 +1,4 @@
-#ifndef __AP_ACCELCAL_H__
-#define __AP_ACCELCAL_H__
+#pragma once
 
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include "AccelCalibrator.h"
@@ -83,5 +82,3 @@ private:
     virtual void _acal_event_cancellation() {};
     virtual void _acal_event_failure() {};
 };
-
-#endif

--- a/libraries/AP_AccelCal/AccelCalibrator.h
+++ b/libraries/AP_AccelCal/AccelCalibrator.h
@@ -11,9 +11,8 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+#pragma once
 
-#ifndef __ACCELCALIBRATOR_H__
-#define __ACCELCALIBRATOR_H__
 #include <AP_Math/AP_Math.h>
 #include <AP_Math/vectorN.h>
 
@@ -144,4 +143,3 @@ private:
     void calc_jacob(const Vector3f& sample, const struct param_t& params, VectorP& ret) const;
     void run_fit(uint8_t max_iterations, float& fitness);
 };
-#endif //__ACCELCALIBRATOR_H__

--- a/libraries/AP_Airspeed/AP_Airspeed_Backend.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_Backend.h
@@ -14,11 +14,11 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#pragma once
 
 /*
   backend driver class for airspeed
  */
-#pragma once
 
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>

--- a/libraries/AP_Airspeed/AP_Airspeed_I2C.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_I2C.h
@@ -14,11 +14,11 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#pragma once
 
 /*
   backend driver for airspeed from I2C
  */
-#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 

--- a/libraries/AP_Airspeed/AP_Airspeed_PX4.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_PX4.h
@@ -14,11 +14,11 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#pragma once
 
 /*
   backend driver for airspeed from PX4Firmware
  */
-#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #include "AP_Airspeed_Backend.h"

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -1,7 +1,5 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef __AP_ARMING_H__
-#define __AP_ARMING_H__ 
+#pragma once
 
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_BattMonitor/AP_BattMonitor.h>
@@ -110,5 +108,3 @@ protected:
 
     bool manual_transmitter_checks(bool report);
 };
-
-#endif //__AP_ARMING_H__

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -1,7 +1,5 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef __AP_BOARDCONFIG_H__
-#define __AP_BOARDCONFIG_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Common/AP_Common.h>
@@ -37,7 +35,3 @@ private:
 
 #endif
 };
-
-#endif // __AP_BOARDCONFIG_H__
-
-

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -2,9 +2,7 @@
 
 /// @file	AP_Camera.h
 /// @brief	Photo or video camera manager, with EEPROM-backed storage of constants.
-
-#ifndef AP_CAMERA_H
-#define AP_CAMERA_H
+#pragma once
 
 #include <AP_Param/AP_Param.h>
 #include <AP_Common/AP_Common.h>
@@ -102,5 +100,3 @@ private:
     bool            _timer_installed:1;
     uint8_t         _last_pin_state;
 };
-
-#endif /* AP_CAMERA_H */

--- a/libraries/AP_EPM/AP_EPM.h
+++ b/libraries/AP_EPM/AP_EPM.h
@@ -11,9 +11,7 @@
 
 /// @file	AP_EPM.h
 /// @brief	AP_EPM control class
-
-#ifndef __AP_EPM_h__
-#define __AP_EPM_h__
+#pragma once
 
 #include <AP_Math/AP_Math.h>
 #include <AP_Common/AP_Common.h>
@@ -71,5 +69,3 @@ private:
     // internal variables
     uint32_t    _last_grab_or_release;
 };
-
-#endif /* _AP_EPM_H_ */

--- a/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_Telem.h
@@ -13,9 +13,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-
-#ifndef __AP_FRSKY_TELEM_H__
-#define __AP_FRSKY_TELEM_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
@@ -184,4 +182,3 @@ private:
 
     uint8_t _sport_status;
 };
-#endif

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -13,9 +13,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-#ifndef __AP_GPS_H__
-#define __AP_GPS_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #include <inttypes.h>
@@ -411,5 +409,3 @@ private:
 #include "AP_GPS_SBF.h"
 #include "AP_GPS_GSOF.h"
 #include "AP_GPS_ERB.h"
-
-#endif // __AP_GPS_H__

--- a/libraries/AP_GPS/AP_GPS_GSOF.h
+++ b/libraries/AP_GPS/AP_GPS_GSOF.h
@@ -18,9 +18,7 @@
 //  Trimble GPS driver for ArduPilot.
 //	Code by Michael Oborne
 //
-
-#ifndef __AP_GPS_GSOF_H__
-#define __AP_GPS_GSOF_H__
+#pragma once
 
 #include "AP_GPS.h"
 
@@ -88,5 +86,3 @@ private:
     uint32_t crc_error_counter = 0;
     uint32_t last_injected_data_ms = 0;
 };
-
-#endif // __AP_GPS_GSOF_H__

--- a/libraries/AP_GPS/AP_GPS_MTK.h
+++ b/libraries/AP_GPS/AP_GPS_MTK.h
@@ -22,8 +22,7 @@
 //
 // Note - see AP_GPS_MTK16.h for firmware 1.6 and later.
 //
-#ifndef __AP_GPS_MTK_H__
-#define __AP_GPS_MTK_H__
+#pragma once
 
 #include "AP_GPS.h"
 #include "AP_GPS_MTK_Common.h"
@@ -80,5 +79,3 @@ private:
 
     static const char _initialisation_blob[];
 };
-
-#endif  // __AP_GPS_MTK_H__

--- a/libraries/AP_GPS/AP_GPS_MTK19.h
+++ b/libraries/AP_GPS/AP_GPS_MTK19.h
@@ -20,8 +20,7 @@
 //
 //	GPS configuration : Custom protocol per "Customize Function Specification, 3D Robotics, v1.6, v1.7, v1.8, v1.9"
 //
-#ifndef AP_GPS_MTK19_h
-#define AP_GPS_MTK19_h
+#pragma once
 
 #include "AP_GPS.h"
 #include "AP_GPS_MTK_Common.h"
@@ -81,5 +80,3 @@ private:
         uint8_t bytes[];
     } _buffer;
 };
-
-#endif  // AP_GPS_MTK19_H

--- a/libraries/AP_GPS/AP_GPS_MTK_Common.h
+++ b/libraries/AP_GPS/AP_GPS_MTK_Common.h
@@ -19,9 +19,7 @@
 //	Code by Michael Smith, Jordi Munoz and Jose Julio, Craig Elder, DIYDrones.com
 //
 // Common definitions for MediaTek GPS modules.
-
-#ifndef __AP_GPS_MTK_COMMON_H__
-#define __AP_GPS_MTK_COMMON_H__
+#pragma once
 
 #define MTK_SET_BINARY		"$PGCMD,16,0,0,0,0,0*6A\r\n"
 #define MTK_SET_NMEA		"$PGCMD,16,1,1,1,1,1*6B\r\n"
@@ -41,5 +39,3 @@
 
 #define WAAS_ON         	"$PMTK301,2*2E\r\n"
 #define WAAS_OFF        	"$PMTK301,0*2C\r\n"
-
-#endif // __AP_GPS_MTK_COMMON_H__

--- a/libraries/AP_GPS/AP_GPS_NMEA.h
+++ b/libraries/AP_GPS/AP_GPS_NMEA.h
@@ -42,10 +42,7 @@
 /// qualifier field (this is common with e.g. older SiRF units) it is
 /// not considered a source of fix-valid information.
 ///
-
-
-#ifndef __AP_GPS_NMEA_H__
-#define __AP_GPS_NMEA_H__
+#pragma once
 
 #include "AP_GPS.h"
 
@@ -162,5 +159,3 @@ private:
 
     static const char _initialisation_blob[];
 };
-
-#endif // __AP_GPS_NMEA_H__

--- a/libraries/AP_GPS/AP_GPS_PX4.h
+++ b/libraries/AP_GPS/AP_GPS_PX4.h
@@ -18,8 +18,7 @@
 //  GPS proxy driver for APM on PX4 platforms
 //  Code by Holger Steinhaus
 //
-#ifndef __AP_GPS_PX4_H__
-#define __AP_GPS_PX4_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #include "AP_GPS.h"
@@ -37,5 +36,3 @@ private:
     struct vehicle_gps_position_s _gps_pos;
 };
 #endif // CONFIG_HAL_BOARD
-#endif // AP_GPS_PX4_H
-

--- a/libraries/AP_GPS/AP_GPS_SBF.h
+++ b/libraries/AP_GPS/AP_GPS_SBF.h
@@ -18,9 +18,7 @@
 //  Septentrio GPS driver for ArduPilot.
 //	Code by Michael Oborne
 //
-
-#ifndef __AP_GPS_SBF_H__
-#define __AP_GPS_SBF_H__
+#pragma once
 
 #include "AP_GPS.h"
 
@@ -138,6 +136,3 @@ private:
 
     void log_ExtEventPVTGeodetic(const msg4007 &temp);
 };
-
-#endif // __AP_GPS_SBF_H__
-

--- a/libraries/AP_GPS/AP_GPS_SBP.h
+++ b/libraries/AP_GPS/AP_GPS_SBP.h
@@ -20,9 +20,7 @@
 //
 //  Swift Binary Protocol format: http://docs.swift-nav.com/
 //
-
-#ifndef __AP_GPS_SBP_H__
-#define __AP_GPS_SBP_H__
+#pragma once
 
 #include "AP_GPS.h"
 
@@ -169,5 +167,3 @@ private:
    
 
 };
-
-#endif // __AP_GPS_SBP_H__

--- a/libraries/AP_GPS/AP_GPS_SIRF.h
+++ b/libraries/AP_GPS/AP_GPS_SIRF.h
@@ -18,8 +18,7 @@
 //  SiRF Binary GPS driver for ArduPilot and ArduPilotMega.
 //	Code by Michael Smith.
 //
-#ifndef __AP_GPS_SIRF_H__
-#define __AP_GPS_SIRF_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Common/AP_Common.h>
@@ -105,5 +104,3 @@ private:
 
     static const uint8_t _initialisation_blob[];
 };
-
-#endif // AP_GPS_SIRF_h

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -19,9 +19,7 @@
 //	Code by Michael Smith, Jordi Munoz and Jose Julio, DIYDrones.com
 //
 //  UBlox Lea6H protocol: http://www.u-blox.com/images/downloads/Product_Docs/u-blox6_ReceiverDescriptionProtocolSpec_%28GPS.G6-SW-10018%29.pdf
-
-#ifndef __AP_GPS_UBLOX_H__
-#define __AP_GPS_UBLOX_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #include "AP_GPS.h"
@@ -537,5 +535,3 @@ private:
         return (uint8_t)(ubx_msg + (state.instance * UBX_MSG_TYPES));
     }
 };
-
-#endif // __AP_GPS_UBLOX_H__

--- a/libraries/AP_GPS/GPS_Backend.h
+++ b/libraries/AP_GPS/GPS_Backend.h
@@ -17,8 +17,7 @@
 /*
   GPS driver backend class
  */
-#ifndef __AP_GPS_BACKEND_H__
-#define __AP_GPS_BACKEND_H__
+#pragma once
 
 #include <GCS_MAVLink/GCS_MAVLink.h>
 #include "AP_GPS.h"
@@ -70,5 +69,3 @@ protected:
     */
     void make_gps_time(uint32_t bcd_date, uint32_t bcd_milliseconds);
 };
-
-#endif // __AP_GPS_BACKEND_H__

--- a/libraries/AP_HAL_FLYMAPLE/AP_HAL_FLYMAPLE.h
+++ b/libraries/AP_HAL_FLYMAPLE/AP_HAL_FLYMAPLE.h
@@ -15,9 +15,7 @@
 /*
   Flymaple port by Mike McCauley
  */
-
-#ifndef __AP_HAL_FLYMAPLE_H__
-#define __AP_HAL_FLYMAPLE_H__
+#pragma once
 
 /* Your layer exports should depend on AP_HAL.h ONLY. */
 #include <AP_HAL/AP_HAL.h>
@@ -49,6 +47,3 @@
 #include "HAL_FLYMAPLE_Class.h"
 
 #endif // CONFIG_HAL_BOARD
-
-#endif //__AP_HAL_FLYMAPLE_H__
-

--- a/libraries/AP_HAL_FLYMAPLE/AP_HAL_FLYMAPLE_Namespace.h
+++ b/libraries/AP_HAL_FLYMAPLE/AP_HAL_FLYMAPLE_Namespace.h
@@ -15,9 +15,7 @@
 /*
   Flymaple port by Mike McCauley
  */
-
-#ifndef __AP_HAL_FLYMAPLE_NAMESPACE_H__
-#define __AP_HAL_FLYMAPLE_NAMESPACE_H__
+#pragma once
 
 /* While not strictly required, names inside the FLYMAPLE namespace are prefixed
  * AP_HAL_FLYMAPLE_NS for clarity. (Some of our users aren't familiar with all of the
@@ -40,6 +38,3 @@ namespace AP_HAL_FLYMAPLE_NS {
     class FLYMAPLEScheduler;
     class FLYMAPLEUtil;
 }
-
-#endif // __AP_HAL_FLYMAPLE_NAMESPACE_H__
-

--- a/libraries/AP_HAL_FLYMAPLE/AP_HAL_FLYMAPLE_Private.h
+++ b/libraries/AP_HAL_FLYMAPLE/AP_HAL_FLYMAPLE_Private.h
@@ -15,9 +15,7 @@
 /*
   Flymaple port by Mike McCauley
  */
-
-#ifndef __AP_HAL_FLYMAPLE_PRIVATE_H__
-#define __AP_HAL_FLYMAPLE_PRIVATE_H__
+#pragma once
 
 /* Umbrella header for all private headers of the AP_HAL_FLYMAPLE module.
  * Only import this header from inside AP_HAL_FLYMAPLE
@@ -34,6 +32,3 @@
 #include "Semaphores.h"
 #include "Scheduler.h"
 #include "Util.h"
-
-#endif // __AP_HAL_FLYMAPLE_PRIVATE_H__
-

--- a/libraries/AP_HAL_FLYMAPLE/AnalogIn.h
+++ b/libraries/AP_HAL_FLYMAPLE/AnalogIn.h
@@ -15,9 +15,7 @@
 /*
   Flymaple port by Mike McCauley
  */
-
-#ifndef __AP_HAL_FLYMAPLE_ANALOGIN_H__
-#define __AP_HAL_FLYMAPLE_ANALOGIN_H__
+#pragma once
 
 #include "AP_HAL_FLYMAPLE.h"
 
@@ -101,4 +99,3 @@ private:
     // divider (25k/5k) 
     FLYMAPLEAnalogSource _vcc;
 };
-#endif // __AP_HAL_FLYMAPLE_ANALOGIN_H__

--- a/libraries/AP_HAL_FLYMAPLE/GPIO.h
+++ b/libraries/AP_HAL_FLYMAPLE/GPIO.h
@@ -15,9 +15,7 @@
 /*
   Flymaple port by Mike McCauley
  */
-
-#ifndef __AP_HAL_FLYMAPLE_GPIO_H__
-#define __AP_HAL_FLYMAPLE_GPIO_H__
+#pragma once
 
 #include "AP_HAL_FLYMAPLE.h"
 
@@ -54,5 +52,3 @@ public:
 private:
     uint8_t _v;
 };
-
-#endif // __AP_HAL_FLYMAPLE_GPIO_H__

--- a/libraries/AP_HAL_FLYMAPLE/I2CDriver.h
+++ b/libraries/AP_HAL_FLYMAPLE/I2CDriver.h
@@ -15,9 +15,7 @@
 /*
   Flymaple port by Mike McCauley
  */
-
-#ifndef __AP_HAL_FLYMAPLE_I2CDRIVER_H__
-#define __AP_HAL_FLYMAPLE_I2CDRIVER_H__
+#pragma once
 
 #include "AP_HAL_FLYMAPLE.h"
 
@@ -60,5 +58,3 @@ private:
     AP_HAL::Semaphore* _semaphore;
     uint16_t           _timeout_ms;
 };
-
-#endif // __AP_HAL_FLYMAPLE_I2CDRIVER_H__

--- a/libraries/AP_HAL_FLYMAPLE/RCInput.h
+++ b/libraries/AP_HAL_FLYMAPLE/RCInput.h
@@ -15,9 +15,7 @@
 /*
   Flymaple port by Mike McCauley
  */
-
-#ifndef __AP_HAL_FLYMAPLE_RCINPUT_H__
-#define __AP_HAL_FLYMAPLE_RCINPUT_H__
+#pragma once
 
 #include "AP_HAL_FLYMAPLE.h"
 
@@ -50,5 +48,3 @@ private:
     /* override state */
     uint16_t _override[FLYMAPLE_RC_INPUT_NUM_CHANNELS]; 
 };
-
-#endif // __AP_HAL_FLYMAPLE_RCINPUT_H__

--- a/libraries/AP_HAL_FLYMAPLE/RCOutput.h
+++ b/libraries/AP_HAL_FLYMAPLE/RCOutput.h
@@ -15,9 +15,7 @@
 /*
   Flymaple port by Mike McCauley
  */
-
-#ifndef __AP_HAL_FLYMAPLE_RCOUTPUT_H__
-#define __AP_HAL_FLYMAPLE_RCOUTPUT_H__
+#pragma once
 
 #include "AP_HAL_FLYMAPLE.h"
 
@@ -45,5 +43,3 @@ private:
 
     uint32_t _clocks_per_msecond[FLYMAPLE_RC_OUTPUT_NUM_CHANNELS];
 };
-
-#endif // __AP_HAL_FLYMAPLE_RCOUTPUT_H__

--- a/libraries/AP_HAL_FLYMAPLE/SPIDriver.h
+++ b/libraries/AP_HAL_FLYMAPLE/SPIDriver.h
@@ -15,9 +15,7 @@
 /*
   Flymaple port by Mike McCauley
  */
-
-#ifndef __AP_HAL_FLYMAPLE_SPIDRIVER_H__
-#define __AP_HAL_FLYMAPLE_SPIDRIVER_H__
+#pragma once
 
 #include "AP_HAL_FLYMAPLE.h"
 #include "Semaphores.h"
@@ -47,5 +45,3 @@ public:
 private:
     FLYMAPLESPIDeviceDriver _device;
 };
-
-#endif // __AP_HAL_FLYMAPLE_SPIDRIVER_H__

--- a/libraries/AP_HAL_FLYMAPLE/Scheduler.h
+++ b/libraries/AP_HAL_FLYMAPLE/Scheduler.h
@@ -15,9 +15,7 @@
 /*
   Flymaple port by Mike McCauley
  */
-
-#ifndef __AP_HAL_FLYMAPLE_SCHEDULER_H__
-#define __AP_HAL_FLYMAPLE_SCHEDULER_H__
+#pragma once
 
 #include "AP_HAL_FLYMAPLE.h"
 
@@ -67,5 +65,3 @@ private:
     static AP_HAL::MemberProc _timer_proc[FLYMAPLE_SCHEDULER_MAX_TIMER_PROCS];
     static uint8_t _num_timer_procs;
 };
-
-#endif // __AP_HAL_FLYMAPLE_SCHEDULER_H__

--- a/libraries/AP_HAL_FLYMAPLE/Semaphores.h
+++ b/libraries/AP_HAL_FLYMAPLE/Semaphores.h
@@ -15,9 +15,7 @@
 /*
   Flymaple port by Mike McCauley
  */
-
-#ifndef __AP_HAL_FLYMAPLE_SEMAPHORE_H__
-#define __AP_HAL_FLYMAPLE_SEMAPHORE_H__
+#pragma once
 
 #include "AP_HAL_FLYMAPLE.h"
 
@@ -33,5 +31,3 @@ private:
 
     bool _taken;
 };
-
-#endif // __AP_HAL_FLYMAPLE_SEMAPHORE_H__

--- a/libraries/AP_HAL_FLYMAPLE/Storage.h
+++ b/libraries/AP_HAL_FLYMAPLE/Storage.h
@@ -15,9 +15,7 @@
 /*
   Flymaple port by Mike McCauley
  */
-
-#ifndef __AP_HAL_FLYMAPLE_STORAGE_H__
-#define __AP_HAL_FLYMAPLE_STORAGE_H__
+#pragma once
 
 #include "AP_HAL_FLYMAPLE.h"
 
@@ -32,5 +30,3 @@ private:
     uint8_t read_byte(uint16_t loc);
     void write_byte(uint16_t loc, uint8_t value);
 };
-
-#endif // __AP_HAL_FLYMAPLE_STORAGE_H__

--- a/libraries/AP_HAL_FLYMAPLE/UARTDriver.h
+++ b/libraries/AP_HAL_FLYMAPLE/UARTDriver.h
@@ -15,9 +15,7 @@
 /*
   Flymaple port by Mike McCauley
  */
-
-#ifndef __AP_HAL_FLYMAPLE_UARTDRIVER_H__
-#define __AP_HAL_FLYMAPLE_UARTDRIVER_H__
+#pragma once
 
 #include "AP_HAL_FLYMAPLE.h"
 
@@ -51,5 +49,3 @@ private:
     uint8_t*           _rxBuf; // If need more than libmaple usart driver buffer of 63
     uint16_t           _rxBufSize; // Allocated space in _rxBuf
 };
-
-#endif // __AP_HAL_FLYMAPLE_UARTDRIVER_H__

--- a/libraries/AP_HAL_FLYMAPLE/Util.h
+++ b/libraries/AP_HAL_FLYMAPLE/Util.h
@@ -15,9 +15,7 @@
 /*
   Flymaple port by Mike McCauley
  */
-
-#ifndef __AP_HAL_FLYMAPLE_UTIL_H__
-#define __AP_HAL_FLYMAPLE_UTIL_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #include "AP_HAL_FLYMAPLE_Namespace.h"
@@ -26,5 +24,3 @@ class AP_HAL_FLYMAPLE_NS::FLYMAPLEUtil : public AP_HAL::Util {
 public:
     bool run_debug_shell(AP_HAL::BetterStream *stream) { return false; }
 };
-
-#endif // __AP_HAL_FLYMAPLE_UTIL_H__

--- a/libraries/AP_HAL_FLYMAPLE/utility/EEPROM.h
+++ b/libraries/AP_HAL_FLYMAPLE/utility/EEPROM.h
@@ -1,5 +1,4 @@
-#ifndef __EEPROM_H
-#define __EEPROM_H
+#pragma once
 
 #define EEPROM_USES_16BIT_WORDS
 
@@ -95,5 +94,3 @@ private:
 };
 
 extern EEPROMClass EEPROM;
-
-#endif	/* __EEPROM_H */

--- a/libraries/AP_HAL_FLYMAPLE/utility/flash_stm32.h
+++ b/libraries/AP_HAL_FLYMAPLE/utility/flash_stm32.h
@@ -1,5 +1,4 @@
-#ifndef __FLASH_STM32_H
-#define __FLASH_STM32_H
+#pragma once
 
 #ifdef __cplusplus
  extern "C" {
@@ -32,5 +31,3 @@ void FLASH_Lock(void);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* __FLASH_STM32_H */

--- a/libraries/AP_HAL_PX4/AP_HAL_PX4.h
+++ b/libraries/AP_HAL_PX4/AP_HAL_PX4.h
@@ -1,6 +1,4 @@
-
-#ifndef __AP_HAL_PX4_H__
-#define __AP_HAL_PX4_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 
@@ -8,5 +6,3 @@
 #include "HAL_PX4_Class.h"
 
 #endif // CONFIG_HAL_BOARD
-#endif // __AP_HAL_PX4_H__
-

--- a/libraries/AP_HAL_PX4/AP_HAL_PX4_Namespace.h
+++ b/libraries/AP_HAL_PX4/AP_HAL_PX4_Namespace.h
@@ -1,6 +1,4 @@
-
-#ifndef __AP_HAL_PX4_NAMESPACE_H__
-#define __AP_HAL_PX4_NAMESPACE_H__
+#pragma once
 
 namespace PX4 {
 	class PX4Scheduler;
@@ -18,6 +16,3 @@ namespace PX4 {
         class PX4_I2C;
         class Semaphore;
 }
-
-#endif //__AP_HAL_PX4_NAMESPACE_H__
-

--- a/libraries/AP_HAL_PX4/AnalogIn.h
+++ b/libraries/AP_HAL_PX4/AnalogIn.h
@@ -1,7 +1,5 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef __AP_HAL_PX4_ANALOGIN_H__
-#define __AP_HAL_PX4_ANALOGIN_H__
+#pragma once
 
 #include "AP_HAL_PX4.h"
 #include <pthread.h>
@@ -82,4 +80,3 @@ private:
 
     void next_stop_pin(void);
 };
-#endif // __AP_HAL_PX4_ANALOGIN_H__

--- a/libraries/AP_HAL_PX4/GPIO.h
+++ b/libraries/AP_HAL_PX4/GPIO.h
@@ -1,7 +1,5 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef __AP_HAL_PX4_GPIO_H__
-#define __AP_HAL_PX4_GPIO_H__
+#pragma once
 
 #include "AP_HAL_PX4.h"
 
@@ -67,5 +65,3 @@ public:
 private:
     uint8_t _v;
 };
-
-#endif // __AP_HAL_PX4_GPIO_H__

--- a/libraries/AP_HAL_PX4/I2CDriver.h
+++ b/libraries/AP_HAL_PX4/I2CDriver.h
@@ -1,6 +1,4 @@
-
-#ifndef __AP_HAL_PX4_I2CDRIVER_H__
-#define __AP_HAL_PX4_I2CDRIVER_H__
+#pragma once
 
 #include "AP_HAL_PX4.h"
 #include <AP_HAL_Empty/AP_HAL_Empty.h>
@@ -47,5 +45,3 @@ private:
     Empty::Semaphore semaphore;
     PX4_I2C *px4_i2c = nullptr;
 };
-
-#endif // __AP_HAL_PX4_I2CDRIVER_H__

--- a/libraries/AP_HAL_PX4/RCInput.h
+++ b/libraries/AP_HAL_PX4/RCInput.h
@@ -1,6 +1,4 @@
-
-#ifndef __AP_HAL_PX4_RCINPUT_H__
-#define __AP_HAL_PX4_RCINPUT_H__
+#pragma once
 
 #include "AP_HAL_PX4.h"
 #include <drivers/drv_rc_input.h>
@@ -38,5 +36,3 @@ private:
     perf_counter_t _perf_rcin;
     pthread_mutex_t rcin_mutex;
 };
-
-#endif // __AP_HAL_PX4_RCINPUT_H__

--- a/libraries/AP_HAL_PX4/RCOutput.h
+++ b/libraries/AP_HAL_PX4/RCOutput.h
@@ -1,6 +1,4 @@
-
-#ifndef __AP_HAL_PX4_RCOUTPUT_H__
-#define __AP_HAL_PX4_RCOUTPUT_H__
+#pragma once
 
 #include "AP_HAL_PX4.h"
 #include <systemlib/perf_counter.h>
@@ -63,5 +61,3 @@ private:
     void _arm_actuators(bool arm);
     void set_freq_fd(int fd, uint32_t chmask, uint16_t freq_hz);
 };
-
-#endif // __AP_HAL_PX4_RCOUTPUT_H__

--- a/libraries/AP_HAL_PX4/Scheduler.h
+++ b/libraries/AP_HAL_PX4/Scheduler.h
@@ -1,6 +1,4 @@
-
-#ifndef __AP_HAL_PX4_SCHEDULER_H__
-#define __AP_HAL_PX4_SCHEDULER_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #if CONFIG_HAL_BOARD == HAL_BOARD_PX4
@@ -102,6 +100,3 @@ private:
     perf_counter_t  _perf_delay;
 };
 #endif
-#endif // __AP_HAL_PX4_SCHEDULER_H__
-
-

--- a/libraries/AP_HAL_PX4/Storage.h
+++ b/libraries/AP_HAL_PX4/Storage.h
@@ -1,7 +1,4 @@
-
-
-#ifndef __AP_HAL_PX4_STORAGE_H__
-#define __AP_HAL_PX4_STORAGE_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #include "AP_HAL_PX4_Namespace.h"
@@ -43,5 +40,3 @@ private:
 #endif
     void bus_lock(bool lock);
 };
-
-#endif // __AP_HAL_PX4_STORAGE_H__

--- a/libraries/AP_HAL_PX4/UARTDriver.h
+++ b/libraries/AP_HAL_PX4/UARTDriver.h
@@ -1,6 +1,4 @@
-
-#ifndef __AP_HAL_PX4_UARTDRIVER_H__
-#define __AP_HAL_PX4_UARTDRIVER_H__
+#pragma once
 
 #include "AP_HAL_PX4.h"
 #include <systemlib/perf_counter.h>
@@ -80,5 +78,3 @@ private:
     pid_t _uart_owner_pid;
 
 };
-
-#endif // __AP_HAL_PX4_UARTDRIVER_H__

--- a/libraries/AP_HAL_PX4/Util.h
+++ b/libraries/AP_HAL_PX4/Util.h
@@ -1,6 +1,4 @@
-
-#ifndef __AP_HAL_PX4_UTIL_H__
-#define __AP_HAL_PX4_UTIL_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #include "AP_HAL_PX4_Namespace.h"
@@ -64,5 +62,3 @@ private:
     int _safety_handle;
     PX4::NSHShellStream _shell_stream;
 };
-
-#endif // __AP_HAL_PX4_UTIL_H__

--- a/libraries/AP_HAL_QURT/AP_HAL_QURT.h
+++ b/libraries/AP_HAL_QURT/AP_HAL_QURT.h
@@ -12,9 +12,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-#ifndef __AP_HAL_QURT_H__
-#define __AP_HAL_QURT_H__
+#pragma once
 
 /* Your layer exports should depend on AP_HAL.h ONLY. */
 #include <AP_HAL/AP_HAL.h>
@@ -25,6 +23,3 @@
 #include "AP_HAL_QURT_Main.h"
 
 #endif // CONFIG_HAL_BOARD
-
-#endif //__AP_HAL_QURT_H__
-

--- a/libraries/AP_HAL_QURT/AP_HAL_QURT_Main.h
+++ b/libraries/AP_HAL_QURT/AP_HAL_QURT_Main.h
@@ -12,8 +12,4 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-#ifndef __AP_HAL_QURT_MAIN_H__
-#define __AP_HAL_QURT_MAIN_H__
-
-#endif // __AP_HAL_QURT_MAIN_H__
+#pragma once

--- a/libraries/AP_HAL_QURT/AP_HAL_QURT_Private.h
+++ b/libraries/AP_HAL_QURT/AP_HAL_QURT_Private.h
@@ -12,9 +12,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-#ifndef __AP_HAL_QURT_PRIVATE_H__
-#define __AP_HAL_QURT_PRIVATE_H__
+#pragma once
 
 /* Umbrella header for all private headers of the AP_HAL_QURT module.
  * Only import this header from inside AP_HAL_QURT
@@ -23,6 +21,3 @@
 #include "UARTDriver.h"
 #include "UDPDriver.h"
 #include "Util.h"
-
-#endif // __AP_HAL_QURT_PRIVATE_H__
-

--- a/libraries/AP_HAL_QURT/HAL_QURT_Class.h
+++ b/libraries/AP_HAL_QURT/HAL_QURT_Class.h
@@ -12,9 +12,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-#ifndef __AP_HAL_QURT_CLASS_H__
-#define __AP_HAL_QURT_CLASS_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 
@@ -25,6 +23,3 @@ public:
     HAL_QURT();
     void run(int argc, char* const* argv, Callbacks* callbacks) const override;
 };
-
-#endif // __AP_HAL_QURT_CLASS_H__
-

--- a/libraries/AP_HAL_SITL/AP_HAL_SITL.h
+++ b/libraries/AP_HAL_SITL/AP_HAL_SITL.h
@@ -1,6 +1,4 @@
-
-#ifndef __AP_HAL_SITL_H__
-#define __AP_HAL_SITL_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 
@@ -9,6 +7,3 @@
 #include "HAL_SITL_Class.h"
 
 #endif // CONFIG_HAL_BOARD
-
-#endif // __AP_HAL_SITL_H__
-

--- a/libraries/AP_HAL_SITL/AP_HAL_SITL_Namespace.h
+++ b/libraries/AP_HAL_SITL/AP_HAL_SITL_Namespace.h
@@ -1,6 +1,4 @@
-
-#ifndef __AP_HAL_SITL_NAMESPACE_H__
-#define __AP_HAL_SITL_NAMESPACE_H__
+#pragma once
 
 namespace HALSITL {
 class UARTDriver;
@@ -15,5 +13,3 @@ class RCInput;
 class Util;
 class Semaphore;
 }
-
-#endif // __AP_HAL_SITL_NAMESPACE_H__

--- a/libraries/AP_HAL_SITL/AP_HAL_SITL_Private.h
+++ b/libraries/AP_HAL_SITL/AP_HAL_SITL_Private.h
@@ -1,6 +1,4 @@
-
-#ifndef __AP_HAL_SITL_PRIVATE_H__
-#define __AP_HAL_SITL_PRIVATE_H__
+#pragma once
 
 #include "AP_HAL_SITL_Namespace.h"
 #include "Scheduler.h"
@@ -8,6 +6,3 @@
 #include "UARTDriver.h"
 #include "SITL_State.h"
 #include "Semaphores.h"
-
-#endif // __AP_HAL_SITL_PRIVATE_H__
-

--- a/libraries/AP_HAL_SITL/AnalogIn.h
+++ b/libraries/AP_HAL_SITL/AnalogIn.h
@@ -1,6 +1,4 @@
-
-#ifndef __AP_HAL_SITL_ANALOG_IN_H__
-#define __AP_HAL_SITL_ANALOG_IN_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #include "AP_HAL_SITL_Namespace.h"
@@ -46,5 +44,3 @@ private:
     static ADCSource* _channels[SITL_INPUT_MAX_CHANNELS];
     SITL_State *_sitlState;
 };
-
-#endif // __AP_HAL_SITL_ANALOG_IN_H__

--- a/libraries/AP_HAL_SITL/RCOutput.h
+++ b/libraries/AP_HAL_SITL/RCOutput.h
@@ -1,6 +1,4 @@
-
-#ifndef __AP_HAL_SITL_RCOUTPUT_H__
-#define __AP_HAL_SITL_RCOUTPUT_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
@@ -28,5 +26,3 @@ private:
 };
 
 #endif
-#endif // __AP_HAL_SITL_RCOUTPUT_H__
-

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -1,6 +1,4 @@
-
-#ifndef __AP_HAL_SITL_STATE_H__
-#define __AP_HAL_SITL_STATE_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 
@@ -219,5 +217,3 @@ private:
 };
 
 #endif // CONFIG_HAL_BOARD == HAL_BOARD_SITL
-#endif // __AP_HAL_SITL_STATE_H__
-

--- a/libraries/AP_HAL_SITL/Storage.h
+++ b/libraries/AP_HAL_SITL/Storage.h
@@ -1,7 +1,4 @@
-
-
-#ifndef __AP_HAL_SITL_STORAGE_H__
-#define __AP_HAL_SITL_STORAGE_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #include "AP_HAL_SITL_Namespace.h"
@@ -19,5 +16,3 @@ private:
     int _eeprom_fd;
     void _eeprom_open(void);
 };
-
-#endif // __AP_HAL_SITL_STORAGE_H__

--- a/libraries/AP_HAL_SITL/UARTDriver.h
+++ b/libraries/AP_HAL_SITL/UARTDriver.h
@@ -1,7 +1,6 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+#pragma once
 
-#ifndef __AP_HAL_SITL_UART_DRIVER_H__
-#define __AP_HAL_SITL_UART_DRIVER_H__
 #include <AP_HAL/AP_HAL.h>
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 
@@ -101,5 +100,3 @@ private:
 };
 
 #endif
-#endif // __AP_HAL_SITL_UART_DRIVER_H__
-

--- a/libraries/AP_HAL_SITL/Util.h
+++ b/libraries/AP_HAL_SITL/Util.h
@@ -1,6 +1,4 @@
-
-#ifndef __AP_HAL_SITL_UTIL_H__
-#define __AP_HAL_SITL_UTIL_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #include "AP_HAL_SITL_Namespace.h"
@@ -33,5 +31,3 @@ public:
 private:
     SITL_State *sitlState;
 };
-
-#endif // __AP_HAL_SITL_UTIL_H__

--- a/libraries/AP_HAL_SITL/fenv_polyfill.h
+++ b/libraries/AP_HAL_SITL/fenv_polyfill.h
@@ -1,6 +1,4 @@
-
-#ifndef __FENV_POLYFILL_H__
-#define __FENV_POLYFILL_H__
+#pragma once
 
 #if (defined __APPLE__) && (defined(__i386__) || defined(__x86_64__))
 
@@ -27,6 +25,3 @@ feenableexcept (unsigned int excepts)
 }
 
 #endif // APPLE
-
-#endif // __FENV_POLYFILL_H__
-

--- a/libraries/AP_HAL_VRBRAIN/AP_HAL_VRBRAIN.h
+++ b/libraries/AP_HAL_VRBRAIN/AP_HAL_VRBRAIN.h
@@ -1,6 +1,4 @@
-
-#ifndef __AP_HAL_VRBRAIN_H__
-#define __AP_HAL_VRBRAIN_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 
@@ -8,5 +6,3 @@
 #include "HAL_VRBRAIN_Class.h"
 
 #endif // CONFIG_HAL_BOARD
-#endif // __AP_HAL_VRBRAIN_H__
-

--- a/libraries/AP_HAL_VRBRAIN/AP_HAL_VRBRAIN_Namespace.h
+++ b/libraries/AP_HAL_VRBRAIN/AP_HAL_VRBRAIN_Namespace.h
@@ -1,6 +1,4 @@
-
-#ifndef __AP_HAL_VRBRAIN_NAMESPACE_H__
-#define __AP_HAL_VRBRAIN_NAMESPACE_H__
+#pragma once
 
 namespace VRBRAIN {
 	class VRBRAINScheduler;
@@ -14,6 +12,3 @@ namespace VRBRAIN {
         class VRBRAINGPIO;
         class VRBRAINDigitalSource;
 }
-
-#endif //__AP_HAL_VRBRAIN_NAMESPACE_H__
-

--- a/libraries/AP_HAL_VRBRAIN/AnalogIn.h
+++ b/libraries/AP_HAL_VRBRAIN/AnalogIn.h
@@ -1,7 +1,5 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef __AP_HAL_VRBRAIN_ANALOGIN_H__
-#define __AP_HAL_VRBRAIN_ANALOGIN_H__
+#pragma once
 
 #include "AP_HAL_VRBRAIN.h"
 #include <pthread.h>
@@ -83,4 +81,3 @@ private:
 
     void next_stop_pin(void);
 };
-#endif // __AP_HAL_VRBRAIN_ANALOGIN_H__

--- a/libraries/AP_HAL_VRBRAIN/GPIO.h
+++ b/libraries/AP_HAL_VRBRAIN/GPIO.h
@@ -1,7 +1,5 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef __AP_HAL_VRBRAIN_GPIO_H__
-#define __AP_HAL_VRBRAIN_GPIO_H__
+#pragma once
 
 #include "AP_HAL_VRBRAIN.h"
 
@@ -52,5 +50,3 @@ public:
 private:
     uint8_t _v;
 };
-
-#endif // __AP_HAL_VRBRAIN_GPIO_H__

--- a/libraries/AP_HAL_VRBRAIN/RCInput.h
+++ b/libraries/AP_HAL_VRBRAIN/RCInput.h
@@ -1,6 +1,4 @@
-
-#ifndef __AP_HAL_VRBRAIN_RCINPUT_H__
-#define __AP_HAL_VRBRAIN_RCINPUT_H__
+#pragma once
 
 #include "AP_HAL_VRBRAIN.h"
 #include <drivers/drv_rc_input.h>
@@ -31,5 +29,3 @@ private:
     perf_counter_t _perf_rcin;
     pthread_mutex_t rcin_mutex;
 };
-
-#endif // __AP_HAL_VRBRAIN_RCINPUT_H__

--- a/libraries/AP_HAL_VRBRAIN/RCOutput.h
+++ b/libraries/AP_HAL_VRBRAIN/RCOutput.h
@@ -1,6 +1,4 @@
-
-#ifndef __AP_HAL_VRBRAIN_RCOUTPUT_H__
-#define __AP_HAL_VRBRAIN_RCOUTPUT_H__
+#pragma once
 
 #include "AP_HAL_VRBRAIN.h"
 #include <systemlib/perf_counter.h>
@@ -41,5 +39,3 @@ private:
 
     void _init_alt_channels(void);
 };
-
-#endif // __AP_HAL_VRBRAIN_RCOUTPUT_H__

--- a/libraries/AP_HAL_VRBRAIN/Scheduler.h
+++ b/libraries/AP_HAL_VRBRAIN/Scheduler.h
@@ -1,6 +1,4 @@
-
-#ifndef __AP_HAL_VRBRAIN_SCHEDULER_H__
-#define __AP_HAL_VRBRAIN_SCHEDULER_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #if CONFIG_HAL_BOARD == HAL_BOARD_VRBRAIN
@@ -78,6 +76,3 @@ private:
     perf_counter_t  _perf_delay;
 };
 #endif
-#endif // __AP_HAL_VRBRAIN_SCHEDULER_H__
-
-

--- a/libraries/AP_HAL_VRBRAIN/Storage.h
+++ b/libraries/AP_HAL_VRBRAIN/Storage.h
@@ -1,7 +1,4 @@
-
-
-#ifndef __AP_HAL_VRBRAIN_STORAGE_H__
-#define __AP_HAL_VRBRAIN_STORAGE_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #include "AP_HAL_VRBRAIN_Namespace.h"
@@ -38,5 +35,3 @@ private:
     uint32_t _mtd_signature(void);
     void _mtd_write_signature(void);
 };
-
-#endif // __AP_HAL_VRBRAIN_STORAGE_H__

--- a/libraries/AP_HAL_VRBRAIN/UARTDriver.h
+++ b/libraries/AP_HAL_VRBRAIN/UARTDriver.h
@@ -1,6 +1,4 @@
-
-#ifndef __AP_HAL_VRBRAIN_UARTDRIVER_H__
-#define __AP_HAL_VRBRAIN_UARTDRIVER_H__
+#pragma once
 
 #include "AP_HAL_VRBRAIN.h"
 #include <systemlib/perf_counter.h>
@@ -77,5 +75,3 @@ private:
     uint32_t _total_written;
     enum flow_control _flow_control;
 };
-
-#endif // __AP_HAL_VRBRAIN_UARTDRIVER_H__

--- a/libraries/AP_HAL_VRBRAIN/Util.h
+++ b/libraries/AP_HAL_VRBRAIN/Util.h
@@ -1,6 +1,4 @@
-
-#ifndef __AP_HAL_VRBRAIN_UTIL_H__
-#define __AP_HAL_VRBRAIN_UTIL_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #include "AP_HAL_VRBRAIN_Namespace.h"
@@ -27,5 +25,3 @@ public:
 private:
     int _safety_handle;
 };
-
-#endif // __AP_HAL_VRBRAIN_UTIL_H__

--- a/libraries/AP_IRLock/AP_IRLock_PX4.h
+++ b/libraries/AP_IRLock/AP_IRLock_PX4.h
@@ -4,9 +4,7 @@
  *  Created on: Nov 10, 2014
  *      Author: MLandes
  */
-
-#ifndef AP_IRLOCK_PX4_H_
-#define AP_IRLOCK_PX4_H_
+#pragma once
 
 #include "IRLock.h"
 
@@ -25,5 +23,3 @@ private:
     int _fd;
     uint64_t _last_timestamp;
 };
-
-#endif /* AP_IRLOCK_PX4_H_ */

--- a/libraries/AP_IRLock/IRLock.h
+++ b/libraries/AP_IRLock/IRLock.h
@@ -19,9 +19,7 @@
  *  Created on: Nov 10, 2014
  *      Author: MLandes
  */
-
-#ifndef __IRLOCK_H__
-#define __IRLOCK_H__
+#pragma once
 
 #include <AP_AHRS/AP_AHRS.h>
 
@@ -75,6 +73,3 @@ protected:
 
     irlock_target_info _target_info[IRLOCK_MAX_TARGETS];
 };
-
-
-#endif /* __IRLOCK_H__ */

--- a/libraries/AP_InertialNav/AP_InertialNav.h
+++ b/libraries/AP_InertialNav/AP_InertialNav.h
@@ -1,7 +1,5 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef __AP_INERTIALNAV_H__
-#define __AP_INERTIALNAV_H__
+#pragma once
 
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_InertialSensor/AP_InertialSensor.h>          // ArduPilot Mega IMU Library
@@ -120,5 +118,3 @@ public:
 #if AP_AHRS_NAVEKF_AVAILABLE
 #include "AP_InertialNav_NavEKF.h"
 #endif
-
-#endif // __AP_INERTIALNAV_H__

--- a/libraries/AP_InertialNav/AP_InertialNav_NavEKF.h
+++ b/libraries/AP_InertialNav/AP_InertialNav_NavEKF.h
@@ -5,10 +5,7 @@
   filter if available, and falls back to the AP_InertialNav filter
   when EKF is not available
  */
-
-
-#ifndef __AP_INERTIALNAV_NAVEKF_H__
-#define __AP_INERTIALNAV_NAVEKF_H__
+#pragma once
 
 #include <AP_NavEKF/AP_Nav_Common.h>              // definitions shared by inertial and ekf nav filters
 
@@ -124,5 +121,3 @@ private:
     bool _haveabspos;
     AP_AHRS_NavEKF &_ahrs_ekf;
 };
-
-#endif // __AP_INERTIALNAV_NAVEKF_H__

--- a/libraries/AP_L1_Control/AP_L1_Control.h
+++ b/libraries/AP_L1_Control/AP_L1_Control.h
@@ -1,4 +1,5 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+#pragma once
 
 /// @file    AP_L1_Control.h
 /// @brief   L1 Control algorithm. This is a instance of an
@@ -12,9 +13,6 @@
  *  - Explicit control over track capture angle
  *  - Ability to use loiter radius smaller than L1 length
  */
-
-#ifndef AP_L1_CONTROL_H
-#define AP_L1_CONTROL_H
 
 #include <AP_Math/AP_Math.h>
 #include <AP_AHRS/AP_AHRS.h>
@@ -106,6 +104,3 @@ private:
     float _L1_xtrack_i_gain_prev = 0;
     uint32_t _last_update_waypoint_us;
 };
-
-
-#endif //AP_L1_CONTROL_H

--- a/libraries/AP_LandingGear/AP_LandingGear.h
+++ b/libraries/AP_LandingGear/AP_LandingGear.h
@@ -2,9 +2,7 @@
 
 /// @file	AP_LandingGear.h
 /// @brief	Landing gear control library
-
-#ifndef AP_LANDINGGEAR_H
-#define AP_LANDINGGEAR_H
+#pragma once
 
 #include <AP_Param/AP_Param.h>
 #include <AP_Common/AP_Common.h>
@@ -75,5 +73,3 @@ private:
     /// deploy - deploy the landing gear
     void deploy();
 };
-
-#endif /* AP_LANDINGGEAR_H */

--- a/libraries/AP_Math/matrix3.h
+++ b/libraries/AP_Math/matrix3.h
@@ -36,9 +36,7 @@
 // Matrix3ul	3x3 matrix of unsigned longs
 // Matrix3f		3x3 matrix of signed floats
 //
-
-#ifndef MATRIX3_H
-#define MATRIX3_H
+#pragma once
 
 #include "vector3.h"
 
@@ -242,5 +240,3 @@ typedef Matrix3<int32_t>                Matrix3l;
 typedef Matrix3<uint32_t>               Matrix3ul;
 typedef Matrix3<float>                  Matrix3f;
 typedef Matrix3<double>                 Matrix3d;
-
-#endif // MATRIX3_H

--- a/libraries/AP_Math/quaternion.h
+++ b/libraries/AP_Math/quaternion.h
@@ -16,9 +16,7 @@
 
 // Copyright 2012 Andrew Tridgell, all rights reserved.
 // Refactored by Jonathan Challinger
-
-#ifndef QUATERNION_H
-#define QUATERNION_H
+#pragma once
 
 #include <math.h>
 #if MATH_CHECK_INDEXES
@@ -124,4 +122,3 @@ public:
     Quaternion &operator*=(const Quaternion &v);
     Quaternion operator/(const Quaternion &v) const;
 };
-#endif // QUATERNION_H

--- a/libraries/AP_Math/vector2.h
+++ b/libraries/AP_Math/vector2.h
@@ -28,9 +28,7 @@
 * © 2003, This code is provided "as is" and you can use it freely as long as
 * credit is given to Bill Perone in the application it is used in
 ****************************************/
-
-#ifndef VECTOR2_H
-#define VECTOR2_H
+#pragma once
 
 #include <math.h>
 
@@ -161,5 +159,3 @@ typedef Vector2<uint16_t>       Vector2ui;
 typedef Vector2<int32_t>        Vector2l;
 typedef Vector2<uint32_t>       Vector2ul;
 typedef Vector2<float>          Vector2f;
-
-#endif // VECTOR2_H

--- a/libraries/AP_Math/vector3.h
+++ b/libraries/AP_Math/vector3.h
@@ -46,9 +46,7 @@
 *           or if the matrix (A) * b = 0
 *
 ****************************************/
-
-#ifndef VECTOR3_H
-#define VECTOR3_H
+#pragma once
 
 #include <math.h>
 #include <float.h>
@@ -219,5 +217,3 @@ typedef Vector3<int32_t>                Vector3l;
 typedef Vector3<uint32_t>               Vector3ul;
 typedef Vector3<float>                  Vector3f;
 typedef Vector3<double>                 Vector3d;
-
-#endif // VECTOR3_H

--- a/libraries/AP_Math/vectorN.h
+++ b/libraries/AP_Math/vectorN.h
@@ -13,9 +13,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-#ifndef VECTORN_H
-#define VECTORN_H
+#pragma once
 
 #include <math.h>
 #include <string.h>
@@ -140,5 +138,3 @@ public:
 private:
     T _v[N];
 };
-
-#endif // VECTORN_H

--- a/libraries/AP_Menu/AP_Menu.h
+++ b/libraries/AP_Menu/AP_Menu.h
@@ -12,9 +12,7 @@
 ///
 /// Arguments passed to the handler function are pre-converted to both
 /// long and float for convenience.
-
-#ifndef __AP_MENU_H__
-#define __AP_MENU_H__
+#pragma once
 
 #include <inttypes.h>
 #include <AP_HAL/AP_HAL.h>
@@ -173,5 +171,3 @@ private:
 #define MENU2(name, prompt, commands, preprompt)                                \
     static const char __menu_name__ ## name[] = prompt;      \
     static Menu name(__menu_name__ ## name, commands, ARRAY_SIZE(commands), preprompt)
-
-#endif // __AP_COMMON_MENU_H__

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -12,8 +12,7 @@
  *   - accounts for the DO_JUMP command
  *
  */
-#ifndef AP_Mission_h
-#define AP_Mission_h
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Vehicle/AP_Vehicle.h>
@@ -467,5 +466,3 @@ private:
     // last time that mission changed
     uint32_t _last_change_time_ms;
 };
-
-#endif

--- a/libraries/AP_Motors/AP_Motors.h
+++ b/libraries/AP_Motors/AP_Motors.h
@@ -1,7 +1,5 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef __AP_MOTORS_H__
-#define __AP_MOTORS_H__
+#pragma once
 
 #include "AP_Motors_Class.h"
 #include "AP_MotorsMulticopter.h"
@@ -15,5 +13,3 @@
 #include "AP_MotorsHeli_Single.h"
 #include "AP_MotorsSingle.h"
 #include "AP_MotorsCoax.h"
-
-#endif // __AP_MOTORS_H__

--- a/libraries/AP_Motors/AP_MotorsCoax.h
+++ b/libraries/AP_Motors/AP_MotorsCoax.h
@@ -2,9 +2,7 @@
 
 /// @file	AP_MotorsCoax.h
 /// @brief	Motor and Servo control class for Co-axial helicopters with two motors and two flaps
-
-#ifndef __AP_MOTORS_COAX_H__
-#define __AP_MOTORS_COAX_H__
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Math/AP_Math.h>        // ArduPilot Mega Vector/Matrix math Library
@@ -71,5 +69,3 @@ protected:
     RC_Channel&         _servo1;
     RC_Channel&         _servo2;
 };
-
-#endif  // AP_MOTORSCOAX

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -2,9 +2,7 @@
 
 /// @file	AP_MotorsHeli.h
 /// @brief	Motor control class for Traditional Heli
-
-#ifndef __AP_MOTORS_HELI_H__
-#define __AP_MOTORS_HELI_H__
+#pragma once
 
 #include <inttypes.h>
 
@@ -246,5 +244,3 @@ protected:
     int16_t         _collective_range = 0;           // maximum absolute collective pitch range (500 - 1000)
     uint8_t         _servo_test_cycle_counter = 0;   // number of test cycles left to run after bootup
 };
-
-#endif  // AP_MOTORSHELI

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -1,7 +1,5 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef __AP_MOTORS_HELI_RSC_H__
-#define __AP_MOTORS_HELI_RSC_H__
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Math/AP_Math.h>            // ArduPilot Mega Vector/Matrix math Library
@@ -118,5 +116,3 @@ private:
     // write_rsc - outputs pwm onto output rsc channel. servo_out parameter is of the range 0 ~ 1000
     void            write_rsc(int16_t servo_out);
 };
-
-#endif // AP_MOTORS_HELI_RSC_H

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.h
@@ -2,9 +2,7 @@
 
 /// @file	AP_MotorsHeli_Single.h
 /// @brief	Motor control class for traditional heli
-
-#ifndef __AP_MOTORS_HELI_SINGLE_H__
-#define __AP_MOTORS_HELI_SINGLE_H__
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Math/AP_Math.h>            // ArduPilot Mega Vector/Matrix math Library
@@ -186,5 +184,3 @@ protected:
 
     bool            _acro_tail = false;
 };
-
-#endif  // __AP_MOTORS_HELI_SINGLE_H__

--- a/libraries/AP_Motors/AP_MotorsHexa.h
+++ b/libraries/AP_Motors/AP_MotorsHexa.h
@@ -2,9 +2,7 @@
 
 /// @file	AP_MotorsHexa.h
 /// @brief	Motor control class for Hexacopters
-
-#ifndef __AP_MOTORS_HEXA_H__
-#define __AP_MOTORS_HEXA_H__
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Math/AP_Math.h>        // ArduPilot Mega Vector/Matrix math Library
@@ -26,5 +24,3 @@ public:
 protected:
 
 };
-
-#endif  // AP_MOTORSHEXA

--- a/libraries/AP_Motors/AP_MotorsMatrix.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix.h
@@ -2,9 +2,7 @@
 
 /// @file	AP_MotorsMatrix.h
 /// @brief	Motor control class for Matrixcopters
-
-#ifndef __AP_MOTORS_MATRIX_H__
-#define __AP_MOTORS_MATRIX_H__
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Math/AP_Math.h>        // ArduPilot Mega Vector/Matrix math Library
@@ -79,5 +77,3 @@ protected:
     float               _yaw_factor[AP_MOTORS_MAX_NUM_MOTORS];  // each motors contribution to yaw (normally 1 or -1)
     uint8_t             _test_order[AP_MOTORS_MAX_NUM_MOTORS];  // order of the motors in the test sequence
 };
-
-#endif  // AP_MOTORSMATRIX

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -2,9 +2,7 @@
 
 /// @file	AP_MotorsMulticopter.h
 /// @brief	Motor control class for Multicopters
-
-#ifndef __AP_MOTORS_MULTICOPTER_H__
-#define __AP_MOTORS_MULTICOPTER_H__
+#pragma once
 
 #include "AP_Motors_Class.h"
 
@@ -177,4 +175,3 @@ protected:
     float               _lift_max;              // maximum lift ratio from battery voltage
     float               _throttle_limit;        // ratio of throttle limit between hover and maximum
 };
-#endif  // __AP_MOTORS_MULTICOPTER_H__

--- a/libraries/AP_Motors/AP_MotorsOcta.h
+++ b/libraries/AP_Motors/AP_MotorsOcta.h
@@ -2,9 +2,7 @@
 
 /// @file	AP_MotorsOcta.h
 /// @brief	Motor control class for Octacopters
-
-#ifndef __AP_MOTORS_OCTA_H__
-#define __AP_MOTORS_OCTA_H__
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Math/AP_Math.h>        // ArduPilot Mega Vector/Matrix math Library
@@ -26,5 +24,3 @@ public:
 protected:
 
 };
-
-#endif  // AP_MOTORSOCTA

--- a/libraries/AP_Motors/AP_MotorsOctaQuad.h
+++ b/libraries/AP_Motors/AP_MotorsOctaQuad.h
@@ -2,9 +2,7 @@
 
 /// @file	AP_MotorsOctaQuad.h
 /// @brief	Motor control class for OctaQuadcopters
-
-#ifndef __AP_MOTORS_OCTA_QUAD_H__
-#define __AP_MOTORS_OCTA_QUAD_H__
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Math/AP_Math.h>        // ArduPilot Mega Vector/Matrix math Library
@@ -26,5 +24,3 @@ public:
 protected:
 
 };
-
-#endif  // AP_MOTORSOCTAQUAD

--- a/libraries/AP_Motors/AP_MotorsQuad.h
+++ b/libraries/AP_Motors/AP_MotorsQuad.h
@@ -2,9 +2,7 @@
 
 /// @file	AP_MotorsQuad.h
 /// @brief	Motor control class for Quadcopters
-
-#ifndef __AP_MOTORS_QUAD_H__
-#define __AP_MOTORS_QUAD_H__
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Math/AP_Math.h>        // ArduPilot Mega Vector/Matrix math Library
@@ -26,5 +24,3 @@ public:
 protected:
 
 };
-
-#endif  // AP_MOTORSQUAD

--- a/libraries/AP_Motors/AP_MotorsSingle.h
+++ b/libraries/AP_Motors/AP_MotorsSingle.h
@@ -2,9 +2,7 @@
 
 /// @file	AP_MotorsSingle.h
 /// @brief	Motor and Servo control class for Singlecopters
-
-#ifndef __AP_MOTORS_SING_H__
-#define __AP_MOTORS_SING_H__
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Math/AP_Math.h>        // ArduPilot Mega Vector/Matrix math Library
@@ -74,5 +72,3 @@ protected:
     RC_Channel&         _servo3;
     RC_Channel&         _servo4;
 };
-
-#endif  // AP_MOTORSSINGLE

--- a/libraries/AP_Motors/AP_MotorsTri.h
+++ b/libraries/AP_Motors/AP_MotorsTri.h
@@ -2,9 +2,7 @@
 
 /// @file	AP_MotorsTri.h
 /// @brief	Motor control class for Tricopters
-
-#ifndef __AP_MOTORS_TRI_H__
-#define __AP_MOTORS_TRI_H__
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Math/AP_Math.h>        // ArduPilot Mega Vector/Matrix math Library
@@ -64,5 +62,3 @@ protected:
     AP_Int16        _yaw_servo_min;                     // Minimum angle limit of yaw servo
     AP_Int16        _yaw_servo_max;                     // Maximum angle limit of yaw servo
 };
-
-#endif  // AP_MOTORSTRI

--- a/libraries/AP_Motors/AP_MotorsY6.h
+++ b/libraries/AP_Motors/AP_MotorsY6.h
@@ -2,9 +2,7 @@
 
 /// @file	AP_MotorsY6.h
 /// @brief	Motor control class for Y6 frames
-
-#ifndef __AP_MOTORS_Y6_H__
-#define __AP_MOTORS_Y6_H__
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Math/AP_Math.h>        // ArduPilot Mega Vector/Matrix math Library
@@ -28,5 +26,3 @@ public:
 protected:
 
 };
-
-#endif  // AP_MOTORSY6

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -1,7 +1,5 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef __AP_MOTORS_CLASS_H__
-#define __AP_MOTORS_CLASS_H__
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Math/AP_Math.h>        // ArduPilot Mega Vector/Matrix math Library
@@ -169,4 +167,3 @@ protected:
     uint8_t             _motor_map[AP_MOTORS_MAX_NUM_MOTORS];
     uint16_t            _motor_map_mask;
 };
-#endif  // __AP_MOTORS_CLASS_H__

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -19,8 +19,7 @@
 * Comments: All angles in degrees * 100, distances in meters*
 *			unless otherwise stated.						*
 ************************************************************/
-#ifndef __AP_MOUNT_H__
-#define __AP_MOUNT_H__
+#pragma once
 
 #include <AP_Math/AP_Math.h>
 #include <AP_Common/AP_Common.h>
@@ -186,5 +185,3 @@ protected:
 
     DataFlash_Class *_dataflash;
 };
-
-#endif // __AP_MOUNT_H__

--- a/libraries/AP_Mount/AP_Mount_Alexmos.h
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.h
@@ -3,9 +3,7 @@
 /*
   Alexmos Serial controlled mount backend class
 */
-
-#ifndef __AP_MOUNT_ALEXMOS_H__
-#define __AP_MOUNT_ALEXMOS_H__
+#pragma once
 
 #include "AP_Mount.h"
 #include <AP_HAL/AP_HAL.h>
@@ -319,5 +317,3 @@ private:
     // confirmed that last command was ok
     bool _last_command_confirmed : 1;
 };
-
-#endif

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -18,9 +18,7 @@
   Mount driver backend class. Each supported mount type
   needs to have an object derived from this class.
  */
-
-#ifndef __AP_MOUNT_BACKEND_H__
-#define __AP_MOUNT_BACKEND_H__
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 #include "AP_Mount.h"
@@ -100,5 +98,3 @@ protected:
     uint8_t     _instance;  // this instance's number
     Vector3f    _angle_ef_target_rad;   // desired earth-frame roll, tilt and vehicle-relative pan angles in radians
 };
-
-#endif // __AP_MOUNT_BACKEND_H__

--- a/libraries/AP_Mount/AP_Mount_SToRM32.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.h
@@ -3,9 +3,7 @@
 /*
   SToRM32 mount backend class
  */
-
-#ifndef __AP_MOUNT_STORM32_H__
-#define __AP_MOUNT_STORM32_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_AHRS/AP_AHRS.h>
@@ -58,5 +56,3 @@ private:
     mavlink_channel_t _chan;        // mavlink channel used to communicate with gimbal.  Currently hard-coded to Telem2
     uint32_t _last_send;            // system time of last do_mount_control sent to gimbal
 };
-
-#endif // __AP_MOUNT_STORM32_H__

--- a/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32_serial.h
@@ -3,9 +3,7 @@
 /*
   SToRM32 mount using serial protocol backend class
  */
-
-#ifndef __AP_MOUNT_STORM32_SERIAL_H__
-#define __AP_MOUNT_STORM32_SERIAL_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_AHRS/AP_AHRS.h>
@@ -153,5 +151,3 @@ private:
     // keep the last _current_angle values
     Vector3l _current_angle;
 };
-
-#endif // __AP_MOUNT_STORM32_SERIAL_H__

--- a/libraries/AP_Mount/AP_Mount_Servo.h
+++ b/libraries/AP_Mount/AP_Mount_Servo.h
@@ -3,9 +3,7 @@
 /*
   Servo controlled mount backend class
  */
-
-#ifndef __AP_MOUNT_SERVO_H__
-#define __AP_MOUNT_SERVO_H__
+#pragma once
 
 #include <AP_Math/AP_Math.h>
 #include <AP_Common/AP_Common.h>
@@ -80,5 +78,3 @@ private:
 
     uint32_t _last_check_servo_map_ms;  // system time of latest call to check_servo_map function
 };
-
-#endif // __AP_MOUNT_SERVO_H__

--- a/libraries/AP_Mount/AP_Mount_SoloGimbal.h
+++ b/libraries/AP_Mount/AP_Mount_SoloGimbal.h
@@ -3,9 +3,7 @@
 /*
   MAVLink enabled mount backend class
  */
-
-#ifndef __AP_MOUNT_SOLOGIMBAL_H__
-#define __AP_MOUNT_SOLOGIMBAL_H__
+#pragma once
 
 
 #include <AP_HAL/AP_HAL.h>
@@ -66,5 +64,3 @@ private:
 };
 
 #endif // AP_AHRS_NAVEKF_AVAILABLE
-
-#endif // __AP_MOUNT_SOLOGIMBAL_H__

--- a/libraries/AP_Mount/SoloGimbal.h
+++ b/libraries/AP_Mount/SoloGimbal.h
@@ -6,8 +6,7 @@
 * Author:  Arthur Benemann, Paul Riseborough;               *
 *                                                           *
 ************************************************************/
-#ifndef __SOLOGIMBAL_H__
-#define __SOLOGIMBAL_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_AHRS/AP_AHRS.h>
@@ -158,5 +157,3 @@ private:
 };
 
 #endif // AP_AHRS_NAVEKF_AVAILABLE
-
-#endif // __AP_MOUNT_H__

--- a/libraries/AP_Mount/SoloGimbalEKF.h
+++ b/libraries/AP_Mount/SoloGimbalEKF.h
@@ -17,9 +17,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-#ifndef _SOLO_GIMBAL_EKF_
-#define _SOLO_GIMBAL_EKF_
+#pragma once
 
 #include <AP_Math/AP_Math.h>
 #include <AP_InertialSensor/AP_InertialSensor.h>
@@ -172,5 +170,3 @@ private:
     // Force symmmetry and non-negative diagonals on state covarinace matrix
     void fixCovariance();
 };
-
-#endif // _SOLO_GIMBAL_EKF_

--- a/libraries/AP_Mount/SoloGimbal_Parameters.h
+++ b/libraries/AP_Mount/SoloGimbal_Parameters.h
@@ -1,5 +1,4 @@
-#ifndef __SOLOGIMBAL_PARAMETERS__
-#define __SOLOGIMBAL_PARAMETERS__
+#pragma once
 #include <AP_Math/AP_Math.h>
 #include <AP_Common/AP_Common.h>
 #include <GCS_MAVLink/GCS_MAVLink.h>
@@ -89,6 +88,3 @@ private:
 
     mavlink_channel_t _chan;
 };
-
-
-#endif // __SOLOGIMBAL_PARAMETERS__

--- a/libraries/AP_NavEKF/AP_NavEKF.h
+++ b/libraries/AP_NavEKF/AP_NavEKF.h
@@ -17,9 +17,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-#ifndef AP_NavEKF
-#define AP_NavEKF
+#pragma once
 
 #include <AP_Math/AP_Math.h>
 #include <AP_InertialSensor/AP_InertialSensor.h>
@@ -300,5 +298,3 @@ private:
     AP_Int8 _gpsCheck;              // Bitmask controlling which preflight GPS checks are bypassed
 
 };
-
-#endif // AP_NavEKF

--- a/libraries/AP_NavEKF/AP_NavEKF_core.h
+++ b/libraries/AP_NavEKF/AP_NavEKF_core.h
@@ -17,9 +17,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-#ifndef AP_NavEKF_core
-#define AP_NavEKF_core
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_NavEKF/AP_NavEKF.h>
@@ -875,5 +873,3 @@ private:
     // vehicle specific initial gyro bias uncertainty
     float InitialGyroBiasUncertainty(void) const;
 };
-
-#endif // AP_NavEKF_core

--- a/libraries/AP_NavEKF/AP_Nav_Common.h
+++ b/libraries/AP_NavEKF/AP_Nav_Common.h
@@ -15,9 +15,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-#ifndef AP_Nav_Common
-#define AP_Nav_Common
+#pragma once
 
 union nav_filter_status {
     struct {
@@ -55,5 +53,3 @@ union nav_gps_status {
     } flags;
     uint16_t value;
 };
-
-#endif // AP_Nav_Common

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -18,9 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-#ifndef AP_NavEKF2_Tuning
-#define AP_NavEKF2_Tuning
+#pragma once
 
 #include <AP_Math/AP_Math.h>
 #include <AP_Param/AP_Param.h>
@@ -341,5 +339,3 @@ private:
     const uint8_t gndGradientSigma;     // RMS terrain gradient percentage assumed by the terrain height estimation
     const uint8_t fusionTimeStep_ms;    // The minimum time interval between covariance predictions and measurement fusions in msec
 };
-
-#endif //AP_NavEKF2

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -17,9 +17,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-#ifndef AP_NavEKF2_core
-#define AP_NavEKF2_core
+#pragma once
 
 #pragma GCC optimize("O3")
 
@@ -934,5 +932,3 @@ private:
     // vehicle specific initial gyro bias uncertainty
     float InitialGyroBiasUncertainty(void) const;
 };
-
-#endif // AP_NavEKF2_core

--- a/libraries/AP_Navigation/AP_Navigation.h
+++ b/libraries/AP_Navigation/AP_Navigation.h
@@ -9,9 +9,7 @@
   interface. All variables used by controllers should be in their
   own class.
  */
-
-#ifndef AP_NAVIGATION_H
-#define AP_NAVIGATION_H
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 
@@ -110,6 +108,3 @@ public:
 		CONTROLLER_L1           = 1
 	};
 };
-
-
-#endif // AP_NAVIGATION_H

--- a/libraries/AP_Parachute/AP_Parachute.h
+++ b/libraries/AP_Parachute/AP_Parachute.h
@@ -2,9 +2,7 @@
 
 /// @file	AP_Parachute.h
 /// @brief	Parachute release library
-
-#ifndef AP_PARACHUTE_H
-#define AP_PARACHUTE_H
+#pragma once
 
 #include <AP_Param/AP_Param.h>
 #include <AP_Common/AP_Common.h>
@@ -75,5 +73,3 @@ private:
     bool        _release_in_progress:1;  // true if the parachute release is in progress
     bool        _released:1;    // true if the parachute has been released
 };
-
-#endif /* AP_PARACHUTE_H */

--- a/libraries/AP_RCMapper/AP_RCMapper.h
+++ b/libraries/AP_RCMapper/AP_RCMapper.h
@@ -1,6 +1,5 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-#ifndef AP_RCMAPPER_H
-#define AP_RCMAPPER_H
+#pragma once
 
 #include <inttypes.h>
 #include <AP_Common/AP_Common.h>
@@ -34,4 +33,3 @@ private:
     AP_Int8 _ch_yaw;
     AP_Int8 _ch_throttle;
 };
-#endif

--- a/libraries/AP_RPM/AP_RPM.h
+++ b/libraries/AP_RPM/AP_RPM.h
@@ -13,9 +13,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-#ifndef __RPM_H__
-#define __RPM_H__
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
@@ -97,4 +95,3 @@ private:
     void detect_instance(uint8_t instance);
     void update_instance(uint8_t instance);  
 };
-#endif // __RPM_H__

--- a/libraries/AP_RPM/RPM_Backend.h
+++ b/libraries/AP_RPM/RPM_Backend.h
@@ -13,9 +13,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-#ifndef __AP_RPM_BACKEND_H__
-#define __AP_RPM_BACKEND_H__
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
@@ -39,4 +37,3 @@ protected:
     AP_RPM &ap_rpm;
     AP_RPM::RPM_State &state;
 };
-#endif // __AP_RPM_BACKEND_H__

--- a/libraries/AP_RPM/RPM_PX4_PWM.h
+++ b/libraries/AP_RPM/RPM_PX4_PWM.h
@@ -13,9 +13,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
- 
-#ifndef AP_RPM_PX4_PWM_H
-#define AP_RPM_PX4_PWM_H
+#pragma once
 
 #include "AP_RPM.h"
 #include "RPM_Backend.h"
@@ -41,5 +39,3 @@ private:
 
     ModeFilterFloat_Size5 signal_quality_filter {3};
 };
-
-#endif // AP_RPM_PX4_PWM_H

--- a/libraries/AP_RPM/RPM_SITL.h
+++ b/libraries/AP_RPM/RPM_SITL.h
@@ -13,9 +13,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
- 
-#ifndef AP_RPM_SITL_H
-#define AP_RPM_SITL_H
+#pragma once
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 
@@ -37,4 +35,3 @@ private:
 };
 
 #endif // CONFIG_HAL_BOARD
-#endif // AP_RPM_SITL_H

--- a/libraries/AP_RSSI/AP_RSSI.h
+++ b/libraries/AP_RSSI/AP_RSSI.h
@@ -13,9 +13,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
- 
-#ifndef AP_RSSI_H
-#define AP_RSSI_H
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
@@ -77,5 +75,3 @@ private:
     // Scale and constrain a float rssi value to 0.0 to 1.0 range 
     float scale_and_constrain_float_rssi(float current_rssi_value, float low_rssi_range, float high_rssi_range);
 };
-
-#endif // AP_RSSI_H

--- a/libraries/AP_Rally/AP_Rally.h
+++ b/libraries/AP_Rally/AP_Rally.h
@@ -14,8 +14,7 @@
  * - provides access to the rally points, including logic to find the nearest one
  *
  */
-#ifndef AP_Rally_h
-#define AP_Rally_h
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
@@ -75,6 +74,3 @@ private:
 
     uint32_t _last_change_time_ms;
 };
-
-
-#endif // AP_Rally_h

--- a/libraries/AP_RangeFinder/AP_RangeFinder_BBB_PRU.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_BBB_PRU.h
@@ -1,5 +1,4 @@
-#ifndef __AP_RANGEFINDER_PRU_H__
-#define __AP_RANGEFINDER_PRU_H__
+#pragma once
 
 #include "RangeFinder.h"
 #include "RangeFinder_Backend.h"
@@ -33,4 +32,3 @@ public:
 private:
 
 };
-#endif  // __AP_RANGEFINDER_PRU_H__

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.h
@@ -1,7 +1,5 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef __AP_RANGEFINDER_LIGHTWARELRF_H__
-#define __AP_RANGEFINDER_LIGHTWARELRF_H__
+#pragma once
 
 #include "RangeFinder.h"
 #include "RangeFinder_Backend.h"
@@ -23,4 +21,3 @@ private:
     // get a reading
     bool get_reading(uint16_t &reading_cm);
 };
-#endif  // __AP_RANGEFINDER_LIGHTWARELRF_H__

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.h
@@ -1,7 +1,5 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef __AP_RANGEFINDER_LIGHTWARESERIAL_H__
-#define __AP_RANGEFINDER_LIGHTWARESERIAL_H__
+#pragma once
 
 #include "RangeFinder.h"
 #include "RangeFinder_Backend.h"
@@ -29,4 +27,3 @@ private:
     char linebuf[10];
     uint8_t linebuf_len = 0;
 };
-#endif  // __AP_RANGEFINDER_LIGHTWARESERIAL_H__

--- a/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_MaxsonarI2CXL.h
@@ -1,7 +1,5 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef __AP_RANGEFINDER_MAXSONARI2CXL_H__
-#define __AP_RANGEFINDER_MAXSONARI2CXL_H__
+#pragma once
 
 #include "RangeFinder.h"
 #include "RangeFinder_Backend.h"
@@ -32,4 +30,3 @@ private:
     static bool start_reading(void);
     static bool get_reading(uint16_t &reading_cm);
 };
-#endif  // __AP_RANGEFINDER_MAXSONARI2CXL_H__

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PX4.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PX4.h
@@ -13,9 +13,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
- 
-#ifndef AP_RangeFinder_PX4_H
-#define AP_RangeFinder_PX4_H
+#pragma once
 
 #include "RangeFinder.h"
 #include "RangeFinder_Backend.h"
@@ -49,5 +47,3 @@ private:
     // try to open the PX4 driver and return its fd
     static int open_driver(void);
 };
-
-#endif // AP_RangeFinder_PX4_H

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PX4_PWM.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PX4_PWM.h
@@ -13,9 +13,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
- 
-#ifndef AP_RangeFinder_PX4_PWM_H
-#define AP_RangeFinder_PX4_PWM_H
+#pragma once
 
 #include "RangeFinder.h"
 #include "RangeFinder_Backend.h"
@@ -43,5 +41,3 @@ private:
     uint32_t _good_sample_count;
     float _last_sample_distance_cm;
 };
-
-#endif // AP_RangeFinder_PX4_PWM_H

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PulsedLightLRF.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PulsedLightLRF.h
@@ -1,7 +1,5 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef __AP_RANGEFINDER_PULSEDLIGHTLRF_H__
-#define __AP_RANGEFINDER_PULSEDLIGHTLRF_H__
+#pragma once
 
 #include "RangeFinder.h"
 #include "RangeFinder_Backend.h"
@@ -49,4 +47,3 @@ private:
     static bool start_reading(void);
     static bool get_reading(uint16_t &reading_cm);
 };
-#endif  // __AP_RANGEFINDER_PULSEDLIGHTLRF_H__

--- a/libraries/AP_RangeFinder/AP_RangeFinder_analog.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_analog.h
@@ -1,7 +1,5 @@
 /// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
-
-#ifndef __AP_RANGEFINDER_ANALOG_H__
-#define __AP_RANGEFINDER_ANALOG_H__
+#pragma once
 
 #include "RangeFinder.h"
 #include "RangeFinder_Backend.h"
@@ -24,5 +22,3 @@ private:
 
     AP_HAL::AnalogSource *source;
 };
-#endif // __AP_RANGEFINDER_ANALOG_H__
-

--- a/libraries/AP_RangeFinder/RangeFinder.h
+++ b/libraries/AP_RangeFinder/RangeFinder.h
@@ -13,9 +13,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-#ifndef __RANGEFINDER_H__
-#define __RANGEFINDER_H__
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
@@ -191,4 +189,3 @@ private:
 
     void update_pre_arm_check(uint8_t instance);
 };
-#endif // __RANGEFINDER_H__

--- a/libraries/AP_RangeFinder/RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/RangeFinder_Backend.h
@@ -13,9 +13,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-#ifndef __AP_RANGEFINDER_BACKEND_H__
-#define __AP_RANGEFINDER_BACKEND_H__
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
@@ -50,4 +48,3 @@ protected:
     RangeFinder &ranger;
     RangeFinder::RangeFinder_State &state;
 };
-#endif // __AP_RANGEFINDER_BACKEND_H__

--- a/libraries/AP_Relay/AP_Relay.h
+++ b/libraries/AP_Relay/AP_Relay.h
@@ -9,9 +9,7 @@
 
 /// @file	AP_Relay.h
 /// @brief	APM relay control class
-
-#ifndef __AP_RELAY_H__
-#define __AP_RELAY_H__
+#pragma once
 
 #include <AP_Param/AP_Param.h>
 
@@ -44,5 +42,3 @@ private:
     AP_Int8 _pin[AP_RELAY_NUM_RELAYS];
     AP_Int8 _default;
 };
-
-#endif /* AP_RELAY_H_ */

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -20,9 +20,7 @@
   serial ports and provides helper functions so objects (like a gimbal) can
   find which serial port they should use
  */
-
-#ifndef _AP_SERIALMANAGER_
-#define _AP_SERIALMANAGER_
+#pragma once
 
 #include <AP_Math/AP_Math.h>
 #include <AP_Common/AP_Common.h>
@@ -131,5 +129,3 @@ private:
     // protocol_match - returns true if the protocols match
     bool protocol_match(enum SerialProtocol protocol1, enum SerialProtocol protocol2) const;
 };
-
-#endif // _AP_SERIALMANAGER_

--- a/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.h
+++ b/libraries/AP_ServoRelayEvents/AP_ServoRelayEvents.h
@@ -6,9 +6,7 @@
  * handle DO_SET_SERVO, DO_REPEAT_SERVO, DO_SET_RELAY and
  * DO_REPEAT_RELAY commands
  */
-
-#ifndef __AP_SERVORELAYEVENTS_H__
-#define __AP_SERVORELAYEVENTS_H__
+#pragma once
 
 #include <AP_Param/AP_Param.h>
 #include <AP_Relay/AP_Relay.h>
@@ -62,5 +60,3 @@ private:
 	// PWM for servos
 	uint16_t servo_value;
 };
-
-#endif /* AP_SERVORELAYEVENTS_H_ */

--- a/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
+++ b/libraries/AP_SpdHgtControl/AP_SpdHgtControl.h
@@ -1,4 +1,5 @@
 // -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: t -*-
+#pragma once
 
 /// @file    AP_SpdHgtControl.h
 /// @brief   generic speed & height controller interface
@@ -9,9 +10,6 @@
   interface. All variables used by controllers should be in their
   own class.
  */
-
-#ifndef AP_SPDHGTCONTROL_H
-#define AP_SPDHGTCONTROL_H
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
@@ -85,6 +83,3 @@ public:
 	
 
 };
-
-
-#endif // AP_SPDHGTCONTROL_H

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -18,9 +18,7 @@
  *  - Relative ease of tuning through use of intuitive time constant, trim rate and damping parameters and the use
  *    of easy to measure aircraft performance data
  */
-
-#ifndef AP_TECS_H
-#define AP_TECS_H
+#pragma once
 
 #include <AP_Math/AP_Math.h>
 #include <AP_AHRS/AP_AHRS.h>
@@ -348,5 +346,3 @@ private:
 
 #define TECS_LOG_FORMAT(msg) { msg, sizeof(AP_TECS::log_TECS_Tuning),	\
 							   "TECS", "Qffffffffffff", "TimeUS,h,dh,h_dem,dh_dem,sp_dem,sp,dsp,ith,iph,th,ph,dsp_dem" }
-
-#endif //AP_TECS_H

--- a/libraries/AP_Terrain/AP_Terrain.h
+++ b/libraries/AP_Terrain/AP_Terrain.h
@@ -13,9 +13,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-#ifndef __AP_TERRAIN_H__
-#define __AP_TERRAIN_H__
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
@@ -410,4 +408,3 @@ private:
     enum TerrainStatus system_status = TerrainStatusDisabled;
 };
 #endif // AP_TERRAIN_AVAILABLE
-#endif // __AP_TERRAIN_H__

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -12,8 +12,8 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef AP_VEHICLE_H
-#define AP_VEHICLE_H
+#pragma once
+
 /*
   this header holds a parameter structure for each vehicle type for
   parameters needed by multiple libraries
@@ -54,5 +54,3 @@ public:
 
 
 #include "AP_Vehicle_Type.h"
-
-#endif // AP_VEHICLE_H

--- a/libraries/AP_Vehicle/AP_Vehicle_Type.h
+++ b/libraries/AP_Vehicle/AP_Vehicle_Type.h
@@ -12,8 +12,7 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef AP_VEHICLE_TYPE_H
-#define AP_VEHICLE_TYPE_H
+#pragma once
 
 /*
   define common vehicle build types. Note that the APM_BUILD_DIRECTORY
@@ -38,5 +37,3 @@
 #else
 #define APM_BUILD_TYPE(type) ((type) == APM_BUILD_UNKNOWN)
 #endif
-
-#endif // AP_VEHICLE_TYPE_H

--- a/libraries/DataFlash/DFMessageWriter.h
+++ b/libraries/DataFlash/DFMessageWriter.h
@@ -1,5 +1,4 @@
-#ifndef DF_LOGSTARTUP_H
-#define DF_LOGSTARTUP_H
+#pragma once
 
 #include "DataFlash_Backend.h"
 
@@ -112,6 +111,3 @@ private:
     DFMessageWriter_WriteSysInfo _writesysinfo;
     DFMessageWriter_WriteEntireMission _writeentiremission;
 };
-
-#endif
-

--- a/libraries/DataFlash/DataFlash.h
+++ b/libraries/DataFlash/DataFlash.h
@@ -3,8 +3,7 @@
 /* ************************************************************ */
 /* Test for DataFlash Log library                               */
 /* ************************************************************ */
-#ifndef DataFlash_h
-#define DataFlash_h
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Common/AP_Common.h>
@@ -179,5 +178,3 @@ private:
     DataFlash_Backend *backends[DATAFLASH_MAX_BACKENDS];
     const char *_firmware_string;
 };
-
-#endif

--- a/libraries/DataFlash/DataFlash_Backend.h
+++ b/libraries/DataFlash/DataFlash_Backend.h
@@ -1,5 +1,4 @@
-#ifndef DATAFLASH_BACKEND_H
-#define DATAFLASH_BACKEND_H
+#pragma once
 
 #include "DataFlash.h"
 
@@ -134,5 +133,3 @@ private:
     uint32_t _last_periodic_1Hz;
     uint32_t _last_periodic_10Hz;
 };
-
-#endif

--- a/libraries/DataFlash/DataFlash_Block.h
+++ b/libraries/DataFlash/DataFlash_Block.h
@@ -3,9 +3,7 @@
 /* 
    DataFlash logging - block oriented variant
  */
-
-#ifndef DataFlash_block_h
-#define DataFlash_block_h
+#pragma once
 
 #include "DataFlash_Backend.h"
 
@@ -125,6 +123,3 @@ protected:
 
 
 #include "DataFlash_SITL.h"
-
-#endif // DataFlash_block_h
-

--- a/libraries/DataFlash/DataFlash_File.h
+++ b/libraries/DataFlash/DataFlash_File.h
@@ -6,9 +6,7 @@
    This uses posix file IO to create log files called logNN.dat in the
    given directory
  */
-
-#ifndef DataFlash_File_h
-#define DataFlash_File_h
+#pragma once
 
 #if HAL_OS_POSIX_IO
 
@@ -153,5 +151,3 @@ private:
 };
 
 #endif // HAL_OS_POSIX_IO
-
-#endif // DataFlash_File_h

--- a/libraries/DataFlash/DataFlash_MAVLink.h
+++ b/libraries/DataFlash/DataFlash_MAVLink.h
@@ -5,9 +5,7 @@
 
    - transfers blocks of the open log file to a client using MAVLink
  */
-
-#ifndef DATAFLASH_MAVLINK_H
-#define DATAFLASH_MAVLINK_H
+#pragma once
 
 #define DATAFLASH_MAVLINK_SUPPORT 1
 
@@ -192,6 +190,3 @@ private:
 };
 
 #endif // DATAFLASH_MAVLINK_SUPPORT
-
-#endif // DATAFLASH_MAVLINK_H
-

--- a/libraries/DataFlash/DataFlash_SITL.h
+++ b/libraries/DataFlash/DataFlash_SITL.h
@@ -1,8 +1,7 @@
 /* ************************************************************ */
 /* DataFlash_SITL Log library                                 */
 /* ************************************************************ */
-#ifndef __DATAFLASH_SITL_H__
-#define __DATAFLASH_SITL_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 
@@ -49,4 +48,3 @@ public:
 };
 
 #endif // CONFIG_HAL_BOARD == HAL_BOARD_SITL
-#endif // __DATAFLASH_SITL_H__

--- a/libraries/DataFlash/LogStructure.h
+++ b/libraries/DataFlash/LogStructure.h
@@ -1,5 +1,4 @@
-#ifndef _LOGSTRUCTURE_H
-#define _LOGSTRUCTURE_H
+#pragma once
 
 /*
   unfortunately these need to be macros because of a limitation of
@@ -983,5 +982,3 @@ enum LogOriginType {
     ekf_origin = 0,
     ahrs_home = 1
 };
-
-#endif

--- a/libraries/GCS_Console/GCS_Console.h
+++ b/libraries/GCS_Console/GCS_Console.h
@@ -1,6 +1,4 @@
-
-#ifndef __GCS_CONSOLE_H__
-#define __GCS_CONSOLE_H__
+#pragma once
 
 #include <GCS_MAVLink/GCS_MAVLink.h>
 
@@ -21,5 +19,3 @@ void gcs_console_handle_data16(mavlink_message_t* msg);
 void gcs_console_handle_data32(mavlink_message_t* msg);
 
 void gcs_console_send(mavlink_channel_t chan);
-
-#endif // __GCS_CONSOLE_H__

--- a/libraries/GCS_Console/examples/Console/simplegcs.h
+++ b/libraries/GCS_Console/examples/Console/simplegcs.h
@@ -1,6 +1,4 @@
-
-#ifndef __SIMPLE_GCS_H__
-#define __SIMPLE_GCS_H__
+#pragma once
 
 #include <GCS_MAVLink/GCS_MAVLink.h>
 
@@ -10,6 +8,3 @@ bool try_send_statustext(mavlink_channel_t chan, const char *text, int len);
 
 void simplegcs_update(mavlink_channel_t chan);
 void handle_message(mavlink_channel_t chan, mavlink_message_t* msg);
-
-#endif // __SIMPLE_GCS_H__
-

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -3,9 +3,7 @@
 /// @file	GCS.h
 /// @brief	Interface definition for the various Ground Control System
 // protocols.
-
-#ifndef __GCS_H
-#define __GCS_H
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Common/AP_Common.h>
@@ -345,5 +343,3 @@ private:
     // return true if this channel has hardware flow control
     bool have_flow_control(void);
 };
-
-#endif // __GCS_H

--- a/libraries/GCS_MAVLink/GCS_MAVLink.h
+++ b/libraries/GCS_MAVLink/GCS_MAVLink.h
@@ -2,9 +2,7 @@
 
 /// @file	GCS_MAVLink.h
 /// @brief	One size fits all header for MAVLink integration.
-
-#ifndef GCS_MAVLink_h
-#define GCS_MAVLink_h
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
@@ -94,5 +92,3 @@ uint8_t mav_var_type(enum ap_var_type t);
 uint8_t mavlink_get_message_crc(uint8_t msgid);
 
 #pragma GCC diagnostic pop
-
-#endif // GCS_MAVLink_h

--- a/libraries/GCS_MAVLink/MAVLink_routing.h
+++ b/libraries/GCS_MAVLink/MAVLink_routing.h
@@ -2,9 +2,7 @@
 
 /// @file	MAVLink_routing.h
 /// @brief	handle routing of MAVLink packets by ID
-
-#ifndef __MAVLINK_ROUTING_H
-#define __MAVLINK_ROUTING_H
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Common/AP_Common.h>
@@ -63,6 +61,3 @@ private:
     // special handling for heartbeat messages
     void handle_heartbeat(mavlink_channel_t in_channel, const mavlink_message_t* msg);
 };
-
-#endif // __MAVLINK_ROUTING_H
-

--- a/libraries/PID/PID.h
+++ b/libraries/PID/PID.h
@@ -2,9 +2,7 @@
 
 /// @file	PID.h
 /// @brief	Generic PID algorithm, with EEPROM-backed storage of constants.
-
-#ifndef __PID_H__
-#define __PID_H__
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
@@ -120,5 +118,3 @@ private:
     ///
     static const uint8_t        _fCut = 20;
 };
-
-#endif

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -2,9 +2,7 @@
 
 /// @file	RC_Channel.h
 /// @brief	RC_Channel manager, with EEPROM-backed storage of constants.
-
-#ifndef __RC_CHANNEL_H__
-#define __RC_CHANNEL_H__
+#pragma once
 
 #include <AP_Common/AP_Common.h>
 #include <AP_Param/AP_Param.h>
@@ -162,5 +160,3 @@ protected:
 
 // This is ugly, but it fixes poorly architected library
 #include "RC_Channel_aux.h"
-
-#endif

--- a/libraries/RC_Channel/RC_Channel_aux.h
+++ b/libraries/RC_Channel/RC_Channel_aux.h
@@ -3,9 +3,7 @@
 /// @file	RC_Channel_aux.h
 /// @brief	RC_Channel manager for auxiliary channels (5..8), with EEPROM-backed storage of constants.
 /// @author Amilcar Lucas
-
-#ifndef __RC_CHANNEL_AUX_H__
-#define __RC_CHANNEL_AUX_H__
+#pragma once
 
 #include <AP_HAL/AP_HAL.h>
 #include "RC_Channel.h"
@@ -151,5 +149,3 @@ private:
 
     void aux_servo_function_setup(void);
 };
-
-#endif /* RC_CHANNEL_AUX_H_ */


### PR DESCRIPTION
This replaces all occurrences (that I could find with a tweaked grep) of the header guards with "#pragma once".  We've been doing this a lot in the last months, making the changes in the same patches that do other things.  Here I try to stop that by doing all at once.

Benefit is not having to invent the name for the macro and easier maintenance. It used to yield better compiler performance, but nowadays it's the same for both gcc and clang.

I was not sure if I would split this giant commit or use a "Global:" commit. I decided to split because some maintainers may want to hold this change so it doesn't conflict with their pending changes.