### PR TITLE
Silence unknown warning options

### DIFF
--- a/mk/board_native.mk
+++ b/mk/board_native.mk
@@ -20,7 +20,8 @@ WARNFLAGSCXX    = \
         -Werror=uninitialized \
         -Werror=init-self \
         -Wfatal-errors \
-        -Wundef
+        -Wundef \
+        -Wno-unknown-warning-option
 
 DEPFLAGS        =   -MD -MP -MT $@
 


### PR DESCRIPTION
* Clang doesn't implement all the warnings of GCC so this ends up spamming the console and not being helpful
* Will bring the log message down so https://github.com/diydrones/ardupilot/pull/3689 can potentially run (at the moment it is hitting the travis 4MB limit), note that I don't know whether this will solve that issue entirely, but it will remove a lot of spam from the log