### PR TITLE
Plane: fix short loiters exiting early

### DIFF
--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -619,7 +619,7 @@ bool Plane::verify_loiter_time()
     update_loiter(0);
 
     if (loiter.start_time_ms == 0) {
-        if (nav_controller->reached_loiter_target()) {
+        if (nav_controller->reached_loiter_target() && loiter.sum_cd > 1) {
             // we've reached the target, start the timer
             loiter.start_time_ms = millis();
         }
@@ -649,7 +649,7 @@ bool Plane::verify_loiter_turns()
 
     if (condition_value != 0) {
         // primary goal, loiter time
-        if (loiter.sum_cd > loiter.total_cd) {
+        if (loiter.sum_cd > loiter.total_cd && loiter.sum_cd > 1) {
             // primary goal completed, initialize secondary heading goal
             condition_value = 0;
             result = verify_loiter_heading(true);
@@ -678,7 +678,7 @@ bool Plane::verify_loiter_to_alt()
     //has target altitude been reached?
     if (condition_value != 0) {
         // primary goal, loiter alt
-        if (labs(condition_value - current_loc.alt) < 500) {
+        if (labs(condition_value - current_loc.alt) < 500 && loiter.sum_cd > 1) {
             // primary goal completed, initialize secondary heading goal
             condition_value = 0;
             result = verify_loiter_heading(true);


### PR DESCRIPTION
Loiter exits on a tangent. It does this by calculating the ground heading compared to the next waypoint heading when the loiter criteria completes (turns/time/alt is met). However, if the loiter criteria is met almost instantly with just being captured via already at alt or time is 1s then the calculation is wrong because you have not yet entered the arc of the loiter; your ground heading is still pointing at the center of the loiter. This patch fixes that by forcing you to have navigated along the circle edge for at least 2 degrees. That gives the ground heading time to actually become an arc so the exit calculation is accurate.