### PR TITLE
Waf: support Clang [v2]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
     branch_pattern: coverity_scan
 
 before_install:
+  - export PATH=$(echo ${PATH} | awk -v RS=':' -v ORS=':' '/clang/ {next} {print}' | sed 's/:*$//')
   - APMDIR=$(pwd) && pushd .. && $APMDIR/Tools/scripts/configure-ci.sh && . ~/.profile && popd
 
 script:
@@ -30,6 +31,8 @@ notifications:
     on_failure: always  # options: [always|never|change] default: always
     on_start: false     # default: false
 
+compiler: gcc
+
 env:
   global:
     # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
@@ -39,3 +42,10 @@ env:
     - CI_BUILD_TARGET="px4-v2 sitl linux"
     - CI_BUILD_TARGET="navio raspilot minlure bebop"
     - CI_BUILD_TARGET="sitltest"
+
+matrix:
+  include:
+    - compiler: clang
+      env: CI_BUILD_TARGET="sitl linux minlure"
+    - compiler: clang
+      env: CI_BUILD_TARGET="navio raspilot bebop"

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -26,6 +26,9 @@ class Board:
     abstract = True
 
     def configure(self, cfg):
+        cfg.load('toolchain')
+        cfg.load('compiler_cxx compiler_c')
+
         env = waflib.ConfigSet.ConfigSet()
         self.configure_env(cfg, env)
 
@@ -45,9 +48,6 @@ class Board:
                 cfg.env.prepend_value(k, val)
             else:
                 cfg.env[k] = val
-
-        cfg.load('toolchain')
-        cfg.load('compiler_cxx compiler_c')
 
     def configure_env(self, cfg, env):
         # Use a dictionary instead of the convetional list for definitions to

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -44,7 +44,7 @@ class Board:
                     keys.sort()
                 val = ['%s=%s' % (vk, val[vk]) for vk in keys]
 
-            if k in cfg.env and isinstance(cfg.env, list):
+            if k in cfg.env and isinstance(cfg.env[k], list):
                 cfg.env.prepend_value(k, val)
             else:
                 cfg.env[k] = val

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -17,6 +17,9 @@ class BoardMeta(type):
         if cls.abstract:
             return
 
+        if not hasattr(cls, 'toolchain'):
+            cls.toolchain = 'native'
+
         board_name = getattr(cls, 'name', name)
         if board_name in _board_classes:
             raise Exception('board named %s already exists' % board_name)
@@ -26,6 +29,7 @@ class Board:
     abstract = True
 
     def configure(self, cfg):
+        cfg.env.TOOLCHAIN = self.toolchain
         cfg.load('toolchain')
         cfg.load('compiler_cxx compiler_c')
 
@@ -198,107 +202,119 @@ class minlure(linux):
 
 
 class erleboard(linux):
+    toolchain = 'arm-linux-gnueabihf'
+
     def configure_env(self, cfg, env):
         super(erleboard, self).configure_env(cfg, env)
 
-        env.TOOLCHAIN = 'arm-linux-gnueabihf'
         env.DEFINES.update(
             CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_LINUX_ERLEBOARD',
         )
 
 class navio(linux):
+    toolchain = 'arm-linux-gnueabihf'
+
     def configure_env(self, cfg, env):
         super(navio, self).configure_env(cfg, env)
 
-        env.TOOLCHAIN = 'arm-linux-gnueabihf'
         env.DEFINES.update(
             CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_LINUX_NAVIO',
         )
 
 class navio2(linux):
+    toolchain = 'arm-linux-gnueabihf'
+
     def configure_env(self, cfg, env):
         super(navio2, self).configure_env(cfg, env)
 
-        env.TOOLCHAIN = 'arm-linux-gnueabihf'
         env.DEFINES.update(
             CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_LINUX_NAVIO2',
         )
 
 class zynq(linux):
+    toolchain = 'arm-xilinx-linux-gnueabi'
+
     def configure_env(self, cfg, env):
         super(zynq, self).configure_env(cfg, env)
 
-        env.TOOLCHAIN = 'arm-xilinx-linux-gnueabi'
         env.DEFINES.update(
             CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_LINUX_ZYNQ',
         )
 
 class bbbmini(linux):
+    toolchain = 'arm-linux-gnueabihf'
+
     def configure_env(self, cfg, env):
         super(bbbmini, self).configure_env(cfg, env)
 
-        env.TOOLCHAIN = 'arm-linux-gnueabihf'
         env.DEFINES.update(
             CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_LINUX_BBBMINI',
         )
 
 class pxf(linux):
+    toolchain = 'arm-linux-gnueabihf'
+
     def configure_env(self, cfg, env):
         super(pxf, self).configure_env(cfg, env)
 
-        env.TOOLCHAIN = 'arm-linux-gnueabihf'
         env.DEFINES.update(
             CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_LINUX_PXF',
         )
 
 class bebop(linux):
+    toolchain = 'arm-linux-gnueabihf'
+
     def configure_env(self, cfg, env):
         super(bebop, self).configure_env(cfg, env)
 
-        env.TOOLCHAIN = 'arm-linux-gnueabihf'
         env.DEFINES.update(
             CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_LINUX_BEBOP',
         )
         env.STATIC_LINKING = True
 
 class raspilot(linux):
+    toolchain = 'arm-linux-gnueabihf'
+
     def configure_env(self, cfg, env):
         super(raspilot, self).configure_env(cfg, env)
 
-        env.TOOLCHAIN = 'arm-linux-gnueabihf'
         env.DEFINES.update(
             CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_LINUX_RASPILOT',
         )
 
 class erlebrain2(linux):
+    toolchain = 'arm-linux-gnueabihf'
+
     def configure_env(self, cfg, env):
         super(erlebrain2, self).configure_env(cfg, env)
 
-        env.TOOLCHAIN = 'arm-linux-gnueabihf'
         env.DEFINES.update(
             CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_LINUX_ERLEBRAIN2',
         )
 
 class bhat(linux):
+    toolchain = 'arm-linux-gnueabihf'
+
     def configure_env(self, cfg, env):
         super(bhat, self).configure_env(cfg, env)
 
-        env.TOOLCHAIN = 'arm-linux-gnueabihf'
         env.DEFINES.update(
             CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_LINUX_BH',
         )
 
 class pxfmini(linux):
+    toolchain = 'arm-linux-gnueabihf'
+
     def configure_env(self, cfg, env):
         super(pxfmini, self).configure_env(cfg, env)
 
-        env.TOOLCHAIN = 'arm-linux-gnueabihf'
         env.DEFINES.update(
             CONFIG_HAL_BOARD_SUBTYPE = 'HAL_BOARD_SUBTYPE_LINUX_PXFMINI',
         )
 
 class px4(Board):
     abstract = True
+    toolchain = 'arm-none-eabi'
 
     def __init__(self):
         self.version = None
@@ -314,7 +330,6 @@ class px4(Board):
     def configure_env(self, cfg, env):
         super(px4, self).configure_env(cfg, env)
 
-        env.TOOLCHAIN = 'arm-none-eabi'
         env.DEFINES.update(
             CONFIG_HAL_BOARD = 'HAL_BOARD_PX4',
             HAVE_STD_NULLPTR_T = 0,

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -71,6 +71,18 @@ class Board:
             '-Wno-redundant-decls',
         ]
 
+        if 'clang' in cfg.env.COMPILER_CC:
+            env.CFLAGS += [
+                '-fcolor-diagnostics',
+
+                '-Wno-gnu-designator',
+                '-Wno-inconsistent-missing-override',
+                '-Wno-mismatched-tags',
+                '-Wno-gnu-variable-sized-type-not-at-end',
+                '-Wno-unknown-pragmas',
+                '-Wno-c++11-narrowing'
+            ]
+
         env.CXXFLAGS += [
             '-std=gnu++11',
 
@@ -92,11 +104,26 @@ class Board:
             '-Wno-redundant-decls',
             '-Werror=format-security',
             '-Werror=array-bounds',
-            '-Werror=unused-but-set-variable',
             '-Werror=uninitialized',
             '-Werror=init-self',
             '-Wfatal-errors',
         ]
+
+        if 'clang++' in cfg.env.COMPILER_CXX:
+            env.CXXFLAGS += [
+                '-fcolor-diagnostics',
+
+                '-Wno-gnu-designator',
+                '-Wno-inconsistent-missing-override',
+                '-Wno-mismatched-tags',
+                '-Wno-gnu-variable-sized-type-not-at-end',
+                '-Wno-unknown-pragmas',
+                '-Wno-c++11-narrowing'
+            ]
+        else:
+            env.CXXFLAFS += [
+                '-Werror=unused-but-set-variable'
+            ]
 
         env.LINKFLAGS += [
             '-Wl,--gc-sections',

--- a/Tools/ardupilotwaf/toolchain.py
+++ b/Tools/ardupilotwaf/toolchain.py
@@ -12,11 +12,11 @@ Example::
         cfg.load('cxx_compiler')
 """
 
-from waflib import Utils
+from waflib import Utils, Context
+
+import os
 
 suffixes = dict(
-    CXX='g++',
-    CC='gcc',
     AS='gcc',
     AR='ar',
     LD='g++',
@@ -24,14 +24,70 @@ suffixes = dict(
     OBJCOPY='objcopy',
 )
 
-def configure(cfg):
-    if not cfg.env.TOOLCHAIN:
-        cfg.env.TOOLCHAIN = 'native'
-        prefix = ''
-    else:
-        cfg.env.TOOLCHAIN = Utils.to_list(cfg.env.TOOLCHAIN)[0]
-        cfg.msg('Using toolchain prefix', cfg.env.TOOLCHAIN)
-        prefix = cfg.env.TOOLCHAIN + '-'
+def find_realexec_path(cfg, filename, path_list=[]):
+    if not filename:
+        return ''
 
-    for k in suffixes:
-        cfg.env.append_value(k, prefix + suffixes[k])
+    if not path_list:
+        path_list = cfg.environ.get('PATH','').split(os.pathsep)
+
+    for dir in path_list:
+        path = os.path.abspath(os.path.expanduser(os.path.join(dir, filename)))
+
+        if os.path.isfile(path):
+            if os.path.islink(path):
+                realpath = os.path.realpath(path)
+
+                if filename not in os.path.basename(realpath):
+                    continue
+                else:
+                    return os.path.dirname(realpath)
+
+            else:
+                return os.path.dirname(path)
+
+    cfg.fatal('Could not find real exec path to %s in path_list %s:' % (filename, path_list))
+
+def configure(cfg):
+    toolchain = cfg.env.TOOLCHAIN
+
+    if toolchain != 'native':
+        cfg.msg('Using toolchain prefix', toolchain)
+        prefix = toolchain + '-'
+
+        c_compiler = cfg.options.check_c_compiler or 'gcc'
+        cxx_compiler = cfg.options.check_cxx_compiler or 'g++'
+
+        if 'gcc' == c_compiler or 'g++' == cxx_compiler or 'clang' == c_compiler or 'clang++' == cxx_compiler:
+            toolchain_path = os.path.abspath(os.path.join(find_realexec_path(cfg, prefix + suffixes['AR']), '..'))
+            cfg.msg('Using toolchain path', toolchain_path)
+
+            if 'gcc' == c_compiler or 'g++' == cxx_compiler:
+                for k in suffixes:
+                    cfg.env[k] = [prefix + suffixes[k]]
+
+            if 'clang' == c_compiler or 'clang++' == cxx_compiler:
+                sysroot = cfg.cmd_and_log([prefix + 'gcc', '--print-sysroot'], quiet=Context.BOTH)[:-1]
+                clang_flags = [
+                    '--target=' + toolchain,
+                    '--gcc-toolchain=' + toolchain_path,
+                    '--sysroot=' + sysroot,
+                    '-B' + os.path.join(toolchain_path, 'bin')
+                ]
+                cfg.env.LINKFLAGS += clang_flags
+
+        if 'gcc' == c_compiler:
+            cfg.env['CC'] = [prefix + 'gcc']
+
+        elif 'clang' == c_compiler:
+            cfg.env['CC'] = [c_compiler]
+            cfg.env['AR'] = [prefix + suffixes['AR']]
+            cfg.env.CFLAGS += clang_flags
+
+        if 'g++' == cxx_compiler:
+            cfg.env['CXX'] = [prefix + 'g++']
+
+        elif 'clang++' == cxx_compiler:
+            cfg.env['CXX'] = [cxx_compiler]
+            cfg.env['AR'] = [prefix + suffixes['AR']]
+            cfg.env.CXXFLAGS += clang_flags

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -8,6 +8,8 @@ set -ex
 . ~/.profile
 
 # CXX and CC are exported by default by travis
+c_compiler=${CC:-gcc}
+cxx_compiler=${CXX:-g++}
 unset CXX CC
 
 export BUILDROOT=/tmp/travis.build.$$
@@ -61,26 +63,29 @@ for board in $($waf list_boards | head -n1); do waf_supported_boards[$board]=1; 
 
 echo "Targets: $CI_BUILD_TARGET"
 for t in $CI_BUILD_TARGET; do
-    echo "Starting make based build for target ${t}..."
-    for v in ${!build_platforms[@]}; do
-        if [[ ${build_platforms[$v]} != *$t* ]]; then
-            continue
-        fi
-        echo "Building $v for ${t}..."
+    # skip make-based build for clang
+    if [[ "$cxx_compiler" != "clang++" ]]; then
+        echo "Starting make based build for target ${t}..."
+        for v in ${!build_platforms[@]}; do
+            if [[ ${build_platforms[$v]} != *$t* ]]; then
+                continue
+            fi
+            echo "Building $v for ${t}..."
 
-        pushd $v
-        make clean
-        if [ ${build_extra_clean[$t]+_} ]; then
-            ${build_extra_clean[$t]}
-        fi
+            pushd $v
+            make clean
+            if [ ${build_extra_clean[$t]+_} ]; then
+                ${build_extra_clean[$t]}
+            fi
 
-        make $t ${build_concurrency[$t]}
-        popd
-    done
+            make $t ${build_concurrency[$t]}
+            popd
+        done
+    fi
 
     if [[ -n ${waf_supported_boards[$t]} ]]; then
         echo "Starting waf build for board ${t}..."
-        $waf configure --board $t --enable-benchmarks
+        $waf configure --board $t --enable-benchmarks --check-c-compiler="$c_compiler" --check-cxx-compiler="$cxx_compiler"
         $waf clean
         $waf ${build_concurrency[$t]} all
         if [[ $t == linux ]]; then

--- a/Tools/scripts/configure-ci.sh
+++ b/Tools/scripts/configure-ci.sh
@@ -4,7 +4,7 @@
 set -ex
 
 PKGS="build-essential gawk ccache genromfs libc6-i386 \
-      python-argparse python-empy python-serial python-pexpect python-dev python-pip zlib1g-dev gcc-4.9 g++-4.9 cmake cmake-data"
+      python-argparse python-empy python-serial python-pexpect python-dev python-pip zlib1g-dev gcc-4.9 g++-4.9 cmake cmake-data clang-3.7"
 
 ARM_ROOT="gcc-arm-none-eabi-4_9-2015q3"
 ARM_TARBALL="$ARM_ROOT-20150921-linux.tar.bz2"
@@ -22,8 +22,12 @@ elif [ "$UBUNTU_CODENAME" = "trusty" ]; then
     sudo add-apt-repository ppa:george-edison55/cmake-3.x -y
 fi
 
+wget -q -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
+sudo add-apt-repository "deb http://llvm.org/apt/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-3.7 main" -y
 sudo apt-get -qq -y update
 sudo apt-get -y install $PKGS
+sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.7 37 \
+    --slave /usr/bin/clang++ clang++ /usr/bin/clang++-3.7
 sudo pip install mavproxy
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 90 \
     --slave /usr/bin/g++ g++ /usr/bin/g++-4.9

--- a/Tools/scripts/configure-ci.sh
+++ b/Tools/scripts/configure-ci.sh
@@ -25,6 +25,7 @@ fi
 wget -q -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
 sudo add-apt-repository "deb http://llvm.org/apt/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-3.7 main" -y
 sudo apt-get -qq -y update
+sudo apt-get -qq -y remove clang llvm
 sudo apt-get -y install $PKGS
 sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.7 37 \
     --slave /usr/bin/clang++ clang++ /usr/bin/clang++-3.7

--- a/Tools/scripts/configure-ci.sh
+++ b/Tools/scripts/configure-ci.sh
@@ -63,9 +63,9 @@ ln -s /usr/bin/ccache ~/bin/arm-none-eabi-gcc
 ln -s /usr/bin/ccache ~/bin/arm-linux-gnueabihf-g++
 ln -s /usr/bin/ccache ~/bin/arm-linux-gnueabihf-gcc
 
-exportline="export PATH=$HOME/bin:"
-exportline="${exportline}:$HOME/opt/gcc-arm-none-eabi-4_9-2015q3/bin:"
-exportline="${exportline}:$HOME/opt/tools-master/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin:"
+exportline="export PATH=$HOME/bin"
+exportline="${exportline}:$HOME/opt/gcc-arm-none-eabi-4_9-2015q3/bin"
+exportline="${exportline}:$HOME/opt/tools-master/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin"
 exportline="${exportline}:\$PATH"
 
 if grep -Fxq "$exportline" ~/.profile; then

--- a/libraries/AP_HAL_Linux/SPIDriver.cpp
+++ b/libraries/AP_HAL_Linux/SPIDriver.cpp
@@ -72,10 +72,14 @@ SPIDeviceDriver SPIDeviceManager::_device[] = {
 };
 #else
 // empty device table
-SPIDeviceDriver SPIDeviceManager::_device[0];
+SPIDeviceDriver SPIDeviceManager::_device[] = { };
+#define LINUX_SPI_DEVICE_NUM_DEVICES 0
 #endif
 
+#ifndef LINUX_SPI_DEVICE_NUM_DEVICES
 #define LINUX_SPI_DEVICE_NUM_DEVICES ARRAY_SIZE(SPIDeviceManager::_device)
+#endif
+
 const uint8_t SPIDeviceManager::_n_device_desc = LINUX_SPI_DEVICE_NUM_DEVICES;
 
 SPIDeviceDriver::SPIDeviceDriver(const char *name, uint16_t bus, uint16_t subdev, enum AP_HAL::SPIDeviceType type, uint8_t mode, uint8_t bitsPerWord, int16_t cs_pin, uint32_t lowspeed, uint32_t highspeed):


### PR DESCRIPTION
This is the v2 version of the PR #3722

Changes from that version are:
- rebased on master
- toolchain and compiler tools are now loaded by boards and before configuring the environment (this allows detection for compiler flags to be done in a standard way)
- fixed bug in boards configure
- toolchain is now a class attribute instead of define in the environment
- CC/CXX environment variables can't be used to select Clang, now you can only use the _--check-c/cxx-compiler_ flags
- PX4 builds aren't supported (because it imports compiler flags from PX4Firmware that aren't supported by Clang)

@guludo I tried to directly load the tools to choose which one we wanted in case of non-native, but it wasn't pretty, both in code and in display. Doing it that way means we are replacing the compiler_c/cxx tools and in that case, and since we are using our own waf module, what should be done is to directly integrate toolchain support in each tool.

I think the way it is done now is the best: it defaults to GCC if no flag is passed, just like now. If the flags are passed it checks if it is GCC or Clang making the necessary changes for each. If it isn't any of them it doesn't do anything and let the tools do their work. You can use CC/CXX env vars to change   the binary, even in GCC/Clang cases, satisfying @lucasdemarchi request.

For last **two important points** I missed to make in the previous PR:
- Clang 3.4.2, at least, is needed, but this was only tested with version 3.7
- The toolchain support for Clang assumes you are using an unzipped version and not a toolchain installed via a package manager