### PR TITLE
LSM9DS0 IMU fix

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -539,9 +539,9 @@ AP_InertialSensor::detect_backends(void)
 #elif HAL_INS_DEFAULT == HAL_INS_FLYMAPLE
     _add_backend(AP_InertialSensor_Flymaple::detect(*this));
 #elif HAL_INS_DEFAULT == HAL_INS_LSM9DS0
-    _add_backend(AP_InertialSensor_LSM9DS0::probe(*this),
-                 hal.spi->get_device(HAL_INS_LSM9DS0_A_NAME),
-                 hal.spi->get_device(HAL_INS_LSM9DS0_G_NAME));
+    _add_backend(AP_InertialSensor_LSM9DS0::probe(*this,
+                 hal.spi->get_device(HAL_INS_LSM9DS0_G_NAME),
+                 hal.spi->get_device(HAL_INS_LSM9DS0_A_NAME)));
 #elif HAL_INS_DEFAULT == HAL_INS_L3G4200D
     _add_backend(AP_InertialSensor_L3G4200D::probe(*this, hal.i2c_mgr->get_device(HAL_INS_L3G4200D_I2C_BUS, HAL_INS_L3G4200D_I2C_ADDR));
 #elif HAL_INS_DEFAULT == HAL_INS_RASPILOT


### PR DESCRIPTION
Corrects a bracket error for the LSM9DS0 IMU
Switches the probe of the accel and gyro so they boot correctly (was failing the WHOAMI with a switched result)