### PR TITLE
AP_Notify: add class to turn LED off

### DIFF
--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -91,7 +91,8 @@ struct AP_Notify::notify_events_type AP_Notify::events;
         ToneAlarm_Linux tonealarm;
         NotifyDevice *AP_Notify::_devices[] = {&toshibaled, &tonealarm};
     #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_MINLURE
-        NotifyDevice *AP_Notify::_devices[0];
+        RCOutputRGBLedOff led(15, 13, 14, 255);
+        NotifyDevice *AP_Notify::_devices[] = { &led };
     #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_ERLEBRAIN2 || \
       CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_PXFMINI
         AP_BoardLED boardled;

--- a/libraries/AP_Notify/RCOutputRGBLed.h
+++ b/libraries/AP_Notify/RCOutputRGBLed.h
@@ -10,10 +10,25 @@ public:
     RCOutputRGBLed(uint8_t red_channel, uint8_t green_channel,
                    uint8_t blue_channel);
     bool hw_init();
-    bool hw_set_rgb(uint8_t red, uint8_t green, uint8_t blue);
+    virtual bool hw_set_rgb(uint8_t red, uint8_t green, uint8_t blue);
 
 private:
     uint8_t _red_channel;
     uint8_t _green_channel;
     uint8_t _blue_channel;
+};
+
+class RCOutputRGBLedOff : public RCOutputRGBLed {
+public:
+    RCOutputRGBLedOff(uint8_t red_channel, uint8_t green_channel,
+                      uint8_t blue_channel, uint8_t led_off)
+        : RCOutputRGBLed(red_channel, green_channel, blue_channel,
+                         led_off, led_off, led_off, led_off)
+    { }
+
+    /* Replace the hw_set_rgb with an empty one */
+    bool hw_set_rgb(uint8_t red, uint8_t green, uint8_t blue) override
+    {
+        return RCOutputRGBLed::hw_set_rgb(_led_off, _led_off, _led_off);
+    }
 };


### PR DESCRIPTION
On early versions of minlure an RGB LED was wrongly placed next to the
barometer, causing trouble on it.

Additionally depending on the LED intensity it may be a pain to leave it
turned on for boards supposed to be used for bench testing. This allows
to disable the LED by software so we don't have to remove it.