### PR TITLE
Update param meta data increments for better usability

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -298,7 +298,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @User: Standard
     // @Range: 300 700
     // @Units: Percent*10
-    // @Increment: 1
+    // @Increment: 10
     GSCALAR(throttle_mid,        "THR_MID",    THR_MID_DEFAULT),
 
     // @Param: THR_DZ
@@ -471,7 +471,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @DisplayName: RC Feel Roll/Pitch
     // @Description: RC feel for roll/pitch which controls vehicle response to user input with 0 being extremely soft and 100 being crisp
     // @Range: 0 100
-    // @Increment: 1
+    // @Increment: 25
     // @User: Standard
     // @Values: 0:Very Soft, 25:Soft, 50:Medium, 75:Crisp, 100:Very Crisp
     GSCALAR(rc_feel_rp, "RC_FEEL_RP",  RC_FEEL_RP_MEDIUM),
@@ -650,7 +650,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @DisplayName: Roll axis rate controller P gain
     // @Description: Roll axis rate controller P gain.  Converts the difference between desired roll rate and actual roll rate into a motor speed output
     // @Range: 0.08 0.30
-    // @Increment: 0.005
+    // @Increment: 0.05
     // @User: Standard
 
     // @Param: RATE_RLL_I
@@ -782,6 +782,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @DisplayName: Throttle acceleration controller P gain
     // @Description: Throttle acceleration controller P gain.  Converts the difference between desired vertical acceleration and actual acceleration into a motor output
     // @Range: 0.500 1.500
+    // @Increment: 0.05
     // @User: Standard
 
     // @Param: ACCEL_Z_I

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -471,7 +471,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @DisplayName: RC Feel Roll/Pitch
     // @Description: RC feel for roll/pitch which controls vehicle response to user input with 0 being extremely soft and 100 being crisp
     // @Range: 0 100
-    // @Increment: 25
+    // @Increment: 10
     // @User: Standard
     // @Values: 0:Very Soft, 25:Soft, 50:Medium, 75:Crisp, 100:Very Crisp
     GSCALAR(rc_feel_rp, "RC_FEEL_RP",  RC_FEEL_RP_MEDIUM),

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -320,7 +320,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @User: Standard
     // @Range: 300 700
     // @Units: Percent*10
-    // @Increment: 1
+    // @Increment: 10
     AP_GROUPINFO("THR_MID", 28, QuadPlane, throttle_mid, 500),
 
     // @Param: TRAN_PIT_MAX


### PR DESCRIPTION
Currently QGC uses the increment meta data to set up the slider detents on this screen:
![screen shot 2016-02-28 at 11 09 28 am](https://cloud.githubusercontent.com/assets/5876851/13381509/c883e37a-de12-11e5-8c41-b5c063b90612.png)
Given that, you want on click on the slider left/right to provide good results for a user. I believe Tower also using the increments to set up tablet style spin box support. QGC will soon have the same thing on tablet.

The issue is that the current values don't lead to a good user experience. The params which control these sliders are as follows, including the previous values and what I'd like to change them to:
* THR_MID old:1, new:10 
* RC_FEEL_RP old:1, new:25
* RATE_RLL_P old:0.05, new:0.05 
* ACCEL_Z_P old:missing, new:0.05

The new values came from a discussion between @R-Lefebvre and I. Open, to changing them to whatever may make more sense.