### PR TITLE
AP_HAL_SITL: Force the simulated gps time to be on valid intervals for u-blox hardware

### DIFF
--- a/libraries/AP_HAL_SITL/sitl_gps.cpp
+++ b/libraries/AP_HAL_SITL/sitl_gps.cpp
@@ -162,7 +162,7 @@ static void gps_time(uint16_t *time_week, uint32_t *time_week_ms)
     const uint32_t epoch = 86400*(10*365 + (1980-1969)/4 + 1 + 6 - 2) - 15;
     uint32_t epoch_seconds = tv.tv_sec - epoch;
     *time_week = epoch_seconds / (86400*7UL);
-    *time_week_ms = (epoch_seconds % (86400*7UL))*1000 + tv.tv_usec/1000;
+    *time_week_ms = (epoch_seconds % (86400*7UL))*1000 + ((tv.tv_usec/1000/200) * 200);
 }
 
 /*


### PR DESCRIPTION
Fixes an issue in SITL where you see perpetual warnings about the GPS not maintaining 5hz rates. (which was a correct warning)