### PR TITLE
Add OS X compatibility

### DIFF
--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -329,10 +329,10 @@ void Plane::Log_Write_Status()
         ,is_flying   : is_flying()
         ,is_flying_probability : isFlyingProbability
         ,armed       : hal.util->get_soft_armed()
-        ,safety      : hal.util->safety_switch_state()
+        ,safety      : static_cast<uint8_t>(hal.util->safety_switch_state())
         ,is_crashed  : crash_state.is_crashed
         ,is_still    : plane.ins.is_still()
-        ,stage       : flight_stage
+        ,stage       : static_cast<uint8_t>(flight_stage)
         ,impact      : crash_state.impact_detected
         };
 

--- a/ArduPlane/test.cpp
+++ b/ArduPlane/test.cpp
@@ -141,7 +141,7 @@ int8_t Plane::test_radio(uint8_t argc, const Menu::arg *argv)
 
 int8_t Plane::test_failsafe(uint8_t argc, const Menu::arg *argv)
 {
-    uint8_t fail_test;
+    uint8_t fail_test = 0;
     print_hit_enter();
     for(int16_t i = 0; i < 50; i++) {
         hal.scheduler->delay(20);

--- a/libraries/APM_Control/AP_AutoTune.cpp
+++ b/libraries/APM_Control/AP_AutoTune.cpp
@@ -337,7 +337,7 @@ void AP_AutoTune::write_log(float servo, float demanded, float achieved)
     struct log_ATRP pkt = {
         LOG_PACKET_HEADER_INIT(LOG_ATRP_MSG),
         time_us    : AP_HAL::micros64(),
-        type       : type,
+        type       : static_cast<uint8_t>(type),
     	state      : (uint8_t)state,
         servo      : (int16_t)(servo*100),
         demanded   : demanded,

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -24,7 +24,6 @@
 extern const AP_HAL::HAL& hal;
 
 using namespace HALSITL;
-using namespace SITL;
 
 void SITL_State::_set_param_default(const char *parm)
 {
@@ -93,10 +92,10 @@ void SITL_State::_sitl_setup(const char *home_str)
         _update_gps(0, 0, 0, 0, 0, 0, false);
 #endif
         if (enable_gimbal) {
-            gimbal = new Gimbal(_sitl->state);
+            gimbal = new SITL::Gimbal(_sitl->state);
         }
         if (enable_ADSB) {
-            adsb = new ADSB(_sitl->state, home_str);
+            adsb = new SITL::ADSB(_sitl->state, home_str);
         }
 
         fg_socket.connect("127.0.0.1", 5503);
@@ -254,7 +253,7 @@ void SITL_State::_output_to_flightgear(void)
  */
 void SITL_State::_fdm_input_local(void)
 {
-    Aircraft::sitl_input input;
+    SITL::Aircraft::sitl_input input;
 
     // check for direct RC input
     _fdm_input();
@@ -315,7 +314,7 @@ void SITL_State::_apply_servo_filter(float deltat)
 /*
   create sitl_input structure for sending to FDM
  */
-void SITL_State::_simulator_servos(Aircraft::sitl_input &input)
+void SITL_State::_simulator_servos(SITL::Aircraft::sitl_input &input)
 {
     static uint32_t last_update_usec;
 

--- a/libraries/AP_RPM/RPM_SITL.cpp
+++ b/libraries/AP_RPM/RPM_SITL.cpp
@@ -25,7 +25,7 @@ extern const AP_HAL::HAL& hal;
    open the sensor in constructor
 */
 AP_RPM_SITL::AP_RPM_SITL(AP_RPM &_ap_rpm, uint8_t _instance, AP_RPM::RPM_State &_state) :
-	AP_RPM_Backend(_ap_rpm, instance, _state)
+	AP_RPM_Backend(_ap_rpm, _instance, _state)
 {
     sitl = (SITL::SITL *)AP_Param::find_object("SIM_");
     instance = _instance;

--- a/libraries/DataFlash/LogFile.cpp
+++ b/libraries/DataFlash/LogFile.cpp
@@ -1555,7 +1555,7 @@ void DataFlash_Class::Log_Write_CameraInfo(enum LogMessages msg, const AP_AHRS &
     }
 
     struct log_Camera pkt = {
-        LOG_PACKET_HEADER_INIT(msg),
+        LOG_PACKET_HEADER_INIT(static_cast<uint8_t>(msg)),
         time_us     : AP_HAL::micros64(),
         gps_time    : gps.time_week_ms(),
         gps_week    : gps.time_week(),

--- a/libraries/SITL/SIM_Tracker.cpp
+++ b/libraries/SITL/SIM_Tracker.cpp
@@ -72,7 +72,7 @@ void Tracker::update(const struct sitl_input &input)
     // how much time has passed?
     float delta_time = frame_time_us * 1.0e-6f;
 
-    float yaw_rate, pitch_rate;
+    float yaw_rate = 0.0f, pitch_rate = 0.0f;
 
     yaw_input = (input.servos[0]-1500)/500.0f;
     pitch_input = (input.servos[1]-1500)/500.0f;


### PR DESCRIPTION
* Combined with https://github.com/tridge/jsbsim/pull/1 this allows http://dev.ardupilot.com/wiki/setting-up-sitl-on-linux/ to work on OS X
* Mostly just minor fixes for compiling with clang rather than gcc
<img width="810" alt="arduplane-osx" src="https://cloud.githubusercontent.com/assets/2834638/13343852/aa0d2fd2-dc1e-11e5-9e92-58114aa126bd.png">
