### PR TITLE
Waf: support Clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
     branch_pattern: coverity_scan
 
 before_install:
+  - export PATH=$(echo ${PATH} | awk -v RS=':' -v ORS=':' '/clang/ {next} {print}' | sed 's/:*$//')
   - APMDIR=$(pwd) && pushd .. && $APMDIR/Tools/scripts/configure-ci.sh && . ~/.profile && popd
 
 script:
@@ -30,6 +31,10 @@ notifications:
     on_failure: always  # options: [always|never|change] default: always
     on_start: false     # default: false
 
+compiler:
+  - gcc
+  - clang
+
 env:
   global:
     # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
@@ -39,3 +44,8 @@ env:
     - CI_BUILD_TARGET="px4-v2 sitl linux"
     - CI_BUILD_TARGET="navio raspilot minlure bebop"
     - CI_BUILD_TARGET="sitltest"
+
+matrix:
+  exclude:
+    - compiler: clang
+      env: CI_BUILD_TARGET="sitltest"

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -48,7 +48,6 @@ COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
     'Filter',
     'GCS_MAVLink',
     'RC_Channel',
-    'SITL',
     'StorageManager',
 ]
 

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -18,7 +18,7 @@ class BoardMeta(type):
 class Board:
     def configure(self, cfg):
         env = waflib.ConfigSet.ConfigSet()
-        self.configure_env(env)
+        self.configure_env(cfg, env)
 
         d = env.get_merged_dict()
         # Always prepend so that arguments passed in the command line get
@@ -37,7 +37,7 @@ class Board:
             else:
                 cfg.env[k] = val
 
-    def configure_env(self, env):
+    def configure_env(self, cfg, env):
         # Use a dictionary instead of the convetional list for definitions to
         # make easy to override them. Convert back to list before consumption.
         env.DEFINES = {}
@@ -58,6 +58,20 @@ class Board:
             '-Wno-unused-parameter',
             '-Wno-redundant-decls',
         ]
+        
+        c_compiler = cfg.options.check_c_compiler or cfg.environ.get('CC', '')
+        
+        if 'clang' in c_compiler:
+            env.CFLAGS += [
+                '-fcolor-diagnostics',
+                
+                '-Wno-gnu-designator',
+                '-Wno-inconsistent-missing-override',
+                '-Wno-mismatched-tags',
+                '-Wno-gnu-variable-sized-type-not-at-end',
+                '-Wno-unknown-pragmas',
+                '-Wno-c++11-narrowing'
+            ]
 
         env.CXXFLAGS += [
             '-std=gnu++11',
@@ -80,11 +94,28 @@ class Board:
             '-Wno-redundant-decls',
             '-Werror=format-security',
             '-Werror=array-bounds',
-            '-Werror=unused-but-set-variable',
             '-Werror=uninitialized',
             '-Werror=init-self',
             '-Wfatal-errors',
         ]
+        
+        cxx_compiler = cfg.options.check_cxx_compiler or cfg.environ.get('CXX', '')
+        
+        if 'clang++' in cxx_compiler:
+            env.CXXFLAGS += [
+                '-fcolor-diagnostics',
+                
+                '-Wno-gnu-designator',
+                '-Wno-inconsistent-missing-override',
+                '-Wno-mismatched-tags',
+                '-Wno-gnu-variable-sized-type-not-at-end',
+                '-Wno-unknown-pragmas',
+                '-Wno-c++11-narrowing'
+            ]
+        else:
+            env.CXXFLAFS += [
+                '-Werror=unused-but-set-variable'
+            ]
 
         env.LINKFLAGS += [
             '-Wl,--gc-sections',
@@ -103,8 +134,8 @@ def get_board(name):
 # be worthy to keep board definitions in files of their own.
 
 class sitl(Board):
-    def configure_env(self, env):
-        super(sitl, self).configure_env(env)
+    def configure_env(self, cfg, env):
+        super(sitl, self).configure_env(cfg, env)
 
         env.DEFINES.update(
             CONFIG_HAL_BOARD = 'HAL_BOARD_SITL',
@@ -123,8 +154,8 @@ class sitl(Board):
         ]
 
 class linux(Board):
-    def configure_env(self, env):
-        super(linux, self).configure_env(env)
+    def configure_env(self, cfg, env):
+        super(linux, self).configure_env(cfg, env)
 
         env.DEFINES.update(
             CONFIG_HAL_BOARD = 'HAL_BOARD_LINUX',
@@ -143,8 +174,8 @@ class linux(Board):
         ]
 
 class minlure(linux):
-    def configure_env(self, env):
-        super(minlure, self).configure_env(env)
+    def configure_env(self, cfg, env):
+        super(minlure, self).configure_env(cfg, env)
 
         env.DEFINES.update(
             CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_LINUX_MINLURE',
@@ -152,8 +183,8 @@ class minlure(linux):
 
 
 class erleboard(linux):
-    def configure_env(self, env):
-        super(erleboard, self).configure_env(env)
+    def configure_env(self, cfg, env):
+        super(erleboard, self).configure_env(cfg, env)
 
         env.TOOLCHAIN = 'arm-linux-gnueabihf'
         env.DEFINES.update(
@@ -161,8 +192,8 @@ class erleboard(linux):
         )
 
 class navio(linux):
-    def configure_env(self, env):
-        super(navio, self).configure_env(env)
+    def configure_env(self, cfg, env):
+        super(navio, self).configure_env(cfg, env)
 
         env.TOOLCHAIN = 'arm-linux-gnueabihf'
         env.DEFINES.update(
@@ -170,8 +201,8 @@ class navio(linux):
         )
 
 class navio2(linux):
-    def configure_env(self, env):
-        super(navio2, self).configure_env(env)
+    def configure_env(self, cfg, env):
+        super(navio2, self).configure_env(cfg, env)
 
         env.TOOLCHAIN = 'arm-linux-gnueabihf'
         env.DEFINES.update(
@@ -179,8 +210,8 @@ class navio2(linux):
         )
 
 class zynq(linux):
-    def configure_env(self, env):
-        super(zynq, self).configure_env(env)
+    def configure_env(self, cfg, env):
+        super(zynq, self).configure_env(cfg, env)
 
         env.TOOLCHAIN = 'arm-xilinx-linux-gnueabi'
         env.DEFINES.update(
@@ -188,8 +219,8 @@ class zynq(linux):
         )
 
 class bbbmini(linux):
-    def configure_env(self, env):
-        super(bbbmini, self).configure_env(env)
+    def configure_env(self, cfg, env):
+        super(bbbmini, self).configure_env(cfg, env)
 
         env.TOOLCHAIN = 'arm-linux-gnueabihf'
         env.DEFINES.update(
@@ -197,8 +228,8 @@ class bbbmini(linux):
         )
 
 class pxf(linux):
-    def configure_env(self, env):
-        super(pxf, self).configure_env(env)
+    def configure_env(self, cfg, env):
+        super(pxf, self).configure_env(cfg, env)
 
         env.TOOLCHAIN = 'arm-linux-gnueabihf'
         env.DEFINES.update(
@@ -206,8 +237,8 @@ class pxf(linux):
         )
 
 class bebop(linux):
-    def configure_env(self, env):
-        super(bebop, self).configure_env(env)
+    def configure_env(self, cfg, env):
+        super(bebop, self).configure_env(cfg, env)
 
         env.TOOLCHAIN = 'arm-linux-gnueabihf'
         env.DEFINES.update(
@@ -216,8 +247,8 @@ class bebop(linux):
         env.STATIC_LINKING = True
 
 class raspilot(linux):
-    def configure_env(self, env):
-        super(raspilot, self).configure_env(env)
+    def configure_env(self, cfg, env):
+        super(raspilot, self).configure_env(cfg, env)
 
         env.TOOLCHAIN = 'arm-linux-gnueabihf'
         env.DEFINES.update(
@@ -225,8 +256,8 @@ class raspilot(linux):
         )
 
 class erlebrain2(linux):
-    def configure_env(self, env):
-        super(erlebrain2, self).configure_env(env)
+    def configure_env(self, cfg, env):
+        super(erlebrain2, self).configure_env(cfg, env)
 
         env.TOOLCHAIN = 'arm-linux-gnueabihf'
         env.DEFINES.update(
@@ -234,8 +265,8 @@ class erlebrain2(linux):
         )
 
 class bhat(linux):
-    def configure_env(self, env):
-        super(bhat, self).configure_env(env)
+    def configure_env(self, cfg, env):
+        super(bhat, self).configure_env(cfg, env)
 
         env.TOOLCHAIN = 'arm-linux-gnueabihf'
         env.DEFINES.update(
@@ -243,8 +274,8 @@ class bhat(linux):
         )
 
 class pxfmini(linux):
-    def configure_env(self, env):
-        super(pxfmini, self).configure_env(env)
+    def configure_env(self, cfg, env):
+        super(pxfmini, self).configure_env(cfg, env)
 
         env.TOOLCHAIN = 'arm-linux-gnueabihf'
         env.DEFINES.update(

--- a/Tools/ardupilotwaf/toolchain.py
+++ b/Tools/ardupilotwaf/toolchain.py
@@ -13,6 +13,7 @@ Example::
 """
 
 from waflib import Utils
+import os
 
 suffixes = dict(
     CXX='g++',
@@ -24,6 +25,30 @@ suffixes = dict(
     OBJCOPY='objcopy',
 )
 
+def find_realexec_path(cfg, filename, path_list=[]):
+    if not filename:
+        return ''
+
+    if not path_list:
+        path_list = cfg.environ.get('PATH','').split(os.pathsep)
+
+    for dir in path_list:
+        path = os.path.abspath(os.path.expanduser(os.path.join(dir, filename)))
+
+        if os.path.isfile(path):
+            if os.path.islink(path):
+                realpath = os.path.realpath(path)
+
+                if filename not in os.path.basename(realpath):
+                    continue
+                else:
+                    return os.path.dirname(realpath)
+
+            else:
+                return os.path.dirname(path)
+
+    cfg.fatal('Could not find real exec path to %s in path_list %s:' % (filename, path_list))
+
 def configure(cfg):
     if not cfg.env.TOOLCHAIN:
         cfg.env.TOOLCHAIN = 'native'
@@ -33,5 +58,45 @@ def configure(cfg):
         cfg.msg('Using toolchain prefix', cfg.env.TOOLCHAIN)
         prefix = cfg.env.TOOLCHAIN + '-'
 
-    for k in suffixes:
-        cfg.env.append_value(k, prefix + suffixes[k])
+    if cfg.env.TOOLCHAIN != 'native':
+        for k in suffixes:
+            cfg.env.append_value(k, prefix + suffixes[k])
+
+        c_compiler = cfg.options.check_c_compiler or cfg.environ.get('CC', '')
+        cxx_compiler = cfg.options.check_cxx_compiler or cfg.environ.get('CXX', '')
+        cfg.environ.pop('CC', None)
+        cfg.environ.pop('CXX', None)
+
+        if 'clang' in c_compiler:
+            toolchain_path = os.path.abspath(os.path.join(find_realexec_path(cfg, cfg.env['CC'][0]), '..'))
+
+            cfg.env['CC'] = [ c_compiler ]
+            cfg.env.CFLAGS += [
+                '--target=' + cfg.env.TOOLCHAIN,
+                '--gcc-toolchain=' + toolchain_path,
+                '--sysroot=' + os.path.join(toolchain_path, cfg.env.TOOLCHAIN, 'libc'),
+                '-B' + os.path.join(toolchain_path, 'bin')
+            ]
+            cfg.env.LINKFLAGS += [
+                '--target=' + cfg.env.TOOLCHAIN,
+                '--gcc-toolchain=' + toolchain_path,
+                '--sysroot=' + os.path.join(toolchain_path, cfg.env.TOOLCHAIN, 'libc'),
+                '-B' + os.path.join(toolchain_path, 'bin')
+            ]
+
+        if 'clang++' in cxx_compiler:
+            toolchain_path = os.path.abspath(os.path.join(find_realexec_path(cfg, cfg.env['CXX'][0]), '..'))
+
+            cfg.env['CXX'] = [ cxx_compiler ]
+            cfg.env.CXXFLAGS += [
+                '--target=' + cfg.env.TOOLCHAIN,
+                '--gcc-toolchain=' + toolchain_path,
+                '--sysroot=' + os.path.join(toolchain_path, cfg.env.TOOLCHAIN, 'libc'),
+                '-B' + os.path.join(toolchain_path, 'bin')
+            ]
+            cfg.env.LINKFLAGS += [
+                '--target=' + cfg.env.TOOLCHAIN,
+                '--gcc-toolchain=' + toolchain_path,
+                '--sysroot=' + os.path.join(toolchain_path, cfg.env.TOOLCHAIN, 'libc'),
+                '-B' + os.path.join(toolchain_path, 'bin')
+            ]

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -7,9 +7,6 @@ set -ex
 
 . ~/.profile
 
-# CXX and CC are exported by default by travis
-unset CXX CC
-
 export BUILDROOT=/tmp/travis.build.$$
 rm -rf $BUILDROOT
 
@@ -61,22 +58,25 @@ for board in $($waf list_boards | head -n1); do waf_supported_boards[$board]=1; 
 
 echo "Targets: $CI_BUILD_TARGET"
 for t in $CI_BUILD_TARGET; do
-    echo "Starting make based build for target ${t}..."
-    for v in ${!build_platforms[@]}; do
-        if [[ ${build_platforms[$v]} != *$t* ]]; then
-            continue
-        fi
-        echo "Building $v for ${t}..."
+    # skip make-based build for clang
+    if [[ "$CXX" != "clang++" ]]; then
+        echo "Starting make based build for target ${t}..."
+        for v in ${!build_platforms[@]}; do
+            if [[ ${build_platforms[$v]} != *$t* ]]; then
+                continue
+            fi
+            echo "Building $v for ${t}..."
 
-        pushd $v
-        make clean
-        if [ ${build_extra_clean[$t]+_} ]; then
-            ${build_extra_clean[$t]}
-        fi
+            pushd $v
+            make clean
+            if [ ${build_extra_clean[$t]+_} ]; then
+                ${build_extra_clean[$t]}
+            fi
 
-        make $t ${build_concurrency[$t]}
-        popd
-    done
+            make $t ${build_concurrency[$t]}
+            popd
+        done
+    fi
 
     if [[ -n ${waf_supported_boards[$t]} ]]; then
         echo "Starting waf build for board ${t}..."

--- a/Tools/scripts/configure-ci.sh
+++ b/Tools/scripts/configure-ci.sh
@@ -21,7 +21,7 @@ sudo apt-get -qq -y update
 sudo apt-get -qq -y install $PKGS
 sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.7 37 \
     --slave /usr/bin/clang++ clang++ /usr/bin/clang++-3.7
-sudo pip install mavproxy
+pip install --user mavproxy
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 90 \
     --slave /usr/bin/g++ g++ /usr/bin/g++-4.9
 
@@ -56,9 +56,9 @@ ln -s /usr/bin/ccache ~/bin/arm-none-eabi-gcc
 ln -s /usr/bin/ccache ~/bin/arm-linux-gnueabihf-g++
 ln -s /usr/bin/ccache ~/bin/arm-linux-gnueabihf-gcc
 
-exportline="export PATH=$HOME/bin:"
-exportline="${exportline}:$HOME/opt/gcc-arm-none-eabi-4_9-2015q3/bin:"
-exportline="${exportline}:$HOME/opt/tools-master/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin:"
+exportline="export PATH=$HOME/bin"
+exportline="${exportline}:$HOME/opt/gcc-arm-none-eabi-4_9-2015q3/bin"
+exportline="${exportline}:$HOME/opt/tools-master/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin"
 exportline="${exportline}:\$PATH"
 
 if grep -Fxq "$exportline" ~/.profile; then

--- a/Tools/scripts/configure-ci.sh
+++ b/Tools/scripts/configure-ci.sh
@@ -4,7 +4,7 @@
 set -ex
 
 PKGS="build-essential gawk ccache genromfs libc6-i386 \
-      python-argparse python-empy python-serial python-pexpect python-dev python-pip zlib1g-dev gcc-4.9 g++-4.9"
+      python-argparse python-empy python-serial python-pexpect python-dev python-pip zlib1g-dev gcc-4.9 g++-4.9 clang-3.7"
 
 ARM_ROOT="gcc-arm-none-eabi-4_9-2015q3"
 ARM_TARBALL="$ARM_ROOT-20150921-linux.tar.bz2"
@@ -12,9 +12,15 @@ ARM_TARBALL="$ARM_ROOT-20150921-linux.tar.bz2"
 RPI_ROOT="master"
 RPI_TARBALL="$RPI_ROOT.tar.gz"
 
+read -r UBUNTU_CODENAME <<<$(lsb_release -c -s)
+
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+wget -q -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
+sudo add-apt-repository "deb http://llvm.org/apt/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-3.7 main" -y
 sudo apt-get -qq -y update
 sudo apt-get -qq -y install $PKGS
+sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.7 37 \
+    --slave /usr/bin/clang++ clang++ /usr/bin/clang++-3.7
 sudo pip install mavproxy
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 90 \
     --slave /usr/bin/g++ g++ /usr/bin/g++-4.9

--- a/Tools/scripts/configure-ci.sh
+++ b/Tools/scripts/configure-ci.sh
@@ -18,6 +18,7 @@ sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 wget -q -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
 sudo add-apt-repository "deb http://llvm.org/apt/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-3.7 main" -y
 sudo apt-get -qq -y update
+sudo apt-get -qq -y remove clang llvm
 sudo apt-get -qq -y install $PKGS
 sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.7 37 \
     --slave /usr/bin/clang++ clang++ /usr/bin/clang++-3.7

--- a/libraries/AP_HAL_Linux/SPIDriver.cpp
+++ b/libraries/AP_HAL_Linux/SPIDriver.cpp
@@ -72,10 +72,14 @@ SPIDeviceDriver SPIDeviceManager::_device[] = {
 };
 #else
 // empty device table
-SPIDeviceDriver SPIDeviceManager::_device[0];
+SPIDeviceDriver SPIDeviceManager::_device[] = { };
+#define LINUX_SPI_DEVICE_NUM_DEVICES 0
 #endif
 
+#ifndef LINUX_SPI_DEVICE_NUM_DEVICES
 #define LINUX_SPI_DEVICE_NUM_DEVICES ARRAY_SIZE(SPIDeviceManager::_device)
+#endif
+
 const uint8_t SPIDeviceManager::_n_device_desc = LINUX_SPI_DEVICE_NUM_DEVICES;
 
 SPIDeviceDriver::SPIDeviceDriver(const char *name, uint16_t bus, uint16_t subdev, enum AP_HAL::SPIDeviceType type, uint8_t mode, uint8_t bitsPerWord, int16_t cs_pin, uint32_t lowspeed, uint32_t highspeed):

--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -91,7 +91,8 @@ struct AP_Notify::notify_events_type AP_Notify::events;
         ToneAlarm_Linux tonealarm;
         NotifyDevice *AP_Notify::_devices[] = {&toshibaled, &tonealarm};
     #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_MINLURE
-        NotifyDevice *AP_Notify::_devices[0];
+    #define CONFIG_NOTIFY_DEVICES_COUNT 0
+        NotifyDevice *AP_Notify::_devices[] = { };
     #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_ERLEBRAIN2 || \
       CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_PXFMINI
         AP_BoardLED boardled;
@@ -112,7 +113,9 @@ struct AP_Notify::notify_events_type AP_Notify::events;
     NotifyDevice *AP_Notify::_devices[] = {&boardled, &toshibaled};
 #endif
 
+#ifndef CONFIG_NOTIFY_DEVICES_COUNT
 #define CONFIG_NOTIFY_DEVICES_COUNT (ARRAY_SIZE(AP_Notify::_devices))
+#endif
 
 // initialisation
 void AP_Notify::init(bool enable_external_leds)


### PR DESCRIPTION
Following the initial work of @8W9aG and with the precious help from @lucasdemarchi I've made compilation with Clang in Waf possible, not only for native targets but also for cross-compilation.

To use Clang you have two options:
- define the environment variables CC and CXX
- use the flags _--check-c-compiler=clang_ and _--check-cxx-compiler=clang++_ in the configure stage of Waf

The flags take priority over the env vars. These can also be used for GCC but Waf will default to that.

For cross-compiling you need to have:
- somewhere in the system, the GCC toolchain for the board to be build
- have the bin folder of that toolchain in the PATH environment variable

This has only been tested with a specially modified sitltest target in Travis (https://travis-ci.org/OXINARF/ardupilot/builds/114686931), so testing in actual boards is really needed.

I haven't worked much with Python and, although I've been watching the development of the Waf build system here in Ardupilot, I know very very little about Waf. Because of that, input from @guludo is really requested here. Specifically:
- I don't quite like the way of detecting the compiler at the board configure_env but the compiler is only detected after that, so I couldn't see how to do it in another way. I though of changing the order but I'm not sure if that's possible
- the function to help detect the toolchain path isn't bullet proof (for example, a double symlink wouldn't work) but I felt the work to do that would be too high for the reward

Ccache for Clang isn't setup in CI at the moment because it wasn't working properly with it - I'll leave that for future work.

**Clang 3.4.2, at least, is needed, but this was only tested with version 3.7**