### PR TITLE
Plane: Some extra auto-landing param knobs

### DIFF
--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -522,8 +522,13 @@ void Plane::calc_nav_roll()
 void Plane::throttle_slew_limit(int16_t last_throttle)
 {
     uint8_t slewrate = aparm.throttle_slewrate;
-    if (control_mode==AUTO && auto_state.takeoff_complete == false && g.takeoff_throttle_slewrate != 0) {
-        slewrate = g.takeoff_throttle_slewrate;
+    if (control_mode==AUTO) {
+        if (auto_state.takeoff_complete == false && g.takeoff_throttle_slewrate != 0) {
+            slewrate = g.takeoff_throttle_slewrate;
+        } else if (g.land_throttle_slewrate != 0 &&
+                (flight_stage == AP_SpdHgtControl::FLIGHT_LAND_APPROACH || flight_stage == AP_SpdHgtControl::FLIGHT_LAND_FINAL || flight_stage == AP_SpdHgtControl::FLIGHT_LAND_PREFLARE)) {
+            slewrate = g.land_throttle_slewrate;
+        }
     }
     // if slew limit rate is set to zero then do not slew limit
     if (slewrate) {                   

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -198,6 +198,15 @@ const AP_Param::Info Plane::var_info[] = {
     // @User: User
     GSCALAR(takeoff_throttle_slewrate, "TKOFF_THR_SLEW",  0),
 
+    // @Param: LAND_THR_SLEW
+    // @DisplayName: Landing throttle slew rate
+    // @Description: This parameter sets the slew rate for the throttle during auto landing. When this is zero the THR_SLEWRATE parameter is used during landing. The value is a percentage throttle change per second, so a value of 20 means to advance the throttle over 5 seconds on landing. Values below 50 are not recommended as it may cause a stall when airspeed is low and you can not throttle up fast enough.
+    // @Units: percent
+    // @Range: 0 127
+    // @Increment: 1
+    // @User: User
+    GSCALAR(land_throttle_slewrate, "LAND_THR_SLEW",  0),
+
     // @Param: TKOFF_FLAP_PCNT
     // @DisplayName: Takeoff flap percentage
     // @Description: The amount of flaps (as a percentage) to apply in automatic takeoff

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -148,6 +148,7 @@ public:
         k_param_parachute_channel,
         k_param_crash_accel_threshold,
         k_param_override_safety,
+        k_param_land_throttle_slewrate, // 104
 
         // 105: Extra parameters
         k_param_fence_retalt = 105,
@@ -492,6 +493,7 @@ public:
     AP_Float takeoff_tdrag_speed1;
     AP_Float takeoff_rotate_speed;
     AP_Int8 takeoff_throttle_slewrate;
+    AP_Int8 land_throttle_slewrate;
     AP_Int8 level_roll_limit;
     AP_Int8 flapin_channel;
     AP_Int8 flaperon_output;

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -148,6 +148,7 @@ private:
     AP_Float _timeConst;
     AP_Float _landTimeConst;
     AP_Float _ptchDamp;
+    AP_Float _land_pitch_damp;
     AP_Float _landDamp;
     AP_Float _thrDamp;
     AP_Float _land_throttle_damp;

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -150,6 +150,7 @@ private:
     AP_Float _ptchDamp;
     AP_Float _landDamp;
     AP_Float _thrDamp;
+    AP_Float _land_throttle_damp;
     AP_Float _integGain;
     AP_Float _vertAccLim;
     AP_Float _rollComp;

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -152,6 +152,8 @@ private:
     AP_Float _thrDamp;
     AP_Float _land_throttle_damp;
     AP_Float _integGain;
+    AP_Float _integGain_takeoff;
+    AP_Float _integGain_land;
     AP_Float _vertAccLim;
     AP_Float _rollComp;
     AP_Float _spdWeight;
@@ -317,6 +319,9 @@ private:
 
     // Update Demanded Throttle Non-Airspeed
     void _update_throttle_option(int16_t throttle_nudge);
+
+    // get integral gain which is flight_stage dependent
+    float _get_i_gain(void);
 
     // Detect Bad Descent
     void _detect_bad_descent(void);


### PR DESCRIPTION
I've added a few params for tweaking out more performance in your auto-lands. These all just add land variants to already existing params and when set to zero uses the existing behavior (which is default).

LAND_THR_SLEW - takeoff and normal have separate throttle slews, now land has one too! Good for reverse thrust tuning

TECS_LAND_TDAMP - Land throttle damp

TECS_LAND_PDAMP - land pitch damp

TECS_LAND_IGAIN - integrator gain, helps dampen system when higher than normal one

TECS_TKOFF_IGAIN - integrator gain, helps reduce top overshoot when lower than normal one