### PR TITLE
waf: fix environment boolean values

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
+from collections import OrderedDict
 import sys
 
 import waflib
@@ -26,10 +27,15 @@ class Board:
             # Dictionaries (like 'DEFINES') are converted to lists to
             # conform to waf conventions.
             if isinstance(val, dict):
-                for item in val.items():
-                    cfg.env.prepend_value(k, '%s=%s' % item)
-            else:
+                keys = list(val.keys())
+                if not isinstance(val, OrderedDict):
+                    keys.sort()
+                val = ['%s=%s' % (vk, val[vk]) for vk in keys]
+
+            if k in cfg.env and isinstance(cfg.env, list):
                 cfg.env.prepend_value(k, val)
+            else:
+                cfg.env[k] = val
 
     def configure_env(self, env):
         # Use a dictionary instead of the convetional list for definitions to

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -204,7 +204,7 @@ class bebop(linux):
         env.DEFINES.update(
             CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_LINUX_BEBOP',
         )
-        env.STATIC_LINKING = [True]
+        env.STATIC_LINKING = True
 
 class raspilot(linux):
     def configure_env(self, env):

--- a/wscript
+++ b/wscript
@@ -114,7 +114,7 @@ def configure(cfg):
     ])
 
     if cfg.options.submodule_update:
-        cfg.env.SUBMODULE_UPDATE = [True]
+        cfg.env.SUBMODULE_UPDATE = True
 
 def collect_dirs_to_recurse(bld, globs, **kw):
     dirs = []


### PR DESCRIPTION
Hi all,

This PR changes the use of boolean values for environment variables to be more natural. The use of `[True]` was introduced actually because of a bug in `boards.py`. That pattern used also in `wscript` was probably just a propagation of the disease.

Best regards,
Gustavo Sousa