### PR TITLE
AP_NavEKF2: Fix bug in initial alignment calculation

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -298,7 +298,7 @@ bool NavEKF2_core::InitialiseFilterBootstrap(void)
         pitch = asinf(initAccVec.x);
 
         // calculate initial roll angle
-        roll = -asinf(initAccVec.y / cosf(pitch));
+        roll = atan2f(-initAccVec.y , -initAccVec.z);
     }
 
     // calculate initial roll and pitch orientation


### PR DESCRIPTION
The bug caused the initial roll angle to be incorrect if the vehicle was powered up when inverted, causing long alignment times.