### PR TITLE
Always depart loiter WP towards next WP

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -824,6 +824,7 @@ private:
     bool verify_vtol_land(const AP_Mission::Mission_Command &cmd);
     void do_loiter_at_location();
     void do_take_picture();
+    bool do_break_out_of_loiter_via_heading(void);
     void log_picture();
     void exit_mission_callback();
     void update_commands(void);

--- a/libraries/AP_Common/AP_Common.h
+++ b/libraries/AP_Common/AP_Common.h
@@ -87,6 +87,7 @@ struct PACKED Location_Option_Flags {
     uint8_t unused1      : 1;           // unused flag (defined so that loiter_ccw uses the correct bit)
     uint8_t loiter_ccw   : 1;           // 0 if clockwise, 1 if counter clockwise
     uint8_t terrain_alt  : 1;           // this altitude is above terrain
+    uint8_t heading_req  : 1;           // heading is required for task
 };
 
 struct PACKED Location {

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -476,8 +476,6 @@ MAV_MISSION_RESULT AP_Mission::mavlink_to_mission_cmd(const mavlink_mission_item
 {
     bool copy_location = false;
     bool copy_alt = false;
-    uint8_t num_turns, radius_m; // used by MAV_CMD_NAV_LOITER_TURNS & _TO_ALT
-    uint8_t heading_req;         // used by MAV_CMD_NAV_LOITER_TO_ALT
 
     // command's position in mission list and mavlink id
     cmd.index = packet.seq;
@@ -510,16 +508,20 @@ MAV_MISSION_RESULT AP_Mission::mavlink_to_mission_cmd(const mavlink_mission_item
         break;
 
     case MAV_CMD_NAV_LOITER_TURNS:                      // MAV ID: 18
+    {
         copy_location = true;
-        num_turns = packet.param1;                      // number of times to circle is held in param1
-        radius_m = fabsf(packet.param3);                // radius in meters is held in high in param3
-        cmd.p1 = (((uint16_t)radius_m)<<8) | (uint16_t)num_turns;   // store radius in high byte of p1, num turns in low byte of p1
+        uint16_t num_turns = packet.param1;              // param 1 is number of times to circle is held in low p1
+        uint16_t radius_m = fabsf(packet.param3);        // param 3 is radius in meters is held in high p1
+        cmd.p1 = (radius_m<<8) | (num_turns & 0x00FF);   // store radius in high byte of p1, num turns in low byte of p1
         cmd.content.location.flags.loiter_ccw = (packet.param3 < 0);
+        cmd.content.location.flags.heading_req = !is_equal(packet.param2,0);  // param2 is bool for if heading to next wp is required to exit loiter
+    }
         break;
 
     case MAV_CMD_NAV_LOITER_TIME:                       // MAV ID: 19
         copy_location = true;
         cmd.p1 = packet.param1;                         // loiter time in seconds uses all 16 bits, 8bit seconds is too small. No room for radius.
+        cmd.content.location.flags.heading_req = !is_equal(packet.param2,0);  // param2 is bool for if heading to next wp is required to exit loiter
         cmd.content.location.flags.loiter_ccw = (packet.param3 < 0);
         break;
 
@@ -547,10 +549,9 @@ MAV_MISSION_RESULT AP_Mission::mavlink_to_mission_cmd(const mavlink_mission_item
 
     case MAV_CMD_NAV_LOITER_TO_ALT:                     // MAV ID: 31
         copy_location = true;
-        heading_req = packet.param1;                    //heading towards next waypoint required (0 = False)
-        radius_m = fabsf(packet.param2);                // radius in meters is held in high in param2
-        cmd.p1 = (((uint16_t)radius_m)<<8) | (uint16_t)heading_req; // store "radius" in high byte of p1, heading_req in low byte of p1
+        cmd.p1 = fabsf(packet.param2);                  // param2 is radius in meters
         cmd.content.location.flags.loiter_ccw = (packet.param2 < 0);
+        cmd.content.location.flags.heading_req = !is_equal(packet.param1,0);
         break;
 
     case MAV_CMD_NAV_SPLINE_WAYPOINT:                   // MAV ID: 82
@@ -846,6 +847,7 @@ bool AP_Mission::mission_cmd_to_mavlink(const AP_Mission::Mission_Command& cmd, 
         copy_location = true;
         packet.param1 = LOWBYTE(cmd.p1);                // number of times to circle is held in low byte of p1
         packet.param3 = HIGHBYTE(cmd.p1);               // radius is held in high byte of p1
+        packet.param2 = cmd.content.location.flags.heading_req;  // param2 is bool for if heading to next wp is required to exit loiter
         if (cmd.content.location.flags.loiter_ccw) {
             packet.param3 = -packet.param3;
         }
@@ -854,9 +856,10 @@ bool AP_Mission::mission_cmd_to_mavlink(const AP_Mission::Mission_Command& cmd, 
     case MAV_CMD_NAV_LOITER_TIME:                       // MAV ID: 19
         copy_location = true;
         packet.param1 = cmd.p1;                         // loiter time in seconds
+        packet.param2 = cmd.content.location.flags.heading_req;
         if (cmd.content.location.flags.loiter_ccw) {
             packet.param3 = -1;
-        }else{
+        } else {
             packet.param3 = 1;
         }
         break;
@@ -885,12 +888,11 @@ bool AP_Mission::mission_cmd_to_mavlink(const AP_Mission::Mission_Command& cmd, 
 
     case MAV_CMD_NAV_LOITER_TO_ALT:                     // MAV ID: 31
         copy_location = true;
-        packet.param1 = LOWBYTE(cmd.p1);                //heading towards next waypoint required (0 = False) 
-        packet.param2 = HIGHBYTE(cmd.p1);               //loiter radius(m)
+        packet.param1 = cmd.content.location.flags.heading_req; //heading towards next waypoint required (0 = False)
+        packet.param2 = cmd.p1;                        // loiter radius(m)
         if (cmd.content.location.flags.loiter_ccw) {
             packet.param2 = -packet.param2;
         }
-
         break;
 
     case MAV_CMD_NAV_SPLINE_WAYPOINT:                   // MAV ID: 82


### PR DESCRIPTION
This is only helpful for plane but available for all. When exiting a liter_turns, loiter_alt, or loiter_time there is now an optional cmd param field of heading required where when set to 1 yo must be +/- 10deg of the next waypoint before you are allowed to exit the loiter.

There needs to be a GCS change to added the bool label field 3 for loiter time/turns.

This fixes https://github.com/diydrones/ardupilot/issues/1906