### PR TITLE
Add support for condition_delay absolute time to Plane and Rover

### DIFF
--- a/APMrover2/commands_logic.cpp
+++ b/APMrover2/commands_logic.cpp
@@ -271,7 +271,14 @@ bool Rover::verify_RTL()
 void Rover::do_wait_delay(const AP_Mission::Mission_Command& cmd)
 {
 	condition_start = millis();
-	condition_value  = cmd.content.delay.seconds * 1000;    // convert seconds to milliseconds
+    if (!is_zero(cmd.content.delay.seconds)) {
+        // relative delay
+        condition_value = cmd.content.delay.seconds * 1000;     // convert seconds to milliseconds
+    } else {
+        // absolute delay to utc time
+        condition_value = gps.get_ms_until_time_of_week(cmd.content.delay.day_utc, cmd.content.delay.hour_utc, cmd.content.delay.min_utc, cmd.content.delay.sec_utc, 0);
+    }
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Delaying %u sec",(unsigned int)(condition_value/1000));
 }
 
 void Rover::do_within_distance(const AP_Mission::Mission_Command& cmd)

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -1008,6 +1008,7 @@ private:
     void do_set_home(const AP_Mission::Mission_Command& cmd);
     void do_roi(const AP_Mission::Mission_Command& cmd);
     void do_mount_control(const AP_Mission::Mission_Command& cmd);
+    uint32_t get_ms_until_time_of_week(uint16_t day, uint16_t hour, uint16_t min, uint16_t sec, uint16_t ms) const;
 #if CAMERA == ENABLED
     void do_digicam_configure(const AP_Mission::Mission_Command& cmd);
     void do_digicam_control(const AP_Mission::Mission_Command& cmd);

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -1008,7 +1008,6 @@ private:
     void do_set_home(const AP_Mission::Mission_Command& cmd);
     void do_roi(const AP_Mission::Mission_Command& cmd);
     void do_mount_control(const AP_Mission::Mission_Command& cmd);
-    uint32_t get_ms_until_time_of_week(uint16_t day, uint16_t hour, uint16_t min, uint16_t sec, uint16_t ms) const;
 #if CAMERA == ENABLED
     void do_digicam_configure(const AP_Mission::Mission_Command& cmd);
     void do_digicam_control(const AP_Mission::Mission_Command& cmd);

--- a/ArduCopter/commands_logic.cpp
+++ b/ArduCopter/commands_logic.cpp
@@ -726,7 +726,7 @@ void Copter::do_wait_delay(const AP_Mission::Mission_Command& cmd)
         condition_value = cmd.content.delay.seconds * 1000;     // convert seconds to milliseconds
     } else {
         // absolute delay to utc time
-        condition_value = get_ms_until_time_of_week(cmd.content.delay.day_utc, cmd.content.delay.hour_utc, cmd.content.delay.min_utc, cmd.content.delay.sec_utc, 0);
+        condition_value = gps.get_ms_until_time_of_week(cmd.content.delay.day_utc, cmd.content.delay.hour_utc, cmd.content.delay.min_utc, cmd.content.delay.sec_utc, 0);
     }
     gcs_send_text_fmt(MAV_SEVERITY_CRITICAL, "Delaying %u sec",(unsigned int)(condition_value/1000));
 }
@@ -923,69 +923,3 @@ void Copter::do_mount_control(const AP_Mission::Mission_Command& cmd)
 #endif
 }
 
-// get milliseconds from now to a target time of week expressed as day, hour, min, sec, ms
-//    match starts from first non-zero value specified.  I.e. specifying day=0, hour=10 will ignore the day and return time until 10am (utc)
-//    to match with sunday, specify day as 7.  To match with midnight specify hour as 24.
-uint32_t Copter::get_ms_until_time_of_week(uint16_t day, uint16_t hour, uint16_t min, uint16_t sec, uint16_t ms) const
-{
-    // determine highest value specified (0=none, 1=ms, 2=sec, 3=min, 4=hour, 5=day)
-    int8_t largest_element = 0;
-    if (ms != 0) largest_element = 1;
-    if (sec != 0) largest_element = 2;
-    if (min != 0) largest_element = 3;
-    if (hour != 0) largest_element = 4;
-    if (day != 0) largest_element = 5;
-
-    // exit immediately if no time specified
-    if (largest_element == 0) {
-        return 0;
-    }
-
-    // get start_time_ms as d, h, m, s, ms
-    uint16_t curr_day, curr_hour, curr_min, curr_sec, curr_ms;
-    gps.time_week_utc(curr_day, curr_hour, curr_min, curr_sec, curr_ms);
-    int32_t total_delay_ms = 0;
-
-    // calculate ms to target
-    if (largest_element >= 1) {
-        total_delay_ms += ms - curr_ms;
-    }
-    if (largest_element == 1 && total_delay_ms < 0) {
-        total_delay_ms += 1000;
-    }
-
-    // calculate sec to target
-    if (largest_element >= 2) {
-        total_delay_ms += (sec - curr_sec)*1000;
-    }
-    if (largest_element == 2 && total_delay_ms < 0) {
-        total_delay_ms += (60*1000);
-    }
-
-    // calculate min to target
-    if (largest_element >= 3) {
-        total_delay_ms += (min - curr_min)*60*1000;
-    }
-    if (largest_element == 3 && total_delay_ms < 0) {
-        total_delay_ms += (60*60*1000);
-    }
-
-    // calculate hours to target
-    if (largest_element >= 4) {
-        total_delay_ms += (hour - curr_hour)*60*60*1000;
-    }
-    if (largest_element == 4 && total_delay_ms < 0) {
-        total_delay_ms += (24*60*60*1000);
-    }
-
-    // calculate days to target
-    if (largest_element >= 5) {
-        total_delay_ms += (day - curr_day)*24*60*60*1000;
-    }
-    if (largest_element == 5 && total_delay_ms < 0) {
-        total_delay_ms += (7*24*60*60*1000);
-    }
-
-    // total delay in milliseconds
-    return (uint32_t)total_delay_ms;
-}

--- a/ArduCopter/commands_logic.cpp
+++ b/ArduCopter/commands_logic.cpp
@@ -721,7 +721,14 @@ bool Copter::verify_nav_guided_enable(const AP_Mission::Mission_Command& cmd)
 void Copter::do_wait_delay(const AP_Mission::Mission_Command& cmd)
 {
     condition_start = millis();
-    condition_value = cmd.content.delay.seconds * 1000;     // convert seconds to milliseconds
+    if (!is_zero(cmd.content.delay.seconds)) {
+        // relative delay
+        condition_value = cmd.content.delay.seconds * 1000;     // convert seconds to milliseconds
+    } else {
+        // absolute delay to utc time
+        condition_value = get_ms_until_time_of_week(cmd.content.delay.day_utc, cmd.content.delay.hour_utc, cmd.content.delay.min_utc, cmd.content.delay.sec_utc, 0);
+    }
+    gcs_send_text_fmt(MAV_SEVERITY_CRITICAL, "Delaying %u sec",(unsigned int)(condition_value/1000));
 }
 
 void Copter::do_change_alt(const AP_Mission::Mission_Command& cmd)
@@ -914,4 +921,71 @@ void Copter::do_mount_control(const AP_Mission::Mission_Command& cmd)
 #if MOUNT == ENABLED
     camera_mount.set_angle_targets(cmd.content.mount_control.roll, cmd.content.mount_control.pitch, cmd.content.mount_control.yaw);
 #endif
+}
+
+// get milliseconds from now to a target time of week expressed as day, hour, min, sec, ms
+//    match starts from first non-zero value specified.  I.e. specifying day=0, hour=10 will ignore the day and return time until 10am (utc)
+//    to match with sunday, specify day as 7.  To match with midnight specify hour as 24.
+uint32_t Copter::get_ms_until_time_of_week(uint16_t day, uint16_t hour, uint16_t min, uint16_t sec, uint16_t ms) const
+{
+    // determine highest value specified (0=none, 1=ms, 2=sec, 3=min, 4=hour, 5=day)
+    int8_t largest_element = 0;
+    if (ms != 0) largest_element = 1;
+    if (sec != 0) largest_element = 2;
+    if (min != 0) largest_element = 3;
+    if (hour != 0) largest_element = 4;
+    if (day != 0) largest_element = 5;
+
+    // exit immediately if no time specified
+    if (largest_element == 0) {
+        return 0;
+    }
+
+    // get start_time_ms as d, h, m, s, ms
+    uint16_t curr_day, curr_hour, curr_min, curr_sec, curr_ms;
+    gps.time_week_utc(curr_day, curr_hour, curr_min, curr_sec, curr_ms);
+    int32_t total_delay_ms = 0;
+
+    // calculate ms to target
+    if (largest_element >= 1) {
+        total_delay_ms += ms - curr_ms;
+    }
+    if (largest_element == 1 && total_delay_ms < 0) {
+        total_delay_ms += 1000;
+    }
+
+    // calculate sec to target
+    if (largest_element >= 2) {
+        total_delay_ms += (sec - curr_sec)*1000;
+    }
+    if (largest_element == 2 && total_delay_ms < 0) {
+        total_delay_ms += (60*1000);
+    }
+
+    // calculate min to target
+    if (largest_element >= 3) {
+        total_delay_ms += (min - curr_min)*60*1000;
+    }
+    if (largest_element == 3 && total_delay_ms < 0) {
+        total_delay_ms += (60*60*1000);
+    }
+
+    // calculate hours to target
+    if (largest_element >= 4) {
+        total_delay_ms += (hour - curr_hour)*60*60*1000;
+    }
+    if (largest_element == 4 && total_delay_ms < 0) {
+        total_delay_ms += (24*60*60*1000);
+    }
+
+    // calculate days to target
+    if (largest_element >= 5) {
+        total_delay_ms += (day - curr_day)*24*60*60*1000;
+    }
+    if (largest_element == 5 && total_delay_ms < 0) {
+        total_delay_ms += (7*24*60*60*1000);
+    }
+
+    // total delay in milliseconds
+    return (uint32_t)total_delay_ms;
 }

--- a/ArduCopter/commands_logic.cpp
+++ b/ArduCopter/commands_logic.cpp
@@ -728,7 +728,7 @@ void Copter::do_wait_delay(const AP_Mission::Mission_Command& cmd)
         // absolute delay to utc time
         condition_value = gps.get_ms_until_time_of_week(cmd.content.delay.day_utc, cmd.content.delay.hour_utc, cmd.content.delay.min_utc, cmd.content.delay.sec_utc, 0);
     }
-    gcs_send_text_fmt(MAV_SEVERITY_CRITICAL, "Delaying %u sec",(unsigned int)(condition_value/1000));
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Delaying %u sec",(unsigned int)(condition_value/1000));
 }
 
 void Copter::do_change_alt(const AP_Mission::Mission_Command& cmd)

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -783,7 +783,14 @@ bool Plane::verify_altitude_wait(const AP_Mission::Mission_Command &cmd)
 void Plane::do_wait_delay(const AP_Mission::Mission_Command& cmd)
 {
     condition_start = millis();
-    condition_value  = cmd.content.delay.seconds * 1000;    // convert seconds to milliseconds
+    if (!is_zero(cmd.content.delay.seconds)) {
+        // relative delay
+        condition_value = cmd.content.delay.seconds * 1000;     // convert seconds to milliseconds
+    } else {
+        // absolute delay to utc time
+        condition_value = gps.get_ms_until_time_of_week(cmd.content.delay.day_utc, cmd.content.delay.hour_utc, cmd.content.delay.min_utc, cmd.content.delay.sec_utc, 0);
+    }
+    GCS_MAVLINK::send_statustext_all(MAV_SEVERITY_INFO, "Delaying %u sec",(unsigned int)(condition_value/1000));
 }
 
 /*

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -449,6 +449,28 @@ AP_GPS::update(void)
 }
 
 /*
+  GPS time of week in days, hours, minutes, seconds, milliseconds
+*/
+void AP_GPS::time_week_utc(uint8_t instance, uint16_t &day, uint16_t &hour, uint16_t &min, uint16_t &sec, uint16_t &ms) const
+{
+    // get time of week in ms
+    uint32_t time_ms = time_week_ms(instance);
+
+    // separate time into ms, sec, min, hour and days but all expressed in milliseconds
+    ms = time_ms % 1000;
+    uint32_t sec_ms = (time_ms % (60 * 1000)) - ms;
+    uint32_t min_ms = (time_ms % (60 * 60 * 1000)) - sec_ms - ms;
+    uint32_t hour_ms = (time_ms % (24 * 60 * 60 * 1000)) - min_ms - sec_ms - ms;
+    uint32_t day_ms = time_ms - hour_ms - min_ms - sec_ms - ms;
+
+    // convert times as milliseconds into appropriate units
+    sec = sec_ms / 1000;
+    min = min_ms / (60 * 1000);
+    hour = hour_ms / (60 * 60 * 1000);
+    day = day_ms / (24 * 60 * 60 * 1000);
+}
+
+/*
   set HIL (hardware in the loop) status for a GPS instance
  */
 void 

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -255,6 +255,7 @@ public:
     void time_week_utc(uint16_t &day, uint16_t &hour, uint16_t &min, uint16_t &sec, uint16_t &ms) const {
         return time_week_utc(primary_instance, day, hour, min, sec, ms);
     }
+    uint32_t get_ms_until_time_of_week(uint16_t day, uint16_t hour, uint16_t min, uint16_t sec, uint16_t ms) const;
 
     // horizontal dilution of precision
     uint16_t get_hdop(uint8_t instance) const {

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -250,6 +250,12 @@ public:
         return time_week(primary_instance);
     }
 
+    // GPS time of week in days, hours, minutes, seconds, milliseconds
+    void time_week_utc(uint8_t instance, uint16_t &day, uint16_t &hour, uint16_t &min, uint16_t &sec, uint16_t &ms) const;
+    void time_week_utc(uint16_t &day, uint16_t &hour, uint16_t &min, uint16_t &sec, uint16_t &ms) const {
+        return time_week_utc(primary_instance, day, hour, min, sec, ms);
+    }
+
     // horizontal dilution of precision
     uint16_t get_hdop(uint8_t instance) const {
         return state[instance].hdop;

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -176,6 +176,22 @@ void AP_Mission::update()
         return;
     }
 
+    // check if we have an active do command
+    if (!_flags.do_cmd_loaded) {
+        advance_current_do_cmd();
+    } else {
+        // run the active do command
+        if (_cmd_verify_fn(_do_cmd)) {
+            // market _nav_cmd as complete (it will be started on the next iteration)
+            _flags.do_cmd_loaded = false;
+        }
+    }
+
+    // do not advance state machine if do-conditional-delay command is active
+    if (_flags.do_cmd_loaded && (_do_cmd.id == MAV_CMD_CONDITION_DELAY)) {
+        return;
+    }
+
     // check if we have an active nav command
     if (!_flags.nav_cmd_loaded || _nav_cmd.index == AP_MISSION_CMD_INDEX_NONE) {
         // advance in mission if no active nav command
@@ -195,17 +211,6 @@ void AP_Mission::update()
                 complete();
                 return;
             }
-        }
-    }
-
-    // check if we have an active do command
-    if (!_flags.do_cmd_loaded) {
-        advance_current_do_cmd();
-    }else{
-        // run the active do command
-        if (_cmd_verify_fn(_do_cmd)) {
-            // market _nav_cmd as complete (it will be started on the next iteration)
-            _flags.do_cmd_loaded = false;
         }
     }
 }

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -562,6 +562,10 @@ MAV_MISSION_RESULT AP_Mission::mavlink_to_mission_cmd(const mavlink_mission_item
 
     case MAV_CMD_CONDITION_DELAY:                       // MAV ID: 112
         cmd.content.delay.seconds = packet.param1;      // delay in seconds
+        cmd.content.delay.day_utc = (uint8_t)constrain_float(packet.param2,0.0f,7.0f);  // absolute time's day of week (utc)
+        cmd.content.delay.hour_utc = (uint8_t)constrain_float(packet.param3,0.0f,24.0f);// absolute time's hour (utc)
+        cmd.content.delay.min_utc = (uint8_t)constrain_float(packet.param4,0.0f, 60.0f);// absolute time's min (utc)
+        cmd.content.delay.sec_utc = (uint8_t)constrain_float(packet.x,0.0f, 60.0f);     // absolute time's second (utc)
         break;
 
     case MAV_CMD_CONDITION_CHANGE_ALT:                  // MAV ID: 113
@@ -900,6 +904,10 @@ bool AP_Mission::mission_cmd_to_mavlink(const AP_Mission::Mission_Command& cmd, 
 
     case MAV_CMD_CONDITION_DELAY:                       // MAV ID: 112
         packet.param1 = cmd.content.delay.seconds;      // delay in seconds
+        packet.param2 = cmd.content.delay.day_utc;      // absolute time's day of week (utc)
+        packet.param3 = cmd.content.delay.hour_utc;     // absolute time's hour (utc)
+        packet.param4 = cmd.content.delay.min_utc;      // absolute time's min (utc)
+        packet.x = cmd.content.delay.sec_utc;           // absolute time's second (utc)
         break;
 
     case MAV_CMD_CONDITION_CHANGE_ALT:                  // MAV ID: 113

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -56,7 +56,7 @@ public:
         float seconds;          // period of delay in seconds
     };
 
-    // condition delay command structure
+    // condition distance command structure
     struct PACKED Conditional_Distance_Command {
         float meters;           // distance from next waypoint in meters
     };

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -54,6 +54,10 @@ public:
     // condition delay command structure
     struct PACKED Conditional_Delay_Command {
         float seconds;          // period of delay in seconds
+        uint8_t day_utc;        // absolute time's day of week (utc)
+        uint8_t hour_utc;       // absolute time's hour (utc)
+        uint8_t min_utc;        // absolute time's min (utc)
+        uint8_t sec_utc;        // absolute time's sec (utc)
     };
 
     // condition distance command structure


### PR DESCRIPTION
This extends (and depends on) https://github.com/diydrones/ardupilot/pull/3708 to plane and rover. It also moves the worker functions to the GPS library so they're common.