### PR TITLE
waf: add option --no-submodule-update [edited][v2]

### DIFF
--- a/wscript
+++ b/wscript
@@ -54,6 +54,13 @@ def options(opt):
                  action='store_true',
                  help='Output all test programs')
 
+    g.add_option('--no-submodule-update',
+                 dest='submodule_update',
+                 action='store_false',
+                 default=True,
+                 help='Don\'t update git submodules. Useful for building ' +
+                      'with submodules at specific revisions.')
+
 def configure(cfg):
     cfg.env.BOARD = cfg.options.board
     # use a different variant for each board
@@ -96,6 +103,9 @@ def configure(cfg):
     cfg.env.prepend_value('DEFINES', [
         'SKETCHBOOK="' + cfg.srcnode.abspath() + '"',
     ])
+
+    if cfg.options.submodule_update:
+        cfg.env.SUBMODULE_UPDATE = [True]
 
 def collect_dirs_to_recurse(bld, globs, **kw):
     dirs = []
@@ -198,9 +208,10 @@ def build(bld):
 
     _build_cmd_tweaks(bld)
 
-    bld.add_group('git_submodules')
-    for name in bld.env.GIT_SUBMODULES:
-        bld.git_submodule(name)
+    if bld.env.SUBMODULE_UPDATE:
+        bld.add_group('git_submodules')
+        for name in bld.env.GIT_SUBMODULES:
+            bld.git_submodule(name)
 
     bld.add_group('dynamic_sources')
     _build_dynamic_sources(bld)


### PR DESCRIPTION
That is useful when the user wants to build with one or more submodules at a
specific revision. In case of a developer, that is useful for when a submodule
is modification process and she needs to (constantly) test the build.