### PR TITLE
AP_HAL: add RCOutput::read_last_sent

### DIFF
--- a/libraries/AP_HAL/RCOutput.h
+++ b/libraries/AP_HAL/RCOutput.h
@@ -67,9 +67,15 @@ public:
     virtual void     push() { }
 
     /* Read back current output state, as either single channel or
-     * array of channels. */
+     * array of channels. On boards that have a separate IO controller,
+     * this returns the latest output value that the IO controller has
+     * reported */
     virtual uint16_t read(uint8_t ch) = 0;
     virtual void     read(uint16_t* period_us, uint8_t len) = 0;
+
+    /* Read the current input state. This returns the last value that was written. */
+    virtual uint16_t read_last_sent(uint8_t ch) { return read(ch); }
+    virtual void     read_last_sent(uint16_t* period_us, uint8_t len) { read(period_us, len); };
 
     /*
       set PWM to send to a set of channels when the safety switch is

--- a/libraries/AP_HAL_PX4/RCOutput.cpp
+++ b/libraries/AP_HAL_PX4/RCOutput.cpp
@@ -285,6 +285,22 @@ void PX4RCOutput::read(uint16_t* period_us, uint8_t len)
     }
 }
 
+uint16_t PX4RCOutput::read_last_sent(uint8_t ch)
+{
+    if (ch >= PX4_NUM_OUTPUT_CHANNELS) {
+        return 0;
+    }
+
+    return _period[ch];
+}
+
+void PX4RCOutput::read_last_sent(uint16_t* period_us, uint8_t len)
+{
+    for (uint8_t i=0; i<len; i++) {
+        period_us[i] = read_last_sent(i);
+    }
+}
+
 /*
   update actuator armed state
  */

--- a/libraries/AP_HAL_PX4/RCOutput.h
+++ b/libraries/AP_HAL_PX4/RCOutput.h
@@ -20,6 +20,8 @@ public:
     void     write(uint8_t ch, uint16_t period_us) override;
     uint16_t read(uint8_t ch) override;
     void     read(uint16_t* period_us, uint8_t len) override;
+    uint16_t read_last_sent(uint8_t ch) override;
+    void     read_last_sent(uint16_t* period_us, uint8_t len) override;
     void     set_safety_pwm(uint32_t chmask, uint16_t period_us) override;
     void     set_failsafe_pwm(uint32_t chmask, uint16_t period_us) override;
     bool     force_safety_on(void) override;


### PR DESCRIPTION
To be used for multirotor high-rate motor output logging.