### PR TITLE
GCS_MAVLINK: globally replace gcs sendtext* with static gcs_sendtext and queue them

### DIFF
--- a/APMrover2/APMrover2.cpp
+++ b/APMrover2/APMrover2.cpp
@@ -59,6 +59,7 @@ const AP_Scheduler::Task Rover::scheduler_tasks[] = {
     SCHED_TASK(update_logging1,        10,   1000),
     SCHED_TASK(update_logging2,        10,   1000),
     SCHED_TASK(gcs_retry_deferred,     50,   1000),
+    SCHED_TASK(gcs_retry_sendtext,     50,   1000),
     SCHED_TASK(gcs_update,             50,   1700),
     SCHED_TASK(gcs_data_stream_send,   50,   3000),
     SCHED_TASK(read_control_switch,     7,   1000),

--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -1390,7 +1390,7 @@ void Rover::mavlink_delay_cb()
     }
     if (tnow - last_5s > 5000) {
         last_5s = tnow;
-        gcs_send_text(MAV_SEVERITY_INFO, "Initialising APM");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Initialising APM");
     }
     check_usb_mux();
 

--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -1450,44 +1450,6 @@ void Rover::gcs_update(void)
     }
 }
 
-void Rover::gcs_send_text(MAV_SEVERITY severity, const char *str)
-{
-    for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs[i].initialised) {
-            gcs[i].send_text(severity, str);
-    }
-    }
-#if LOGGING_ENABLED == ENABLED
-    DataFlash.Log_Write_Message(str);
-#endif
-}
-
-/*
- *  send a low priority formatted message to the GCS
- *  only one fits in the queue, so if you send more than one before the
- *  last one gets into the serial buffer then the old one will be lost
- */
-void Rover::gcs_send_text_fmt(MAV_SEVERITY severity, const char *fmt, ...)
-{
-    va_list arg_list;
-    gcs[0].pending_status.severity = (uint8_t)severity;
-    va_start(arg_list, fmt);
-    hal.util->vsnprintf((char *)gcs[0].pending_status.text,
-            sizeof(gcs[0].pending_status.text), fmt, arg_list);
-    va_end(arg_list);
-#if LOGGING_ENABLED == ENABLED
-    DataFlash.Log_Write_Message(gcs[0].pending_status.text);
-#endif
-    gcs[0].send_message(MSG_STATUSTEXT);
-    for (uint8_t i=1; i<num_gcs; i++) {
-        if (gcs[i].initialised) {
-            gcs[i].pending_status = gcs[0].pending_status;
-            gcs[i].send_message(MSG_STATUSTEXT);
-        }
-    }
-}
-
-
 /**
    retry any deferred messages
  */

--- a/APMrover2/GCS_Mavlink.cpp
+++ b/APMrover2/GCS_Mavlink.cpp
@@ -1495,3 +1495,8 @@ void Rover::gcs_retry_deferred(void)
 {
     gcs_send_message(MSG_RETRY_DEFERRED);
 }
+
+void Rover::gcs_retry_sendtext(void)
+{
+    GCS_MAVLINK::retry_statustext();
+}

--- a/APMrover2/Log.cpp
+++ b/APMrover2/Log.cpp
@@ -408,12 +408,12 @@ void Rover::log_init(void)
 {
 	DataFlash.Init(log_structure, ARRAY_SIZE(log_structure));
     if (!DataFlash.CardInserted()) {
-        gcs_send_text(MAV_SEVERITY_WARNING, "No dataflash card inserted");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "No dataflash card inserted");
         g.log_bitmask.set(0);
     } else if (DataFlash.NeedPrep()) {
-        gcs_send_text(MAV_SEVERITY_INFO, "Preparing log system");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Preparing log system");
         DataFlash.Prep();
-        gcs_send_text(MAV_SEVERITY_INFO, "Prepared log system");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Prepared log system");
         for (uint8_t i=0; i<num_gcs; i++) {
             gcs[i].reset_cli_timeout();
         }

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -407,7 +407,6 @@ private:
     void send_pid_tuning(mavlink_channel_t chan);
     void send_rangefinder(mavlink_channel_t chan);
     void send_current_waypoint(mavlink_channel_t chan);
-    void send_statustext(mavlink_channel_t chan);
     bool telemetry_delayed(mavlink_channel_t chan);
     void gcs_send_message(enum ap_message id);
     void gcs_send_mission_item_reached_message(uint16_t mission_index);

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -415,6 +415,7 @@ private:
     void gcs_update(void);
     void gcs_send_text(MAV_SEVERITY severity, const char *str);
     void gcs_retry_deferred(void);
+    void gcs_retry_sendtext(void);
 
     void do_erase_logs(void);
     void Log_Write_Performance();

--- a/APMrover2/Rover.h
+++ b/APMrover2/Rover.h
@@ -413,7 +413,6 @@ private:
     void gcs_send_mission_item_reached_message(uint16_t mission_index);
     void gcs_data_stream_send(void);
     void gcs_update(void);
-    void gcs_send_text(MAV_SEVERITY severity, const char *str);
     void gcs_retry_deferred(void);
     void gcs_retry_sendtext(void);
 
@@ -504,7 +503,6 @@ private:
     bool should_log(uint32_t mask);
     void frsky_telemetry_send(void);
     void print_hit_enter();    
-    void gcs_send_text_fmt(MAV_SEVERITY severity, const char *fmt, ...);
     void print_mode(AP_HAL::BetterStream *port, uint8_t mode);
     bool start_command(const AP_Mission::Mission_Command& cmd);
     bool verify_command(const AP_Mission::Mission_Command& cmd);

--- a/APMrover2/Steering.cpp
+++ b/APMrover2/Steering.cpp
@@ -29,7 +29,7 @@ bool Rover::auto_check_trigger(void) {
 
     // check for user pressing the auto trigger to off
     if (auto_triggered && g.auto_trigger_pin != -1 && check_digital_pin(g.auto_trigger_pin) == 1) {
-        gcs_send_text(MAV_SEVERITY_WARNING, "AUTO triggered off");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "AUTO triggered off");
         auto_triggered = false;
         return false;
     }
@@ -47,7 +47,7 @@ bool Rover::auto_check_trigger(void) {
     }
 
     if (g.auto_trigger_pin != -1 && check_digital_pin(g.auto_trigger_pin) == 0) {
-        gcs_send_text(MAV_SEVERITY_WARNING, "Triggered AUTO with pin");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "Triggered AUTO with pin");
         auto_triggered = true;
         return true;
     }
@@ -55,7 +55,7 @@ bool Rover::auto_check_trigger(void) {
     if (!is_zero(g.auto_kickstart)) {
         float xaccel = ins.get_accel().x;
         if (xaccel >= g.auto_kickstart) {
-            gcs_send_text_fmt(MAV_SEVERITY_WARNING, "Triggered AUTO xaccel=%.1f", (double)xaccel);
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "Triggered AUTO xaccel=%.1f", (double)xaccel);
             auto_triggered = true;
             return true;
         }

--- a/APMrover2/commands.cpp
+++ b/APMrover2/commands.cpp
@@ -30,7 +30,7 @@ void Rover::set_next_WP(const struct Location& loc)
     // location as the previous waypoint, to prevent immediately
     // considering the waypoint complete
     if (location_passed_point(current_loc, prev_WP, next_WP)) {
-        gcs_send_text(MAV_SEVERITY_NOTICE, "Resetting previous WP");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_NOTICE, "Resetting previous WP");
         prev_WP = current_loc;
     }
 
@@ -63,7 +63,7 @@ void Rover::init_home()
         return;
     }
 
-	gcs_send_text(MAV_SEVERITY_INFO, "Init HOME");
+	GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Init HOME");
 
     ahrs.set_home(gps.location());
 	home_is_set = HOME_SET_NOT_LOCKED;

--- a/APMrover2/commands_logic.cpp
+++ b/APMrover2/commands_logic.cpp
@@ -17,7 +17,7 @@ bool Rover::start_command(const AP_Mission::Mission_Command& cmd)
         return false;
     }
 
-    gcs_send_text_fmt(MAV_SEVERITY_INFO, "Executing command ID #%i",cmd.id);
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Executing command ID #%i",cmd.id);
 
     // remember the course of our next navigation leg
     next_navigation_leg_cd = mission.get_next_ground_course_cd(0);
@@ -117,7 +117,7 @@ bool Rover::start_command(const AP_Mission::Mission_Command& cmd)
 void Rover::exit_mission()
 {
     if (control_mode == AUTO) {
-        gcs_send_text_fmt(MAV_SEVERITY_NOTICE, "No commands. Can't set AUTO. Setting HOLD");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_NOTICE, "No commands. Can't set AUTO. Setting HOLD");
         set_mode(HOLD);
     }
 }
@@ -164,7 +164,7 @@ bool Rover::verify_command(const AP_Mission::Mission_Command& cmd)
                 // this is a command that doesn't require verify
                 return true;
             }
-            gcs_send_text(MAV_SEVERITY_CRITICAL,"Verify conditon. Unsupported command");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"Verify conditon. Unsupported command");
             return true;
 	}
     return false;
@@ -203,7 +203,7 @@ bool Rover::verify_nav_wp(const AP_Mission::Mission_Command& cmd)
         // Check if we need to loiter at this waypoint
         if (loiter_time_max > 0) {
             if (loiter_time == 0) {  // check if we are just starting loiter
-                gcs_send_text_fmt(MAV_SEVERITY_INFO, "Reached waypoint #%i. Loiter for %i seconds",
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Reached waypoint #%i. Loiter for %i seconds",
                                   (unsigned)cmd.index,
                                   (unsigned)loiter_time_max);
                 // record the current time i.e. start timer
@@ -214,7 +214,7 @@ bool Rover::verify_nav_wp(const AP_Mission::Mission_Command& cmd)
                 return false;
             }
         } else {
-            gcs_send_text_fmt(MAV_SEVERITY_INFO, "Reached waypoint #%i. Distance %um",
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Reached waypoint #%i. Distance %um",
                               (unsigned)cmd.index,
                               (unsigned)get_distance(current_loc, next_WP));
         }
@@ -228,7 +228,7 @@ bool Rover::verify_nav_wp(const AP_Mission::Mission_Command& cmd)
         // check if we have gone futher past the wp then last time and output new message if we have
         if ((uint32_t)distance_past_wp != (uint32_t)get_distance(current_loc, next_WP)) {
             distance_past_wp = get_distance(current_loc, next_WP);
-            gcs_send_text_fmt(MAV_SEVERITY_INFO, "Passed waypoint #%i. Distance %um",
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Passed waypoint #%i. Distance %um",
                               (unsigned)cmd.index,
                               (unsigned)distance_past_wp);
         }
@@ -248,14 +248,14 @@ bool Rover::verify_nav_wp(const AP_Mission::Mission_Command& cmd)
 bool Rover::verify_RTL()
 {
 	if (wp_distance <= g.waypoint_radius) {
-		gcs_send_text(MAV_SEVERITY_INFO,"Reached destination");
+		GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO,"Reached destination");
                 rtl_complete = true;
 		return true;
 	}
 
     // have we gone past the waypoint?
     if (location_passed_point(current_loc, prev_WP, next_WP)) {
-        gcs_send_text_fmt(MAV_SEVERITY_INFO, "Reached destination. Distance away %um",
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Reached destination. Distance away %um",
                           (unsigned)get_distance(current_loc, next_WP));
         rtl_complete = true;
         return true;
@@ -309,12 +309,12 @@ void Rover::do_change_speed(const AP_Mission::Mission_Command& cmd)
 {
     if (cmd.content.speed.target_ms > 0) {
         g.speed_cruise.set(cmd.content.speed.target_ms);
-        gcs_send_text_fmt(MAV_SEVERITY_INFO, "Cruise speed: %.1f m/s", (double)g.speed_cruise.get());
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Cruise speed: %.1f m/s", (double)g.speed_cruise.get());
     }
 
 	if (cmd.content.speed.throttle_pct > 0 && cmd.content.speed.throttle_pct <= 100) {
 		g.throttle_cruise.set(cmd.content.speed.throttle_pct);
-        gcs_send_text_fmt(MAV_SEVERITY_INFO, "Cruise throttle: %.1f", g.throttle_cruise.get());
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Cruise throttle: %.1f", g.throttle_cruise.get());
     }
 }
 

--- a/APMrover2/sensors.cpp
+++ b/APMrover2/sensors.cpp
@@ -4,9 +4,9 @@
 
 void Rover::init_barometer(void)
 {
-    gcs_send_text(MAV_SEVERITY_INFO, "Calibrating barometer");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Calibrating barometer");
     barometer.calibrate();
-    gcs_send_text(MAV_SEVERITY_INFO, "Barometer calibration complete");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Barometer calibration complete");
 }
 
 void Rover::init_sonar(void)
@@ -70,7 +70,7 @@ void Rover::read_sonars(void)
                 obstacle.detected_count++;
             }
             if (obstacle.detected_count == g.sonar_debounce) {
-                gcs_send_text_fmt(MAV_SEVERITY_INFO, "Sonar1 obstacle %u cm",
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Sonar1 obstacle %u cm",
                                   (unsigned)obstacle.sonar1_distance_cm);
             }
             obstacle.detected_time_ms = AP_HAL::millis();
@@ -81,7 +81,7 @@ void Rover::read_sonars(void)
                 obstacle.detected_count++;
             }
             if (obstacle.detected_count == g.sonar_debounce) {
-                gcs_send_text_fmt(MAV_SEVERITY_INFO, "Sonar2 obstacle %u cm",
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Sonar2 obstacle %u cm",
                                   (unsigned)obstacle.sonar2_distance_cm);
             }
             obstacle.detected_time_ms = AP_HAL::millis();
@@ -97,7 +97,7 @@ void Rover::read_sonars(void)
                 obstacle.detected_count++;
             }
             if (obstacle.detected_count == g.sonar_debounce) {
-                gcs_send_text_fmt(MAV_SEVERITY_INFO, "Sonar obstacle %u cm",
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Sonar obstacle %u cm",
                                   (unsigned)obstacle.sonar1_distance_cm);
             }
             obstacle.detected_time_ms = AP_HAL::millis();
@@ -110,7 +110,7 @@ void Rover::read_sonars(void)
     // no object detected - reset after the turn time
     if (obstacle.detected_count >= g.sonar_debounce &&
         AP_HAL::millis() > obstacle.detected_time_ms + g.sonar_turn_time*1000) { 
-        gcs_send_text_fmt(MAV_SEVERITY_INFO, "Obstacle passed");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Obstacle passed");
         obstacle.detected_count = 0;
         obstacle.turn_angle = 0;
     }

--- a/APMrover2/system.cpp
+++ b/APMrover2/system.cpp
@@ -214,10 +214,10 @@ void Rover::startup_ground(void)
 {
     set_mode(INITIALISING);
     
-	gcs_send_text(MAV_SEVERITY_INFO,"<startup_ground> Ground start");
+	GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO,"<startup_ground> Ground start");
 
 	#if(GROUND_START_DELAY > 0)
-		gcs_send_text(MAV_SEVERITY_NOTICE,"<startup_ground> With delay");
+		GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_NOTICE,"<startup_ground> With delay");
 		delay(GROUND_START_DELAY * 1000);
 	#endif
 
@@ -241,7 +241,7 @@ void Rover::startup_ground(void)
     ins.set_raw_logging(should_log(MASK_LOG_IMU_RAW));
     ins.set_dataflash(&DataFlash);
 
-	gcs_send_text(MAV_SEVERITY_INFO,"Ready to drive");
+	GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO,"Ready to drive");
 }
 
 /*
@@ -357,7 +357,7 @@ void Rover::failsafe_trigger(uint8_t failsafe_type, bool on)
     }
     if (failsafe.triggered != 0 && failsafe.bits == 0) {
         // a failsafe event has ended
-        gcs_send_text_fmt(MAV_SEVERITY_INFO, "Failsafe ended");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Failsafe ended");
     }
 
     failsafe.triggered &= failsafe.bits;
@@ -368,7 +368,7 @@ void Rover::failsafe_trigger(uint8_t failsafe_type, bool on)
         control_mode != RTL &&
         control_mode != HOLD) {
         failsafe.triggered = failsafe.bits;
-        gcs_send_text_fmt(MAV_SEVERITY_WARNING, "Failsafe trigger 0x%x", (unsigned)failsafe.triggered);
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "Failsafe trigger 0x%x", (unsigned)failsafe.triggered);
         switch (g.fs_action) {
         case 0:
             break;
@@ -384,12 +384,12 @@ void Rover::failsafe_trigger(uint8_t failsafe_type, bool on)
 
 void Rover::startup_INS_ground(void)
 {
-    gcs_send_text(MAV_SEVERITY_INFO, "Warming up ADC");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Warming up ADC");
  	mavlink_delay(500);
 
 	// Makes the servos wiggle twice - about to begin INS calibration - HOLD LEVEL AND STILL!!
 	// -----------------------
-    gcs_send_text(MAV_SEVERITY_INFO, "Beginning INS calibration. Do not move vehicle");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Beginning INS calibration. Do not move vehicle");
 	mavlink_delay(1000);
 
     ahrs.init();

--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -125,6 +125,7 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
     SCHED_TASK(gcs_check_input,      400,    180),
     SCHED_TASK(gcs_send_heartbeat,     1,    110),
     SCHED_TASK(gcs_send_deferred,     50,    550),
+    SCHED_TASK(gcs_retry_sendtext,    50,   1000),
     SCHED_TASK(gcs_data_stream_send,  50,    550),
     SCHED_TASK(update_mount,          50,     75),
     SCHED_TASK(update_trigger,        50,     75),

--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -125,7 +125,7 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
     SCHED_TASK(gcs_check_input,      400,    180),
     SCHED_TASK(gcs_send_heartbeat,     1,    110),
     SCHED_TASK(gcs_send_deferred,     50,    550),
-    SCHED_TASK(gcs_retry_sendtext,    50,   1000),
+    SCHED_TASK(gcs_retry_statustext,  50,   1000),
     SCHED_TASK(gcs_data_stream_send,  50,    550),
     SCHED_TASK(update_mount,          50,     75),
     SCHED_TASK(update_trigger,        50,     75),

--- a/ArduCopter/ArduCopter.cpp
+++ b/ArduCopter/ArduCopter.cpp
@@ -208,7 +208,7 @@ void Copter::perf_update(void)
     if (should_log(MASK_LOG_PM))
         Log_Write_Performance();
     if (scheduler.debug()) {
-        gcs_send_text_fmt(MAV_SEVERITY_WARNING, "PERF: %u/%u %lu %lu\n",
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "PERF: %u/%u %lu %lu\n",
                           (unsigned)perf_info_get_num_long_running(),
                           (unsigned)perf_info_get_num_loops(),
                           (unsigned long)perf_info_get_max_time(),

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -634,7 +634,6 @@ private:
     void send_rpm(mavlink_channel_t chan);
     void rpm_update();
     void send_pid_tuning(mavlink_channel_t chan);
-    void send_statustext(mavlink_channel_t chan);
     bool telemetry_delayed(mavlink_channel_t chan);
     void gcs_send_message(enum ap_message id);
     void gcs_send_mission_item_reached_message(uint16_t mission_index);

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -617,7 +617,7 @@ private:
     void rotate_body_frame_to_NE(float &x, float &y);
     void gcs_send_heartbeat(void);
     void gcs_send_deferred(void);
-    void gcs_retry_sendtext(void);
+    void gcs_retry_statustext(void);
     void send_heartbeat(mavlink_channel_t chan);
     void send_attitude(mavlink_channel_t chan);
     void send_limits_status(mavlink_channel_t chan);

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -640,7 +640,6 @@ private:
     void gcs_send_mission_item_reached_message(uint16_t mission_index);
     void gcs_data_stream_send(void);
     void gcs_check_input(void);
-    void gcs_send_text(MAV_SEVERITY severity, const char *str);
     void do_erase_logs(void);
     void Log_Write_AutoTune(uint8_t axis, uint8_t tune_step, float meas_target, float meas_min, float meas_max, float new_gain_rp, float new_gain_rd, float new_gain_sp, float new_ddt);
     void Log_Write_AutoTuneDetails(float angle_cd, float rate_cds);
@@ -971,7 +970,6 @@ private:
     void takeoff_get_climb_rates(float& pilot_climb_rate, float& takeoff_climb_rate);
     void print_hit_enter();
     void tuning();
-    void gcs_send_text_fmt(MAV_SEVERITY severity, const char *fmt, ...);
     bool start_command(const AP_Mission::Mission_Command& cmd);
     bool verify_command(const AP_Mission::Mission_Command& cmd);
     bool verify_command_callback(const AP_Mission::Mission_Command& cmd);

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -617,6 +617,7 @@ private:
     void rotate_body_frame_to_NE(float &x, float &y);
     void gcs_send_heartbeat(void);
     void gcs_send_deferred(void);
+    void gcs_retry_sendtext(void);
     void send_heartbeat(mavlink_channel_t chan);
     void send_attitude(mavlink_channel_t chan);
     void send_limits_status(mavlink_channel_t chan);

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -2093,33 +2093,3 @@ void Copter::gcs_check_input(void)
     }
 }
 
-void Copter::gcs_send_text(MAV_SEVERITY severity, const char *str)
-{
-    for (uint8_t i=0; i<num_gcs; i++) {
-        if (gcs[i].initialised) {
-            gcs[i].send_text(severity, str);
-        }
-    }
-}
-
-/*
- *  send a low priority formatted message to the GCS
- *  only one fits in the queue, so if you send more than one before the
- *  last one gets into the serial buffer then the old one will be lost
- */
-void Copter::gcs_send_text_fmt(MAV_SEVERITY severity, const char *fmt, ...)
-{
-    va_list arg_list;
-    gcs[0].pending_status.severity = (uint8_t)severity;
-    va_start(arg_list, fmt);
-    hal.util->vsnprintf((char *)gcs[0].pending_status.text,
-            sizeof(gcs[0].pending_status.text), fmt, arg_list);
-    va_end(arg_list);
-    gcs[0].send_message(MSG_STATUSTEXT);
-    for (uint8_t i=1; i<num_gcs; i++) {
-        if (gcs[i].initialised) {
-            gcs[i].pending_status = gcs[0].pending_status;
-            gcs[i].send_message(MSG_STATUSTEXT);
-        }
-    }
-}

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -15,6 +15,11 @@ void Copter::gcs_send_deferred(void)
     gcs_send_message(MSG_RETRY_DEFERRED);
 }
 
+void Copter::gcs_send_deferred(void)
+{
+    GCS_MAVLINK::retry_statustext();
+}
+
 /*
  *  !!NOTE!!
  *

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -15,7 +15,7 @@ void Copter::gcs_send_deferred(void)
     gcs_send_message(MSG_RETRY_DEFERRED);
 }
 
-void Copter::gcs_send_deferred(void)
+void Copter::gcs_retry_statustext(void)
 {
     GCS_MAVLINK::retry_statustext();
 }

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -2033,7 +2033,7 @@ void Copter::mavlink_delay_cb()
     }
     if (tnow - last_5s > 5000) {
         last_5s = tnow;
-        gcs_send_text(MAV_SEVERITY_INFO, "Initialising APM");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Initialising APM");
     }
     check_usb_mux();
 

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -153,9 +153,9 @@ int8_t Copter::process_logs(uint8_t argc, const Menu::arg *argv)
 
 void Copter::do_erase_logs(void)
 {
-    gcs_send_text(MAV_SEVERITY_INFO, "Erasing logs");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Erasing logs");
     DataFlash.EraseAll();
-    gcs_send_text(MAV_SEVERITY_INFO, "Log erase complete");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Log erase complete");
 }
 
 #if AUTOTUNE_ENABLED == ENABLED
@@ -845,12 +845,12 @@ void Copter::log_init(void)
 {
     DataFlash.Init(log_structure, ARRAY_SIZE(log_structure));
     if (!DataFlash.CardInserted()) {
-        gcs_send_text(MAV_SEVERITY_WARNING, "No dataflash card inserted");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "No dataflash card inserted");
         g.log_bitmask.set(0);
     } else if (DataFlash.NeedPrep()) {
-        gcs_send_text(MAV_SEVERITY_INFO, "Preparing log system");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Preparing log system");
         DataFlash.Prep();
-        gcs_send_text(MAV_SEVERITY_INFO, "Prepared log system");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Prepared log system");
         for (uint8_t i=0; i<num_gcs; i++) {
             gcs[i].reset_cli_timeout();
         }

--- a/ArduCopter/adsb.cpp
+++ b/ArduCopter/adsb.cpp
@@ -46,7 +46,7 @@ void Copter::adsb_handle_vehicle_threats(void)
     if (adsb.get_is_evading_threat() && !adsb.get_possible_threat()) {
         adsb.set_is_evading_threat(false);
         Log_Write_Error(ERROR_SUBSYSTEM_FAILSAFE_ADSB, ERROR_CODE_FAILSAFE_RESOLVED);
-        gcs_send_text(MAV_SEVERITY_CRITICAL, "ADS-B threat cleared");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "ADS-B threat cleared");
         return;
     }
 
@@ -54,7 +54,7 @@ void Copter::adsb_handle_vehicle_threats(void)
     if (!adsb.get_is_evading_threat() && adsb.get_possible_threat()) {
         adsb.set_is_evading_threat(true);
         Log_Write_Error(ERROR_SUBSYSTEM_FAILSAFE_ADSB, ERROR_CODE_FAILSAFE_OCCURRED);
-        gcs_send_text(MAV_SEVERITY_CRITICAL, "ADS-B threat!");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "ADS-B threat!");
         return;
     }
 }

--- a/ArduCopter/arming_checks.cpp
+++ b/ArduCopter/arming_checks.cpp
@@ -42,7 +42,7 @@ bool Copter::pre_arm_checks(bool display_failure)
     // at the same time.  This cannot be allowed.
     if (check_if_auxsw_mode_used(AUXSW_MOTOR_INTERLOCK) && check_if_auxsw_mode_used(AUXSW_MOTOR_ESTOP)){
         if (display_failure) {
-            gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Interlock/E-Stop Conflict");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: Interlock/E-Stop Conflict");
         }
         return false;
     }
@@ -53,7 +53,7 @@ bool Copter::pre_arm_checks(bool display_failure)
     // as state can change at any time.
     if (ap.using_interlock && motors.get_interlock()){
         if (display_failure) {
-            gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Motor Interlock Enabled");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: Motor Interlock Enabled");
         }
         return false;
     }
@@ -77,7 +77,7 @@ bool Copter::pre_arm_checks(bool display_failure)
     pre_arm_rc_checks();
     if (!ap.pre_arm_rc_check) {
         if (display_failure) {
-            gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: RC not calibrated");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: RC not calibrated");
         }
         return false;
     }
@@ -86,7 +86,7 @@ bool Copter::pre_arm_checks(bool display_failure)
         // barometer health check
         if (!barometer.all_healthy()) {
             if (display_failure) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Barometer not healthy");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: Barometer not healthy");
             }
             return false;
         }
@@ -98,7 +98,7 @@ bool Copter::pre_arm_checks(bool display_failure)
         if (using_baro_ref) {
             if (fabsf(inertial_nav.get_altitude() - baro_alt) > PREARM_MAX_ALT_DISPARITY_CM) {
                 if (display_failure) {
-                    gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Altitude disparity");
+                    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: Altitude disparity");
                 }
                 return false;
             }
@@ -110,7 +110,7 @@ bool Copter::pre_arm_checks(bool display_failure)
         //check if compass has calibrated and requires reboot
         if (compass.compass_cal_requires_reboot()) {
             if (display_failure) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL, "PreArm: Compass calibrated requires reboot");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "PreArm: Compass calibrated requires reboot");
             }
             return false;
         }
@@ -118,7 +118,7 @@ bool Copter::pre_arm_checks(bool display_failure)
         // check the primary compass is healthy
         if (!compass.healthy()) {
             if (display_failure) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Compass not healthy");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: Compass not healthy");
             }
             return false;
         }
@@ -126,7 +126,7 @@ bool Copter::pre_arm_checks(bool display_failure)
         // check compass learning is on or offsets have been set
         if (!compass.configured()) {
             if (display_failure) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Compass not calibrated");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: Compass not calibrated");
             }
             return false;
         }
@@ -135,7 +135,7 @@ bool Copter::pre_arm_checks(bool display_failure)
         Vector3f offsets = compass.get_offsets();
         if (offsets.length() > COMPASS_OFFSETS_MAX) {
             if (display_failure) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Compass offsets too high");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: Compass offsets too high");
             }
             return false;
         }
@@ -144,7 +144,7 @@ bool Copter::pre_arm_checks(bool display_failure)
         float mag_field = compass.get_field().length();
         if (mag_field > COMPASS_MAGFIELD_EXPECTED*1.65f || mag_field < COMPASS_MAGFIELD_EXPECTED*0.35f) {
             if (display_failure) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Check mag field");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: Check mag field");
             }
             return false;
         }
@@ -152,7 +152,7 @@ bool Copter::pre_arm_checks(bool display_failure)
         // check all compasses point in roughly same direction
         if (!compass.consistent()) {
             if (display_failure) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: inconsistent compasses");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: inconsistent compasses");
             }
             return false;
         }
@@ -168,7 +168,7 @@ bool Copter::pre_arm_checks(bool display_failure)
     // check fence is initialised
     if (!fence.pre_arm_check()) {
         if (display_failure) {
-            gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: check fence");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: check fence");
         }
         return false;
     }
@@ -179,7 +179,7 @@ bool Copter::pre_arm_checks(bool display_failure)
         // check accelerometers have been calibrated
         if (!ins.accel_calibrated_ok_all()) {
             if (display_failure) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Accels not calibrated");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: Accels not calibrated");
             }
             return false;
         }
@@ -187,7 +187,7 @@ bool Copter::pre_arm_checks(bool display_failure)
         // check accels are healthy
         if (!ins.get_accel_health_all()) {
             if (display_failure) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Accelerometers not healthy");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: Accelerometers not healthy");
             }
             return false;
         }
@@ -195,7 +195,7 @@ bool Copter::pre_arm_checks(bool display_failure)
         //check if accelerometers have calibrated and require reboot
         if (ins.accel_cal_requires_reboot()) {
             if (display_failure) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL, "PreArm: Accelerometers calibrated requires reboot");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "PreArm: Accelerometers calibrated requires reboot");
             }
             return false;
         }
@@ -218,7 +218,7 @@ bool Copter::pre_arm_checks(bool display_failure)
                 }
                 if (vec_diff.length() > threshold) {
                     if (display_failure) {
-                        gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: inconsistent Accelerometers");
+                        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: inconsistent Accelerometers");
                     }
                     return false;
                 }
@@ -228,7 +228,7 @@ bool Copter::pre_arm_checks(bool display_failure)
         // check gyros are healthy
         if (!ins.get_gyro_health_all()) {
             if (display_failure) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Gyros not healthy");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: Gyros not healthy");
             }
             return false;
         }
@@ -240,7 +240,7 @@ bool Copter::pre_arm_checks(bool display_failure)
                 Vector3f vec_diff = ins.get_gyro(i) - ins.get_gyro();
                 if (vec_diff.length() > PREARM_MAX_GYRO_VECTOR_DIFF) {
                     if (display_failure) {
-                        gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: inconsistent Gyros");
+                        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: inconsistent Gyros");
                     }
                     return false;
                 }
@@ -250,7 +250,7 @@ bool Copter::pre_arm_checks(bool display_failure)
         // get ekf attitude (if bad, it's usually the gyro biases)
         if (!pre_arm_ekf_attitude_check()) {
             if (display_failure) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: gyros still settling");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: gyros still settling");
             }
             return false;
         }
@@ -261,7 +261,7 @@ bool Copter::pre_arm_checks(bool display_failure)
     if ((g.arming_check == ARMING_CHECK_ALL) || (g.arming_check & ARMING_CHECK_VOLTAGE)) {
         if (hal.analogin->board_voltage() < BOARD_VOLTAGE_MIN || hal.analogin->board_voltage() > BOARD_VOLTAGE_MAX) {
             if (display_failure) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Check Board Voltage");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: Check Board Voltage");
             }
             return false;
         }
@@ -273,7 +273,7 @@ bool Copter::pre_arm_checks(bool display_failure)
     if ((g.arming_check == ARMING_CHECK_ALL) || (g.arming_check & ARMING_CHECK_VOLTAGE)) {
         if (failsafe.battery || (!ap.usb_connected && battery.exhausted(g.fs_batt_voltage, g.fs_batt_mah))) {
             if (display_failure) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Check Battery");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: Check Battery");
             }
             return false;
         }
@@ -285,7 +285,7 @@ bool Copter::pre_arm_checks(bool display_failure)
         // ensure ch7 and ch8 have different functions
         if (check_duplicate_auxsw()) {
             if (display_failure) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Duplicate Aux Switch Options");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: Duplicate Aux Switch Options");
             }
             return false;
         }
@@ -295,7 +295,7 @@ bool Copter::pre_arm_checks(bool display_failure)
             // check throttle min is above throttle failsafe trigger and that the trigger is above ppm encoder's loss-of-signal value of 900
             if (channel_throttle->radio_min <= g.failsafe_throttle_value+10 || g.failsafe_throttle_value < 910) {
                 if (display_failure) {
-                    gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Check FS_THR_VALUE");
+                    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: Check FS_THR_VALUE");
                 }
                 return false;
             }
@@ -304,7 +304,7 @@ bool Copter::pre_arm_checks(bool display_failure)
         // lean angle parameter check
         if (aparm.angle_max < 1000 || aparm.angle_max > 8000) {
             if (display_failure) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Check ANGLE_MAX");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: Check ANGLE_MAX");
             }
             return false;
         }
@@ -312,7 +312,7 @@ bool Copter::pre_arm_checks(bool display_failure)
         // acro balance parameter check
         if ((g.acro_balance_roll > g.p_stabilize_roll.kP()) || (g.acro_balance_pitch > g.p_stabilize_pitch.kP())) {
             if (display_failure) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: ACRO_BAL_ROLL/PITCH");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: ACRO_BAL_ROLL/PITCH");
             }
             return false;
         }
@@ -321,7 +321,7 @@ bool Copter::pre_arm_checks(bool display_failure)
         // check range finder if optflow enabled
         if (optflow.enabled() && !sonar.pre_arm_check()) {
             if (display_failure) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: check range finder");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: check range finder");
             }
             return false;
         }
@@ -340,9 +340,9 @@ bool Copter::pre_arm_checks(bool display_failure)
         if (g.failsafe_throttle != FS_THR_DISABLED && channel_throttle->radio_in < g.failsafe_throttle_value) {
             if (display_failure) {
                 #if FRAME_CONFIG == HELI_FRAME
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Collective below Failsafe");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: Collective below Failsafe");
                 #else
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Throttle below Failsafe");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: Throttle below Failsafe");
                 #endif
             }
             return false;
@@ -401,7 +401,7 @@ bool Copter::pre_arm_gps_checks(bool display_failure)
     // always check if inertial nav has started and is ready
     if (!ahrs.healthy()) {
         if (display_failure) {
-            gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Waiting for Nav Checks");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: Waiting for Nav Checks");
         }
         return false;
     }
@@ -429,7 +429,7 @@ bool Copter::pre_arm_gps_checks(bool display_failure)
             if (reason) {
                 GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "PreArm: %s", reason);
             } else {
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: Need 3D Fix");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: Need 3D Fix");
             }
         }
         AP_Notify::flags.pre_arm_gps_check = false;
@@ -443,7 +443,7 @@ bool Copter::pre_arm_gps_checks(bool display_failure)
     ahrs.get_variances(vel_variance, pos_variance, hgt_variance, mag_variance, tas_variance, offset);
     if (mag_variance.length() >= g.fs_ekf_thresh) {
         if (display_failure) {
-            gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: EKF compass variance");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: EKF compass variance");
         }
         return false;
     }
@@ -451,7 +451,7 @@ bool Copter::pre_arm_gps_checks(bool display_failure)
     // check home and EKF origin are not too far
     if (far_from_EKF_origin(ahrs.get_home())) {
         if (display_failure) {
-            gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: EKF-home variance");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: EKF-home variance");
         }
         AP_Notify::flags.pre_arm_gps_check = false;
         return false;
@@ -466,7 +466,7 @@ bool Copter::pre_arm_gps_checks(bool display_failure)
     // warn about hdop separately - to prevent user confusion with no gps lock
     if (gps.get_hdop() > g.gps_hdop_good) {
         if (display_failure) {
-            gcs_send_text(MAV_SEVERITY_CRITICAL,"PreArm: High GPS HDOP");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"PreArm: High GPS HDOP");
         }
         AP_Notify::flags.pre_arm_gps_check = false;
         return false;
@@ -501,27 +501,27 @@ bool Copter::arm_checks(bool display_failure, bool arming_from_gcs)
         //check if accelerometers have calibrated and require reboot
         if (ins.accel_cal_requires_reboot()) {
             if (display_failure) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL, "PreArm: Accelerometers calibrated requires reboot");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "PreArm: Accelerometers calibrated requires reboot");
             }
             return false;
         }
 
         if (!ins.get_accel_health_all()) {
             if (display_failure) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Accelerometers not healthy");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"Arm: Accelerometers not healthy");
             }
             return false;
         }
         if (!ins.get_gyro_health_all()) {
             if (display_failure) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Gyros not healthy");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"Arm: Gyros not healthy");
             }
             return false;
         }
         // get ekf attitude (if bad, it's usually the gyro biases)
         if (!pre_arm_ekf_attitude_check()) {
             if (display_failure) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: gyros still settling");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"Arm: gyros still settling");
             }
             return false;
         }
@@ -530,14 +530,14 @@ bool Copter::arm_checks(bool display_failure, bool arming_from_gcs)
     // always check if inertial nav has started and is ready
     if (!ahrs.healthy()) {
         if (display_failure) {
-            gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Waiting for Nav Checks");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"Arm: Waiting for Nav Checks");
         }
         return false;
     }
 
     if (compass.is_calibrating()) {
         if (display_failure) {
-            gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Compass calibration running");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"Arm: Compass calibration running");
         }
         return false;
     }
@@ -545,7 +545,7 @@ bool Copter::arm_checks(bool display_failure, bool arming_from_gcs)
     //check if compass has calibrated and requires reboot
     if (compass.compass_cal_requires_reboot()) {
         if (display_failure) {
-            gcs_send_text(MAV_SEVERITY_CRITICAL, "PreArm: Compass calibrated requires reboot");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "PreArm: Compass calibrated requires reboot");
         }
         return false;
     }
@@ -553,7 +553,7 @@ bool Copter::arm_checks(bool display_failure, bool arming_from_gcs)
     // always check if the current mode allows arming
     if (!mode_allows_arming(control_mode, arming_from_gcs)) {
         if (display_failure) {
-            gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Mode not armable");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"Arm: Mode not armable");
         }
         return false;
     }
@@ -565,7 +565,7 @@ bool Copter::arm_checks(bool display_failure, bool arming_from_gcs)
 
     // if we are using motor interlock switch and it's enabled, fail to arm
     if (ap.using_interlock && motors.get_interlock()){
-        gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Motor Interlock Enabled");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"Arm: Motor Interlock Enabled");
         return false;
     }
 
@@ -575,7 +575,7 @@ bool Copter::arm_checks(bool display_failure, bool arming_from_gcs)
         set_motor_emergency_stop(false);
         // if we are using motor Estop switch, it must not be in Estop position
     } else if (check_if_auxsw_mode_used(AUXSW_MOTOR_ESTOP) && ap.motor_emergency_stop){
-        gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Motor Emergency Stopped");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"Arm: Motor Emergency Stopped");
         return false;
     }
 
@@ -589,7 +589,7 @@ bool Copter::arm_checks(bool display_failure, bool arming_from_gcs)
         // baro health check
         if (!barometer.all_healthy()) {
             if (display_failure) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Barometer not healthy");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"Arm: Barometer not healthy");
             }
             return false;
         }
@@ -600,7 +600,7 @@ bool Copter::arm_checks(bool display_failure, bool arming_from_gcs)
         bool using_baro_ref = (!filt_status.flags.pred_horiz_pos_rel && filt_status.flags.pred_horiz_pos_abs);
         if (using_baro_ref && (fabsf(inertial_nav.get_altitude() - baro_alt) > PREARM_MAX_ALT_DISPARITY_CM)) {
             if (display_failure) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Altitude disparity");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"Arm: Altitude disparity");
             }
             return false;
         }
@@ -610,7 +610,7 @@ bool Copter::arm_checks(bool display_failure, bool arming_from_gcs)
     // check vehicle is within fence
     if (!fence.pre_arm_check()) {
         if (display_failure) {
-            gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: check fence");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"Arm: check fence");
         }
         return false;
     }
@@ -620,7 +620,7 @@ bool Copter::arm_checks(bool display_failure, bool arming_from_gcs)
     if ((g.arming_check == ARMING_CHECK_ALL) || (g.arming_check & ARMING_CHECK_INS)) {
         if (degrees(acosf(ahrs.cos_roll()*ahrs.cos_pitch()))*100.0f > aparm.angle_max) {
             if (display_failure) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Leaning");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"Arm: Leaning");
             }
             return false;
         }
@@ -630,7 +630,7 @@ bool Copter::arm_checks(bool display_failure, bool arming_from_gcs)
     if ((g.arming_check == ARMING_CHECK_ALL) || (g.arming_check & ARMING_CHECK_VOLTAGE)) {
         if (failsafe.battery || (!ap.usb_connected && battery.exhausted(g.fs_batt_voltage, g.fs_batt_mah))) {
             if (display_failure) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Check Battery");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"Arm: Check Battery");
             }
             return false;
         }
@@ -642,9 +642,9 @@ bool Copter::arm_checks(bool display_failure, bool arming_from_gcs)
         if (g.failsafe_throttle != FS_THR_DISABLED && channel_throttle->radio_in < g.failsafe_throttle_value) {
             if (display_failure) {
                 #if FRAME_CONFIG == HELI_FRAME
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Collective below Failsafe");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"Arm: Collective below Failsafe");
                 #else
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Throttle below Failsafe");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"Arm: Throttle below Failsafe");
                 #endif
             }
             return false;
@@ -656,9 +656,9 @@ bool Copter::arm_checks(bool display_failure, bool arming_from_gcs)
             if (channel_throttle->control_in > get_takeoff_trigger_throttle()) {
                 if (display_failure) {
                     #if FRAME_CONFIG == HELI_FRAME
-                    gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Collective too high");
+                    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"Arm: Collective too high");
                     #else
-                    gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Throttle too high");
+                    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"Arm: Throttle too high");
                     #endif
                 }
                 return false;
@@ -667,9 +667,9 @@ bool Copter::arm_checks(bool display_failure, bool arming_from_gcs)
             if ((mode_has_manual_throttle(control_mode) || control_mode == DRIFT) && channel_throttle->control_in > 0) {
                 if (display_failure) {
                     #if FRAME_CONFIG == HELI_FRAME
-                    gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Collective too high");
+                    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"Arm: Collective too high");
                     #else
-                    gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Throttle too high");
+                    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"Arm: Throttle too high");
                     #endif
                 }
                 return false;
@@ -680,7 +680,7 @@ bool Copter::arm_checks(bool display_failure, bool arming_from_gcs)
     // check if safety switch has been pushed
     if (hal.util->safety_switch_state() == AP_HAL::Util::SAFETY_DISARMED) {
         if (display_failure) {
-            gcs_send_text(MAV_SEVERITY_CRITICAL,"Arm: Safety Switch");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"Arm: Safety Switch");
         }
         return false;
     }

--- a/ArduCopter/commands_logic.cpp
+++ b/ArduCopter/commands_logic.cpp
@@ -610,7 +610,7 @@ bool Copter::verify_nav_wp(const AP_Mission::Mission_Command& cmd)
 
     // check if timer has run out
     if (((millis() - loiter_time) / 1000) >= loiter_time_max) {
-        gcs_send_text_fmt(MAV_SEVERITY_INFO, "Reached command #%i",cmd.index);
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Reached command #%i",cmd.index);
         return true;
     }else{
         return false;
@@ -692,7 +692,7 @@ bool Copter::verify_spline_wp(const AP_Mission::Mission_Command& cmd)
 
     // check if timer has run out
     if (((millis() - loiter_time) / 1000) >= loiter_time_max) {
-        gcs_send_text_fmt(MAV_SEVERITY_INFO, "Reached command #%i",cmd.index);
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Reached command #%i",cmd.index);
         return true;
     }else{
         return false;

--- a/ArduCopter/compassmot.cpp
+++ b/ArduCopter/compassmot.cpp
@@ -37,7 +37,7 @@ uint8_t Copter::mavlink_compassmot(mavlink_channel_t chan)
 
     // check compass is enabled
     if (!g.compass_enabled) {
-        gcs[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL, "Compass disabled");
+        GCS_MAVLINK::send_statustext_chan(MAV_SEVERITY_CRITICAL, chan, "Compass disabled");
         ap.compass_mot = false;
         return 1;
     }
@@ -46,7 +46,7 @@ uint8_t Copter::mavlink_compassmot(mavlink_channel_t chan)
     compass.read();
     for (uint8_t i=0; i<compass.get_count(); i++) {
         if (!compass.healthy(i)) {
-            gcs[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL, "Check compass");
+            GCS_MAVLINK::send_statustext_chan(MAV_SEVERITY_CRITICAL, chan, "Check compass");
             ap.compass_mot = false;
             return 1;
         }
@@ -55,7 +55,7 @@ uint8_t Copter::mavlink_compassmot(mavlink_channel_t chan)
     // check if radio is calibrated
     pre_arm_rc_checks();
     if (!ap.pre_arm_rc_check) {
-        gcs[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL, "RC not calibrated");
+        GCS_MAVLINK::send_statustext_chan(MAV_SEVERITY_CRITICAL, chan, "RC not calibrated");
         ap.compass_mot = false;
         return 1;
     }
@@ -63,14 +63,14 @@ uint8_t Copter::mavlink_compassmot(mavlink_channel_t chan)
     // check throttle is at zero
     read_radio();
     if (channel_throttle->control_in != 0) {
-        gcs[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL, "Throttle not zero");
+        GCS_MAVLINK::send_statustext_chan(MAV_SEVERITY_CRITICAL, chan, "Throttle not zero");
         ap.compass_mot = false;
         return 1;
     }
 
     // check we are landed
     if (!ap.land_complete) {
-        gcs[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL, "Not landed");
+        GCS_MAVLINK::send_statustext_chan(MAV_SEVERITY_CRITICAL, chan, "Not landed");
         ap.compass_mot = false;
         return 1;
     }
@@ -95,13 +95,13 @@ uint8_t Copter::mavlink_compassmot(mavlink_channel_t chan)
     AP_Notify::flags.esc_calibration = true;
 
     // warn user we are starting calibration
-    gcs[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_INFO, "Starting calibration");
+    GCS_MAVLINK::send_statustext_chan(MAV_SEVERITY_INFO, chan, "Starting calibration");
 
     // inform what type of compensation we are attempting
     if (comp_type == AP_COMPASS_MOT_COMP_CURRENT) {
-        gcs[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_INFO, "Current");
+        GCS_MAVLINK::send_statustext_chan(MAV_SEVERITY_INFO, chan, "Current");
     } else{
-        gcs[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_INFO, "Throttle");
+        GCS_MAVLINK::send_statustext_chan(MAV_SEVERITY_INFO, chan, "Throttle");
     }
 
     // disable throttle and battery failsafe
@@ -245,10 +245,10 @@ uint8_t Copter::mavlink_compassmot(mavlink_channel_t chan)
         }
         compass.save_motor_compensation();
         // display success message
-        gcs[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_INFO, "Calibration successful");
+        GCS_MAVLINK::send_statustext_chan(MAV_SEVERITY_INFO, chan, "Calibration successful");
     } else {
         // compensation vector never updated, report failure
-        gcs[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_NOTICE, "Failed");
+        GCS_MAVLINK::send_statustext_chan(MAV_SEVERITY_NOTICE, chan, "Failed");
         compass.motor_compensation_type(AP_COMPASS_MOT_COMP_DISABLED);
     }
 

--- a/ArduCopter/control_autotune.cpp
+++ b/ArduCopter/control_autotune.cpp
@@ -1011,19 +1011,19 @@ void Copter::autotune_update_gcs(uint8_t message_id)
 {
     switch (message_id) {
         case AUTOTUNE_MESSAGE_STARTED:
-            gcs_send_text(MAV_SEVERITY_INFO,"AutoTune: Started");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO,"AutoTune: Started");
             break;
         case AUTOTUNE_MESSAGE_STOPPED:
-            gcs_send_text(MAV_SEVERITY_INFO,"AutoTune: Stopped");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO,"AutoTune: Stopped");
             break;
         case AUTOTUNE_MESSAGE_SUCCESS:
-            gcs_send_text(MAV_SEVERITY_INFO,"AutoTune: Success");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO,"AutoTune: Success");
             break;
         case AUTOTUNE_MESSAGE_FAILED:
-            gcs_send_text(MAV_SEVERITY_NOTICE,"AutoTune: Failed");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_NOTICE,"AutoTune: Failed");
             break;
         case AUTOTUNE_MESSAGE_SAVED_GAINS:
-            gcs_send_text(MAV_SEVERITY_INFO,"AutoTune: Saved gains");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO,"AutoTune: Saved gains");
             break;
     }
 }

--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -47,7 +47,7 @@ void Copter::crash_check()
         // log an error in the dataflash
         Log_Write_Error(ERROR_SUBSYSTEM_CRASH_CHECK, ERROR_CODE_CRASH_CHECK_CRASH);
         // send message to gcs
-        gcs_send_text(MAV_SEVERITY_EMERGENCY,"Crash: Disarming");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_EMERGENCY,"Crash: Disarming");
         // disarm motors
         init_disarm_motors();
     }
@@ -136,7 +136,7 @@ void Copter::parachute_check()
 void Copter::parachute_release()
 {
     // send message to gcs and dataflash
-    gcs_send_text(MAV_SEVERITY_INFO,"Parachute: Released");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO,"Parachute: Released");
     Log_Write_Event(DATA_PARACHUTE_RELEASED);
 
     // disarm motors
@@ -159,7 +159,7 @@ void Copter::parachute_manual_release()
     // do not release if we are landed or below the minimum altitude above home
     if (ap.land_complete) {
         // warn user of reason for failure
-        gcs_send_text(MAV_SEVERITY_INFO,"Parachute: Landed");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO,"Parachute: Landed");
         // log an error in the dataflash
         Log_Write_Error(ERROR_SUBSYSTEM_PARACHUTE, ERROR_CODE_PARACHUTE_LANDED);
         return;
@@ -168,7 +168,7 @@ void Copter::parachute_manual_release()
     // do not release if we are landed or below the minimum altitude above home
     if ((parachute.alt_min() != 0 && (current_loc.alt < (int32_t)parachute.alt_min() * 100))) {
         // warn user of reason for failure
-        gcs_send_text(MAV_SEVERITY_ALERT,"Parachute: Too low");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_ALERT,"Parachute: Too low");
         // log an error in the dataflash
         Log_Write_Error(ERROR_SUBSYSTEM_PARACHUTE, ERROR_CODE_PARACHUTE_TOO_LOW);
         return;

--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -60,7 +60,7 @@ void Copter::ekf_check()
                 Log_Write_Error(ERROR_SUBSYSTEM_EKFCHECK, ERROR_CODE_EKFCHECK_BAD_VARIANCE);
                 // send message to gcs
                 if ((AP_HAL::millis() - ekf_check_state.last_warn_time) > EKF_CHECK_WARNING_TIME) {
-                    gcs_send_text(MAV_SEVERITY_CRITICAL,"EKF variance");
+                    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"EKF variance");
                     ekf_check_state.last_warn_time = AP_HAL::millis();
                 }
                 failsafe_ekf_event();

--- a/ArduCopter/esc_calibration.cpp
+++ b/ArduCopter/esc_calibration.cpp
@@ -39,7 +39,7 @@ void Copter::esc_calibration_startup_check()
                 // we will enter esc_calibrate mode on next reboot
                 g.esc_calibrate.set_and_save(ESCCAL_PASSTHROUGH_IF_THROTTLE_HIGH);
                 // send message to gcs
-                gcs_send_text(MAV_SEVERITY_CRITICAL,"ESC calibration: Restart board");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"ESC calibration: Restart board");
                 // turn on esc calibration notification
                 AP_Notify::flags.esc_calibration = true;
                 // block until we restart
@@ -85,7 +85,7 @@ void Copter::esc_calibration_passthrough()
     motors.set_update_rate(50);
 
     // send message to GCS
-    gcs_send_text(MAV_SEVERITY_INFO,"ESC calibration: Passing pilot throttle to ESCs");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO,"ESC calibration: Passing pilot throttle to ESCs");
 
     while(1) {
         // arm motors
@@ -115,7 +115,7 @@ void Copter::esc_calibration_auto()
     motors.set_update_rate(50);
 
     // send message to GCS
-    gcs_send_text(MAV_SEVERITY_INFO,"ESC calibration: Auto calibration");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO,"ESC calibration: Auto calibration");
 
     // arm and enable motors
     motors.armed(true);
@@ -131,7 +131,7 @@ void Copter::esc_calibration_auto()
     // wait for safety switch to be pressed
     while (hal.util->safety_switch_state() == AP_HAL::Util::SAFETY_DISARMED) {
         if (!printed_msg) {
-            gcs_send_text(MAV_SEVERITY_INFO,"ESC calibration: Push safety switch");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO,"ESC calibration: Push safety switch");
             printed_msg = true;
         }
         delay(10);

--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -68,7 +68,7 @@ void Copter::failsafe_battery_event(void)
     set_failsafe_battery(true);
 
     // warn the ground station and log to dataflash
-    gcs_send_text(MAV_SEVERITY_WARNING,"Low battery");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING,"Low battery");
     Log_Write_Error(ERROR_SUBSYSTEM_FAILSAFE_BATT, ERROR_CODE_FAILSAFE_OCCURRED);
 
 }

--- a/ArduCopter/motor_test.cpp
+++ b/ArduCopter/motor_test.cpp
@@ -74,19 +74,19 @@ bool Copter::mavlink_motor_test_check(mavlink_channel_t chan, bool check_rc)
     // check rc has been calibrated
     pre_arm_rc_checks();
     if(check_rc && !ap.pre_arm_rc_check) {
-        gcs[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL,"Motor Test: RC not calibrated");
+        GCS_MAVLINK::send_statustext_chan(MAV_SEVERITY_CRITICAL, chan, "Motor Test: RC not calibrated");
         return false;
     }
 
     // ensure we are landed
     if (!ap.land_complete) {
-        gcs[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL,"Motor Test: vehicle not landed");
+        GCS_MAVLINK::send_statustext_chan(MAV_SEVERITY_CRITICAL, chan, "Motor Test: vehicle not landed");
         return false;
     }
 
     // check if safety switch has been pushed
     if (hal.util->safety_switch_state() == AP_HAL::Util::SAFETY_DISARMED) {
-        gcs[chan-MAVLINK_COMM_0].send_text(MAV_SEVERITY_CRITICAL,"Motor Test: Safety switch");
+        GCS_MAVLINK::send_statustext_chan(MAV_SEVERITY_CRITICAL, chan, "Motor Test: Safety switch");
         return false;
     }
 

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -153,7 +153,7 @@ bool Copter::init_arm_motors(bool arming_from_gcs)
     }
 
 #if HIL_MODE != HIL_MODE_DISABLED || CONFIG_HAL_BOARD == HAL_BOARD_SITL
-    gcs_send_text(MAV_SEVERITY_INFO, "Arming motors");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Arming motors");
 #endif
 
     // Remember Orientation
@@ -218,7 +218,7 @@ void Copter::init_disarm_motors()
     }
 
 #if HIL_MODE != HIL_MODE_DISABLED || CONFIG_HAL_BOARD == HAL_BOARD_SITL
-    gcs_send_text(MAV_SEVERITY_INFO, "Disarming motors");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Disarming motors");
 #endif
 
     // save compass offsets learned by the EKF
@@ -288,7 +288,7 @@ void Copter::lost_vehicle_check()
         if (soundalarm_counter >= LOST_VEHICLE_DELAY) {
             if (AP_Notify::flags.vehicle_lost == false) {
                 AP_Notify::flags.vehicle_lost = true;
-                gcs_send_text(MAV_SEVERITY_NOTICE,"Locate Copter alarm");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_NOTICE,"Locate Copter alarm");
             }
         } else {
             soundalarm_counter++;

--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -4,13 +4,13 @@
 
 void Copter::init_barometer(bool full_calibration)
 {
-    gcs_send_text(MAV_SEVERITY_INFO, "Calibrating barometer");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Calibrating barometer");
     if (full_calibration) {
         barometer.calibrate();
     }else{
         barometer.update_calibration();
     }
-    gcs_send_text(MAV_SEVERITY_INFO, "Barometer calibration complete");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Barometer calibration complete");
 }
 
 // return barometric altitude in centimeters

--- a/ArduCopter/switches.cpp
+++ b/ArduCopter/switches.cpp
@@ -597,7 +597,7 @@ void Copter::save_trim()
     float pitch_trim = ToRad((float)channel_pitch->control_in/100.0f);
     ahrs.add_trim(roll_trim, pitch_trim);
     Log_Write_Event(DATA_SAVE_TRIM);
-    gcs_send_text(MAV_SEVERITY_INFO, "Trim saved");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Trim saved");
 }
 
 // auto_trim - slightly adjusts the ahrs.roll_trim and ahrs.pitch_trim towards the current stick positions

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -236,7 +236,7 @@ void Copter::init_ardupilot()
     while (barometer.get_last_update() == 0) {
         // the barometer begins updating when we get the first
         // HIL_STATE message
-        gcs_send_text(MAV_SEVERITY_WARNING, "Waiting for first HIL_STATE message");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "Waiting for first HIL_STATE message");
         delay(1000);
     }
 

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -43,6 +43,7 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
     SCHED_TASK(set_servos,            400,   1600),
     SCHED_TASK(read_control_switch,     7,   1000),
     SCHED_TASK(gcs_retry_deferred,     50,   1000),
+    SCHED_TASK(gcs_retry_sendtext,     50,   1000),
     SCHED_TASK(update_GPS_50Hz,        50,   2500),
     SCHED_TASK(update_GPS_10Hz,        10,   2500),
     SCHED_TASK(navigate,               10,   3000),

--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -342,7 +342,7 @@ void Plane::one_second_loop()
 void Plane::log_perf_info()
 {
     if (scheduler.debug() != 0) {
-        gcs_send_text_fmt(MAV_SEVERITY_INFO, "G_Dt_max=%lu G_Dt_min=%lu\n",
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "G_Dt_max=%lu G_Dt_min=%lu\n",
                           (unsigned long)G_Dt_max, 
                           (unsigned long)G_Dt_min);
     }
@@ -647,7 +647,7 @@ void Plane::update_flight_mode(void)
             if (tdrag_mode && !auto_state.fbwa_tdrag_takeoff_mode) {
                 if (auto_state.highest_airspeed < g.takeoff_tdrag_speed1) {
                     auto_state.fbwa_tdrag_takeoff_mode = true;
-                    gcs_send_text(MAV_SEVERITY_WARNING, "FBWA tdrag mode");
+                    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "FBWA tdrag mode");
                 }
             }
         }
@@ -819,26 +819,26 @@ void Plane::set_flight_stage(AP_SpdHgtControl::FlightStage fs)
 
     switch (fs) {
     case AP_SpdHgtControl::FLIGHT_LAND_APPROACH:
-        gcs_send_text_fmt(MAV_SEVERITY_INFO, "Landing approach start at %.1fm", (double)relative_altitude());
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Landing approach start at %.1fm", (double)relative_altitude());
 #if GEOFENCE_ENABLED == ENABLED 
         if (g.fence_autoenable == 1) {
             if (! geofence_set_enabled(false, AUTO_TOGGLED)) {
-                gcs_send_text(MAV_SEVERITY_NOTICE, "Disable fence failed (autodisable)");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_NOTICE, "Disable fence failed (autodisable)");
             } else {
-                gcs_send_text(MAV_SEVERITY_NOTICE, "Fence disabled (autodisable)");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_NOTICE, "Fence disabled (autodisable)");
             }
         } else if (g.fence_autoenable == 2) {
             if (! geofence_set_floor_enabled(false)) {
-                gcs_send_text(MAV_SEVERITY_NOTICE, "Disable fence floor failed (autodisable)");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_NOTICE, "Disable fence floor failed (autodisable)");
             } else {
-                gcs_send_text(MAV_SEVERITY_NOTICE, "Fence floor disabled (auto disable)");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_NOTICE, "Fence floor disabled (auto disable)");
             }
         }
 #endif
         break;
 
     case AP_SpdHgtControl::FLIGHT_LAND_ABORT:
-        gcs_send_text_fmt(MAV_SEVERITY_NOTICE, "Landing aborted via throttle. Climbing to %dm", auto_state.takeoff_altitude_rel_cm/100);
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_NOTICE, "Landing aborted via throttle. Climbing to %dm", auto_state.takeoff_altitude_rel_cm/100);
         break;
 
     case AP_SpdHgtControl::FLIGHT_LAND_PREFLARE:

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -621,7 +621,7 @@ bool Plane::suppress_throttle(void)
     if (relative_altitude_abs_cm() >= 1000) {
         // we're more than 10m from the home altitude
         throttle_suppressed = false;
-        gcs_send_text_fmt(MAV_SEVERITY_INFO, "Throttle enabled. Altitude %.2f",
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Throttle enabled. Altitude %.2f",
                           (double)(relative_altitude_abs_cm()*0.01f));
         return false;
     }
@@ -632,7 +632,7 @@ bool Plane::suppress_throttle(void)
         // groundspeed with bad GPS reception
         if ((!ahrs.airspeed_sensor_enabled()) || airspeed.get_airspeed() >= 5) {
             // we're moving at more than 5 m/s
-            gcs_send_text_fmt(MAV_SEVERITY_INFO, "Throttle enabled. Speed %.2f airspeed %.2f",
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Throttle enabled. Speed %.2f airspeed %.2f",
                               (double)gps.ground_speed(),
                               (double)airspeed.get_airspeed());
             throttle_suppressed = false;
@@ -641,7 +641,7 @@ bool Plane::suppress_throttle(void)
     }
 
     if (quadplane.is_flying()) {
-        gcs_send_text_fmt(MAV_SEVERITY_INFO, "Throttle enabled VTOL");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Throttle enabled VTOL");
         throttle_suppressed = false;
     }
 
@@ -1185,7 +1185,7 @@ bool Plane::allow_reverse_thrust(void)
 void Plane::demo_servos(uint8_t i) 
 {
     while(i > 0) {
-        gcs_send_text(MAV_SEVERITY_INFO,"Demo servos");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO,"Demo servos");
         demoing_servos = true;
         servo_write(1, 1400);
         hal.scheduler->delay(400);

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -2089,3 +2089,8 @@ void Plane::gcs_retry_deferred(void)
 {
     gcs_send_message(MSG_RETRY_DEFERRED);
 }
+
+void Plane::gcs_retry_sendtext(void)
+{
+    GCS_MAVLINK::retry_statustext();
+}

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -149,9 +149,9 @@ int8_t Plane::process_logs(uint8_t argc, const Menu::arg *argv)
 
 void Plane::do_erase_logs(void)
 {
-    gcs_send_text(MAV_SEVERITY_INFO, "Erasing logs");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Erasing logs");
     DataFlash.EraseAll();
-    gcs_send_text(MAV_SEVERITY_INFO, "Log erase complete");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Log erase complete");
 }
 
 
@@ -548,12 +548,12 @@ void Plane::log_init(void)
 {
     DataFlash.Init(log_structure, ARRAY_SIZE(log_structure));
     if (!DataFlash.CardInserted()) {
-        gcs_send_text(MAV_SEVERITY_WARNING, "No dataflash card inserted");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "No dataflash card inserted");
         g.log_bitmask.set(0);
     } else if (DataFlash.NeedPrep()) {
-        gcs_send_text(MAV_SEVERITY_INFO, "Preparing log system");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Preparing log system");
         DataFlash.Prep();
-        gcs_send_text(MAV_SEVERITY_INFO, "Prepared log system");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Prepared log system");
         for (uint8_t i=0; i<num_gcs; i++) {
             gcs[i].reset_cli_timeout();
         }

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -748,7 +748,6 @@ private:
     void send_rpm(mavlink_channel_t chan);
     void send_rangefinder(mavlink_channel_t chan);
     void send_current_waypoint(mavlink_channel_t chan);
-    void send_statustext(mavlink_channel_t chan);
     bool telemetry_delayed(mavlink_channel_t chan);
     void gcs_send_message(enum ap_message id);
     void gcs_send_mission_item_reached_message(uint16_t mission_index);

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -757,6 +757,7 @@ private:
     void gcs_send_text(MAV_SEVERITY severity, const char *str);
     void gcs_send_airspeed_calibration(const Vector3f &vg);
     void gcs_retry_deferred(void);
+    void gcs_retry_sendtext(void);
 
     void do_erase_logs(void);
     void Log_Write_Attitude(void);

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -754,7 +754,6 @@ private:
     void gcs_send_mission_item_reached_message(uint16_t mission_index);
     void gcs_data_stream_send(void);
     void gcs_update(void);
-    void gcs_send_text(MAV_SEVERITY severity, const char *str);
     void gcs_send_airspeed_calibration(const Vector3f &vg);
     void gcs_retry_deferred(void);
     void gcs_retry_sendtext(void);
@@ -961,7 +960,6 @@ private:
     void update_is_flying_5Hz(void);
     void crash_detection_update(void);
     bool in_preLaunch_flight_stage(void);
-    void gcs_send_text_fmt(MAV_SEVERITY severity, const char *fmt, ...);
     void handle_auto_mode(void);
     void calc_throttle();
     void calc_nav_roll();

--- a/ArduPlane/adsb.cpp
+++ b/ArduPlane/adsb.cpp
@@ -71,18 +71,18 @@ bool Plane::adsb_evasion_start(void)
     switch(adsb.get_behavior()) {
     case AP_ADSB::ADSB_BEHAVIOR_NONE:
     default:
-        gcs_send_text(MAV_SEVERITY_CRITICAL, "ADS-B threat found, no action taken");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "ADS-B threat found, no action taken");
         break;
 
     case AP_ADSB::ADSB_BEHAVIOR_GUIDED:
-        gcs_send_text(MAV_SEVERITY_CRITICAL, "ADS-B threat found, switching to GUIDED mode");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "ADS-B threat found, switching to GUIDED mode");
         set_mode(GUIDED);
         adsb_state.is_evading = true; // must be done AFTER set_mode()
         break;
 
     case AP_ADSB::ADSB_BEHAVIOR_LOITER:
     case AP_ADSB::ADSB_BEHAVIOR_LOITER_AND_DESCEND:
-        gcs_send_text(MAV_SEVERITY_CRITICAL, "ADS-B threat found, performing LOITER");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "ADS-B threat found, performing LOITER");
         set_mode(LOITER);
         adsb_state.is_evading = true; // must be done after set_mode()
         break;
@@ -96,7 +96,7 @@ bool Plane::adsb_evasion_start(void)
  */
 void Plane::adsb_evasion_stop(void)
 {
-    gcs_send_text(MAV_SEVERITY_CRITICAL, "ADS-B threat gone, continuing mission");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "ADS-B threat gone, continuing mission");
 
     FlightMode prev_control_mode = control_mode;
     set_mode(AUTO);

--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -584,7 +584,7 @@ void Plane::rangefinder_height_update(void)
                 flight_stage == AP_SpdHgtControl::FLIGHT_LAND_FINAL) &&
                 g.rangefinder_landing) {
                 rangefinder_state.in_use = true;
-                gcs_send_text_fmt(MAV_SEVERITY_INFO, "Rangefinder engaged at %.2fm", (double)height_estimate);
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Rangefinder engaged at %.2fm", (double)height_estimate);
             }
         }
     } else {
@@ -616,7 +616,7 @@ void Plane::rangefinder_height_update(void)
             if (fabsf(rangefinder_state.correction - rangefinder_state.initial_correction) > 30) {
                 // the correction has changed by more than 30m, reset use of Lidar. We may have a bad lidar
                 if (rangefinder_state.in_use) {
-                    gcs_send_text_fmt(MAV_SEVERITY_INFO, "Rangefinder disengaged at %.2fm", (double)height_estimate);
+                    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Rangefinder disengaged at %.2fm", (double)height_estimate);
                 }
                 memset(&rangefinder_state, 0, sizeof(rangefinder_state));
             }

--- a/ArduPlane/commands.cpp
+++ b/ArduPlane/commands.cpp
@@ -52,7 +52,7 @@ void Plane::set_next_WP(const struct Location &loc)
     // location as the previous waypoint, to prevent immediately
     // considering the waypoint complete
     if (location_passed_point(current_loc, prev_WP_loc, next_WP_loc)) {
-        gcs_send_text(MAV_SEVERITY_NOTICE, "Resetting previous waypoint");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_NOTICE, "Resetting previous waypoint");
         prev_WP_loc = current_loc;
     }
 
@@ -100,14 +100,14 @@ void Plane::set_guided_WP(void)
 // -------------------------------
 void Plane::init_home()
 {
-    gcs_send_text(MAV_SEVERITY_INFO, "Init HOME");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Init HOME");
 
     ahrs.set_home(gps.location());
     home_is_set = HOME_SET_NOT_LOCKED;
     Log_Write_Home_And_Origin();
     GCS_MAVLINK::send_home_all(gps.location());
 
-    gcs_send_text_fmt(MAV_SEVERITY_INFO, "GPS alt: %lu", (unsigned long)home.alt);
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "GPS alt: %lu", (unsigned long)home.alt);
 
     // Save Home to EEPROM
     mission.write_home_to_storage();

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -35,9 +35,9 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
         // reset loiter start time. New command is a new loiter
         loiter.start_time_ms = 0;
 
-        gcs_send_text_fmt(MAV_SEVERITY_INFO, "Executing nav command ID #%i",cmd.id);
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Executing nav command ID #%i",cmd.id);
     } else {
-        gcs_send_text_fmt(MAV_SEVERITY_INFO, "Executing command ID #%i",cmd.id);
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Executing command ID #%i",cmd.id);
     }
 
     switch(cmd.id) {
@@ -136,7 +136,7 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
     case MAV_CMD_DO_INVERTED_FLIGHT:
         if (cmd.p1 == 0 || cmd.p1 == 1) {
             auto_state.inverted_flight = (bool)cmd.p1;
-            gcs_send_text_fmt(MAV_SEVERITY_INFO, "Set inverted %u", cmd.p1);
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Set inverted %u", cmd.p1);
         }
         break;
 
@@ -149,15 +149,15 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
 #if GEOFENCE_ENABLED == ENABLED
         if (cmd.p1 != 2) {
             if (!geofence_set_enabled((bool) cmd.p1, AUTO_TOGGLED)) {
-                gcs_send_text_fmt(MAV_SEVERITY_WARNING, "Unable to set fence. Enabled state to %u", cmd.p1);
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "Unable to set fence. Enabled state to %u", cmd.p1);
             } else {
-                gcs_send_text_fmt(MAV_SEVERITY_INFO, "Set fence enabled state to %u", cmd.p1);
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Set fence enabled state to %u", cmd.p1);
             }
         } else { //commanding to only disable floor
             if (! geofence_set_floor_enabled(false)) {
-                gcs_send_text_fmt(MAV_SEVERITY_WARNING, "Unabled to disable fence floor");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "Unabled to disable fence floor");
             } else {
-                gcs_send_text_fmt(MAV_SEVERITY_WARNING, "Fence floor disabled");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "Fence floor disabled");
             }
         }    
 #endif
@@ -309,9 +309,9 @@ bool Plane::verify_command(const AP_Mission::Mission_Command& cmd)        // Ret
     default:
         // error message
         if (AP_Mission::is_nav_cmd(cmd)) {
-            gcs_send_text(MAV_SEVERITY_WARNING,"Verify nav. Invalid or no current nav cmd");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING,"Verify nav. Invalid or no current nav cmd");
         }else{
-        gcs_send_text(MAV_SEVERITY_WARNING,"Verify conditon. Invalid or no current condition cmd");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING,"Verify conditon. Invalid or no current condition cmd");
     }
         // return true so that we do not get stuck at this command
         return true;
@@ -509,7 +509,7 @@ bool Plane::verify_takeoff()
             float takeoff_course = wrap_PI(radians(gps.ground_course_cd()*0.01f)) - steer_state.locked_course_err;
             takeoff_course = wrap_PI(takeoff_course);
             steer_state.hold_course_cd = wrap_360_cd(degrees(takeoff_course)*100);
-            gcs_send_text_fmt(MAV_SEVERITY_INFO, "Holding course %ld at %.1fm/s (%.1f)",
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Holding course %ld at %.1fm/s (%.1f)",
                               steer_state.hold_course_cd,
                               (double)gps.ground_speed(),
                               (double)degrees(steer_state.locked_course_err));
@@ -526,7 +526,7 @@ bool Plane::verify_takeoff()
     // see if we have reached takeoff altitude
     int32_t relative_alt_cm = adjusted_relative_altitude_cm();
     if (relative_alt_cm > auto_state.takeoff_altitude_rel_cm) {
-        gcs_send_text_fmt(MAV_SEVERITY_INFO, "Takeoff complete at %.2fm",
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Takeoff complete at %.2fm",
                           (double)(relative_alt_cm*0.01f));
         steer_state.hold_course_cd = -1;
         auto_state.takeoff_complete = true;
@@ -535,9 +535,9 @@ bool Plane::verify_takeoff()
 #if GEOFENCE_ENABLED == ENABLED
         if (g.fence_autoenable > 0) {
             if (! geofence_set_enabled(true, AUTO_TOGGLED)) {
-                gcs_send_text(MAV_SEVERITY_NOTICE, "Enable fence failed (cannot autoenable");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_NOTICE, "Enable fence failed (cannot autoenable");
             } else {
-                gcs_send_text(MAV_SEVERITY_INFO, "Fence enabled (autoenabled)");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Fence enabled (autoenabled)");
             }
         }
 #endif
@@ -582,7 +582,7 @@ bool Plane::verify_nav_wp(const AP_Mission::Mission_Command& cmd)
     }
     
     if (auto_state.wp_distance <= acceptance_distance) {
-        gcs_send_text_fmt(MAV_SEVERITY_INFO, "Reached waypoint #%i dist %um",
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Reached waypoint #%i dist %um",
                           (unsigned)mission.get_current_nav_cmd().index,
                           (unsigned)get_distance(current_loc, next_WP_loc));
         return true;
@@ -590,7 +590,7 @@ bool Plane::verify_nav_wp(const AP_Mission::Mission_Command& cmd)
 
     // have we flown past the waypoint?
     if (location_passed_point(current_loc, prev_WP_loc, next_WP_loc)) {
-        gcs_send_text_fmt(MAV_SEVERITY_INFO, "Passed waypoint #%i dist %um",
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Passed waypoint #%i dist %um",
                           (unsigned)mission.get_current_nav_cmd().index,
                           (unsigned)get_distance(current_loc, next_WP_loc));
         return true;
@@ -619,7 +619,7 @@ bool Plane::verify_loiter_time()
             loiter.start_time_ms = millis();
         }
     } else if ((millis() - loiter.start_time_ms) > loiter.time_max_ms) {
-        gcs_send_text(MAV_SEVERITY_WARNING,"Verify nav: LOITER time complete");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING,"Verify nav: LOITER time complete");
         return true;
     }
     return false;
@@ -630,7 +630,7 @@ bool Plane::verify_loiter_turns()
     update_loiter(0);
     if (loiter.sum_cd > loiter.total_cd) {
         loiter.total_cd = 0;
-        gcs_send_text(MAV_SEVERITY_WARNING,"Verify nav: LOITER orbits complete");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING,"Verify nav: LOITER orbits complete");
         // clear the command queue;
         return true;
     }
@@ -719,7 +719,7 @@ bool Plane::verify_RTL()
     update_loiter(abs(g.rtl_radius));
 	if (auto_state.wp_distance <= (uint32_t)MAX(g.waypoint_radius,0) || 
         nav_controller->reached_loiter_target()) {
-			gcs_send_text(MAV_SEVERITY_INFO,"Reached HOME");
+			GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO,"Reached HOME");
 			return true;
     } else {
         return false;
@@ -769,11 +769,11 @@ bool Plane::verify_continue_and_change_alt()
 bool Plane::verify_altitude_wait(const AP_Mission::Mission_Command &cmd)
 {
     if (current_loc.alt > cmd.content.altitude_wait.altitude*100.0f) {
-        gcs_send_text(MAV_SEVERITY_INFO,"Reached altitude");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO,"Reached altitude");
         return true;
     }
     if (auto_state.sink_rate > cmd.content.altitude_wait.descent_rate) {
-        gcs_send_text_fmt(MAV_SEVERITY_INFO, "Reached descent rate %.1f m/s", (double)auto_state.sink_rate);
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Reached descent rate %.1f m/s", (double)auto_state.sink_rate);
         return true;        
     }
 
@@ -879,17 +879,17 @@ void Plane::do_change_speed(const AP_Mission::Mission_Command& cmd)
     case 0:             // Airspeed
         if (cmd.content.speed.target_ms > 0) {
             g.airspeed_cruise_cm.set(cmd.content.speed.target_ms * 100);
-            gcs_send_text_fmt(MAV_SEVERITY_INFO, "Set airspeed %u m/s", (unsigned)cmd.content.speed.target_ms);
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Set airspeed %u m/s", (unsigned)cmd.content.speed.target_ms);
         }
         break;
     case 1:             // Ground speed
-        gcs_send_text_fmt(MAV_SEVERITY_INFO, "Set groundspeed %u", (unsigned)cmd.content.speed.target_ms);
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Set groundspeed %u", (unsigned)cmd.content.speed.target_ms);
         g.min_gndspeed_cm.set(cmd.content.speed.target_ms * 100);
         break;
     }
 
     if (cmd.content.speed.throttle_pct > 0 && cmd.content.speed.throttle_pct <= 100) {
-        gcs_send_text_fmt(MAV_SEVERITY_INFO, "Set throttle %u", (unsigned)cmd.content.speed.throttle_pct);
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Set throttle %u", (unsigned)cmd.content.speed.throttle_pct);
         aparm.throttle_cruise.set(cmd.content.speed.throttle_pct);
     }
 }
@@ -1014,7 +1014,7 @@ bool Plane::verify_command_callback(const AP_Mission::Mission_Command& cmd)
 void Plane::exit_mission_callback()
 {
     if (control_mode == AUTO) {
-        gcs_send_text_fmt(MAV_SEVERITY_INFO, "Returning to HOME");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Returning to HOME");
         memset(&auto_rtl_command, 0, sizeof(auto_rtl_command));
         auto_rtl_command.content.location = 
             rally.calc_best_rally_or_home_location(current_loc, get_RTL_altitude());

--- a/ArduPlane/control_modes.cpp
+++ b/ArduPlane/control_modes.cpp
@@ -77,17 +77,17 @@ void Plane::read_control_switch()
             if (hal.util->get_soft_armed() || setup_failsafe_mixing()) {
                 px4io_override_enabled = true;
                 // disable output channels to force PX4IO override
-                gcs_send_text(MAV_SEVERITY_WARNING, "PX4IO override enabled");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "PX4IO override enabled");
             } else {
                 // we'll try again next loop. The PX4IO code sometimes
                 // rejects a mixer, probably due to it being busy in
                 // some way?
-                gcs_send_text(MAV_SEVERITY_WARNING, "PX4IO override enable failed");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "PX4IO override enable failed");
             }
         } else if (!override && px4io_override_enabled) {
             px4io_override_enabled = false;
             RC_Channel_aux::enable_aux_servos();
-            gcs_send_text(MAV_SEVERITY_WARNING, "PX4IO override disabled");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "PX4IO override disabled");
         }
         if (px4io_override_enabled && 
             hal.util->safety_switch_state() != AP_HAL::Util::SAFETY_ARMED &&

--- a/ArduPlane/events.cpp
+++ b/ArduPlane/events.cpp
@@ -7,7 +7,7 @@ void Plane::failsafe_short_on_event(enum failsafe_state fstype)
     // This is how to handle a short loss of control signal failsafe.
     failsafe.state = fstype;
     failsafe.ch3_timer_ms = millis();
-    gcs_send_text(MAV_SEVERITY_WARNING, "Failsafe. Short event on, ");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "Failsafe. Short event on, ");
     switch(control_mode)
     {
     case MANUAL:
@@ -54,13 +54,13 @@ void Plane::failsafe_short_on_event(enum failsafe_state fstype)
     default:
         break;
     }
-    gcs_send_text_fmt(MAV_SEVERITY_INFO, "Flight mode = %u", (unsigned)control_mode);
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Flight mode = %u", (unsigned)control_mode);
 }
 
 void Plane::failsafe_long_on_event(enum failsafe_state fstype)
 {
     // This is how to handle a long loss of control signal failsafe.
-    gcs_send_text(MAV_SEVERITY_WARNING, "Failsafe. Long event on, ");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "Failsafe. Long event on, ");
     //  If the GCS is locked up we allow control to revert to RC
     hal.rcin->clear_overrides();
     failsafe.state = fstype;
@@ -111,15 +111,15 @@ void Plane::failsafe_long_on_event(enum failsafe_state fstype)
         break;
     }
     if (fstype == FAILSAFE_GCS) {
-        gcs_send_text(MAV_SEVERITY_CRITICAL, "No GCS heartbeat");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "No GCS heartbeat");
     }
-    gcs_send_text_fmt(MAV_SEVERITY_INFO, "Flight mode = %u", (unsigned)control_mode);
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Flight mode = %u", (unsigned)control_mode);
 }
 
 void Plane::failsafe_short_off_event()
 {
     // We're back in radio contact
-    gcs_send_text(MAV_SEVERITY_WARNING, "Failsafe. Short event off");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "Failsafe. Short event off");
     failsafe.state = FAILSAFE_NONE;
 
     // re-read the switch so we can return to our preferred mode
@@ -135,7 +135,7 @@ void Plane::low_battery_event(void)
     if (failsafe.low_battery) {
         return;
     }
-    gcs_send_text_fmt(MAV_SEVERITY_WARNING, "Low battery %.2fV used %.0f mAh",
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "Low battery %.2fV used %.0f mAh",
                       (double)battery.voltage(), (double)battery.current_total_mah());
     if (flight_stage != AP_SpdHgtControl::FLIGHT_LAND_FINAL &&
         flight_stage != AP_SpdHgtControl::FLIGHT_LAND_PREFLARE &&

--- a/ArduPlane/geofence.cpp
+++ b/ArduPlane/geofence.cpp
@@ -137,13 +137,13 @@ void Plane::geofence_load(void)
     geofence_state->boundary_uptodate = true;
     geofence_state->fence_triggered = false;
 
-    gcs_send_text(MAV_SEVERITY_INFO,"Geofence loaded");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO,"Geofence loaded");
     gcs_send_message(MSG_FENCE_STATUS);
     return;
 
 failed:
     g.fence_action.set(FENCE_ACTION_NONE);
-    gcs_send_text(MAV_SEVERITY_WARNING,"Geofence setup error");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING,"Geofence setup error");
 }
 
 /*
@@ -335,7 +335,7 @@ void Plane::geofence_check(bool altitude_check_only)
         if (geofence_state->fence_triggered && !altitude_check_only) {
             // we have moved back inside the fence
             geofence_state->fence_triggered = false;
-            gcs_send_text(MAV_SEVERITY_INFO,"Geofence OK");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO,"Geofence OK");
  #if FENCE_TRIGGERED_PIN > 0
             hal.gpio->pinMode(FENCE_TRIGGERED_PIN, HAL_GPIO_OUTPUT);
             hal.gpio->write(FENCE_TRIGGERED_PIN, 0);
@@ -365,7 +365,7 @@ void Plane::geofence_check(bool altitude_check_only)
     hal.gpio->write(FENCE_TRIGGERED_PIN, 1);
  #endif
 
-    gcs_send_text(MAV_SEVERITY_NOTICE,"Geofence triggered");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_NOTICE,"Geofence triggered");
     gcs_send_message(MSG_FENCE_STATUS);
 
     // see what action the user wants

--- a/ArduPlane/is_flying.cpp
+++ b/ArduPlane/is_flying.cpp
@@ -264,9 +264,9 @@ void Plane::crash_detection_update(void)
 
         if (g.crash_detection_enable == CRASH_DETECT_ACTION_BITMASK_DISABLED) {
             if (crashed_near_land_waypoint) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL, "Hard landing detected. No action taken");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "Hard landing detected. No action taken");
             } else {
-                gcs_send_text(MAV_SEVERITY_EMERGENCY, "Crash detected. No action taken");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_EMERGENCY, "Crash detected. No action taken");
             }
         }
         else {
@@ -275,9 +275,9 @@ void Plane::crash_detection_update(void)
             }
             auto_state.land_complete = true;
             if (crashed_near_land_waypoint) {
-                gcs_send_text(MAV_SEVERITY_CRITICAL, "Hard landing detected");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "Hard landing detected");
             } else {
-                gcs_send_text(MAV_SEVERITY_EMERGENCY, "Crash detected");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_EMERGENCY, "Crash detected");
             }
         }
     }

--- a/ArduPlane/landing.cpp
+++ b/ArduPlane/landing.cpp
@@ -66,9 +66,9 @@ bool Plane::verify_land()
         if (!auto_state.land_complete) {
             auto_state.post_landing_stats = true;
             if (!is_flying() && (millis()-auto_state.last_flying_ms) > 3000) {
-                gcs_send_text_fmt(MAV_SEVERITY_CRITICAL, "Flare crash detected: speed=%.1f", (double)gps.ground_speed());
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, "Flare crash detected: speed=%.1f", (double)gps.ground_speed());
             } else {
-                gcs_send_text_fmt(MAV_SEVERITY_INFO, "Flare %.1fm sink=%.2f speed=%.1f dist=%.1f",
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Flare %.1fm sink=%.2f speed=%.1f dist=%.1f",
                                   (double)height, (double)auto_state.sink_rate,
                                   (double)gps.ground_speed(),
                                   (double)get_distance(current_loc, next_WP_loc));
@@ -111,7 +111,7 @@ bool Plane::verify_land()
     // this is done before disarm_if_autoland_complete() so that it happens on the next loop after the disarm
     if (auto_state.post_landing_stats && !arming.is_armed()) {
         auto_state.post_landing_stats = false;
-        gcs_send_text_fmt(MAV_SEVERITY_INFO, "Distance from LAND point=%.2fm", (double)get_distance(current_loc, next_WP_loc));
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Distance from LAND point=%.2fm", (double)get_distance(current_loc, next_WP_loc));
     }
 
     // check if we should auto-disarm after a confirmed landing
@@ -140,7 +140,7 @@ void Plane::disarm_if_autoland_complete()
         /* we have auto disarm enabled. See if enough time has passed */
         if (millis() - auto_state.last_flying_ms >= g.land_disarm_delay*1000UL) {
             if (disarm_motors()) {
-                gcs_send_text(MAV_SEVERITY_INFO,"Auto disarmed");
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO,"Auto disarmed");
             }
         }
     }
@@ -261,14 +261,14 @@ bool Plane::restart_landing_sequence()
             mission.set_current_cmd(current_index+1))
     {
         // if the next immediate command is MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT to climb, do it
-        gcs_send_text_fmt(MAV_SEVERITY_NOTICE, "Restarted landing sequence. Climbing to %dm", cmd.content.location.alt/100);
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_NOTICE, "Restarted landing sequence. Climbing to %dm", cmd.content.location.alt/100);
         success =  true;
     }
     else if (do_land_start_index != 0 &&
             mission.set_current_cmd(do_land_start_index))
     {
         // look for a DO_LAND_START and use that index
-        gcs_send_text_fmt(MAV_SEVERITY_NOTICE, "Restarted landing via DO_LAND_START: %d",do_land_start_index);
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_NOTICE, "Restarted landing via DO_LAND_START: %d",do_land_start_index);
         success =  true;
     }
     else if (prev_cmd_with_wp_index != AP_MISSION_CMD_INDEX_NONE &&
@@ -276,10 +276,10 @@ bool Plane::restart_landing_sequence()
     {
         // if a suitable navigation waypoint was just executed, one that contains lat/lng/alt, then
         // repeat that cmd to restart the landing from the top of approach to repeat intended glide slope
-        gcs_send_text_fmt(MAV_SEVERITY_NOTICE, "Restarted landing sequence at waypoint %d", prev_cmd_with_wp_index);
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_NOTICE, "Restarted landing sequence at waypoint %d", prev_cmd_with_wp_index);
         success =  true;
     } else {
-        gcs_send_text_fmt(MAV_SEVERITY_WARNING, "Unable to restart landing sequence");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "Unable to restart landing sequence");
         success =  false;
     }
     return success;
@@ -302,12 +302,12 @@ bool Plane::jump_to_landing_sequence(void)
                 mission.resume();
             }
 
-            gcs_send_text(MAV_SEVERITY_INFO, "Landing sequence start");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Landing sequence start");
             return true;
         }            
     }
 
-    gcs_send_text(MAV_SEVERITY_WARNING, "Unable to start landing sequence");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "Unable to start landing sequence");
     return false;
 }
 

--- a/ArduPlane/parachute.cpp
+++ b/ArduPlane/parachute.cpp
@@ -21,7 +21,7 @@ void Plane::parachute_release()
     }
     
     // send message to gcs and dataflash
-    gcs_send_text(MAV_SEVERITY_CRITICAL,"Parachute: Released");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL,"Parachute: Released");
 
     // release parachute
     parachute.release();
@@ -42,12 +42,12 @@ bool Plane::parachute_manual_release()
     // do not release if vehicle is not flying
     if (!is_flying()) {
         // warn user of reason for failure
-        gcs_send_text(MAV_SEVERITY_WARNING,"Parachute: Not flying");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING,"Parachute: Not flying");
         return false;
     }
 
     if (relative_altitude() < parachute.alt_min()) {
-        gcs_send_text_fmt(MAV_SEVERITY_WARNING, "Parachute: Too low");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "Parachute: Too low");
         return false;
     }
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -943,29 +943,29 @@ bool QuadPlane::init_mode(void)
 bool QuadPlane::handle_do_vtol_transition(const mavlink_command_long_t &packet)
 {
     if (!available()) {
-        plane.gcs_send_text_fmt(MAV_SEVERITY_NOTICE, "VTOL not available");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_NOTICE, "VTOL not available");
         return MAV_RESULT_FAILED;
     }
     if (plane.control_mode != AUTO) {
-        plane.gcs_send_text_fmt(MAV_SEVERITY_NOTICE, "VTOL transition only in AUTO");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_NOTICE, "VTOL transition only in AUTO");
         return MAV_RESULT_FAILED;
     }
     switch ((uint8_t)packet.param1) {
     case MAV_VTOL_STATE_MC:
         if (!plane.auto_state.vtol_mode) {
-            plane.gcs_send_text_fmt(MAV_SEVERITY_NOTICE, "Entered VTOL mode");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_NOTICE, "Entered VTOL mode");
         }
         plane.auto_state.vtol_mode = true;
         return MAV_RESULT_ACCEPTED;
     case MAV_VTOL_STATE_FW:
         if (plane.auto_state.vtol_mode) {
-            plane.gcs_send_text_fmt(MAV_SEVERITY_NOTICE, "Exited VTOL mode");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_NOTICE, "Exited VTOL mode");
         }
         plane.auto_state.vtol_mode = false;
         return MAV_RESULT_ACCEPTED;
     }
 
-    plane.gcs_send_text_fmt(MAV_SEVERITY_NOTICE, "Invalid VTOL mode");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_NOTICE, "Invalid VTOL mode");
     return MAV_RESULT_FAILED;
 }
 
@@ -1231,7 +1231,7 @@ bool QuadPlane::verify_vtol_land(const AP_Mission::Mission_Command &cmd)
     if (land_state == QLAND_POSITION &&
         plane.auto_state.wp_distance < 2) {
         land_state = QLAND_DESCEND;
-        plane.gcs_send_text(MAV_SEVERITY_INFO,"Land descend started");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO,"Land descend started");
         plane.set_next_WP(cmd.content.location);        
     }
 
@@ -1244,7 +1244,7 @@ bool QuadPlane::verify_vtol_land(const AP_Mission::Mission_Command &cmd)
         plane.current_loc.alt < plane.next_WP_loc.alt+land_final_alt*100) {
         land_state = QLAND_FINAL;
         pos_control->set_alt_target(inertial_nav.get_altitude());
-        plane.gcs_send_text(MAV_SEVERITY_INFO,"Land final started");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO,"Land final started");
     }
 
     if (land_state == QLAND_FINAL &&
@@ -1252,7 +1252,7 @@ bool QuadPlane::verify_vtol_land(const AP_Mission::Mission_Command &cmd)
          millis() - motors_lower_limit_start_ms > 5000)) {
         plane.disarm_motors();
         land_state = QLAND_COMPLETE;
-        plane.gcs_send_text(MAV_SEVERITY_INFO,"Land complete");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO,"Land complete");
     }
     return false;
 }

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -244,7 +244,7 @@ void Plane::control_failsafe(uint16_t pwm)
             // throttle has dropped below the mark
             failsafe.ch3_counter++;
             if (failsafe.ch3_counter == 10) {
-                gcs_send_text_fmt(MAV_SEVERITY_WARNING, "MSG FS ON %u", (unsigned)pwm);
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "MSG FS ON %u", (unsigned)pwm);
                 failsafe.ch3_failsafe = true;
                 AP_Notify::flags.failsafe_radio = true;
             }
@@ -260,7 +260,7 @@ void Plane::control_failsafe(uint16_t pwm)
                 failsafe.ch3_counter = 3;
             }
             if (failsafe.ch3_counter == 1) {
-                gcs_send_text_fmt(MAV_SEVERITY_WARNING, "MSG FS OFF %u", (unsigned)pwm);
+                GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "MSG FS OFF %u", (unsigned)pwm);
             } else if(failsafe.ch3_counter == 0) {
                 failsafe.ch3_failsafe = false;
                 AP_Notify::flags.failsafe_radio = false;

--- a/ArduPlane/sensors.cpp
+++ b/ArduPlane/sensors.cpp
@@ -5,10 +5,10 @@
 
 void Plane::init_barometer(void)
 {
-    gcs_send_text(MAV_SEVERITY_INFO, "Calibrating barometer");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Calibrating barometer");
     barometer.calibrate();
 
-    gcs_send_text(MAV_SEVERITY_INFO, "Barometer calibration complete");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Barometer calibration complete");
 }
 
 void Plane::init_rangefinder(void)
@@ -113,7 +113,7 @@ void Plane::zero_airspeed(bool in_startup)
     read_airspeed();
     // update barometric calibration with new airspeed supplied temperature
     barometer.update_calibration();
-    gcs_send_text(MAV_SEVERITY_INFO,"Zero airspeed calibrated");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO,"Zero airspeed calibrated");
 }
 
 // read_battery - reads battery voltage and current and invokes failsafe

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -261,10 +261,10 @@ void Plane::startup_ground(void)
 {
     set_mode(INITIALISING);
 
-    gcs_send_text(MAV_SEVERITY_INFO,"<startup_ground> Ground start");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO,"<startup_ground> Ground start");
 
 #if (GROUND_START_DELAY > 0)
-    gcs_send_text(MAV_SEVERITY_NOTICE,"<startup_ground> With delay");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_NOTICE,"<startup_ground> With delay");
     delay(GROUND_START_DELAY * 1000);
 #endif
 
@@ -311,7 +311,7 @@ void Plane::startup_ground(void)
     ins.set_raw_logging(should_log(MASK_LOG_IMU_RAW));
     ins.set_dataflash(&DataFlash);    
 
-    gcs_send_text(MAV_SEVERITY_INFO,"Ready to fly");
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO,"Ready to fly");
 }
 
 enum FlightMode Plane::get_previous_mode() {
@@ -591,14 +591,14 @@ void Plane::startup_INS_ground(void)
         while (barometer.get_last_update() == 0) {
             // the barometer begins updating when we get the first
             // HIL_STATE message
-            gcs_send_text(MAV_SEVERITY_WARNING, "Waiting for first HIL_STATE message");
+            GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "Waiting for first HIL_STATE message");
             hal.scheduler->delay(1000);
         }
     }
 #endif
 
     if (ins.gyro_calibration_timing() != AP_InertialSensor::GYRO_CAL_NEVER) {
-        gcs_send_text(MAV_SEVERITY_ALERT, "Beginning INS calibration. Do not move plane");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_ALERT, "Beginning INS calibration. Do not move plane");
         hal.scheduler->delay(100);
     }
 
@@ -619,7 +619,7 @@ void Plane::startup_INS_ground(void)
         // --------------------------
         zero_airspeed(true);
     } else {
-        gcs_send_text(MAV_SEVERITY_WARNING,"No airspeed");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING,"No airspeed");
     }
 }
 

--- a/ArduPlane/takeoff.cpp
+++ b/ArduPlane/takeoff.cpp
@@ -22,7 +22,7 @@ bool Plane::auto_takeoff_check(void)
 
     // Reset states if process has been interrupted
     if (last_check_ms && (now - last_check_ms) > 200) {
-        gcs_send_text_fmt(MAV_SEVERITY_WARNING, "Timer interrupted AUTO");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "Timer interrupted AUTO");
 	    launchTimerStarted = false;
 	    last_tkoff_arm_time = 0;
         last_check_ms = now;
@@ -48,13 +48,13 @@ bool Plane::auto_takeoff_check(void)
     if (!launchTimerStarted) {
         launchTimerStarted = true;
         last_tkoff_arm_time = now;
-        gcs_send_text_fmt(MAV_SEVERITY_INFO, "Armed AUTO, xaccel = %.1f m/s/s, waiting %.1f sec",
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Armed AUTO, xaccel = %.1f m/s/s, waiting %.1f sec",
                 (double)SpdHgt_Controller->get_VXdot(), (double)(wait_time_ms*0.001f));
     }
 
     // Only perform velocity check if not timed out
     if ((now - last_tkoff_arm_time) > wait_time_ms+100U) {
-        gcs_send_text_fmt(MAV_SEVERITY_WARNING, "Timeout AUTO");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "Timeout AUTO");
         goto no_launch;
     }
 
@@ -62,14 +62,14 @@ bool Plane::auto_takeoff_check(void)
     if (ahrs.pitch_sensor <= -3000 ||
         ahrs.pitch_sensor >= 4500 ||
         labs(ahrs.roll_sensor) > 3000) {
-        gcs_send_text_fmt(MAV_SEVERITY_WARNING, "Bad launch AUTO");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_WARNING, "Bad launch AUTO");
         goto no_launch;
     }
 
     // Check ground speed and time delay
     if (((gps.ground_speed() > g.takeoff_throttle_min_speed || is_zero(g.takeoff_throttle_min_speed))) &&
         ((now - last_tkoff_arm_time) >= wait_time_ms)) {
-        gcs_send_text_fmt(MAV_SEVERITY_INFO, "Triggered AUTO. GPS speed = %.1f", (double)gps.ground_speed());
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Triggered AUTO. GPS speed = %.1f", (double)gps.ground_speed());
         launchTimerStarted = false;
         last_tkoff_arm_time = 0;
         steer_state.locked_course_err = 0; // use current heading without any error offset
@@ -180,7 +180,7 @@ int8_t Plane::takeoff_tail_hold(void)
 
 return_zero:
     if (auto_state.fbwa_tdrag_takeoff_mode) {
-        gcs_send_text(MAV_SEVERITY_NOTICE, "FBWA tdrag off");
+        GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_NOTICE, "FBWA tdrag off");
         auto_state.fbwa_tdrag_takeoff_mode = false;
     }
     return 0;

--- a/libraries/AP_AccelCal/AP_AccelCal.cpp
+++ b/libraries/AP_AccelCal/AP_AccelCal.cpp
@@ -352,6 +352,6 @@ void AP_AccelCal::_printf(const char* fmt, ...)
     }
 
 #if !APM_BUILD_TYPE(APM_BUILD_Replay)
-    _gcs->send_text(MAV_SEVERITY_CRITICAL, msg);
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, msg);
 #endif
 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_UserInteract_MAVLink.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_UserInteract_MAVLink.cpp
@@ -58,5 +58,5 @@ void AP_InertialSensor_UserInteract_MAVLink::printf(const char* fmt, ...)
     while (uart->txspace() < MAVLINK_NUM_NON_PAYLOAD_BYTES+MAVLINK_MSG_ID_STATUSTEXT_LEN) {
         hal.scheduler->delay(1);
     }
-    _gcs->send_text(MAV_SEVERITY_CRITICAL, msg);
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_CRITICAL, msg);
 }

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -88,7 +88,6 @@ public:
     void        init(AP_HAL::UARTDriver *port, mavlink_channel_t mav_chan);
     void        setup_uart(const AP_SerialManager& serial_manager, AP_SerialManager::SerialProtocol protocol, uint8_t instance);
     void        send_message(enum ap_message id);
-    void        send_text(MAV_SEVERITY severity, const char *str);
     void        data_stream_send(void);
     void        queued_param_send();
     void        queued_waypoint_send();
@@ -126,10 +125,6 @@ public:
 
     // see if we should send a stream now. Called at 50Hz
     bool        stream_trigger(enum streams stream_num);
-
-	// this costs us 51 bytes per instance, but means that low priority
-	// messages don't block the CPU
-    mavlink_statustext_t pending_status;
 
     // call to reset the timeout window for entering the cli
     void reset_cli_timeout();

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -27,6 +27,7 @@ extern const AP_HAL::HAL& hal;
 
 uint32_t GCS_MAVLINK::last_radio_status_remrssi_ms;
 uint8_t GCS_MAVLINK::mavlink_active = 0;
+ObjectBuffer<GCS_MAVLINK::statustext_t> GCS_MAVLINK::_statustext_queue(GCS_MAVLINK_PAYLOAD_STATUS_CAPACITY);
 
 GCS_MAVLINK::GCS_MAVLINK()
 {
@@ -1137,21 +1138,124 @@ void GCS_MAVLINK::send_ahrs(AP_AHRS &ahrs)
  */
 void GCS_MAVLINK::send_statustext_all(MAV_SEVERITY severity, const char *fmt, ...)
 {
-    for (uint8_t i=0; i<MAVLINK_COMM_NUM_BUFFERS; i++) {
-        if ((1U<<i) & mavlink_active) {
-            mavlink_channel_t chan = (mavlink_channel_t)(MAVLINK_COMM_0+i);
-            if (comm_get_txspace(chan) >= MAVLINK_NUM_NON_PAYLOAD_BYTES + MAVLINK_MSG_ID_STATUSTEXT_LEN) {
-                char msg2[50] {};
-                va_list arg_list;
-                va_start(arg_list, fmt);
-                hal.util->vsnprintf((char *)msg2, sizeof(msg2), fmt, arg_list);
-                va_end(arg_list);
-                mavlink_msg_statustext_send(chan,
-                                            severity,
-                                            msg2);
-            }
-        }
+    char text[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN] {};
+    va_list arg_list;
+    va_start(arg_list, fmt);
+    hal.util->vsnprintf((char *)text, sizeof(text), fmt, arg_list);
+    va_end(arg_list);
+    _send_statustext(severity, mavlink_active, text);
+}
+
+/*
+  send a statustext message to specific MAVLink channel, zero indexed
+ */
+void GCS_MAVLINK::send_statustext_chan(MAV_SEVERITY severity, uint8_t dest_chan, const char *fmt, ...)
+{
+    char text[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN] {};
+    va_list arg_list;
+    va_start(arg_list, fmt);
+    hal.util->vsnprintf((char *)text, sizeof(text), fmt, arg_list);
+    va_end(arg_list);
+    _send_statustext(severity, (1<<dest_chan), text);
+}
+
+/*
+  send a statustext message to specific MAVLink connections in a bitmask
+ */
+void GCS_MAVLINK::send_statustext_bitmask(MAV_SEVERITY severity, uint8_t dest_bitmask, const char *fmt, ...)
+{
+    char text[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN] {};
+    va_list arg_list;
+    va_start(arg_list, fmt);
+    hal.util->vsnprintf((char *)text, sizeof(text), fmt, arg_list);
+    va_end(arg_list);
+    _send_statustext(severity, dest_bitmask, text);
+}
+
+/*
+  send a statustext text string to specific MAVLink bitmask
+ */
+void GCS_MAVLINK::_send_statustext(MAV_SEVERITY severity, uint8_t dest_bitmask, const char* text)
+{
+    // create bitmask of what mavlink ports we should send this text to.
+    // note, if sending to all ports, we only need to store the bitmask for each and the string only once.
+    // once we send over a link, clear the port but other busy ports bit may stay allowing for faster links
+    // to clear the bit and send quickly but slower links to still store the string. Regardless of mixed
+    // bitrates of ports, a maximum of GCS_MAVLINK_PAYLOAD_STATUS_CAPACITY strings can be buffered. Downside
+    // is if you have a super slow link mixed with a faster port, if there are GCS_MAVLINK_PAYLOAD_STATUS_CAPACITY
+    // string in the slow queue then a 6th item can not be queued for the faster link
+
+    dest_bitmask &= mavlink_active;
+    if (!dest_bitmask) {
+        // nowhere to send
+        return;
     }
+
+    statustext_t statustext{};
+    statustext.bitmask = mavlink_active & dest_bitmask;
+    statustext.msg.severity = severity;
+    memcpy(statustext.msg.text, text, sizeof(statustext.msg.text));
+    _statustext_queue.push(statustext);
+}
+
+/*
+  send a statustext message to specific MAVLink connections in a bitmask
+ */
+void GCS_MAVLINK::retry_statustext(void)
+{
+    // create bitmask of what mavlink ports we should send this text to.
+    // note, if sending to all ports, we only need to store the bitmask for each and the string only once.
+    // once we send over a link, clear the port but other busy ports bit may stay allowing for faster links
+    // to clear the bit and send quickly but slower links to still store the string. Regardless of mixed
+    // bitrates of ports, a maximum of GCS_MAVLINK_PAYLOAD_STATUS_CAPACITY strings can be buffered. Downside
+    // is if you have a super slow link mixed with a faster port, if there are GCS_MAVLINK_PAYLOAD_STATUS_CAPACITY
+    // string in the slow queue then a 6th item can not be queued for the faster link
+
+    if (_statustext_queue.empty()) {
+        // nothing to do
+        return;
+    }
+
+    // keep sending until all channels have unable to send (full) or have nothing to send
+    bool still_sending = true;
+
+    // using 'while' to ensure we either run out of text to send or all buffers on all ports are full
+    while (still_sending) {
+        still_sending = false; // if we send something, keep going
+
+        // populate statustext
+        statustext_t statustext; // no need to {} init it because the pop will memcpy all bytes
+        if (!_statustext_queue.pop(statustext)) {
+            // all done, nothing to send
+            return;
+        }
+
+        // try and send to all active mavlink ports listed in the statustext.bitmask
+        for (uint8_t i=0; i<MAVLINK_COMM_NUM_BUFFERS; i++) {
+
+            uint8_t chan_bit = (1<<i);
+            // logical AND (&) to mask them all together
+            if (statustext.bitmask & // something is queued
+                    mavlink_active & // to an active port
+                    chan_bit) {      // and that's the port index we're looping at
+
+                // if we have space then send then clear that channel bit on the mask.
+                mavlink_channel_t chan_index = (mavlink_channel_t)(MAVLINK_COMM_0+i);
+                if (comm_get_txspace(chan_index) > MAVLINK_NUM_NON_PAYLOAD_BYTES + MAVLINK_MSG_ID_STATUSTEXT_LEN) {
+
+                    mavlink_msg_statustext_send(chan_index, statustext.msg.severity, statustext.msg.text);
+                    statustext.bitmask &= ~chan_bit;
+                    still_sending = true;
+                }
+            }
+        } // for
+
+        if (statustext.bitmask) {
+            // Still more to send but the port buffer was full. Queue it again to try later.
+            // Pushing back to the RingBuffer will allow slower links to not block faster links.
+            _statustext_queue.push(statustext);
+        }
+    } // while
 }
 
 /*


### PR DESCRIPTION
Existing buffer allowed for queuing a single gcs status text string via deferring it. Now we can queue an arbitrary queue depth, currently set to 5 deep.