### PR TITLE
Add support for getting the rally count from the autopilot

### DIFF
--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -1888,6 +1888,13 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
         break;
 
 #if AC_RALLY == ENABLED
+    // GCS request the full list of commands, we return just the number and leave the GCS to then request each command individually
+    case MAVLINK_MSG_ID_RALLY_REQUEST_LIST:       // MAV ID: 227
+    {
+        handle_rally_request_list(copter.rally, msg);
+        break;
+    }
+
     // receive a rally point from GCS and store in EEPROM
     case MAVLINK_MSG_ID_RALLY_POINT: {
         mavlink_rally_point_t packet;

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1686,6 +1686,13 @@ void GCS_MAVLINK::handleMessage(mavlink_message_t* msg)
     }
 #endif // GEOFENCE_ENABLED
 
+    // GCS request the full list of commands, we return just the number and leave the GCS to then request each command individually
+    case MAVLINK_MSG_ID_RALLY_REQUEST_LIST:
+    {
+        handle_rally_request_list(plane.rally, msg);
+        break;
+    }
+
     // receive a rally point from GCS and store in EEPROM
     case MAVLINK_MSG_ID_RALLY_POINT: {
         mavlink_rally_point_t packet;

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -18,6 +18,7 @@
 #include <AP_SerialManager/AP_SerialManager.h>
 #include <AP_Mount/AP_Mount.h>
 #include <AP_HAL/utility/RingBuffer.h>
+#include <AP_Rally/AP_Rally.h>
 
 // check if a message will fit in the payload space available
 #define HAVE_PAYLOAD_SPACE(chan, id) (comm_get_txspace(chan) >= MAVLINK_NUM_NON_PAYLOAD_BYTES+MAVLINK_MSG_ID_ ## id ## _LEN)
@@ -328,6 +329,8 @@ private:
     void handle_mission_clear_all(AP_Mission &mission, mavlink_message_t *msg);
     void handle_mission_write_partial_list(AP_Mission &mission, mavlink_message_t *msg);
     bool handle_mission_item(mavlink_message_t *msg, AP_Mission &mission);
+
+    void handle_rally_request_list(AP_Rally &rally, mavlink_message_t *msg);
 
     void handle_request_data_stream(mavlink_message_t *msg, bool save);
     void handle_param_request_list(mavlink_message_t *msg);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -746,6 +746,19 @@ GCS_MAVLINK::handle_gps_inject(const mavlink_message_t *msg, AP_GPS &gps)
 
 }
 
+/*
+  handle a RALLY_REQUEST_LIST mavlink packet
+ */
+void GCS_MAVLINK::handle_rally_request_list(AP_Rally &rally, mavlink_message_t *msg)
+{
+    // decode
+    mavlink_rally_request_list_t packet;
+    mavlink_msg_rally_request_list_decode(msg, &packet);
+
+    // reply with number of commands in the mission.  The GCS will then request each command separately
+    mavlink_msg_rally_count_send(chan,msg->sysid, msg->compid, rally.get_rally_total());
+}
+
 // send a message using mavlink, handling message queueing
 void GCS_MAVLINK::send_message(enum ap_message id)
 {


### PR DESCRIPTION
Makes rally points implement the same protocol that mission items implement.

Depends upon mavlink #524. (I wasn't sure how to get the submodule to reflect that correctly)