### PR TITLE
waf: ardupilotwaf: don't use Node object for ap_program target

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -104,10 +104,9 @@ def ap_program(bld, program_group='bin',
     kw['features'] = common_features(bld) + kw.get('features', [])
 
     name = os.path.join(program_group, program_name)
-    target = bld.bldnode.find_or_declare(name)
 
     tg = bld.program(
-        target=target,
+        target='#%s' % name,
         name=name,
         **kw
     )


### PR DESCRIPTION
Hi all,

Using a Node object as target will make platform specific naming be ignored. We use a string instead, to let Waf tweak the target name correctly for us. The '#' prefix is to tell Waf that the path is relative to bld.bldnode (instead of bld.path, which is the default).

I needed to modify the submodule for the '#' prefix feature. We can update it to version 1.9 of Waf when that is released.

Best regards,
Gustavo Sousa