### PR TITLE
Tools: Use GCC 4.9 as an Ubuntu pre-requisite

### DIFF
--- a/Tools/scripts/install-prereqs-ubuntu.sh
+++ b/Tools/scripts/install-prereqs-ubuntu.sh
@@ -11,7 +11,7 @@ PX4_PKGS="python-serial python-argparse openocd flex bison libncurses5-dev \
           autoconf texinfo build-essential libftdi-dev libtool zlib1g-dev \
           zip genromfs python-empy"
 BEBOP_PKGS="g++-arm-linux-gnueabihf"
-UBUNTU64_PKGS="libc6:i386 libgcc1:i386 gcc-4.6-base:i386 libstdc++5:i386 libstdc++6:i386"
+UBUNTU64_PKGS="libc6:i386 libgcc1:i386 gcc-4.9-base:i386 libstdc++5:i386 libstdc++6:i386"
 ASSUME_YES=false
 
 # GNU Tools for ARM Embedded Processors


### PR DESCRIPTION
Tools: Use GCC 4.9 as an Ubuntu pre-requisite as older version is no longer available for new installs.