### PR TITLE
autotest: Added submodule update and removed old modules update

### DIFF
--- a/Tools/scripts/build_autotest.sh
+++ b/Tools/scripts/build_autotest.sh
@@ -87,9 +87,11 @@ report_pull_failure() {
 
 oldhash=$(cd APM && git rev-parse HEAD)
 
+echo "Updating APM"
 pushd APM
 git checkout -f master
 git fetch origin
+git submodule update
 git reset --hard origin/master
 git pull || report_pull_failure
 git clean -f -f -x -d -d
@@ -98,47 +100,6 @@ cp ../config.mk .
 popd
 
 rsync -a APM/Tools/autotest/web-firmware/ buildlogs/binaries/
-
-pushd PX4Firmware
-git fetch origin
-git reset --hard origin/master
-for v in ArduPlane ArduCopter APMrover2; do
-    git tag -d $v-beta || true
-    git tag -d $v-stable || true
-done
-git fetch origin --tags
-git show
-popd
-
-pushd PX4NuttX
-git fetch origin
-git reset --hard origin/master
-for v in ArduPlane ArduCopter APMrover2; do
-    git tag -d $v-beta || true
-    git tag -d $v-stable || true
-done
-git fetch origin --tags
-git show
-popd
-
-pushd uavcan
-git fetch origin
-git reset --hard origin/master
-for v in ArduPlane ArduCopter APMrover2; do
-    git tag -d $v-beta || true
-    git tag -d $v-stable || true
-done
-git fetch origin --tags
-git show
-popd
-
-echo "Updating pymavlink"
-pushd mavlink/pymavlink
-git fetch origin
-git reset --hard origin/master
-git show
-python setup.py build install --user
-popd
 
 echo "Updating MAVProxy"
 pushd MAVProxy


### PR DESCRIPTION
Firstly build.All was failing as the submodules had not been updated
so the 'git submodule update' in this commit resovles that.
Secondly, now that the dependant projects like PX4Firmware etc are git
submodules of ardupilot we no longer need to check them out separately
and update them so I have removed all those.
I left MAVProxy as it isn't a submodule of ardupilot.